### PR TITLE
chore: gate Linux deps install on env flag

### DIFF
--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Only run when explicitly requested
+if [[ "${INSTALL_LINUX_DEPS:-}" != "true" ]]; then
+  echo "[deps] INSTALL_LINUX_DEPS not true; skipping installation." >&2
+  exit 0
+fi
+
 # Installs the required system libraries to run VS Code/Electron in headless Linux.
 # Supports Ubuntu 24.04 (t64 packages) and older variants when available.
 


### PR DESCRIPTION
## Summary
- skip Linux dependency installation unless INSTALL_LINUX_DEPS=true

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b45d204bf4832380c512fac886b9d2