### PR TITLE
ci(releases): auto-set prerelease on published releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
       - '**'
     tags:
       - 'v*'
+  release:
+    types: [published]
   pull_request:
   workflow_dispatch:
 
@@ -87,7 +89,8 @@ jobs:
 
   package:
     name: Package VSIX
-    if: startsWith(github.ref, 'refs/tags/v')
+    # Run on tag pushes or on published GitHub Releases
+    if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release'
     needs: build_and_test
     runs-on: ubuntu-latest
     timeout-minutes: 20
@@ -97,6 +100,7 @@ jobs:
       actions: write
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -118,7 +122,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           MINOR=$(node -p "require('./package.json').version.split('.')[1]")
-          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_NAME="${TAG_NAME}"
           # default: even minor => stable, odd minor => pre-release
           if [ $((MINOR % 2)) -eq 1 ]; then
             PRE_RELEASE=true
@@ -156,7 +160,8 @@ jobs:
 
   publish:
     name: Publish to Marketplace
-    if: startsWith(github.ref, 'refs/tags/v') && github.repository == 'Electivus/Apex-Log-Viewer'
+    # Run on tag pushes or published Releases in this repo
+    if: (startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release') && github.repository == 'Electivus/Apex-Log-Viewer'
     needs: package
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -165,6 +170,7 @@ jobs:
     environment: marketplace
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || github.event.release.tag_name }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -186,7 +192,7 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           MINOR=$(node -p "require('./package.json').version.split('.')[1]")
-          TAG_NAME="${GITHUB_REF_NAME}"
+          TAG_NAME="${TAG_NAME}"
           if [ $((MINOR % 2)) -eq 1 ]; then PRE_RELEASE=true; else PRE_RELEASE=false; fi
           if [[ "$TAG_NAME" == *"-pre"* || "$TAG_NAME" == *"-beta"* || "$TAG_NAME" == *"-alpha"* || "$TAG_NAME" == *"-rc"* ]]; then PRE_RELEASE=true; fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT

--- a/.github/workflows/release-flags.yml
+++ b/.github/workflows/release-flags.yml
@@ -1,0 +1,59 @@
+name: Release Flags
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-flags-${{ github.event.release.tag_name }}
+  cancel-in-progress: false
+
+jobs:
+  set-prerelease-flag:
+    name: Set prerelease flag based on version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Compute prerelease from semver minor
+        id: semver
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          # Strip leading 'v' if present
+          VERSION=${TAG#v}
+          IFS='.' read -r MAJOR MINOR PATCH <<<"$VERSION"
+          if [ -z "$MINOR" ]; then
+            echo "Could not parse minor from tag $TAG" >&2
+            exit 1
+          fi
+          if [ $((MINOR % 2)) -eq 1 ]; then
+            PRE=true
+          else
+            PRE=false
+          fi
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
+          echo "prerelease=$PRE" >> $GITHUB_OUTPUT
+          echo "Computed prerelease=$PRE for $TAG"
+
+      - name: Update GitHub Release prerelease flag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const tag = core.getInput('tag') || process.env.TAG;
+            const prerelease = (core.getInput('prerelease') || process.env.PRERELEASE || 'false') === 'true';
+            const { data: rel } = await github.rest.repos.getReleaseByTag({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              tag
+            });
+            await github.rest.repos.updateRelease({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              release_id: rel.id,
+              prerelease
+            });
+          env:
+            TAG: ${{ steps.semver.outputs.tag }}
+            PRERELEASE: ${{ steps.semver.outputs.prerelease }}
+


### PR DESCRIPTION
Automatically marks GitHub Releases as pre-release when minor is odd; stable otherwise.