### PR TITLE
refactor: extract org list parsing helper

### DIFF
--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -258,6 +258,75 @@ export async function getOrgAuth(targetUsernameOrAlias?: string): Promise<OrgAut
   );
 }
 
+function parseOrgList(json: string): OrgItem[] {
+  const parsed = JSON.parse(json);
+  const res = parsed.result || parsed;
+  let groups: any[] = [];
+  if (Array.isArray(res.orgs)) {
+    groups = groups.concat(res.orgs);
+  }
+  if (Array.isArray(res.nonScratchOrgs)) {
+    groups = groups.concat(res.nonScratchOrgs);
+  }
+  if (Array.isArray(res.scratchOrgs)) {
+    groups = groups.concat(res.scratchOrgs);
+  }
+  if (Array.isArray(res.sandboxes)) {
+    groups = groups.concat(res.sandboxes);
+  }
+  if (Array.isArray(res.devHubs)) {
+    groups = groups.concat(res.devHubs);
+  }
+  const map = new Map<string, OrgItem>();
+  for (const o of groups) {
+    const username: string | undefined = o.username || o.usernameOrAlias || o.usernameOrEmail;
+    if (!username) {
+      continue;
+    }
+    const item: OrgItem = {
+      username,
+      alias: o.alias,
+      isDefaultUsername: !!(o.isDefaultUsername || o.isDefault),
+      isDefaultDevHubUsername: !!o.isDefaultDevHubUsername,
+      isScratchOrg: !!(o.isScratchOrg || o.isScratch)
+    };
+    if (o.instanceUrl) {
+      item.instanceUrl = o.instanceUrl;
+    }
+    map.set(username, Object.assign(map.get(username) || {}, item));
+  }
+  if (Array.isArray(res.results)) {
+    for (const o of res.results) {
+      const username: string | undefined = o.username;
+      if (!username) {
+        continue;
+      }
+      const prev = map.get(username) || ({ username } as OrgItem);
+      const updated: OrgItem = {
+        ...prev,
+        alias: prev.alias || o.alias,
+        isDefaultUsername: prev.isDefaultUsername || !!o.isDefaultUsername,
+        isDefaultDevHubUsername: prev.isDefaultDevHubUsername || !!o.isDefaultDevHubUsername,
+        isScratchOrg: prev.isScratchOrg || !!o.isScratchOrg,
+        instanceUrl: prev.instanceUrl || o.instanceUrl
+      };
+      map.set(username, updated);
+    }
+  }
+  const arr = Array.from(map.values());
+  arr.sort((a, b) => {
+    const ad = a.isDefaultUsername ? 0 : 1;
+    const bd = b.isDefaultUsername ? 0 : 1;
+    if (ad !== bd) {
+      return ad - bd;
+    }
+    const an = (a.alias || a.username).toLowerCase();
+    const bn = (b.alias || b.username).toLowerCase();
+    return an.localeCompare(bn);
+  });
+  return arr;
+}
+
 export async function listOrgs(): Promise<OrgItem[]> {
   const candidates: Array<{ program: string; args: string[] }> = [
     { program: 'sf', args: ['org', 'list', '--json'] },
@@ -270,72 +339,7 @@ export async function listOrgs(): Promise<OrgItem[]> {
         logTrace('listOrgs: trying', program, args.join(' '));
       } catch {}
       const { stdout } = await execCommand(program, args);
-      const parsed = JSON.parse(stdout);
-      const res = parsed.result || parsed;
-      let groups: any[] = [];
-      if (Array.isArray(res.orgs)) {
-        groups = groups.concat(res.orgs);
-      }
-      if (Array.isArray(res.nonScratchOrgs)) {
-        groups = groups.concat(res.nonScratchOrgs);
-      }
-      if (Array.isArray(res.scratchOrgs)) {
-        groups = groups.concat(res.scratchOrgs);
-      }
-      if (Array.isArray(res.sandboxes)) {
-        groups = groups.concat(res.sandboxes);
-      }
-      if (Array.isArray(res.devHubs)) {
-        groups = groups.concat(res.devHubs);
-      }
-      const map = new Map<string, OrgItem>();
-      for (const o of groups) {
-        const username: string | undefined = o.username || o.usernameOrAlias || o.usernameOrEmail;
-        if (!username) {
-          continue;
-        }
-        const item: OrgItem = {
-          username,
-          alias: o.alias,
-          isDefaultUsername: !!(o.isDefaultUsername || o.isDefault),
-          isDefaultDevHubUsername: !!o.isDefaultDevHubUsername,
-          isScratchOrg: !!(o.isScratchOrg || o.isScratch)
-        };
-        if (o.instanceUrl) {
-          item.instanceUrl = o.instanceUrl;
-        }
-        map.set(username, Object.assign(map.get(username) || {}, item));
-      }
-      if (Array.isArray(res.results)) {
-        for (const o of res.results) {
-          const username: string | undefined = o.username;
-          if (!username) {
-            continue;
-          }
-          const prev = map.get(username) || ({ username } as OrgItem);
-          const updated: OrgItem = {
-            ...prev,
-            alias: prev.alias || o.alias,
-            isDefaultUsername: prev.isDefaultUsername || !!o.isDefaultUsername,
-            isDefaultDevHubUsername: prev.isDefaultDevHubUsername || !!o.isDefaultDevHubUsername,
-            isScratchOrg: prev.isScratchOrg || !!o.isScratchOrg,
-            instanceUrl: prev.instanceUrl || o.instanceUrl
-          };
-          map.set(username, updated);
-        }
-      }
-      const arr = Array.from(map.values());
-      arr.sort((a, b) => {
-        const ad = a.isDefaultUsername ? 0 : 1;
-        const bd = b.isDefaultUsername ? 0 : 1;
-        if (ad !== bd) {
-          return ad - bd;
-        }
-        const an = (a.alias || a.username).toLowerCase();
-        const bn = (b.alias || b.username).toLowerCase();
-        return an.localeCompare(bn);
-      });
-      return arr;
+      return parseOrgList(stdout);
     } catch (_e) {
       const e: any = _e;
       if (e && e.code === 'ENOENT') {
@@ -356,72 +360,7 @@ export async function listOrgs(): Promise<OrgItem[]> {
             logTrace('listOrgs(login PATH): trying', program, args.join(' '));
           } catch {}
           const { stdout } = await execCommand(program, args, env2);
-          const parsed = JSON.parse(stdout);
-          const res = parsed.result || parsed;
-          let groups: any[] = [];
-          if (Array.isArray(res.orgs)) {
-            groups = groups.concat(res.orgs);
-          }
-          if (Array.isArray(res.nonScratchOrgs)) {
-            groups = groups.concat(res.nonScratchOrgs);
-          }
-          if (Array.isArray(res.scratchOrgs)) {
-            groups = groups.concat(res.scratchOrgs);
-          }
-          if (Array.isArray(res.sandboxes)) {
-            groups = groups.concat(res.sandboxes);
-          }
-          if (Array.isArray(res.devHubs)) {
-            groups = groups.concat(res.devHubs);
-          }
-          const map = new Map<string, OrgItem>();
-          for (const o of groups) {
-            const username: string | undefined = o.username || o.usernameOrAlias || o.usernameOrEmail;
-            if (!username) {
-              continue;
-            }
-            const item: OrgItem = {
-              username,
-              alias: o.alias,
-              isDefaultUsername: !!(o.isDefaultUsername || o.isDefault),
-              isDefaultDevHubUsername: !!o.isDefaultDevHubUsername,
-              isScratchOrg: !!(o.isScratchOrg || o.isScratch)
-            };
-            if (o.instanceUrl) {
-              item.instanceUrl = o.instanceUrl;
-            }
-            map.set(username, Object.assign(map.get(username) || {}, item));
-          }
-          if (Array.isArray(res.results)) {
-            for (const o of res.results) {
-              const username: string | undefined = o.username;
-              if (!username) {
-                continue;
-              }
-              const prev = map.get(username) || ({ username } as OrgItem);
-              const updated: OrgItem = {
-                ...prev,
-                alias: prev.alias || o.alias,
-                isDefaultUsername: prev.isDefaultUsername || !!o.isDefaultUsername,
-                isDefaultDevHubUsername: prev.isDefaultDevHubUsername || !!o.isDefaultDevHubUsername,
-                isScratchOrg: prev.isScratchOrg || !!o.isScratchOrg,
-                instanceUrl: prev.instanceUrl || o.instanceUrl
-              };
-              map.set(username, updated);
-            }
-          }
-          const arr = Array.from(map.values());
-          arr.sort((a, b) => {
-            const ad = a.isDefaultUsername ? 0 : 1;
-            const bd = b.isDefaultUsername ? 0 : 1;
-            if (ad !== bd) {
-              return ad - bd;
-            }
-            const an = (a.alias || a.username).toLowerCase();
-            const bn = (b.alias || b.username).toLowerCase();
-            return an.localeCompare(bn);
-          });
-          return arr;
+          return parseOrgList(stdout);
         } catch {
           try {
             logTrace('listOrgs(login PATH): attempt failed for', program);
@@ -435,3 +374,5 @@ export async function listOrgs(): Promise<OrgItem[]> {
   }
   return [];
 }
+
+export { parseOrgList as __parseOrgListForTests };

--- a/src/test/parseOrgList.test.ts
+++ b/src/test/parseOrgList.test.ts
@@ -1,0 +1,49 @@
+import assert from 'assert/strict';
+import { __parseOrgListForTests } from '../salesforce/cli';
+
+suite('parseOrgList', () => {
+  test('merges groups and sorts with default first, then alias', () => {
+    const payload = {
+      result: {
+        orgs: [
+          {
+            username: 'b@example.com',
+            alias: 'beta',
+            isDefaultUsername: false,
+            instanceUrl: 'https://b.my.salesforce.com'
+          }
+        ],
+        nonScratchOrgs: [
+          {
+            username: 'a@example.com',
+            alias: 'alpha',
+            isDefaultUsername: true,
+            instanceUrl: 'https://a.my.salesforce.com'
+          }
+        ],
+        scratchOrgs: [
+          {
+            username: 'c@example.com',
+            alias: 'charlie',
+            isDefaultUsername: false,
+            instanceUrl: 'https://c.my.salesforce.com'
+          }
+        ],
+        sandboxes: [],
+        devHubs: [],
+        results: [
+          { username: 'b@example.com', alias: 'beta' },
+          { username: 'a@example.com', alias: 'alpha' },
+          { username: 'c@example.com', alias: 'charlie' }
+        ]
+      }
+    };
+    const orgs = __parseOrgListForTests(JSON.stringify(payload));
+    assert.equal(orgs.length, 3);
+    assert.equal(orgs[0]!.username, 'a@example.com');
+    assert.equal(orgs[0]!.alias, 'alpha');
+    assert.equal(orgs[0]!.isDefaultUsername, true);
+    assert.equal(orgs[1]!.alias, 'beta');
+    assert.equal(orgs[2]!.alias, 'charlie');
+  });
+});


### PR DESCRIPTION
## Summary
- factor shared org list parsing into `parseOrgList`
- unit test org list parsing helper

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b36d730b8c8323892c5e97dbc91e20