### PR TITLE
Refactor diagram view with modular toolbar

### DIFF
--- a/src/webview/diagram/styles.ts
+++ b/src/webview/diagram/styles.ts
@@ -1,0 +1,21 @@
+export type ActorKind = 'Trigger' | 'Flow' | 'Class' | 'Other';
+
+export function kindFromActor(actor: string): ActorKind {
+  if (actor.startsWith('Trigger:')) return 'Trigger';
+  if (actor.startsWith('Flow:')) return 'Flow';
+  if (actor.startsWith('Class:')) return 'Class';
+  return 'Other';
+}
+
+export function styleByKind(kind: ActorKind) {
+  switch (kind) {
+    case 'Trigger':
+      return { stroke: '#60a5fa', fill: 'rgba(96,165,250,0.14)' };
+    case 'Flow':
+      return { stroke: '#a78bfa', fill: 'rgba(167,139,250,0.14)' };
+    case 'Class':
+      return { stroke: '#34d399', fill: 'rgba(52,211,153,0.14)' };
+    default:
+      return { stroke: 'rgba(148,163,184,0.9)', fill: 'rgba(148,163,184,0.10)' };
+  }
+}

--- a/src/webview/diagram/toolbar.ts
+++ b/src/webview/diagram/toolbar.ts
@@ -1,0 +1,84 @@
+import { h } from '../utils/dom';
+import { styleByKind } from './styles';
+
+interface ToolbarOptions {
+  hideSystem: boolean;
+  collapseRepeats: boolean;
+  onHideSystemChange: (v: boolean) => void;
+  onCollapseRepeatsChange: (v: boolean) => void;
+  onExpandAll: () => void;
+  onCollapseAll: () => void;
+}
+
+export function createToolbar(opts: ToolbarOptions): HTMLElement {
+  return h('div', { class: 'toolbar' }, [
+    h('label', {}, [
+      h(
+        'input',
+        {
+          type: 'checkbox',
+          checked: opts.hideSystem ? 'checked' : undefined,
+          onchange: (e: any) => opts.onHideSystemChange(!!e.target.checked)
+        },
+        []
+      ),
+      ' Hide System'
+    ]),
+    h('label', {}, [
+      h(
+        'input',
+        {
+          type: 'checkbox',
+          checked: opts.collapseRepeats ? 'checked' : undefined,
+          onchange: (e: any) => opts.onCollapseRepeatsChange(!!e.target.checked)
+        },
+        []
+      ),
+      ' Collapse repeats'
+    ]),
+    h(
+      'button',
+      {
+        onclick: () => opts.onExpandAll()
+      },
+      ['Expand all']
+    ),
+    h(
+      'button',
+      {
+        onclick: () => opts.onCollapseAll()
+      },
+      ['Collapse all']
+    ),
+    h('div', { class: 'legend' }, [
+      h('span', { class: 'item' }, [
+        h('span', {
+          class: 'swatch',
+          style: { background: styleByKind('Trigger').fill, border: `1px solid ${styleByKind('Trigger').stroke}` }
+        }),
+        'Trigger'
+      ]),
+      h('span', { class: 'item' }, [
+        h('span', {
+          class: 'swatch',
+          style: { background: styleByKind('Flow').fill, border: `1px solid ${styleByKind('Flow').stroke}` }
+        }),
+        'Flow'
+      ]),
+      h('span', { class: 'item' }, [
+        h('span', {
+          class: 'swatch',
+          style: { background: styleByKind('Class').fill, border: `1px solid ${styleByKind('Class').stroke}` }
+        }),
+        'Class'
+      ]),
+      h('span', { class: 'item' }, [
+        h('span', {
+          class: 'swatch',
+          style: { background: styleByKind('Other').fill, border: `1px solid ${styleByKind('Other').stroke}` }
+        }),
+        'Other'
+      ])
+    ])
+  ]) as HTMLDivElement;
+}

--- a/src/webview/utils/dom.ts
+++ b/src/webview/utils/dom.ts
@@ -1,0 +1,63 @@
+export function h(
+  tag: string,
+  attrs?: Record<string, any>,
+  children?: (Node | string | null | undefined)[]
+): HTMLElement | SVGElement {
+  const svgTags = new Set(['svg', 'path', 'defs', 'marker', 'line', 'text', 'rect', 'g', 'title']);
+  const htmlTags = new Set(['div', 'label', 'span', 'input', 'button']);
+  const el = svgTags.has(tag)
+    ? document.createElementNS('http://www.w3.org/2000/svg', tag)
+    : document.createElement(tag);
+  if (attrs) {
+    for (const k of Object.keys(attrs)) {
+      const v = (attrs as any)[k];
+      if (k === 'style' && typeof v === 'object') Object.assign((el as HTMLElement).style, v);
+      else if (k === 'class') (el as Element).setAttribute('class', String(v));
+      else if (k.startsWith('on') && typeof v === 'function') (el as any)[k] = v;
+      else if (v !== undefined && v !== null) {
+        // Allowlist of safe attributes (prevents event/href/src injection and satisfies CodeQL)
+        const allowed = new Set([
+          'id',
+          'class',
+          'type',
+          'checked',
+          'viewBox',
+          // Position/geometry
+          'x',
+          'y',
+          'x1',
+          'y1',
+          'x2',
+          'y2',
+          'width',
+          'height',
+          'rx',
+          'ry',
+          // Styling
+          'fill',
+          'stroke',
+          'stroke-width',
+          'font-size'
+        ]);
+        if (allowed.has(k)) (el as any).setAttribute?.(k, String(v));
+      }
+    }
+  }
+  if (children)
+    for (const c of children) {
+      if (c === null || c === undefined) continue;
+      if (typeof c === 'string') {
+        el.appendChild(document.createTextNode(c));
+      } else if (c instanceof Node) {
+        // Only allow known-safe node types/tags
+        if (c.nodeType === Node.TEXT_NODE) {
+          el.appendChild(c);
+        } else if (c instanceof SVGElement) {
+          if (svgTags.has((c as Element).tagName.toLowerCase())) el.appendChild(c);
+        } else if (c instanceof HTMLElement) {
+          if (htmlTags.has((c as Element).tagName.toLowerCase())) el.appendChild(c);
+        }
+      }
+    }
+  return el;
+}


### PR DESCRIPTION
## Summary
- extract DOM helper for safe element creation
- separate actor kind styling utilities
- modularize diagram toolbar with legend and controls

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test` *(fails: Test run failed with code 1: Failed to fetch)*

------
https://chatgpt.com/codex/tasks/task_e_68b6db2275f48323a0e8f6b8336e96d4