### PR TITLE
fix: localize tail save failure message

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -12,5 +12,6 @@
   "configuration.sfLogs.pageSize.description": "Number of logs to fetch per page (LIMIT).",
   "configuration.sfLogs.headConcurrency.description": "Maximum number of concurrent requests to fetch log heads.",
   "configuration.sfLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'.",
-  "configuration.sfLogs.tailBufferSize.description": "Maximum number of lines kept in the Tail view's rolling buffer. Larger values keep more history but use more memory."
+  "configuration.sfLogs.tailBufferSize.description": "Maximum number of lines kept in the Tail view's rolling buffer. Larger values keep more history but use more memory.",
+  "tailSaveFailed": "Tail: failed to save log to workspace (best-effort)."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -12,5 +12,6 @@
   "configuration.sfLogs.pageSize.description": "Quantidade de logs por página (LIMIT).",
   "configuration.sfLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos dos logs.",
   "configuration.sfLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'.",
-  "configuration.sfLogs.tailBufferSize.description": "Quantidade máxima de linhas mantidas no buffer da visualização de Tail. Valores maiores mantêm mais histórico, mas consomem mais memória."
+  "configuration.sfLogs.tailBufferSize.description": "Quantidade máxima de linhas mantidas no buffer da visualização de Tail. Valores maiores mantêm mais histórico, mas consomem mais memória.",
+  "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço)."
 }

--- a/scripts/gen-nls.cjs
+++ b/scripts/gen-nls.cjs
@@ -30,6 +30,7 @@ const en = {
   tailSelectDebugLevel: 'Select a debug level',
   tailHardStop: 'Tail stopped after 30 minutes.',
   tailSavedTo: 'Saved to {0}',
+  tailSaveFailed: 'Tail: failed to save log to workspace (best-effort).',
   cliNotFound: 'Salesforce CLI not found. Install Salesforce CLI (sf) or SFDX CLI (sfdx).',
   cliAuthFailed:
     'Could not obtain credentials via sf/sfdx CLI. Verify authentication and try: sf org display --json --verbose',
@@ -51,6 +52,7 @@ const ptBr = {
   tailSelectDebugLevel: 'Selecione um nível de depuração',
   tailHardStop: 'Tail parado após 30 minutos.',
   tailSavedTo: 'Salvo em {0}',
+  tailSaveFailed: 'Tail: falha ao salvar log no workspace (melhor esforço).',
   cliNotFound: 'Salesforce CLI não encontrada. Instale o Salesforce CLI (sf) ou SFDX CLI (sfdx).',
   cliAuthFailed:
     'Não foi possível obter credenciais via sf/sfdx CLI. Verifique a autenticação e tente: sf org display --json --verbose',

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -11,7 +11,11 @@ import {
   ensureApexLogsDir as utilEnsureApexLogsDir,
   getLogFilePathWithUsername as utilGetLogFilePathWithUsername
 } from './workspace';
-import { createConnectionFromAuth, createLoggingStreamingClient, createOrgFromConnection } from '../salesforce/streaming';
+import {
+  createConnectionFromAuth,
+  createLoggingStreamingClient,
+  createOrgFromConnection
+} from '../salesforce/streaming';
 import { LogService } from '@salesforce/apex-node';
 import type { Connection } from '@salesforce/core';
 import type { JsonMap } from '@salesforce/ts-types';
@@ -330,7 +334,7 @@ export class TailService {
         });
       }
     } catch {
-      logWarn('Tail: failed to save log to workspace (best-effort).');
+      logWarn(localize('tailSaveFailed', 'Tail: failed to save log to workspace (best-effort).'));
     }
     for (const l of String(body || '').split(/\r?\n/)) {
       if (l) {


### PR DESCRIPTION
## Summary
- add English and Portuguese messages for failed tail log save
- localize tail save failure warning

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4a47ecebc8323aba27fc6e8a47ef0