### PR TITLE
Add entity filter to diagram (hide specific nodes)

### DIFF
--- a/src/test/unit/diagramFilter.test.ts
+++ b/src/test/unit/diagramFilter.test.ts
@@ -1,0 +1,37 @@
+import assert from 'assert/strict';
+import type { NestedFrame } from '../../shared/apexLogParser';
+import { filterAndCollapse } from '../../webview/utils/diagramFilter';
+
+suite('filterAndCollapse (diagram filter)', () => {
+  test('hides frames from hidden actors', () => {
+    const frames: NestedFrame[] = [
+      { actor: 'Class:Logger', label: 'Logger.log(String)', start: 0, end: 1, depth: 1, kind: 'method' },
+      { actor: 'Class:Service', label: 'Service.run()', start: 1, end: 2, depth: 1, kind: 'method' }
+    ];
+    const out = filterAndCollapse(frames, false, false, new Set(['Class:Logger']));
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.actor, 'Class:Service');
+  });
+
+  test('hides System frames when hideSystem=true', () => {
+    const frames: NestedFrame[] = [
+      { actor: 'Class:System.String', label: 'System.String.join(List<String>)', start: 0, end: 1, depth: 1, kind: 'method' },
+      { actor: 'Class:MyApp', label: 'MyApp.exec()', start: 1, end: 2, depth: 1, kind: 'method' }
+    ];
+    const out = filterAndCollapse(frames, true, false, new Set());
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.actor, 'Class:MyApp');
+  });
+
+  test('collapses consecutive repeats', () => {
+    const frames: NestedFrame[] = [
+      { actor: 'Class:Svc', label: 'Svc.work()', start: 0, end: 1, depth: 1, kind: 'method' },
+      { actor: 'Class:Svc', label: 'Svc.work()', start: 1, end: 2, depth: 1, kind: 'method' }
+    ];
+    const out = filterAndCollapse(frames, false, true, new Set());
+    assert.equal(out.length, 1);
+    assert.equal(out[0]!.actor, 'Class:Svc');
+    assert.equal((out[0] as any).count, 2);
+    assert.equal(out[0]!.end, 2);
+  });
+});

--- a/src/webview/components/diagram/DiagramToolbar.tsx
+++ b/src/webview/components/diagram/DiagramToolbar.tsx
@@ -10,7 +10,10 @@ export function DiagramToolbar({
   showProfilingChips,
   onToggleShowProfilingChips,
   showProfilingSidebar,
-  onToggleShowProfilingSidebar
+  onToggleShowProfilingSidebar,
+  entityPanelOpen,
+  onToggleEntityPanel,
+  hiddenCount
 }: {
   hideSystem: boolean;
   onToggleHideSystem: (v: boolean) => void;
@@ -22,6 +25,9 @@ export function DiagramToolbar({
   onToggleShowProfilingChips: (v: boolean) => void;
   showProfilingSidebar: boolean;
   onToggleShowProfilingSidebar: (v: boolean) => void;
+  entityPanelOpen: boolean;
+  onToggleEntityPanel: (v: boolean) => void;
+  hiddenCount: number;
 }) {
   const Swatch = ({ stroke, fill, label }: { stroke: string; fill: string; label: string }) => (
     <span className="item">
@@ -32,6 +38,9 @@ export function DiagramToolbar({
 
   return (
     <div className="toolbar">
+      <button type="button" onClick={() => onToggleEntityPanel(!entityPanelOpen)}>
+        Entities{hiddenCount ? ` (${hiddenCount} hidden)` : ''} {entityPanelOpen ? '▴' : '▾'}
+      </button>
       <label>
         <input type="checkbox" checked={hideSystem} onChange={e => onToggleHideSystem(e.target.checked)} /> Hide System
       </label>

--- a/src/webview/components/diagram/EntityFilter.tsx
+++ b/src/webview/components/diagram/EntityFilter.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo, useState } from 'react';
+
+type Kind = 'Trigger' | 'Flow' | 'Class' | 'Other';
+
+export function EntityFilter({
+  entities,
+  hidden,
+  onChangeHidden,
+  onClose
+}: {
+  entities: { id: string; label: string; kind: Kind }[];
+  hidden: Set<string>;
+  onChangeHidden: (next: Set<string>) => void;
+  onClose?: () => void;
+}) {
+  const [q, setQ] = useState('');
+
+  const grouped = useMemo(() => {
+    const byKind: Record<Kind, { id: string; label: string; kind: Kind }[]> = {
+      Trigger: [],
+      Flow: [],
+      Class: [],
+      Other: []
+    };
+    const query = q.trim().toLowerCase();
+    for (const e of entities) {
+      if (query) {
+        const hay = `${e.kind}:${e.label}`.toLowerCase();
+        if (!hay.includes(query)) continue;
+      }
+      byKind[e.kind].push(e);
+    }
+    return byKind;
+  }, [entities, q]);
+
+  const counts = useMemo(() => {
+    const total = entities.length;
+    const hiddenCount = hidden.size;
+    return { total, hiddenCount, visibleCount: total - hiddenCount };
+  }, [entities.length, hidden.size]);
+
+  const toggle = (id: string) => {
+    const next = new Set(hidden);
+    if (next.has(id)) next.delete(id);
+    else next.add(id);
+    onChangeHidden(next);
+  };
+
+  const setAll = (ids: string[], hiddenOn: boolean) => {
+    const next = new Set(hidden);
+    if (hiddenOn) {
+      for (const id of ids) next.add(id);
+    } else {
+      for (const id of ids) next.delete(id);
+    }
+    onChangeHidden(next);
+  };
+
+  const kinds: Kind[] = ['Trigger', 'Flow', 'Class', 'Other'];
+
+  return (
+    <div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderBottom: '1px solid var(--vscode-editorGroup-border, rgba(148,163,184,0.25))' }}>
+        <input
+          autoFocus
+          type="text"
+          placeholder="Search entities..."
+          value={q}
+          onChange={e => setQ(e.target.value)}
+          style={{ flex: 1, padding: '6px 8px', borderRadius: 6, border: '1px solid var(--vscode-input-border, rgba(148,163,184,0.35))', background: 'var(--vscode-input-background)', color: 'var(--vscode-input-foreground)' }}
+        />
+        <button type="button" onClick={() => setQ('')}>Clear</button>
+        {onClose && (
+          <button type="button" onClick={onClose}>Close</button>
+        )}
+      </div>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderBottom: '1px solid var(--vscode-editorGroup-border, rgba(148,163,184,0.25))', fontSize: 12 }}>
+        <span>Total: {counts.total}</span>
+        <span>Hidden: {counts.hiddenCount}</span>
+        <span>Visible: {counts.visibleCount}</span>
+        <span style={{ marginLeft: 'auto' }} />
+        <button type="button" onClick={() => onChangeHidden(new Set())}>Show all</button>
+        <button type="button" onClick={() => onChangeHidden(new Set(entities.map(e => e.id)))}>Hide all</button>
+      </div>
+      <div style={{ padding: 10 }}>
+        {kinds.map(kind => {
+          const list = grouped[kind];
+          if (!list || list.length === 0) return null;
+          const ids = list.map(e => e.id);
+          const allHidden = ids.every(id => hidden.has(id));
+          return (
+            <div key={kind} style={{ marginBottom: 10 }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '6px 0', fontWeight: 700, opacity: 0.9 }}>
+                <span style={{ width: 10, height: 10, borderRadius: 3, background: kind === 'Trigger' ? 'rgba(96,165,250,0.14)' : kind === 'Flow' ? 'rgba(167,139,250,0.14)' : kind === 'Class' ? 'rgba(52,211,153,0.14)' : 'rgba(148,163,184,0.10)', border: `1px solid ${kind === 'Trigger' ? '#60a5fa' : kind === 'Flow' ? '#a78bfa' : kind === 'Class' ? '#34d399' : 'rgba(148,163,184,0.9)'}` }} />
+                <span>{kind}</span>
+                <span style={{ marginLeft: 'auto' }} />
+                <button type="button" onClick={() => setAll(ids, false)}>Show</button>
+                <button type="button" onClick={() => setAll(ids, true)}>{allHidden ? 'Hidden' : 'Hide'}</button>
+              </div>
+              {list.map(e => (
+                <label key={e.id} style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 12, padding: '4px 0' }}>
+                  <input type="checkbox" checked={hidden.has(e.id)} onChange={() => toggle(e.id)} />
+                  <span style={{ opacity: 0.85 }}>Hide</span>
+                  <span style={{ opacity: 0.9 }}>{e.label}</span>
+                  <span style={{ opacity: 0.6 }}>· {e.id.split(':')[0]}</span>
+                </label>
+              ))}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+export default EntityFilter;

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -9,7 +9,11 @@ import { LoadingOverlay } from './components/LoadingOverlay';
 
 declare global {
   // Provided by VS Code webview runtime
-  var acquireVsCodeApi: <T = unknown>() => { postMessage: (msg: T) => void };
+  var acquireVsCodeApi: <T = unknown>() => {
+    postMessage: (msg: T) => void;
+    getState: <S = any>() => S | undefined;
+    setState: (state: any) => void;
+  };
 }
 
 const vscode = acquireVsCodeApi<WebviewToExtensionMessage>();

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -9,7 +9,11 @@ import { TailList } from './components/tail/TailList';
 import { LoadingOverlay } from './components/LoadingOverlay';
 
 declare global {
-  var acquireVsCodeApi: <T = unknown>() => { postMessage: (msg: T) => void };
+  var acquireVsCodeApi: <T = unknown>() => {
+    postMessage: (msg: T) => void;
+    getState: <S = any>() => S | undefined;
+    setState: (state: any) => void;
+  };
 }
 
 const vscode = acquireVsCodeApi<WebviewToExtensionMessage>();

--- a/src/webview/utils/diagramFilter.ts
+++ b/src/webview/utils/diagramFilter.ts
@@ -1,0 +1,50 @@
+import type { NestedFrame } from '../../shared/apexLogParser';
+
+export function filterAndCollapse(
+  frames: NestedFrame[] | undefined,
+  hideSystem: boolean,
+  collapseRepeats: boolean,
+  hiddenActors?: Set<string>
+): (NestedFrame & { count?: number })[] {
+  let list: NestedFrame[] = (frames || []).slice();
+  const hidden = hiddenActors || new Set<string>();
+  if (hideSystem) {
+    list = list.filter(fr => !/^Class:System\b/.test(fr.actor) && !/^System\./.test(fr.label));
+  }
+  if (hidden.size) {
+    list = list.filter(fr => !hidden.has(fr.actor));
+  }
+  // Collapse consecutive repeats on same lane, same depth and same label
+  list.sort((a, b) => a.start - b.start || a.depth - b.depth);
+  if (!collapseRepeats) return list as any;
+  const out: (NestedFrame & { count?: number })[] = [];
+  for (const f of list) {
+    const prev = out[out.length - 1];
+    if (
+      prev &&
+      prev.actor === f.actor &&
+      prev.depth === f.depth &&
+      prev.label === f.label &&
+      (prev.end ?? prev.start) <= f.start
+    ) {
+      prev.end = f.end ?? f.start + 1;
+      prev.count = (prev.count || 1) + 1;
+      if (f.profile) {
+        // Sum profiling counters when collapsing
+        (prev.profile ||= {});
+        if (f.profile.soql) prev.profile.soql = (prev.profile.soql || 0) + f.profile.soql;
+        if (f.profile.dml) prev.profile.dml = (prev.profile.dml || 0) + f.profile.dml;
+        if (f.profile.callout) prev.profile.callout = (prev.profile.callout || 0) + f.profile.callout;
+        if (f.profile.cpuMs) prev.profile.cpuMs = (prev.profile.cpuMs || 0) + f.profile.cpuMs;
+        if (f.profile.heapBytes) prev.profile.heapBytes = (prev.profile.heapBytes || 0) + f.profile.heapBytes;
+      }
+    } else {
+      // Clone profile to avoid mutating the source graph when we merge repeats
+      out.push({ ...f, profile: f.profile ? { ...f.profile } : undefined });
+    }
+  }
+  return out;
+}
+
+export default filterAndCollapse;
+


### PR DESCRIPTION
Add entity filter to diagram (hide specific nodes)

Summary
- Add a new Entities panel to the diagram with search + per-entity hide/show for Triggers, Flows, Classes, and Other.
- Support hiding by actor id in the render pipeline so hidden entities (e.g., custom log classes) no longer clutter the flow.
- Persist UI state for the webview session via `vscode.setState` (hidden entities, Hide System, Collapse repeats, profiling chips/sidebar).
- Keep compatibility with existing controls (Hide System, Collapse repeats, Expand/Collapse units).
- Add unit tests covering hide-by-actor, hide System, and collapse behavior.

Files
- UI: `src/webview/diagram.tsx`, `src/webview/components/diagram/DiagramToolbar.tsx`, `src/webview/components/diagram/EntityFilter.tsx` (new)
- Logic: `src/webview/utils/diagramFilter.ts` (new)
- Webview globals: `src/webview/main.tsx`, `src/webview/tail.tsx`
- Tests: `src/test/unit/diagramFilter.test.ts` (new)

Verification Steps
1. Build: `npm run build` (or `npm run watch` + F5 in VS Code).
2. Open a Salesforce `.log` and launch “Apex Log Diagram”.
3. Click “Entities ▾”, search your custom logger class (e.g. `Class:MyLogger`), check “Hide”.
   - Expected: methods/frames for that class disappear from the flow.
4. Toggle “Hide System” and “Collapse repeats” to confirm behavior remains consistent.
5. Use “Show all / Hide all” and per-kind Show/Hide to validate batch operations.
6. Close/reopen the diagram panel to confirm state restoration within the session works.

Risk/Rollback
- Change is scoped to the diagram webview; it does not affect log fetching or parsing.
- Rollback by reverting this commit/PR.

Changelog
- Add: Diagram entity filter to hide specific actors and reduce noise.
