### PR TITLE
feat(tail): virtualize tail; add configurable buffer; viewport-aware paging threshold

### DIFF
--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -6,7 +6,8 @@ The Apex Log Viewer extension exposes several settings under the `Apex Logs` sec
 "sfLogs.pageSize": 100,
 "sfLogs.headConcurrency": 5,
 "sfLogs.saveDirName": "apexlogs",
-"sfLogs.trace": false
+"sfLogs.trace": false,
+"sfLogs.tailBufferSize": 10000
 ```
 
 ## `sfLogs.pageSize`
@@ -32,6 +33,13 @@ The Apex Log Viewer extension exposes several settings under the `Apex Logs` sec
 - **Type**: boolean
 - **Default**: `false`
 - Enables verbose trace logging of CLI and HTTP interactions in the **Apex Log Viewer** output channel. Useful for troubleshooting issues with log retrieval or authentication.
+
+## `sfLogs.tailBufferSize`
+
+- Type: number (1000–200000)
+- Default: `10000`
+- Maximum number of lines retained in the Tail view's rolling buffer. Higher values keep more history visible to filters and search, at the cost of additional memory.
+- Changes take effect immediately in an open Tail view; no reload required.
 
 ## Applying changes
 

--- a/package.json
+++ b/package.json
@@ -77,6 +77,13 @@
           "type": "boolean",
           "default": false,
           "markdownDescription": "Enable verbose trace logging for CLI and HTTP calls (Output: Apex Log Viewer)."
+        },
+        "sfLogs.tailBufferSize": {
+          "type": "number",
+          "default": 10000,
+          "minimum": 1000,
+          "maximum": 200000,
+          "markdownDescription": "%configuration.sfLogs.tailBufferSize.description%"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -11,5 +11,6 @@
   "configuration.title": "Apex Logs",
   "configuration.sfLogs.pageSize.description": "Number of logs to fetch per page (LIMIT).",
   "configuration.sfLogs.headConcurrency.description": "Maximum number of concurrent requests to fetch log heads.",
-  "configuration.sfLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'."
+  "configuration.sfLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'.",
+  "configuration.sfLogs.tailBufferSize.description": "Maximum number of lines kept in the Tail view's rolling buffer. Larger values keep more history but use more memory."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -11,5 +11,6 @@
   "configuration.title": "Apex Logs",
   "configuration.sfLogs.pageSize.description": "Quantidade de logs por página (LIMIT).",
   "configuration.sfLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos dos logs.",
-  "configuration.sfLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'."
+  "configuration.sfLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'.",
+  "configuration.sfLogs.tailBufferSize.description": "Quantidade máxima de linhas mantidas no buffer da visualização de Tail. Valores maiores mantêm mais histórico, mas consomem mais memória."
 }

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -28,6 +28,7 @@ export type ExtensionToWebviewMessage =
   | { type: 'tailStatus'; running: boolean }
   | { type: 'tailData'; lines: string[] }
   | { type: 'tailReset' }
+  | { type: 'tailConfig'; tailBufferSize: number }
   | {
       type: 'tailNewLog';
       logId: string;

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -61,7 +61,9 @@ export function LogsTable({
 
   const handleItemsRendered = (props: ListOnItemsRenderedProps) => {
     const { visibleStopIndex } = props;
-    const threshold = Math.max(0, rows.length - 10);
+    // Trigger load more when within ~one screenful from the end
+    const approxVisible = Math.max(5, Math.ceil(measuredListHeight / defaultRowHeight));
+    const threshold = Math.max(0, rows.length - (approxVisible + 5));
     if (autoPagingActivated && hasMore && !loading && visibleStopIndex >= threshold) {
       onLoadMore();
     }


### PR DESCRIPTION
This PR improves performance and UX in both the Tail view and the main logs table.

Summary
- Tail view: virtualized with `react-window` using `VariableSizeList` and dynamic row heights (via `ResizeObserver`). Keeps DOM small and scrolling smooth even with large buffers.
- Tail buffer size: new setting `sfLogs.tailBufferSize` (default 10000) with NLS strings, applied live to open Tail views via a new `tailConfig` message.
- Auto-scroll UX: enabling Auto-scroll clears selection and jumps to the end, avoiding conflicts where the selected line kept the list centered.
- Logs table paging: load-more threshold adapts to viewport (~one screenful ahead) instead of a fixed 10 items.
- Docs: Settings updated with `sfLogs.tailBufferSize` section.

Files
- Tail virtualization:
  - `src/webview/components/tail/TailList.tsx`
  - `src/webview/tail.tsx`
- Tail buffer setting + messaging:
  - `package.json`
  - `package.nls.json`
  - `package.nls.pt-br.json`
  - `src/shared/messages.ts`
  - `src/provider/SfLogTailViewProvider.ts`
  - `docs/SETTINGS.md`
- Logs table threshold:
  - `src/webview/components/LogsTable.tsx`

Risk/rollback
- Low risk; changes are scoped to Tail webview and logs table rendering logic.
- Rollback by reverting this branch; no persistent data migrations.

Verification
- Tail view remains responsive with large incoming streams; filtering no longer lags on clear/apply.
- Changing `sfLogs.tailBufferSize` updates Tail immediately without reload.
- Selecting a line, then enabling Auto-scroll: selection clears and the view sticks to the end.
- Logs list triggers load more near the end proportionally to viewport height.

---
Notes
- If desired, we can expose `tailBufferSize` in the Tail UI (tooltip or quick pick) in a follow-up.
