### PR TITLE
ci: revert to tag-driven releases; remove release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,6 +20,6 @@ jobs:
           # Use manifest + config files in repo root
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
-          # Defer GitHub Release creation to release.yml so we control
-          # pre-release flags and upload VSIX consistently
-          skip-github-release: true
+          # Let release-please create tag + GitHub Release.
+          # release.yml will edit the release to set pre-release flag
+          # and upload VSIX assets based on odd/even policy.

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,3 +20,6 @@ jobs:
           # Use manifest + config files in repo root
           manifest-file: .release-please-manifest.json
           config-file: release-please-config.json
+          # Defer GitHub Release creation to release.yml so we control
+          # pre-release flags and upload VSIX consistently
+          skip-github-release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -191,6 +191,24 @@ jobs:
             npm run vsce:publish
           fi
 
+      - name: Create or update GitHub release (pre-release)
+        if: env.PRE_RELEASE == 'true'
+        env:
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+          TITLE="Pre-release $TAG"
+          BODY="Automated pre-release."
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Updating existing pre-release $TAG"
+            gh release edit "$TAG" --title "$TITLE" --notes "$BODY" --prerelease
+          else
+            echo "Creating pre-release $TAG"
+            gh release create "$TAG" --title "$TITLE" --notes "$BODY" --prerelease
+          fi
+          # Upload VSIX(es) built in the package job
+          gh release upload "$TAG" ./*.vsix --clobber
+
       - name: Create or update GitHub release (stable)
         if: env.PRE_RELEASE != 'true'
         env:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "changelog-path": "CHANGELOG.md",
@@ -18,4 +19,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Context\n- The pre-release v0.3.1 was tagged as 'apex-log-viewer-v0.3.1' by Release Please and the GitHub Release was not marked as pre-release. Our 'Release (tags)' workflow listens to 'v*' and handles the pre-release flag.\n\nChanges\n- release-please-config.json: set include-component-in-tag=false and include-v-in-tag=true so tags are plain 'vX.Y.Z'.\n- .github/workflows/release-please.yml: set skip-github-release=true to let release.yml handle GitHub Releases (including --prerelease when needed).\n\nWhy\n- Ensures release.yml triggers on tag creation and consistently applies the odd-minor pre-release policy and uploads VSIX assets.\n\nVerification\n- Next release-please run should open/refresh a PR and, upon merge, create tag 'vX.Y.Z'. release.yml will then package and publish, marking pre-release when MINOR is odd or tag has '-pre' suffix.\n\nRisk / Rollback\n- Low. If we need the previous behavior, revert this PR and delete the tag rule change.\n\nNotes\n- No functional code changes; CI unchanged except for tag matching behavior.

---

Update (2025-08-30)
- Add step in .github/workflows/release.yml to create/update a GitHub pre-release when odd-minor channel is detected (env PRE_RELEASE == 'true').
- Uses gh release create/edit with --prerelease and uploads the VSIX built in the package job.
- Stable path unchanged; still creates/updates a normal GitHub release for even-minor.



Update (2025-08-30)
- Remove Release Please workflow and configs; keep tag-based release via release.yml/ci.yml.
- CHANGELOG remains auto-generated by CI using Conventional Commits.
- Pre-release handling (odd minor) and VSIX publication unchanged.

---

Update (2025-08-30)
- Remove Release Please workflow and configs; keep tag-based release via release.yml/ci.yml.
- CHANGELOG remains auto-generated by CI using Conventional Commits.
- Pre-release handling (odd minor) and VSIX publication unchanged.
