### PR TITLE
feat(logging): log org fetch errors and warn on warm-up failures

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,6 +10,10 @@ import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger 
 import { detectReplayDebuggerAvailable } from './utils/warmup';
 import { localize } from './utils/localize';
 
+interface OrgQuickPick extends vscode.QuickPickItem {
+  username: string;
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   logInfo('Activating Apex Log Viewer extension…');
   // Configure trace logging from settings
@@ -90,20 +94,20 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('sfLogs.selectOrg', async () => {
       logInfo('Command sfLogs.selectOrg invoked. Listing orgs…');
       const orgs: OrgItem[] = await listOrgs();
-      const items: (vscode.QuickPickItem & { username: string })[] = orgs.map(o => ({
+      const items: OrgQuickPick[] = orgs.map(o => ({
         label: o.alias ?? o.username,
         description: o.isDefaultUsername ? localize('selectOrgDefault', 'Default') : undefined,
         detail: o.instanceUrl || undefined,
         username: o.username
       }));
-      const picked = await vscode.window.showQuickPick(items, {
+      const picked = await vscode.window.showQuickPick<OrgQuickPick>(items, {
         placeHolder: localize('selectOrgPlaceholder', 'Select an authenticated org')
       });
       if (!picked) {
         logInfo('Select org cancelled.');
         return;
       }
-      const username = (picked as any).username as string;
+      const username = picked.username;
       provider.setSelectedOrg(username);
       logInfo('Selected org:', username);
       await provider.sendOrgs();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -25,8 +25,9 @@ export async function activate(context: vscode.ExtensionContext) {
         }
       })
     );
-  } catch {
-    // ignore
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logWarn('Failed to configure trace logging ->', msg);
   }
   // Soft advice: if Apex Replay Debugger (via Salesforce Extension Pack) is missing, log a tip in Output
   try {
@@ -41,7 +42,9 @@ export async function activate(context: vscode.ExtensionContext) {
         );
       }
     }, 0);
-  } catch {}
+  } catch (e) {
+    logWarn('Failed to detect Apex Replay Debugger availability ->', e instanceof Error ? e.message : String(e));
+  }
   // Try to read sourceApiVersion from sfdx-project.json (first workspace folder)
   const folders = vscode.workspace.workspaceFolders;
   if (folders && folders.length > 0) {
@@ -56,11 +59,14 @@ export async function activate(context: vscode.ExtensionContext) {
           setApiVersion(v);
           logInfo('Detected sourceApiVersion from sfdx-project.json:', v);
         }
-      } catch {
-        logWarn('Could not parse sfdx-project.json for sourceApiVersion.');
+      } catch (e) {
+        logWarn(
+          'Could not parse sfdx-project.json for sourceApiVersion ->',
+          e instanceof Error ? e.message : String(e)
+        );
       }
-    } catch {
-      logInfo('No sfdx-project.json found in first workspace folder.');
+    } catch (e) {
+      logInfo('No sfdx-project.json found in first workspace folder ->', e instanceof Error ? e.message : String(e));
     }
   }
   const provider = new SfLogsViewProvider(context);
@@ -146,7 +152,9 @@ export async function activate(context: vscode.ExtensionContext) {
     };
     // Defer to avoid impacting our own activation time
     setTimeout(() => void warmUp(), 0);
-  } catch {}
+  } catch (e) {
+    logWarn('Failed to warm up Apex Replay Debugger ->', e instanceof Error ? e.message : String(e));
+  }
 
   // Return exports for tests and programmatic use
   return {

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -92,7 +92,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     // Fire-and-forget warm-up of Replay Debugger when the view opens
     try {
       setTimeout(() => void warmUpReplayDebugger(), 0);
-    } catch {}
+    } catch (e) {
+      logWarn('Logs: warm-up of Apex Replay Debugger failed ->', e instanceof Error ? e.message : String(e));
+    }
     // Dispose handling: stop posting and bump token to invalidate in-flight work
     this.context.subscriptions.push(
       webviewView.onDidDispose(() => {
@@ -190,8 +192,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
             if (codeUnit && token === this.refreshToken && !this.disposed) {
               this.post({ type: 'logHead', logId: log.Id, codeUnitStarted: codeUnit });
             }
-          } catch {
-            // ignore individual log error
+          } catch (e) {
+            logWarn('Logs: head fetch failed for', log.Id, '->', e instanceof Error ? e.message : String(e));
           }
         });
       }
@@ -233,8 +235,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
             if (codeUnit && token === this.refreshToken && !this.disposed) {
               this.post({ type: 'logHead', logId: log.Id, codeUnitStarted: codeUnit });
             }
-          } catch {
-            // ignore per-log error
+          } catch (e) {
+            logWarn('Logs: head fetch failed for', log.Id, '->', e instanceof Error ? e.message : String(e));
           }
         });
       }
@@ -299,7 +301,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         async () => {
           try {
             await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', uri);
-          } catch {
+          } catch (e) {
+            logWarn('Logs: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
             await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
           }
         }
@@ -329,7 +332,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       const orgs = await listOrgs();
       const selected = pickSelectedOrg(orgs, this.selectedOrg);
       this.post({ type: 'orgs', data: orgs, selected });
-    } catch {
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logWarn('Logs: sendOrgs failed ->', msg);
+      vscode.window.showErrorMessage(localize('sendOrgsFailed', 'Failed to retrieve orgs: {0}', msg));
       this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
     }
   }


### PR DESCRIPTION
## Summary
- log configuration and warm-up failures instead of silently ignoring
- surface errors when listing orgs in logs and tail views
- add warnings for tail view warm-up and debug level retrieval failures

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b36d0bece4832391caf8c21c0fe442