### PR TITLE
ci(release-please): enable PR creation via GITHUB_TOKEN; fix YAML indent

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -32,6 +32,3 @@ jobs:
           # Use a PAT if provided to allow fork-based PRs when org policy blocks bot PRs
           token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
           fork: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
-          # Fallback: if no PAT, skip PR creation to avoid
-          # "Actions not permitted to create or approve PRs" policy errors
-          skip-github-pull-request: ${{ secrets.RELEASE_PLEASE_TOKEN == '' }}


### PR DESCRIPTION
Enable PR creation now that repo allows Actions PRs.
- Remove skip-github-pull-request
- Keep least-privilege perms + job-level writes
- Add concurrency (already merged)

Please approve to unblock Release Please PR generation (0.2.1).