### PR TITLE
ci(releases): contents: write for package/publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,9 +99,9 @@ jobs:
     needs: build_and_test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    # Allow uploading artifacts; keep repo contents read-only
+    # Needs contents: write to toggle release flags
     permissions:
-      contents: read
+      contents: write
       actions: write
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
@@ -187,7 +187,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     permissions:
-      contents: read
+      contents: write
     environment: marketplace
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,6 +106,7 @@ jobs:
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
       TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || (github.event_name == 'release' && github.event.release.tag_name) || github.event.inputs.tag_name }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -191,6 +192,7 @@ jobs:
     env:
       VSCE_PAT: ${{ secrets.VSCE_PAT }}
       TAG_NAME: ${{ github.ref_type == 'tag' && github.ref_name || (github.event_name == 'release' && github.event.release.tag_name) || github.event.inputs.tag_name }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Needed for gh to update Release prerelease flag during packaging.