### PR TITLE
refactor(tail): log sendOrgs errors

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -178,8 +178,8 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logInfo('Tail: sendOrgs ->', orgs.length, 'org(s)');
       const selected = pickSelectedOrg(orgs, this.selectedOrg);
       this.post({ type: 'orgs', data: orgs, selected });
-    } catch {
-      logWarn('Tail: sendOrgs failed; posting empty list');
+    } catch (e) {
+      logWarn('Tail: sendOrgs failed ->', e instanceof Error ? e.message : String(e));
       this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
     }
   }


### PR DESCRIPTION
## Summary
- log the error message when `sendOrgs` fails in tail view

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b36d6c7fd88323a688274f8cbde6de