### PR TITLE
refactor: type streaming client utilities

### DIFF
--- a/src/salesforce/streaming.ts
+++ b/src/salesforce/streaming.ts
@@ -1,9 +1,11 @@
 import { AuthInfo, Connection, Org, StreamingClient } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import type { JsonMap } from '@salesforce/ts-types';
+import type { AnyJson, JsonMap } from '@salesforce/ts-types';
 import type { OrgAuth } from './types';
 
-export type StreamProcessor = (message: JsonMap) => { completed: boolean; payload?: any };
+export type { StreamingClient };
+
+export type StreamProcessor = (message: JsonMap) => { completed: boolean; payload?: AnyJson };
 
 export async function createConnectionFromAuth(auth: OrgAuth): Promise<Connection> {
   const authInfo = await AuthInfo.create({
@@ -22,7 +24,7 @@ export async function createLoggingStreamingClient(
   org: Org,
   streamProcessor: StreamProcessor
 ): Promise<StreamingClient> {
-  const options = new StreamingClient.DefaultOptions(org, '/systemTopic/Logging', streamProcessor as any);
+  const options = new StreamingClient.DefaultOptions(org, '/systemTopic/Logging', streamProcessor);
   // Align subscribe timeout to our tail hard-stop (30 minutes) like apex-node does
   try {
     options.setSubscribeTimeout(Duration.minutes(30));

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -11,10 +11,15 @@ import {
   ensureApexLogsDir as utilEnsureApexLogsDir,
   getLogFilePathWithUsername as utilGetLogFilePathWithUsername
 } from './workspace';
-import { createConnectionFromAuth, createLoggingStreamingClient, createOrgFromConnection } from '../salesforce/streaming';
+import {
+  createConnectionFromAuth,
+  createLoggingStreamingClient,
+  createOrgFromConnection,
+  type StreamProcessor,
+  type StreamingClient
+} from '../salesforce/streaming';
 import { LogService } from '@salesforce/apex-node';
 import type { Connection } from '@salesforce/core';
-import type { JsonMap } from '@salesforce/ts-types';
 
 /**
  * Handles Apex log tailing mechanics independent of the webview.
@@ -32,7 +37,7 @@ export class TailService {
   private disposed = false;
   private selectedOrg: string | undefined;
   private windowActive = true;
-  private streamingClient: any | undefined;
+  private streamingClient: StreamingClient | undefined;
   private connection: Connection | undefined;
   private logService: LogService | undefined;
   private lastReplayId: number | undefined;
@@ -134,7 +139,7 @@ export class TailService {
         30 * 60 * 1000
       );
       // Create StreamingClient (uses API 36.0 for system topics automatically)
-      const processor = (message: JsonMap) => {
+      const processor: StreamProcessor = (message: Parameters<StreamProcessor>[0]) => {
         try {
           const errName = (message as any)?.errorName;
           if (errName === 'streamListenerAborted') {


### PR DESCRIPTION
## Summary
- type StreamingClient property in TailService
- leverage StreamProcessor without casts

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a42ac4e083238e2d55b6378163be