### PR TITLE
feat(diagram): dynamic collapse + row compression; robust METHOD_EXIT parsing

### DIFF
--- a/src/webview/diagram.ts
+++ b/src/webview/diagram.ts
@@ -306,12 +306,21 @@ function render(graph: Graph) {
   const maxEnd = Math.max(...frames.map(f => f.end ?? f.start + 1));
   const keep = new Array<boolean>(Math.max(0, maxEnd)).fill(false);
 
-  // Units contribute visibility: collapsed units keep only the header row; expanded keep full span
+  // Helper: whether a span is fully inside any collapsed unit interval
+  function withinCollapsed(start: number, endExclusive: number): boolean {
+    for (const it of collapsedIntervals) {
+      if (it.start <= start && endExclusive <= it.end) return true;
+    }
+    return false;
+  }
+
+  // Units contribute visibility: collapsed units OR units inside a collapsed parent keep only header row; expanded keep full span
   for (const u of unitFrames) {
     const uStart = u.start;
     const uEnd = u.end ?? u.start + 1;
     const isCollapsed = collapsedUnits.has(unitId(u));
-    if (isCollapsed) {
+    const forcedMinimal = withinCollapsed(uStart, uEnd);
+    if (isCollapsed || forcedMinimal) {
       if (uStart >= 0 && uStart < keep.length) keep[uStart] = true; // header row only
     } else {
       for (let t = uStart; t < uEnd; t++) keep[t] = true;

--- a/src/webview/diagram.ts
+++ b/src/webview/diagram.ts
@@ -24,7 +24,7 @@ function h(
     for (const k of Object.keys(attrs)) {
       const v = (attrs as any)[k];
       if (k === 'style' && typeof v === 'object') Object.assign((el as HTMLElement).style, v);
-      else if (k === 'class') (el as any).className = v;
+      else if (k === 'class') (el as Element).setAttribute('class', String(v));
       else if (k.startsWith('on') && typeof v === 'function') (el as any)[k] = v;
       else if (v !== undefined && v !== null) {
         // Allowlist of safe attributes (prevents event/href/src injection and satisfies CodeQL)


### PR DESCRIPTION
Summary
- Diagram: dynamic collapse with vertical row compression; nested classes visible; classes expanded by default.
- Parser: handle METHOD_EXIT without signature by inferring class or closing top-of-stack to properly end spans.
- Hardening: set class attribute via setAttribute in webview helper.

Why
- Collapsing units left large blank regions due to long-running method spans not being closed and non-visible rows not being compressed.
- Some logs emit METHOD_EXIT with only the class name; previously these weren't closing spans.

Changes
- src/webview/diagram.ts
  - Build visibility map; compress rows containing only hidden methods.
  - Hide methods fully contained within any collapsed unit span.
  - Units inside a collapsed parent render as header-only rows (no vertical gaps).
  - Minimal height for collapsed unit boxes; classes expanded by default.
- src/shared/apexLogParser.ts
  - Robust METHOD_EXIT handling without signature; prefer top-of-stack fallback.
- src/webview/diagram.ts (hardening)
  - Set CSS class via setAttribute in helper h().

Build & Tests
- Ran locally: npm ci, lint, check-types, build, test (46 passing).

Verification
- Open sample logs under apexlogs/ and view the diagram.
- Collapse/expand classes; nested classes remain; vertical space compresses correctly.

Risk / Rollback
- Low; scoped to parser and webview rendering.
