### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, edited, reopened]
 
+permissions:
+  contents: read
 jobs:
   lint-commits:
     name: Validate commit messages


### PR DESCRIPTION
Potential fix for [https://github.com/Electivus/Apex-Log-Viewer/security/code-scanning/3](https://github.com/Electivus/Apex-Log-Viewer/security/code-scanning/3)

To fix the issue, you need to add a `permissions` block to the workflow file. The most restrictive permission that satisfies the requirements for the job should be used. Since the job only requires access to the repository’s commit history and content for linting and does not perform any write actions (such as creating issues, editing pull requests, etc.), the minimal permission required is `contents: read`. The `permissions` block should be placed at the top-level of the workflow (before `jobs:`), so it will apply to all jobs unless overridden. No additional imports or steps are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
