### PR TITLE
fix: remove duplicate resolvingPATH finalizer

### DIFF
--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -127,9 +127,6 @@ export async function resolvePATHFromLoginShell(): Promise<string | undefined> {
   }).finally(() => {
     resolvingPATH = null;
   });
-  resolvingPATH.finally(() => {
-    resolvingPATH = null;
-  });
   return resolvingPATH;
 }
 


### PR DESCRIPTION
## Summary
- remove redundant `resolvingPATH.finally` so the promise cleanup runs once

## Testing
- `npm run lint`
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b36d37b1f88323a96dac132d091c1c