### PR TITLE
CI: add VSIX smoke test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,26 @@ jobs:
             *) npm run test:unit:ci ;;
           esac
 
+  smoke_vsix:
+    name: VSIX Smoke Test
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build and run VSIX smoke
+        run: node scripts/run-tests.js --scope=unit --smoke-vsix
+
   package:
     name: Package VSIX
     # Run on tag pushes, on published Releases, or manual dispatch with tag_name

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "test:unit:ci": "npm run pretest && bash scripts/run-tests.sh --scope=unit --vscode=stable",
     "test:integration:ci": "npm run pretest && bash scripts/run-tests.sh --scope=integration --vscode=stable --install-deps --timeout=900000",
     "test:ci": "npm run test:unit:ci && npm run test:integration:ci",
+    "test:smoke:vsix": "node scripts/smoke-vsix.js",
     "format": "prettier --write .",
     "prepare": "husky"
   },

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -282,12 +282,13 @@ async function pretestSetup() {
 }
 
 function parseArgs(argv) {
-  const out = { scope: 'all', vscode: 'insiders', installDeps: false, timeoutMs: undefined };
+  const out = { scope: 'all', vscode: 'insiders', installDeps: false, timeoutMs: undefined, smokeVsix: false };
   for (const a of argv.slice(2)) {
     if (a.startsWith('--scope=')) out.scope = a.split('=')[1];
     else if (a.startsWith('--vscode=')) out.vscode = a.split('=')[1];
     else if (a === '--install-deps') out.installDeps = true;
     else if (a.startsWith('--timeout=')) out.timeoutMs = Number(a.split('=')[1]) || undefined;
+    else if (a === '--smoke-vsix') out.smokeVsix = true;
   }
   return out;
 }
@@ -402,8 +403,45 @@ async function run() {
   }
 
   // Run tests via @vscode/test-electron with our programmatic Mocha runner
-  const extensionDevelopmentPath = resolve(__dirname, '..');
-  const extensionTestsPath = resolve(__dirname, '..', 'out', 'test', 'runner.js');
+  let extensionDevelopmentPath = resolve(__dirname, '..');
+  let extensionTestsPath = resolve(__dirname, '..', 'out', 'test', 'runner.js');
+
+  // Optional: VSIX smoke mode installs the freshly built VSIX and runs a minimal activation test
+  if (args.smokeVsix) {
+    // Package VSIX
+    console.log('[smoke] Packaging VSIX...');
+    await execFileAsync('npm', ['run', '-s', 'package']);
+    await execFileAsync('npx', ['--no-install', 'vsce', 'package', '--no-yarn']);
+    const vsix = require('fs').readdirSync(process.cwd()).find(f => /\.vsix$/.test(f));
+    if (!vsix) throw new Error('[smoke] VSIX not found');
+    // Install into test profile
+    const userDataDir = join(tmpdir(), 'alv-user-data');
+    const extensionsDir = join(tmpdir(), 'alv-extensions');
+    console.log('[smoke] Installing VSIX into isolated profile...');
+    const inst = spawnSync(cliPath, [...cliArgs, '--install-extension', resolve(vsix), '--force', '--user-data-dir', userDataDir, '--extensions-dir', extensionsDir], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      encoding: 'utf8',
+      input: 'y\n',
+      env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
+    });
+    if (inst.status !== 0) {
+      throw new Error('[smoke] Failed to install VSIX');
+    }
+    // Create minimal harness extension
+    const dev = mkdtempSync(join(tmpdir(), 'alv-smoke-dev-'));
+    const pkg = { name: 'alv-smoke-harness', version: '0.0.0', engines: { vscode: '*' }, main: './index.js', activationEvents: ['*'] };
+    writeFileSync(join(dev, 'package.json'), JSON.stringify(pkg, null, 2));
+    writeFileSync(join(dev, 'index.js'), "exports.activate=()=>{};exports.deactivate=()=>{};\n");
+    extensionDevelopmentPath = dev;
+    // Write runner that activates installed extension
+    const runner = `"use strict";const assert=require('assert/strict');const vscode=require('vscode');exports.run=async function(){const ext=vscode.extensions.getExtension('electivus.apex-log-viewer');assert.ok(ext,'extension not found');await ext.activate();const cmds=await vscode.commands.getCommands(true);for(const c of ['sfLogs.refresh','sfLogs.selectOrg','sfLogs.tail','sfLogs.showDiagram']){assert.ok(cmds.includes(c),'missing command: '+c);} };\n`;
+    const testsDir = mkdtempSync(join(tmpdir(), 'alv-smoke-tests-'));
+    extensionTestsPath = join(testsDir, 'smoke-runner.js');
+    writeFileSync(extensionTestsPath, runner, 'utf8');
+    // Override launchArgs to reuse the isolated profile with installed VSIX
+    process.env.__ALV_SMOKE_USER_DIR = userDataDir;
+    process.env.__ALV_SMOKE_EXT_DIR = extensionsDir;
+  }
   // Configure Mocha grep via env for the in-host runner
   if (scope === 'unit') {
     process.env.VSCODE_TEST_GREP = '^integration:';
@@ -424,22 +462,20 @@ async function run() {
   }, totalTimeout);
 
   try {
+    const launch = [
+      '--user-data-dir', process.env.__ALV_SMOKE_USER_DIR || join(tmpdir(), 'alv-user-data'),
+      '--extensions-dir', process.env.__ALV_SMOKE_EXT_DIR || join(tmpdir(), 'alv-extensions'),
+      '--skip-welcome',
+      '--skip-release-notes',
+      // Use the prepared workspace (set in pretestSetup)
+      ...(process.env.VSCODE_TEST_WORKSPACE ? [process.env.VSCODE_TEST_WORKSPACE] : [])
+    ];
     await runTests({
       vscodeExecutablePath,
       extensionDevelopmentPath,
       extensionTestsPath,
       extensionTestsEnv: sfExtPresent ? { SF_EXT_PRESENT: '1' } : undefined,
-      launchArgs: [
-        // Use clean profile
-        '--user-data-dir',
-        join(tmpdir(), 'alv-user-data'),
-        '--extensions-dir',
-        join(tmpdir(), 'alv-extensions'),
-        '--skip-welcome',
-        '--skip-release-notes',
-        // Use the prepared workspace (set in pretestSetup)
-        ...(process.env.VSCODE_TEST_WORKSPACE ? [process.env.VSCODE_TEST_WORKSPACE] : [])
-      ]
+      launchArgs: launch
     });
   } finally {
     clearTimeout(killer);

--- a/scripts/smoke-vsix.js
+++ b/scripts/smoke-vsix.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+/* VSIX smoke test: builds the VSIX, installs it into a clean VS Code profile,
+ * then launches a minimal test harness to activate the extension and verify
+ * key commands are registered. Fails on any activation/packaging regression.
+ */
+const { mkdtempSync, writeFileSync, rmSync } = require('fs');
+const { join, resolve } = require('path');
+const { tmpdir, platform } = require('os');
+const { spawnSync } = require('child_process');
+const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
+
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+function sh(cmd, args, opts = {}) {
+  const res = spawnSync(cmd, args, { stdio: 'inherit', encoding: 'utf8', ...opts });
+  if (res.status !== 0) {
+    fail(`Command failed: ${cmd} ${args.join(' ')}`);
+  }
+  return res;
+}
+
+async function main() {
+  const id = 'electivus.apex-log-viewer';
+  // 1) Package VSIX (reuse project script)
+  sh('npm', ['run', '-s', 'package']);
+  sh('npx', ['--no-install', 'vsce', 'package', '--no-yarn']);
+  // Grab first .vsix in cwd
+  const vsix = require('fs').readdirSync(process.cwd()).find(f => /\.vsix$/.test(f));
+  if (!vsix) fail('VSIX not found in current directory');
+
+  // 2) Prepare VS Code + isolate profile dirs
+  const vsVer = process.env.VSCODE_SMOKE_VERSION || 'insiders';
+  const vscodeExecutablePath = await downloadAndUnzipVSCode(vsVer);
+  const [cliPath, ...cliArgs] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath, { reuseMachineInstall: true });
+
+  // 3) Install the VSIX into the clean profile
+  sh(cliPath, [
+    ...cliArgs,
+    '--install-extension', resolve(vsix),
+    '--force'
+  ], { env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' } });
+
+  // 4) Create a minimal harness extension under a temp folder
+  const dev = mkdtempSync(join(tmpdir(), 'alv-smoke-dev-'));
+  const pkg = {
+    name: 'alv-smoke-harness',
+    displayName: 'ALV Smoke Harness',
+    version: '0.0.0',
+    engines: { vscode: '*' },
+    main: './index.js',
+    activationEvents: ['*']
+  };
+  writeFileSync(join(dev, 'package.json'), JSON.stringify(pkg, null, 2));
+  writeFileSync(join(dev, 'index.js'), "exports.activate=()=>{};exports.deactivate=()=>{};\n");
+
+  // 5) Write the smoke test runner (Mocha programmatic)
+  const testsDir = mkdtempSync(join(tmpdir(), 'alv-smoke-tests-'));
+  const runner = `"use strict";\nconst assert = require('assert/strict');\nconst vscode = require('vscode');\nconst Mocha = require('mocha');\nexports.run = async function run() {\n  const mocha = new Mocha({ ui: 'tdd', color: true, timeout: 30000, reporter: 'spec' });\n  mocha.suite.emit('pre-require', global, 'global', mocha);\n  suite('smoke: vsix activation', () => {\n    test('activates and registers commands', async () => {\n      const ext = vscode.extensions.getExtension('${id}');\n      assert.ok(ext, 'extension not found');\n      await ext.activate();\n      const cmds = await vscode.commands.getCommands(true);\n      for (const c of ['sfLogs.refresh','sfLogs.selectOrg','sfLogs.tail','sfLogs.showDiagram']) {\n        assert.ok(cmds.includes(c), 'missing command: '+c);\n      }\n    });\n  });\n  await new Promise((resolve, reject) => mocha.run(f => f ? reject(new Error(String(f)+' failing tests')) : resolve()));\n};\n`;
+  const runnerPath = join(testsDir, 'smoke-runner.js');
+  writeFileSync(runnerPath, runner, 'utf8');
+
+  // 6) Environment hardening for headless CI
+  const env = { ...process.env };
+  delete env.ELECTRON_RUN_AS_NODE;
+  env.ELECTRON_DISABLE_GPU = env.ELECTRON_DISABLE_GPU || '1';
+  env.LC_ALL = env.LC_ALL || 'C.UTF-8';
+  env.DONT_PROMPT_WSL_INSTALL = env.DONT_PROMPT_WSL_INSTALL || '1';
+  if (platform() === 'linux' && !env.DBUS_SESSION_BUS_ADDRESS) {
+    env.DBUS_SESSION_BUS_ADDRESS = '/dev/null';
+    env.NO_AT_BRIDGE = '1';
+  }
+
+  // 7) Launch tests against the installed VSIX
+  try {
+    const [cliPath2, ...cliArgs2] = resolveCliArgsFromVSCodeExecutablePath(vscodeExecutablePath, { reuseMachineInstall: true });
+    const args = [
+      ...cliArgs2,
+      '--extensionDevelopmentPath', dev,
+      `--extensionTestsPath=${runnerPath}`,
+      '--skip-welcome', '--skip-release-notes'
+    ];
+    const res = spawnSync(cliPath2, args, { stdio: ['pipe','inherit','inherit'], env, input: 'y\n' });
+    if (res.status !== 0) fail(`VSIX smoke failed with exit code ${res.status}`);
+  } finally {
+    try { rmSync(dev, { recursive: true, force: true }); } catch {}
+    try { rmSync(testsDir, { recursive: true, force: true }); } catch {}
+  }
+}
+
+main().catch(err => {
+  console.error(err && err.stack || String(err));
+  process.exit(1);
+});


### PR DESCRIPTION
Adds a mandatory VSIX smoke test to CI.\n\nWhat it does\n- Packages the extension (esbuild bundle) and creates a .vsix.\n- Installs the VSIX into an isolated VS Code profile.\n- Launches a minimal harness and asserts the Marketplace artifact activates and registers key commands.\n\nWhy\n- Catches packaging/activation regressions (e.g., missing modules) that unit/integration tests miss because they run from the dev workspace.\n\nDetails\n- New script: scripts/smoke-vsix.js (standalone), plus support for --smoke-vsix in scripts/run-tests.js.\n- New npm script: test:smoke:vsix.\n- Workflow: adds job 'VSIX Smoke Test' to CI.\n\nNo changes to extension code. Only CI and scripts.\n