### PR TITLE
Cache org list and support force refresh

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -98,7 +98,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.selectOrg', async () => {
       logInfo('Command sfLogs.selectOrg invoked. Listing orgs…');
-      const orgs: OrgItem[] = await listOrgs();
+      const orgs: OrgItem[] = await listOrgs(true);
       const items: OrgQuickPick[] = orgs.map(o => ({
         label: o.alias ?? o.username,
         description: o.isDefaultUsername ? localize('selectOrgDefault', 'Default') : undefined,

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -313,9 +313,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     );
   }
 
-  public async sendOrgs() {
+  public async sendOrgs(forceRefresh = false) {
     try {
-      const orgs = await listOrgs();
+      const orgs = await listOrgs(forceRefresh);
       const selected = pickSelectedOrg(orgs, this.selectedOrg);
       this.post({ type: 'orgs', data: orgs, selected });
     } catch {

--- a/src/test/listOrgs.cache.test.ts
+++ b/src/test/listOrgs.cache.test.ts
@@ -1,0 +1,49 @@
+import assert from 'assert/strict';
+import {
+  listOrgs,
+  __setExecFileImplForTests,
+  __resetExecFileImplForTests,
+  __setListOrgsCacheTTLForTests,
+  __resetListOrgsCacheForTests
+} from '../salesforce/cli';
+
+suite('listOrgs caching', () => {
+  teardown(() => {
+    __resetExecFileImplForTests();
+    __resetListOrgsCacheForTests();
+  });
+
+  test('reuses cached data within TTL', async () => {
+    let called = 0;
+    __setListOrgsCacheTTLForTests(1000);
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      called++;
+      const payload = { result: { orgs: [{ username: 'a@example.com' }] } };
+      cb(null, JSON.stringify(payload), '');
+      return undefined as any;
+    }) as any);
+    const first = await listOrgs();
+    const second = await listOrgs();
+    assert.equal(first[0]!.username, 'a@example.com');
+    assert.equal(second[0]!.username, 'a@example.com');
+    assert.equal(called, 1, 'expected single CLI invocation');
+  });
+
+  test('refreshes after expiration', async () => {
+    let called = 0;
+    __setListOrgsCacheTTLForTests(50);
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      called++;
+      const username = called === 1 ? 'a@example.com' : 'b@example.com';
+      const payload = { result: { orgs: [{ username }] } };
+      cb(null, JSON.stringify(payload), '');
+      return undefined as any;
+    }) as any);
+    const first = await listOrgs();
+    await new Promise(r => setTimeout(r, 60));
+    const second = await listOrgs();
+    assert.equal(first[0]!.username, 'a@example.com');
+    assert.equal(second[0]!.username, 'b@example.com');
+    assert.equal(called, 2, 'expected cache refresh after TTL');
+  });
+});


### PR DESCRIPTION
## Summary
- cache org list with 10s TTL and optional force refresh flag
- use cached org list in SfLogsViewProvider and selectOrg command
- add unit tests for cache reuse and expiry

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4c7609c8323b9b79b1c8907c596