### PR TITLE
CI: re-add VSIX smoke test (fixed)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
         run: npm ci
       - name: Build and run VSIX smoke
         run: npm run test:smoke:vsix
+        env:
+          ALWAYS_SMOKE_VSIX: "1"
 
   package:
     name: Package VSIX

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,26 @@ jobs:
             *) npm run test:unit:ci ;;
           esac
 
+  smoke_vsix:
+    name: VSIX Smoke Test
+    needs: build_and_test
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Build and run VSIX smoke
+        run: npm run test:smoke:vsix
+
   package:
     name: Package VSIX
     # Run on tag pushes, on published Releases, or manual dispatch with tag_name

--- a/package.json
+++ b/package.json
@@ -216,6 +216,7 @@
     "test:unit:ci": "npm run pretest && bash scripts/run-tests.sh --scope=unit --vscode=stable",
     "test:integration:ci": "npm run pretest && bash scripts/run-tests.sh --scope=integration --vscode=stable --install-deps --timeout=900000",
     "test:ci": "npm run test:unit:ci && npm run test:integration:ci",
+    "test:smoke:vsix": "node scripts/run-tests.js --scope=unit --smoke-vsix",
     "format": "prettier --write .",
     "prepare": "husky"
   },

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -290,6 +290,9 @@ function parseArgs(argv) {
     else if (a.startsWith('--timeout=')) out.timeoutMs = Number(a.split('=')[1]) || undefined;
     else if (a === '--smoke-vsix') out.smokeVsix = true;
   }
+  if (/^1|true$/i.test(String(process.env.ALWAYS_SMOKE_VSIX || ''))) {
+    out.smokeVsix = true;
+  }
   return out;
 }
 

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -282,12 +282,13 @@ async function pretestSetup() {
 }
 
 function parseArgs(argv) {
-  const out = { scope: 'all', vscode: 'insiders', installDeps: false, timeoutMs: undefined };
+  const out = { scope: 'all', vscode: 'insiders', installDeps: false, timeoutMs: undefined, smokeVsix: false };
   for (const a of argv.slice(2)) {
     if (a.startsWith('--scope=')) out.scope = a.split('=')[1];
     else if (a.startsWith('--vscode=')) out.vscode = a.split('=')[1];
     else if (a === '--install-deps') out.installDeps = true;
     else if (a.startsWith('--timeout=')) out.timeoutMs = Number(a.split('=')[1]) || undefined;
+    else if (a === '--smoke-vsix') out.smokeVsix = true;
   }
   return out;
 }
@@ -402,8 +403,45 @@ async function run() {
   }
 
   // Run tests via @vscode/test-electron with our programmatic Mocha runner
-  const extensionDevelopmentPath = resolve(__dirname, '..');
-  const extensionTestsPath = resolve(__dirname, '..', 'out', 'test', 'runner.js');
+  let extensionDevelopmentPath = resolve(__dirname, '..');
+  let extensionTestsPath = resolve(__dirname, '..', 'out', 'test', 'runner.js');
+
+  // Optional: VSIX smoke mode installs the freshly built VSIX and runs a minimal activation test
+  if (args.smokeVsix) {
+    // Package VSIX
+    console.log('[smoke] Packaging VSIX...');
+    await execFileAsync('npm', ['run', '-s', 'package']);
+    await execFileAsync('npx', ['--no-install', 'vsce', 'package', '--no-yarn']);
+    const vsix = require('fs').readdirSync(process.cwd()).find(f => /\.vsix$/.test(f));
+    if (!vsix) throw new Error('[smoke] VSIX not found');
+    // Install into test profile
+    const userDataDir = join(tmpdir(), 'alv-user-data');
+    const extensionsDir = join(tmpdir(), 'alv-extensions');
+    console.log('[smoke] Installing VSIX into isolated profile...');
+    const inst = spawnSync(cliPath, [...cliArgs, '--install-extension', resolve(vsix), '--force', '--user-data-dir', userDataDir, '--extensions-dir', extensionsDir], {
+      stdio: ['pipe', 'inherit', 'inherit'],
+      encoding: 'utf8',
+      input: 'y\n',
+      env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
+    });
+    if (inst.status !== 0) {
+      throw new Error('[smoke] Failed to install VSIX');
+    }
+    // Create minimal harness extension
+    const dev = mkdtempSync(join(tmpdir(), 'alv-smoke-dev-'));
+    const pkg = { name: 'alv-smoke-harness', version: '0.0.0', engines: { vscode: '*' }, main: './index.js', activationEvents: ['*'] };
+    writeFileSync(join(dev, 'package.json'), JSON.stringify(pkg, null, 2));
+    writeFileSync(join(dev, 'index.js'), "exports.activate=()=>{};exports.deactivate=()=>{};\n");
+    extensionDevelopmentPath = dev;
+    // Write runner that activates installed extension
+    const runner = `"use strict";const assert=require('assert/strict');const vscode=require('vscode');exports.run=async function(){const ext=vscode.extensions.getExtension('electivus.apex-log-viewer');assert.ok(ext,'extension not found');await ext.activate();const cmds=await vscode.commands.getCommands(true);for(const c of ['sfLogs.refresh','sfLogs.selectOrg','sfLogs.tail','sfLogs.showDiagram']){assert.ok(cmds.includes(c),'missing command: '+c);} };\n`;
+    const testsDir = mkdtempSync(join(tmpdir(), 'alv-smoke-tests-'));
+    extensionTestsPath = join(testsDir, 'smoke-runner.js');
+    writeFileSync(extensionTestsPath, runner, 'utf8');
+    // Override launchArgs to reuse the isolated profile with installed VSIX
+    process.env.__ALV_SMOKE_USER_DIR = userDataDir;
+    process.env.__ALV_SMOKE_EXT_DIR = extensionsDir;
+  }
   // Configure Mocha grep via env for the in-host runner
   if (scope === 'unit') {
     process.env.VSCODE_TEST_GREP = '^integration:';
@@ -424,22 +462,20 @@ async function run() {
   }, totalTimeout);
 
   try {
+    const launch = [
+      '--user-data-dir', process.env.__ALV_SMOKE_USER_DIR || join(tmpdir(), 'alv-user-data'),
+      '--extensions-dir', process.env.__ALV_SMOKE_EXT_DIR || join(tmpdir(), 'alv-extensions'),
+      '--skip-welcome',
+      '--skip-release-notes',
+      // Use the prepared workspace (set in pretestSetup)
+      ...(process.env.VSCODE_TEST_WORKSPACE ? [process.env.VSCODE_TEST_WORKSPACE] : [])
+    ];
     await runTests({
       vscodeExecutablePath,
       extensionDevelopmentPath,
       extensionTestsPath,
       extensionTestsEnv: sfExtPresent ? { SF_EXT_PRESENT: '1' } : undefined,
-      launchArgs: [
-        // Use clean profile
-        '--user-data-dir',
-        join(tmpdir(), 'alv-user-data'),
-        '--extensions-dir',
-        join(tmpdir(), 'alv-extensions'),
-        '--skip-welcome',
-        '--skip-release-notes',
-        // Use the prepared workspace (set in pretestSetup)
-        ...(process.env.VSCODE_TEST_WORKSPACE ? [process.env.VSCODE_TEST_WORKSPACE] : [])
-      ]
+      launchArgs: launch
     });
   } finally {
     clearTimeout(killer);


### PR DESCRIPTION
Re-introduces a VSIX smoke test with a stable harness:\n\n- Adds --smoke-vsix mode to scripts/run-tests.js (packages VSIX, installs into isolated profile, activates extension, asserts key commands).\n- Adds npm script test:smoke:vsix.\n- Adds CI job "VSIX Smoke Test" that runs the smoke gate after build+unit/integration.\n\nThis replaces the reverted attempt. Validated locally: smoke passes.\n