### PR TITLE
chore: increase default timeout to 120 seconds

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,7 +26,7 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 - `VSCODE_TEST_VERSION`: VS Code build to test against. Defaults to `insiders` locally. In CI we pin to `stable` to avoid flakiness.
 - `VSCODE_TEST_INSTALL_DEPS=1`: Forces installing dependency extensions even in non‑integration scopes.
 - `VSCODE_TEST_GREP`: Mocha grep filter (string or regexp); use with `VSCODE_TEST_INVERT=1` to invert.
-- `VSCODE_TEST_MOCHA_TIMEOUT_MS`: Per‑test timeout (default 30000ms).
+- `VSCODE_TEST_MOCHA_TIMEOUT_MS`: Per‑test timeout (default 120000ms).
 - `VSCODE_TEST_TOTAL_TIMEOUT_MS`: Global hard timeout for the whole run.
 - `VSCODE_TEST_WORKSPACE`: If set, path opened by the test host. Normally the runner creates one for you.
 - `SF_LOG_TRACE=1`: Enables verbose trace logging in the temporary workspace settings.

--- a/scripts/install-linux-deps.sh
+++ b/scripts/install-linux-deps.sh
@@ -16,7 +16,8 @@ if ! command -v apt-get >/dev/null 2>&1; then
 fi
 
 echo "[deps] Updating APT indexes..."
-sudo apt-get update -y
+# Use quiet mode to avoid spamming the logs with APT index lines
+sudo apt-get update -y -qq
 
 pick_pkg() {
   local a="$1" b="$2"
@@ -70,7 +71,8 @@ for p in "${TO_INSTALL[@]}"; do
 done
 
 echo "[deps] Installing packages: ${FILTERED[*]} ${STATIC[*]}"
-sudo apt-get install -y "${FILTERED[@]}" "${STATIC[@]}" || {
+# Suppress apt progress output; still surfaces errors if installation fails
+sudo apt-get install -y -qq "${FILTERED[@]}" "${STATIC[@]}" || {
   echo "[deps] Failed to install some libraries. Check package names for your distro." >&2
   exit 1
 }

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -5,7 +5,7 @@ import { localize } from '../utils/localize';
 const crossSpawn = require('cross-spawn');
 import type { OrgAuth, OrgItem } from './types';
 
-const CLI_TIMEOUT_MS = 30000;
+const CLI_TIMEOUT_MS = 120000;
 
 // Allow swapping exec implementation in tests
 export type ExecFileFn = (

--- a/src/test/runner.ts
+++ b/src/test/runner.ts
@@ -21,7 +21,7 @@ export async function run(): Promise<void> {
   const outDir = path.resolve(__dirname);
   const testsRoot = outDir; // compiled tests live in out/test
 
-  const timeout = Number(process.env.VSCODE_TEST_MOCHA_TIMEOUT_MS || 30000);
+  const timeout = Number(process.env.VSCODE_TEST_MOCHA_TIMEOUT_MS || 120000);
   const grep = process.env.VSCODE_TEST_GREP;
   const invert = /^1|true$/i.test(String(process.env.VSCODE_TEST_INVERT || ''));
   const fullTrace = /^1|true$/i.test(String(process.env.VSCODE_TEST_MOCHA_FULLTRACE || ''));


### PR DESCRIPTION
## Summary
- extend Salesforce CLI command timeout to 120s
- raise test runner default timeout to 120s
- document new 120s per-test timeout
- quiet Linux dependency installation script to reduce APT noise

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b59f78455883238c407b623e4c167d