### PR TITLE
feat: add collapsible methods in diagram view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Allow expanding or collapsing methods in Apex log diagram, with default collapsed and expand/collapse all controls.
+
 ## [0.4.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.3.1...v0.4.0) (2025-09-01)
 
 ### Features
@@ -37,7 +41,6 @@
 ### Refactoring
 
 - Extract TailService and streaming utilities; typed helpers and module splits ([2233539](https://github.com/Electivus/Apex-Log-Viewer/commit/2233539), [73dab59](https://github.com/Electivus/Apex-Log-Viewer/commit/73dab59), [18c2b03](https://github.com/Electivus/Apex-Log-Viewer/commit/18c2b03), [05e7ad4](https://github.com/Electivus/Apex-Log-Viewer/commit/05e7ad4))
-
 
 ## [0.3.1](https://github.com/Electivus/Apex-Log-Viewer/compare/apex-log-viewer-v0.3.1...apex-log-viewer-v0.3.1) (2025-08-30)
 

--- a/src/shared/apexLogParser.ts
+++ b/src/shared/apexLogParser.ts
@@ -83,7 +83,12 @@ function nodeId(kind: GraphNode['kind'], name: string): string {
   return `${kind}:${name}`;
 }
 
-function upsertNode(nodesById: Map<string, GraphNode>, kind: GraphNode['kind'], name: string, levels?: LogLevels): GraphNode {
+function upsertNode(
+  nodesById: Map<string, GraphNode>,
+  kind: GraphNode['kind'],
+  name: string,
+  levels?: LogLevels
+): GraphNode {
   const id = nodeId(kind, name);
   const existing = nodesById.get(id);
   if (existing) {
@@ -140,7 +145,7 @@ export function parseApexLogToGraph(text: string, maxLines?: number): LogGraph {
     const stack = laneStacks.get(actor);
     if (!stack || stack.length === 0) return;
     const span = stack.pop()!;
-    if (span.end == null) span.end = Math.max(span.start + 1, sequence.length);
+    if (span.end === undefined || span.end === null) span.end = Math.max(span.start + 1, sequence.length);
   };
 
   // Global nested frames (single-column view)
@@ -263,7 +268,7 @@ export function parseApexLogToGraph(text: string, maxLines?: number): LogGraph {
     // Class.MyClass.something => MyClass; Class.MyClass => MyClass
     if (/^Class\./.test(label)) {
       const m = label.match(/^Class\.(.+?)(?:\.|$)/);
-      return (m && m[1]) ? m[1] : label.replace(/^Class\./, '');
+      return m && m[1] ? m[1] : label.replace(/^Class\./, '');
     }
     // Trigger descriptors: "MyTrigger on X trigger event ..." => "MyTrigger"
     if (isTriggerDescriptor(label)) return label.split(' on ')[0]!.trim();
@@ -356,13 +361,13 @@ export function parseApexLogToGraph(text: string, maxLines?: number): LogGraph {
   for (const [actor, stack] of laneStacks) {
     while (stack.length) {
       const span = stack.pop()!;
-      if (span.end == null) span.end = Math.max(span.start + 1, sequence.length);
+      if (span.end === undefined || span.end === null) span.end = Math.max(span.start + 1, sequence.length);
     }
   }
   // Close any nested frames left open
   while (nestedStack.length) {
     const fr = nestedStack.pop()!;
-    if (fr.end == null) fr.end = Math.max(fr.start + 1, sequence.length);
+    if (fr.end === undefined || fr.end === null) fr.end = Math.max(fr.start + 1, sequence.length);
   }
   return { nodes, edges, sequence, flow, nested };
 }

--- a/src/webview/diagram.ts
+++ b/src/webview/diagram.ts
@@ -10,7 +10,11 @@ type Graph = {
 
 const vscode = acquireVsCodeApi();
 
-function h(tag: string, attrs?: Record<string, any>, children?: (Node | string | null | undefined)[]): HTMLElement | SVGElement {
+function h(
+  tag: string,
+  attrs?: Record<string, any>,
+  children?: (Node | string | null | undefined)[]
+): HTMLElement | SVGElement {
   const svgTags = new Set(['svg', 'path', 'defs', 'marker', 'line', 'text', 'rect', 'g', 'title']);
   const el = svgTags.has(tag)
     ? document.createElementNS('http://www.w3.org/2000/svg', tag)
@@ -20,14 +24,21 @@ function h(tag: string, attrs?: Record<string, any>, children?: (Node | string |
       const v = (attrs as any)[k];
       if (k === 'style' && typeof v === 'object') Object.assign((el as HTMLElement).style, v);
       else if (k === 'class') (el as any).className = v;
+      else if (k.startsWith('on') && typeof v === 'function') (el as any)[k] = v;
       else if (v !== undefined && v !== null) (el as any).setAttribute?.(k, String(v));
     }
   }
-  if (children) for (const c of children) { if (c === null || c === undefined) continue; (typeof c === 'string') ? el.appendChild(document.createTextNode(c)) : el.appendChild(c); }
+  if (children)
+    for (const c of children) {
+      if (c === null || c === undefined) continue;
+      typeof c === 'string' ? el.appendChild(document.createTextNode(c)) : el.appendChild(c);
+    }
   return el;
 }
 
-function truncate(s: string, max = 38): string { return s && s.length > max ? s.slice(0, max - 1) + '…' : (s || ''); }
+function truncate(s: string, max = 38): string {
+  return s && s.length > max ? s.slice(0, max - 1) + '…' : s || '';
+}
 
 function sanitizeText(s: string): string {
   if (!s) return '';
@@ -54,6 +65,13 @@ function ensureStyles() {
 let currentGraph: Graph | undefined;
 let hideSystem = true;
 let collapseRepeats = true;
+let collapsedUnits = new Set<string>();
+let allUnitIds: string[] = [];
+let collapseInitialized = false;
+
+function unitId(fr: Nested): string {
+  return `${fr.actor}:${fr.start}`;
+}
 
 function kindFromActor(actor: string): 'Trigger' | 'Flow' | 'Class' | 'Other' {
   if (actor.startsWith('Trigger:')) return 'Trigger';
@@ -85,7 +103,13 @@ function filterAndCollapse(frames: Nested[] | undefined): (Nested & { count?: nu
   const out: (Nested & { count?: number })[] = [];
   for (const f of list) {
     const prev = out[out.length - 1];
-    if (prev && prev.actor === f.actor && prev.depth === f.depth && prev.label === f.label && (prev.end ?? prev.start) <= f.start) {
+    if (
+      prev &&
+      prev.actor === f.actor &&
+      prev.depth === f.depth &&
+      prev.label === f.label &&
+      (prev.end ?? prev.start) <= f.start
+    ) {
       prev.end = f.end ?? f.start + 1;
       prev.count = (prev.count || 1) + 1;
     } else {
@@ -107,21 +131,108 @@ function render(graph: Graph) {
     return;
   }
 
+  const unitIds = frames.filter(f => f.kind === 'unit').map(unitId);
+  allUnitIds = unitIds;
+  collapsedUnits = collapseInitialized ? new Set(unitIds.filter(id => collapsedUnits.has(id))) : new Set(unitIds);
+  collapseInitialized = true;
+
   // Toolbar with toggles + legend
   const toolbar = h('div', { class: 'toolbar' }, [
     h('label', {}, [
-      h('input', { type: 'checkbox', checked: hideSystem ? 'checked' : undefined, onchange: (e: any) => { hideSystem = !!e.target.checked; if (currentGraph) render(currentGraph); } }, []),
+      h(
+        'input',
+        {
+          type: 'checkbox',
+          checked: hideSystem ? 'checked' : undefined,
+          onchange: (e: any) => {
+            hideSystem = !!e.target.checked;
+            if (currentGraph) render(currentGraph);
+          }
+        },
+        []
+      ),
       ' Hide System'
     ]),
     h('label', {}, [
-      h('input', { type: 'checkbox', checked: collapseRepeats ? 'checked' : undefined, onchange: (e: any) => { collapseRepeats = !!e.target.checked; if (currentGraph) render(currentGraph); } }, []),
+      h(
+        'input',
+        {
+          type: 'checkbox',
+          checked: collapseRepeats ? 'checked' : undefined,
+          onchange: (e: any) => {
+            collapseRepeats = !!e.target.checked;
+            if (currentGraph) render(currentGraph);
+          }
+        },
+        []
+      ),
       ' Collapse repeats'
     ]),
+    h(
+      'button',
+      {
+        onclick: () => {
+          collapsedUnits.clear();
+          if (currentGraph) render(currentGraph);
+        }
+      },
+      ['Expand all']
+    ),
+    h(
+      'button',
+      {
+        onclick: () => {
+          collapsedUnits = new Set(allUnitIds);
+          if (currentGraph) render(currentGraph);
+        }
+      },
+      ['Collapse all']
+    ),
     h('div', { class: 'legend' }, [
-      h('span', { class: 'item' }, [h('span', { class: 'swatch', style: { background: styleByKind('Trigger').fill, border: `1px solid ${styleByKind('Trigger').stroke}` } }, []), 'Trigger']),
-      h('span', { class: 'item' }, [h('span', { class: 'swatch', style: { background: styleByKind('Flow').fill, border: `1px solid ${styleByKind('Flow').stroke}` } }, []), 'Flow']),
-      h('span', { class: 'item' }, [h('span', { class: 'swatch', style: { background: styleByKind('Class').fill, border: `1px solid ${styleByKind('Class').stroke}` } }, []), 'Class']),
-      h('span', { class: 'item' }, [h('span', { class: 'swatch', style: { background: styleByKind('Other').fill, border: `1px solid ${styleByKind('Other').stroke}` } }, []), 'Other'])
+      h('span', { class: 'item' }, [
+        h(
+          'span',
+          {
+            class: 'swatch',
+            style: { background: styleByKind('Trigger').fill, border: `1px solid ${styleByKind('Trigger').stroke}` }
+          },
+          []
+        ),
+        'Trigger'
+      ]),
+      h('span', { class: 'item' }, [
+        h(
+          'span',
+          {
+            class: 'swatch',
+            style: { background: styleByKind('Flow').fill, border: `1px solid ${styleByKind('Flow').stroke}` }
+          },
+          []
+        ),
+        'Flow'
+      ]),
+      h('span', { class: 'item' }, [
+        h(
+          'span',
+          {
+            class: 'swatch',
+            style: { background: styleByKind('Class').fill, border: `1px solid ${styleByKind('Class').stroke}` }
+          },
+          []
+        ),
+        'Class'
+      ]),
+      h('span', { class: 'item' }, [
+        h(
+          'span',
+          {
+            class: 'swatch',
+            style: { background: styleByKind('Other').fill, border: `1px solid ${styleByKind('Other').stroke}` }
+          },
+          []
+        ),
+        'Other'
+      ])
     ])
   ]);
   root.appendChild(toolbar);
@@ -131,36 +242,105 @@ function render(graph: Graph) {
   const IND = 18; // indent per depth (x)
   const viewportW = (document.documentElement.clientWidth || window.innerWidth || 800) - 24;
   const W0 = Math.max(360, (root.clientWidth || viewportW) - PAD * 2);
-  const MAX_DEPTH = Math.max(0, ...frames.map(f => f.depth));
   const width = W0; // overall width used by depth=0; inner boxes shrink by depth*IND*2
-  const totalH = PAD + Math.max(...frames.map(f => (f.end ?? f.start + 1))) * ROW + PAD;
+  const totalH = PAD + Math.max(...frames.map(f => f.end ?? f.start + 1)) * ROW + PAD;
 
   const svgW = width + PAD * 2 + 12; // right-side breathing room
   const svgH = totalH + 12; // bottom breathing room
   const svg = h('svg', { width: svgW, height: svgH, viewBox: `0 0 ${svgW} ${svgH}` }) as SVGSVGElement;
 
-  // Draw frames (outer to inner ensures borders visible): iterate by ascending depth
-  frames.sort((a, b) => a.depth - b.depth || a.start - b.start);
+  // Draw frames with simple collapse support
+  frames.sort((a, b) => a.start - b.start || a.depth - b.depth);
+  const stack: { end: number; collapsed: boolean }[] = [];
 
   for (const fr of frames) {
+    while (stack.length > 0 && stack[stack.length - 1]!.end <= fr.start) stack.pop();
+    const parentCollapsed = stack.some(s => s.collapsed);
     const x = PAD + fr.depth * IND;
     const w = Math.max(40, width - fr.depth * IND * 2);
     const y1 = PAD + fr.start * ROW + 3;
     const y2 = PAD + (fr.end ?? fr.start + 1) * ROW - 3;
     const rectH = Math.max(14, y2 - y1);
-    const kind = kindFromActor(fr.actor);
-    const sty = styleByKind(kind);
-    const g = h('g');
-    g.appendChild(h('rect', { x, y: y1, width: w, height: rectH, rx: 8, ry: 8, fill: sty.fill, stroke: sty.stroke, 'stroke-width': fr.kind === 'unit' ? 1.6 : 1 }));
-    const countSuffix = (fr as any).count && (fr as any).count > 1 ? ` ×${(fr as any).count}` : '';
-    const label = truncate(fr.label.replace(/^Class\./, ''), 80) + countSuffix;
-    g.appendChild(h('text', { x: x + 10, y: y1 + 16, fill: 'var(--vscode-foreground)', 'font-size': 12 }, [label]));
-    // Tooltip with full label (sanitized for control chars)
-    g.appendChild(h('title', {}, [sanitizeText(fr.label)]));
-    svg.appendChild(g);
+
+    if (fr.kind === 'unit') {
+      const id = unitId(fr);
+      const collapsed = collapsedUnits.has(id) || parentCollapsed;
+      const sty = styleByKind(kindFromActor(fr.actor));
+      const g = h(
+        'g',
+        {
+          class: 'unit',
+          style: { cursor: 'pointer' },
+          onclick: () => {
+            if (collapsedUnits.has(id)) collapsedUnits.delete(id);
+            else collapsedUnits.add(id);
+            if (currentGraph) render(currentGraph);
+          }
+        },
+        []
+      );
+      g.appendChild(
+        h('rect', {
+          x,
+          y: y1,
+          width: w,
+          height: rectH,
+          rx: 8,
+          ry: 8,
+          fill: sty.fill,
+          stroke: sty.stroke,
+          'stroke-width': 1.6
+        })
+      );
+      const countSuffix = (fr as any).count && (fr as any).count > 1 ? ` ×${(fr as any).count}` : '';
+      const label = truncate(fr.label.replace(/^Class\./, ''), 80) + countSuffix;
+      g.appendChild(h('text', { x: x + 10, y: y1 + 16, fill: 'var(--vscode-foreground)', 'font-size': 12 }, [label]));
+      g.appendChild(h('title', {}, [sanitizeText(fr.label)]));
+      svg.appendChild(g);
+      stack.push({ end: fr.end ?? fr.start + 1, collapsed });
+    } else {
+      const collapsed = parentCollapsed;
+      if (!collapsed) {
+        const sty = styleByKind(kindFromActor(fr.actor));
+        const g = h('g');
+        g.appendChild(
+          h('rect', {
+            x,
+            y: y1,
+            width: w,
+            height: rectH,
+            rx: 8,
+            ry: 8,
+            fill: sty.fill,
+            stroke: sty.stroke,
+            'stroke-width': 1
+          })
+        );
+        const countSuffix = (fr as any).count && (fr as any).count > 1 ? ` ×${(fr as any).count}` : '';
+        const label = truncate(fr.label.replace(/^Class\./, ''), 80) + countSuffix;
+        g.appendChild(h('text', { x: x + 10, y: y1 + 16, fill: 'var(--vscode-foreground)', 'font-size': 12 }, [label]));
+        g.appendChild(h('title', {}, [sanitizeText(fr.label)]));
+        svg.appendChild(g);
+      }
+      stack.push({ end: fr.end ?? fr.start + 1, collapsed });
+    }
   }
 
-  const scroller = h('div', { style: { position: 'absolute', top: '36px', left: '0', right: '0', bottom: '0', overflowY: 'auto', overflowX: 'auto' } }, [svg]);
+  const scroller = h(
+    'div',
+    {
+      style: {
+        position: 'absolute',
+        top: '36px',
+        left: '0',
+        right: '0',
+        bottom: '0',
+        overflowY: 'auto',
+        overflowX: 'auto'
+      }
+    },
+    [svg]
+  );
   root.appendChild(scroller);
 }
 


### PR DESCRIPTION
## Summary
- default diagram methods collapsed with per-unit and global expand/collapse controls
- handle DOM event attributes directly in webview helper
- fix lint warnings in Apex log parser

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b5d47427688323a1f4426cad8fce9d