### PR TITLE
refactor: add numeric config helper and tests

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -9,6 +9,7 @@ import { warmUpReplayDebugger, ensureReplayDebuggerAvailable } from '../utils/wa
 import { buildWebviewHtml } from '../utils/webviewHtml';
 import { TailService } from '../utils/tailService';
 import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
+import { getNumberConfig } from '../utils/config';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
@@ -174,11 +175,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   }
 
   private getTailBufferSize(): number {
-    const cfg = vscode.workspace.getConfiguration();
-    const raw = cfg.get<number>('sfLogs.tailBufferSize');
-    const n = raw && Number.isFinite(raw) ? Math.floor(raw) : 10000;
-    // clamp to a safe range
-    return Math.max(1000, Math.min(200000, n));
+    return getNumberConfig('sfLogs.tailBufferSize', 10000, 1000, 200000);
   }
 
   public async sendOrgs(): Promise<void> {

--- a/src/test/getNumberConfig.test.ts
+++ b/src/test/getNumberConfig.test.ts
@@ -1,0 +1,23 @@
+import assert from 'assert/strict';
+import { workspace } from 'vscode';
+import { getNumberConfig } from '../utils/config';
+
+suite('getNumberConfig', () => {
+  const originalGetConfiguration = workspace.getConfiguration;
+
+  teardown(() => {
+    (workspace.getConfiguration as any) = originalGetConfiguration;
+  });
+
+  test('clamps to minimum value', () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => 5 });
+    const n = getNumberConfig('test.min', 10, 10, 20);
+    assert.equal(n, 10);
+  });
+
+  test('clamps to maximum value', () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => 30 });
+    const n = getNumberConfig('test.max', 10, 1, 20);
+    assert.equal(n, 20);
+  });
+});

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -1,0 +1,18 @@
+import * as vscode from 'vscode';
+
+/**
+ * Retrieve a numeric workspace configuration, applying defaults and clamping.
+ *
+ * @param name configuration key
+ * @param def default value if the setting is absent or invalid
+ * @param min minimum inclusive value
+ * @param max maximum inclusive value
+ */
+export function getNumberConfig(name: string, def: number, min: number, max: number): number {
+  const cfg = vscode.workspace.getConfiguration();
+  const raw = cfg.get<number>(name);
+  const n = raw && Number.isFinite(raw) ? Math.floor(raw) : def;
+  return Math.max(min, Math.min(max, n));
+}
+
+export default getNumberConfig;


### PR DESCRIPTION
## Summary
- add reusable helper to clamp numeric settings
- refactor providers to use new helper
- test config helper edge limits

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a4436ca4832387baba0160dd2cc6