### PR TITLE
feat: add HTTP timeout handling

### DIFF
--- a/src/test/https.timeout.test.ts
+++ b/src/test/https.timeout.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert/strict';
+import { EventEmitter } from 'events';
+import { fetchApexLogBody, __setHttpsRequestImplForTests, __resetHttpsRequestImplForTests } from '../salesforce/http';
+import type { OrgAuth } from '../salesforce/types';
+
+suite('https request timeout', () => {
+  teardown(() => {
+    __resetHttpsRequestImplForTests();
+  });
+
+  test('rejects when request exceeds timeout', async () => {
+    const auth: OrgAuth = { accessToken: 't', instanceUrl: 'https://example.com', username: 'user' };
+
+    __setHttpsRequestImplForTests(((_opts: any, _cb: any) => {
+      const req = new EventEmitter() as any;
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.setTimeout = (ms: number, cb: () => void) => {
+        setTimeout(cb, ms);
+        return req;
+      };
+      req.setHeader = () => {};
+      req.write = () => {};
+      req.end = () => {};
+      return req;
+    }) as any);
+
+    await assert.rejects(fetchApexLogBody(auth, 'LOG', 50), /timed out/i);
+  });
+});


### PR DESCRIPTION
## Summary
- allow specifying a timeout for internal HTTPS requests and fail fast when exceeded
- pass timeout option through Salesforce log fetching helpers
- test timeout behavior with a stubbed unresponsive request

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a41a95508323acd82edb60902d44