### PR TITLE
fix(ci): add permissions block to semantic-pr workflow

### DIFF
--- a/.github/workflows/semantic-pr.yml
+++ b/.github/workflows/semantic-pr.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   semantic:
+    permissions:
+      contents: read
+      pull-requests: write
     name: Validate PR title (Conventional Commits)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
fix(ci): add permissions block to semantic-pr workflow

Set minimal GITHUB_TOKEN permissions required by amannn/action-semantic-pull-request:
- contents: read
- pull-requests: write

Refs: code scanning alert #2.
