### PR TITLE
refactor: extract shared toolbar button style

### DIFF
--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -1,15 +1,7 @@
 import React from 'react';
 import type { OrgItem } from '../../shared/types';
 import { FilterSelect } from './FilterSelect';
-
-const buttonStyle: React.CSSProperties = {
-  padding: '4px 10px',
-  borderRadius: 4,
-  border: '1px solid var(--vscode-button-border, transparent)',
-  background: 'var(--vscode-button-background)',
-  color: 'var(--vscode-button-foreground)',
-  cursor: 'pointer'
-};
+import { commonButtonStyle } from './styles';
 
 type ToolbarProps = {
   loading: boolean;
@@ -63,7 +55,7 @@ export function Toolbar({
 }: ToolbarProps) {
   return (
     <div style={{ display: 'flex', gap: 8, alignItems: 'center', marginBottom: 8, flexWrap: 'wrap' }}>
-      <button onClick={onRefresh} disabled={loading} style={buttonStyle}>
+      <button onClick={onRefresh} disabled={loading} style={commonButtonStyle}>
         {loading ? t.loading : t.refresh}
       </button>
       <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
@@ -88,7 +80,9 @@ export function Toolbar({
         </select>
       </label>
       {orgs.length === 0 && (
-        <span style={{ opacity: 0.7 }} aria-live="polite">{t.noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}</span>
+        <span style={{ opacity: 0.7 }} aria-live="polite">
+          {t.noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}
+        </span>
       )}
       <input
         type="search"
@@ -142,7 +136,10 @@ export function Toolbar({
       <button
         onClick={onClearFilters}
         disabled={loading}
-        style={{ ...buttonStyle, opacity: filterUser || filterOperation || filterStatus || filterCodeUnit ? 1 : 0.7 }}
+        style={{
+          ...commonButtonStyle,
+          opacity: filterUser || filterOperation || filterStatus || filterCodeUnit ? 1 : 0.7
+        }}
       >
         {t.filters?.clear ?? 'Clear filters'}
       </button>

--- a/src/webview/components/styles.ts
+++ b/src/webview/components/styles.ts
@@ -1,0 +1,10 @@
+import type React from 'react';
+
+export const commonButtonStyle: React.CSSProperties = {
+  padding: '4px 10px',
+  borderRadius: 4,
+  border: '1px solid var(--vscode-button-border, transparent)',
+  background: 'var(--vscode-button-background)',
+  color: 'var(--vscode-button-foreground)',
+  cursor: 'pointer'
+};

--- a/src/webview/components/tail/TailToolbar.tsx
+++ b/src/webview/components/tail/TailToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { OrgItem } from '../../../shared/types';
+import { commonButtonStyle } from '../styles';
 
 type TailToolbarProps = {
   running: boolean;
@@ -55,15 +56,6 @@ export function TailToolbar({
   error,
   t
 }: TailToolbarProps) {
-  const buttonStyle: React.CSSProperties = {
-    padding: '4px 10px',
-    borderRadius: 4,
-    border: '1px solid var(--vscode-button-border, transparent)',
-    background: 'var(--vscode-button-background)',
-    color: 'var(--vscode-button-foreground)',
-    cursor: 'pointer'
-  };
-
   const selectStyle: React.CSSProperties = {
     background: 'var(--vscode-dropdown-background, var(--vscode-input-background))',
     color: 'var(--vscode-dropdown-foreground, var(--vscode-input-foreground))',
@@ -83,15 +75,15 @@ export function TailToolbar({
 
   return (
     <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
-      <button onClick={running ? onStop : onStart} style={buttonStyle} disabled={disabled}>
-        {running ? t.tail?.stop ?? 'Stop' : t.tail?.start ?? 'Start'}
+      <button onClick={running ? onStop : onStart} style={commonButtonStyle} disabled={disabled}>
+        {running ? (t.tail?.stop ?? 'Stop') : (t.tail?.start ?? 'Start')}
       </button>
-      <button onClick={onClear} style={buttonStyle} disabled={disabled}>
+      <button onClick={onClear} style={commonButtonStyle} disabled={disabled}>
         {t.tail?.clear ?? 'Clear'}
       </button>
       <button
         onClick={onOpenSelected}
-        style={buttonStyle}
+        style={commonButtonStyle}
         disabled={disabled || !actionsEnabled}
         title={t.tail?.openSelectedLogTitle ?? 'Open selected log'}
       >
@@ -99,7 +91,7 @@ export function TailToolbar({
       </button>
       <button
         onClick={onReplaySelected}
-        style={buttonStyle}
+        style={commonButtonStyle}
         disabled={disabled || !actionsEnabled}
         title={t.tail?.replayDebuggerTitle ?? 'Apex Replay Debugger'}
       >


### PR DESCRIPTION
Refactor toolbar button style into shared constant.

- Extract `commonButtonStyle` into `src/webview/components/styles.ts`
- Use it in both `Toolbar` and `tail/TailToolbar`

Build + type-check + lint OK locally. Webview bundles OK.