### PR TITLE
fix(tail): stop TailService on dispose so tailing works after reopen

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -46,7 +46,8 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       webviewView.onDidDispose(() => {
         this.disposed = true;
         this.view = undefined;
-        this.tailService.dispose();
+        // Stop timers and clear caches, but keep TailService reusable when the view reopens
+        this.tailService.stop();
         logInfo('Tail webview disposed; stopped tail.');
       })
     );


### PR DESCRIPTION
Fix Tail view reuse after close.

- In `SfLogTailViewProvider`, call `tailService.stop()` instead of `dispose()` inside `onDidDispose`.
- `TailService.dispose()` marks the service as permanently disposed, so subsequent `start()` calls no-op via `pollOnce` early return. `stop()` clears timers/caches without blocking reuse.

Build + webview bundles OK locally.