### PR TITLE
Add loading indicator when opening logs

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -228,6 +228,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   }
   // Tail webview actions
   private async openLog(logId: string): Promise<void> {
+    this.post({ type: 'loading', value: true });
     try {
       const filePath = await this.tailService.ensureLogSaved(logId);
       const uri = vscode.Uri.file(filePath);
@@ -238,6 +239,8 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       const msg = e instanceof Error ? e.message : String(e);
       logWarn('Tail: openLog failed ->', msg);
       this.post({ type: 'error', message: msg });
+    } finally {
+      this.post({ type: 'loading', value: false });
     }
   }
 

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -224,6 +224,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async openLog(logId: string) {
+    this.post({ type: 'loading', value: true });
     try {
       // Open directly if already present (works even without CLI)
       const existing = await this.findExistingLogFile(logId);
@@ -245,6 +246,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         localize('openError', 'Failed to open log: ') + (e instanceof Error ? e.message : String(e))
       );
       logWarn('Logs: openLog failed ->', e instanceof Error ? e.message : String(e));
+    } finally {
+      this.post({ type: 'loading', value: false });
     }
   }
 

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -98,7 +98,7 @@ export function LogRow({
                 onOpen(r.Id);
               }}
             >
-              <OpenIcon />
+              {loading ? <SpinnerIcon /> : <OpenIcon />}
             </IconButton>
             <IconButton
               title={t.replay}

--- a/src/webview/components/tail/TailToolbar.tsx
+++ b/src/webview/components/tail/TailToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { OrgItem } from '../../../shared/types';
 import { commonButtonStyle } from '../styles';
+import { SpinnerIcon } from '../icons/ReplayIcon';
 
 type TailToolbarProps = {
   running: boolean;
@@ -87,7 +88,14 @@ export function TailToolbar({
         disabled={disabled || !actionsEnabled}
         title={t.tail?.openSelectedLogTitle ?? 'Open selected log'}
       >
-        {t.tail?.openLog ?? 'Open Log'}
+        {disabled && actionsEnabled ? (
+          <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
+            <SpinnerIcon />
+            {t.tail?.openLog ?? 'Open Log'}
+          </span>
+        ) : (
+          t.tail?.openLog ?? 'Open Log'
+        )}
       </button>
       <button
         onClick={onReplaySelected}


### PR DESCRIPTION
This PR adds a loading indicator when opening logs from both views.\n\nChanges\n- Webview (Apex Logs): show spinner in the row "Open" button and disable actions while loading.\n- Webview (Tail): show spinner next to "Open Log" while loading.\n- Providers: post `{ type: 'loading', value: true/false }` around `openLog` to drive the UI.\n\nVerification\n- From Apex Logs view: click Open on any row; spinner shows and editor opens.\n- From Tail view: select a log header line and click "Open Log"; spinner shows and editor opens.\n\nNotes\n- Keeps behavior consistent with existing refresh/loadMore loading UX.\n- No user settings added; minimal risk.