### PR TITLE
docs: document extension settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,10 @@ Why developers like it
 
 - `sfLogs.pageSize`: Number of logs fetched per page (10–200; default 100).
 - `sfLogs.headConcurrency`: Max concurrent requests to fetch log headers (1–20; default 5).
+- `sfLogs.saveDirName`: Folder name used when saving logs to disk (default `apexlogs`).
+- `sfLogs.trace`: Enable verbose trace logging of CLI and HTTP calls.
+
+See [docs/SETTINGS.md](docs/SETTINGS.md) for more details on configuration.
 
 API version is automatically taken from your workspace `sfdx-project.json` (`sourceApiVersion`).
 

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -1,0 +1,38 @@
+# Settings
+
+The Apex Log Viewer extension exposes several settings under the `Apex Logs` section of the VS Code Settings UI. You can change them from `Preferences: Open Settings (UI)` or by editing your `settings.json` directly.
+
+```jsonc
+"sfLogs.pageSize": 100,
+"sfLogs.headConcurrency": 5,
+"sfLogs.saveDirName": "apexlogs",
+"sfLogs.trace": false
+```
+
+## `sfLogs.pageSize`
+
+- **Type**: number (10–200)
+- **Default**: `100`
+- Number of log headers fetched per page. Reduce this if large log sets cause slow loading, or increase it to load more logs at once.
+
+## `sfLogs.headConcurrency`
+
+- **Type**: number (1–20)
+- **Default**: `5`
+- Maximum number of concurrent requests when retrieving log headers. Lower values decrease load on the Salesforce APIs at the cost of slower fetches.
+
+## `sfLogs.saveDirName`
+
+- **Type**: string
+- **Default**: `"apexlogs"`
+- Folder name used when saving logs to disk. Files are placed under `${workspaceFolder}/.sflogs/<saveDirName>`.
+
+## `sfLogs.trace`
+
+- **Type**: boolean
+- **Default**: `false`
+- Enables verbose trace logging of CLI and HTTP interactions in the **Apex Log Viewer** output channel. Useful for troubleshooting issues with log retrieval or authentication.
+
+## Applying changes
+
+After adjusting settings, reload the VS Code window to ensure the extension picks up the new configuration (`Developer: Reload Window`).


### PR DESCRIPTION
## Summary
- document extension configuration options
- link settings guide from README

## Testing
- *No tests or linters were run; documentation-only changes*

------
https://chatgpt.com/codex/tasks/task_e_68b439a3711c8323850c38f1f0794592