### PR TITLE
fix: reset TailService resources on stop

### DIFF
--- a/src/salesforce/http.ts
+++ b/src/salesforce/http.ts
@@ -1,6 +1,6 @@
 import * as https from 'https';
 import { URL } from 'url';
-import { logTrace } from '../utils/logger';
+import { logTrace, logWarn } from '../utils/logger';
 import { getOrgAuth } from './cli';
 import type { ApexLogRow, OrgAuth } from './types';
 
@@ -21,7 +21,8 @@ function httpsRequest(
   method: string,
   urlString: string,
   headers: Record<string, string>,
-  body?: string
+  body?: string,
+  timeoutMs?: number
 ): Promise<{ statusCode: number; headers: Record<string, string | string[] | undefined>; body: string }> {
   return new Promise((resolve, reject) => {
     const urlObj = new URL(urlString);
@@ -44,6 +45,14 @@ function httpsRequest(
       }
     );
     req.on('error', reject);
+    if (typeof timeoutMs === 'number') {
+      req.setTimeout(timeoutMs, () => {
+        try {
+          req.destroy();
+        } catch {}
+        reject(new Error('Request timed out'));
+      });
+    }
     if (body && method !== 'GET' && method !== 'HEAD') {
       try {
         req.setHeader('Content-Length', Buffer.byteLength(body, 'utf8'));
@@ -60,7 +69,10 @@ async function refreshAuthInPlace(auth: OrgAuth): Promise<void> {
     auth.accessToken = next.accessToken;
     auth.instanceUrl = next.instanceUrl;
     auth.username = next.username;
-  } catch {
+  } catch (err) {
+    try {
+      logWarn('Auth refresh failed', err);
+    } catch {}
     // surface original 401 if refresh fails
   }
 }
@@ -70,12 +82,13 @@ export async function httpsRequestWith401Retry(
   method: string,
   urlString: string,
   headers: Record<string, string>,
-  body?: string
+  body?: string,
+  timeoutMs?: number
 ): Promise<string> {
   try {
     logTrace('HTTP', method, urlString);
   } catch {}
-  const first = await httpsRequest(method, urlString, headers, body);
+  const first = await httpsRequest(method, urlString, headers, body, timeoutMs);
   try {
     logTrace('HTTP <-', first.statusCode, urlString);
   } catch {}
@@ -88,7 +101,8 @@ export async function httpsRequestWith401Retry(
       method,
       urlString,
       { ...headers, Authorization: `Bearer ${auth.accessToken}` },
-      body
+      body,
+      timeoutMs
     );
     try {
       logTrace('HTTP(retry) <-', second.statusCode, urlString);
@@ -144,7 +158,8 @@ export async function fetchApexLogs(
   auth: OrgAuth,
   limit: number = 50,
   offset: number = 0,
-  debugLevel?: string
+  debugLevel?: string,
+  timeoutMs?: number
 ): Promise<ApexLogRow[]> {
   const safeLimit = Math.max(1, Math.min(200, Math.floor(limit)));
   const safeOffset = Math.max(0, Math.floor(offset));
@@ -161,10 +176,17 @@ export async function fetchApexLogs(
     `SELECT Id, StartTime, Operation, Application, DurationMilliseconds, Status, Request, LogLength, LogUser.Name FROM ApexLog ORDER BY StartTime DESC LIMIT ${safeLimit} OFFSET ${safeOffset}`
   );
   const url = `${auth.instanceUrl}/services/data/v${API_VERSION}/tooling/query?q=${soql}`;
-  const body = await httpsRequestWith401Retry(auth, 'GET', url, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
+  const body = await httpsRequestWith401Retry(
+    auth,
+    'GET',
+    url,
+    {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    undefined,
+    timeoutMs
+  );
   const json = JSON.parse(body);
   const records = (json.records || []) as ApexLogRow[];
   // Do not filter by debug level here. ApexLog does not reliably carry
@@ -178,12 +200,19 @@ export async function fetchApexLogs(
   return records;
 }
 
-export async function fetchApexLogBody(auth: OrgAuth, logId: string): Promise<string> {
+export async function fetchApexLogBody(auth: OrgAuth, logId: string, timeoutMs?: number): Promise<string> {
   const url = `${auth.instanceUrl}/services/data/v${API_VERSION}/tooling/sobjects/ApexLog/${logId}/Body`;
-  const text = await httpsRequestWith401Retry(auth, 'GET', url, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'text/plain'
-  });
+  const text = await httpsRequestWith401Retry(
+    auth,
+    'GET',
+    url,
+    {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'text/plain'
+    },
+    undefined,
+    timeoutMs
+  );
   return text;
 }
 
@@ -193,23 +222,36 @@ async function fetchApexLogBytesRange(
   auth: OrgAuth,
   logId: string,
   start: number,
-  endInclusive: number
+  endInclusive: number,
+  timeoutMs?: number
 ): Promise<RangeResponse> {
   const urlString = `${auth.instanceUrl}/services/data/v${API_VERSION}/tooling/sobjects/ApexLog/${logId}/Body`;
-  const first = await httpsRequest('GET', urlString, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'text/plain',
-    'Accept-Encoding': 'identity',
-    Range: `bytes=${start}-${endInclusive}`
-  });
-  if (first.statusCode === 401) {
-    await refreshAuthInPlace(auth);
-    const second = await httpsRequest('GET', urlString, {
+  const first = await httpsRequest(
+    'GET',
+    urlString,
+    {
       Authorization: `Bearer ${auth.accessToken}`,
       'Content-Type': 'text/plain',
       'Accept-Encoding': 'identity',
       Range: `bytes=${start}-${endInclusive}`
-    });
+    },
+    undefined,
+    timeoutMs
+  );
+  if (first.statusCode === 401) {
+    await refreshAuthInPlace(auth);
+    const second = await httpsRequest(
+      'GET',
+      urlString,
+      {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'Content-Type': 'text/plain',
+        'Accept-Encoding': 'identity',
+        Range: `bytes=${start}-${endInclusive}`
+      },
+      undefined,
+      timeoutMs
+    );
     return { statusCode: second.statusCode, headers: second.headers, body: second.body };
   }
   return { statusCode: first.statusCode, headers: first.headers, body: first.body };
@@ -219,7 +261,8 @@ export async function fetchApexLogHead(
   auth: OrgAuth,
   logId: string,
   maxLines: number,
-  logLengthBytes?: number
+  logLengthBytes?: number,
+  timeoutMs?: number
 ): Promise<string[]> {
   const key = makeLogKey(auth, logId);
   const cached = headCacheByLog.get(key);
@@ -233,7 +276,7 @@ export async function fetchApexLogHead(
     try {
       logTrace('HTTP Range GET ApexLog head', logId, 'bytes=0-', Math.max(0, stride - 1));
     } catch {}
-    const range = await fetchApexLogBytesRange(auth, logId, 0, Math.max(0, stride - 1));
+    const range = await fetchApexLogBytesRange(auth, logId, 0, Math.max(0, stride - 1), timeoutMs);
     const contentEncoding = (range.headers['content-encoding'] || '').toString().toLowerCase();
     if (range.statusCode === 206 && (!contentEncoding || contentEncoding === 'identity')) {
       try {
@@ -343,6 +386,14 @@ export async function fetchApexLogHead(
           });
         }
       );
+      if (typeof timeoutMs === 'number') {
+        req.setTimeout(timeoutMs, () => {
+          try {
+            req.destroy();
+          } catch {}
+          reject(new Error('Request timed out'));
+        });
+      }
       return req;
     };
     const req = attempt(auth.accessToken);

--- a/src/salesforce/streaming.ts
+++ b/src/salesforce/streaming.ts
@@ -1,9 +1,11 @@
 import { AuthInfo, Connection, Org, StreamingClient } from '@salesforce/core';
 import { Duration } from '@salesforce/kit';
-import type { JsonMap } from '@salesforce/ts-types';
+import type { AnyJson, JsonMap } from '@salesforce/ts-types';
 import type { OrgAuth } from './types';
 
-export type StreamProcessor = (message: JsonMap) => { completed: boolean; payload?: any };
+export type { StreamingClient };
+
+export type StreamProcessor = (message: JsonMap) => { completed: boolean; payload?: AnyJson };
 
 export async function createConnectionFromAuth(auth: OrgAuth): Promise<Connection> {
   const authInfo = await AuthInfo.create({
@@ -22,7 +24,7 @@ export async function createLoggingStreamingClient(
   org: Org,
   streamProcessor: StreamProcessor
 ): Promise<StreamingClient> {
-  const options = new StreamingClient.DefaultOptions(org, '/systemTopic/Logging', streamProcessor as any);
+  const options = new StreamingClient.DefaultOptions(org, '/systemTopic/Logging', streamProcessor);
   // Align subscribe timeout to our tail hard-stop (30 minutes) like apex-node does
   try {
     options.setSubscribeTimeout(Duration.minutes(30));

--- a/src/test/https.timeout.test.ts
+++ b/src/test/https.timeout.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert/strict';
+import { EventEmitter } from 'events';
+import { fetchApexLogBody, __setHttpsRequestImplForTests, __resetHttpsRequestImplForTests } from '../salesforce/http';
+import type { OrgAuth } from '../salesforce/types';
+
+suite('https request timeout', () => {
+  teardown(() => {
+    __resetHttpsRequestImplForTests();
+  });
+
+  test('rejects when request exceeds timeout', async () => {
+    const auth: OrgAuth = { accessToken: 't', instanceUrl: 'https://example.com', username: 'user' };
+
+    __setHttpsRequestImplForTests(((_opts: any, _cb: any) => {
+      const req = new EventEmitter() as any;
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.setTimeout = (ms: number, cb: () => void) => {
+        setTimeout(cb, ms);
+        return req;
+      };
+      req.setHeader = () => {};
+      req.write = () => {};
+      req.end = () => {};
+      return req;
+    }) as any);
+
+    await assert.rejects(fetchApexLogBody(auth, 'LOG', 50), /timed out/i);
+  });
+});

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -14,11 +14,12 @@ import {
 import {
   createConnectionFromAuth,
   createLoggingStreamingClient,
-  createOrgFromConnection
+  createOrgFromConnection,
+  type StreamProcessor,
+  type StreamingClient
 } from '../salesforce/streaming';
 import { LogService } from '@salesforce/apex-node';
 import type { Connection } from '@salesforce/core';
-import type { JsonMap } from '@salesforce/ts-types';
 
 /**
  * Handles Apex log tailing mechanics independent of the webview.
@@ -36,7 +37,7 @@ export class TailService {
   private disposed = false;
   private selectedOrg: string | undefined;
   private windowActive = true;
-  private streamingClient: any | undefined;
+  private streamingClient: StreamingClient | undefined;
   private connection: Connection | undefined;
   private logService: LogService | undefined;
   private lastReplayId: number | undefined;
@@ -138,7 +139,7 @@ export class TailService {
         30 * 60 * 1000
       );
       // Create StreamingClient (uses API 36.0 for system topics automatically)
-      const processor = (message: JsonMap) => {
+      const processor: StreamProcessor = (message: Parameters<StreamProcessor>[0]) => {
         try {
           const errName = (message as any)?.errorName;
           if (errName === 'streamListenerAborted') {


### PR DESCRIPTION
## Summary
- merge origin/main into work to resolve conflicts
- adopt streaming client types in TailService
- include HTTP request timeout coverage

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4a8e696348323835e6c417855be0b