### PR TITLE
fix: handle org listing failures gracefully

### DIFF
--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -318,7 +318,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       const orgs = await listOrgs();
       const selected = pickSelectedOrg(orgs, this.selectedOrg);
       this.post({ type: 'orgs', data: orgs, selected });
-    } catch {
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      logError('Logs: list orgs failed ->', msg);
+      void vscode.window.showErrorMessage(localize('sendOrgsFailed', 'Failed to list Salesforce orgs: {0}', msg));
       this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
     }
   }

--- a/src/test/sendOrgs.error.test.ts
+++ b/src/test/sendOrgs.error.test.ts
@@ -1,0 +1,42 @@
+import assert from 'assert/strict';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
+import { __setExecFileImplForTests, __resetExecFileImplForTests } from '../salesforce/cli';
+
+suite('SfLogsViewProvider sendOrgs', () => {
+  teardown(() => {
+    __resetExecFileImplForTests();
+  });
+
+  test('shows error message when listOrgs rejects', async () => {
+    __setExecFileImplForTests(((file: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      const err: any = new Error('ENOENT');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+
+    const messages: string[] = [];
+    const origShowError = vscode.window.showErrorMessage;
+    (vscode.window as any).showErrorMessage = (m: string) => {
+      messages.push(m);
+      return Promise.resolve(undefined as any);
+    };
+
+    try {
+      const provider = new SfLogsViewProvider(context);
+      await provider.sendOrgs();
+    } finally {
+      (vscode.window as any).showErrorMessage = origShowError;
+    }
+
+    assert.equal(messages.length, 1, 'should show one error message');
+    assert.ok(messages[0]?.includes('Salesforce CLI not found'), 'message should include context');
+  });
+});


### PR DESCRIPTION
## Summary
- log org listing failures and surface an error notification
- add unit test for sendOrgs error path

## Testing
- `npm run lint`
- `npm test`
- `npm run check-types`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4a492db80832398c6351092cdaff4