### PR TITLE
ci(commitlint): ignore bot commits and skip workflow for bot PRs

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -8,6 +8,9 @@ jobs:
   lint-commits:
     name: Validate commit messages
     runs-on: ubuntu-latest
+    # Skip commitlint for automated bot PRs (e.g., Dependabot), since their bodies
+    # include long lines/links that violate our wrapping rules and are not human-authored.
+    if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'github-actions[bot]' }}
     steps:
       - name: Checkout (full history)
         uses: actions/checkout@v4

--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,4 +1,8 @@
 export default {
   extends: ['@commitlint/config-conventional'],
+  // Ignore automated commits from bots like Dependabot that include long link lines
+  // in the body and do not follow our manual wrapping rules.
+  ignores: [
+    (message) => /Signed-off-by:\s*dependabot\[bot\]/i.test(message) || /^Bumps\s+\[?@?[^\s]+/i.test(message)
+  ]
 };
-


### PR DESCRIPTION
This PR tunes commitlint to play nicely with automated PRs while keeping strict rules for human commits.

- Ignore Dependabot-style commits in commitlint to avoid body max-line-length failures (links/boilerplate)
- Skip the commitlint workflow entirely when the PR actor is a bot (dependabot/github-actions)

Why:
- Bot-generated messages often include long, auto-generated bodies with links that violate `body-max-line-length`.
- We still enforce conventional commits for contributors; bots get a pass to avoid noisy CI failures.

Files:
- commitlint.config.mjs
- .github/workflows/commitlint.yml

Verification:
- Open a Dependabot PR and confirm the commitlint job is skipped and CI proceeds.
- Open a regular PR and confirm commitlint runs and enforces rules as before.
