### PR TITLE
Profiling via timeline + per-category durations and log validator

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,6 +45,19 @@
 - PRs: clear description, linked issues, UI screenshots/GIFs, verification steps, and risk/rollback notes.
 - Gates: `npm run build` and `npm test` must pass. Update `CHANGELOG.md` manually for user‑facing changes (follow SemVer; keep entries concise).
 
+## Branching & Workflow (Agents)
+
+- Never commit directly to `main`.
+- Always start work on a new branch named by scope:
+  - Feature: `feat/<short-topic>` (e.g., `feat/timeline-profiling-validator`)
+  - Fix: `fix/<short-topic>` (e.g., `fix/diagram-empty-on-missing-prefix`)
+  - Chore/Docs/Build: `chore/<topic>`, `docs/<topic>`, `build/<topic>`
+- After implementing and validating locally:
+  1. `git push -u origin <branch>`
+  2. Open a Pull Request targeting `main`.
+  3. Ensure CI passes (`npm run build`, tests) before merge.
+- If a commit is accidentally pushed to `main`, immediately revert on `main`, push the revert, and reapply the changes on a feature branch via cherry-pick or revert-of-revert, then open a PR.
+
 ## Security & Configuration Tips
 
 - Requires Salesforce CLI (`sf` or `sfdx`) with an authenticated org (e.g., `sf org login web`).

--- a/src/webview/components/diagram/DiagramSvg.tsx
+++ b/src/webview/components/diagram/DiagramSvg.tsx
@@ -168,23 +168,19 @@ export function DiagramSvg({
     const lines: string[] = [];
     lines.push(fr.label);
     const p = fr.profile || {};
+    // Timeline duration (from log nanos)
+    if (p.timeMs) lines.push(`Time: ${p.timeMs} ms`);
     const counters: string[] = [];
-    if (p.soql) counters.push(`SOQL: ${p.soql}`);
-    if (p.dml) counters.push(`DML: ${p.dml}`);
-    if (p.callout) counters.push(`Callouts: ${p.callout}`);
+    if (p.soql) counters.push(`SOQL: ${p.soql}${p.soqlTimeMs ? ` (${p.soqlTimeMs} ms)` : ''}`);
+    if (p.dml) counters.push(`DML: ${p.dml}${p.dmlTimeMs ? ` (${p.dmlTimeMs} ms)` : ''}`);
+    if (p.callout) counters.push(`Callouts: ${p.callout}${p.calloutTimeMs ? ` (${p.calloutTimeMs} ms)` : ''}`);
     if (counters.length) lines.push(counters.join(', '));
-    const perf: string[] = [];
-    if (p.cpuMs) perf.push(`CPU: ${p.cpuMs} ms`);
-    if (p.heapBytes) perf.push(`Heap: ${humanBytes(p.heapBytes)}`);
-    if (perf.length) lines.push(perf.join(', '));
     return lines.join('\n');
   }
   function chipText(fr: NestedFrame): string | undefined {
     const p = fr.profile || {};
-    const cpu = p.cpuMs && p.cpuMs > 0 ? `CPU ${p.cpuMs}ms` : '';
-    const heap = p.heapBytes && p.heapBytes > 0 ? `Heap ${humanBytes(p.heapBytes)}` : '';
-    const both = [cpu, heap].filter(Boolean).join(' • ');
-    return both || undefined;
+    const time = p.timeMs && p.timeMs > 0 ? `Time ${p.timeMs}ms` : '';
+    return time || undefined;
   }
   function chipWidth(text: string, fontSize = 11): number {
     const avg = fontSize * 0.62;

--- a/src/webview/diagram.tsx
+++ b/src/webview/diagram.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import type { LogGraph, NestedFrame } from '../shared/apexLogParser';
+import type { LogGraph, NestedFrame, LogIssue } from '../shared/apexLogParser';
 import type { DiagramExtensionToWebviewMessage, DiagramWebviewToExtensionMessage } from '../shared/diagramMessages';
 import { DiagramToolbar } from './components/diagram/DiagramToolbar';
 import { DiagramSvg } from './components/diagram/DiagramSvg';
@@ -196,16 +196,18 @@ function App() {
           />
           {frames.length === 0 && <div style={{ padding: 8, opacity: 0.8 }}>No flow detected.</div>}
         </div>
-        {showProfilingSidebar && <ProfilingSidebar frames={frames} />}
+        {showProfilingSidebar && <ProfilingSidebar frames={frames} issues={graph?.issues || []} />}
       </div>
     </div>
   );
 }
 
 function ProfilingSidebar({
-  frames
+  frames,
+  issues
 }: {
   frames: (NestedFrame & { count?: number })[];
+  issues: LogIssue[];
 }) {
   function kindFromActor(actor: string): 'Trigger' | 'Flow' | 'Class' | 'Other' {
     if (actor.startsWith('Trigger:')) return 'Trigger';
@@ -223,27 +225,40 @@ function ProfilingSidebar({
   const agg = useMemo(() => {
     const map = new Map<
       string,
-      { kind: 'Trigger' | 'Flow' | 'Class' | 'Other'; name: string; soql: number; dml: number; callout: number; cpuMs: number; heapBytes: number }
+      {
+        kind: 'Trigger' | 'Flow' | 'Class' | 'Other';
+        name: string;
+        soql: number;
+        dml: number;
+        callout: number;
+        timeMs: number;
+        soqlTimeMs: number;
+        dmlTimeMs: number;
+        calloutTimeMs: number;
+      }
     >();
     for (const fr of frames) {
       // Aggregate only unit frames to avoid double counting (methods share the same actor id)
       if (fr.kind !== 'unit') continue;
-      const p = fr.profile;
-      if (!p) continue;
-      const has = (p.soql || 0) + (p.dml || 0) + (p.callout || 0) + (p.cpuMs || 0) + (p.heapBytes || 0);
-      if (!has) continue;
+      const p = fr.profile || {};
+      const has = (p.timeMs || 0) + (p.soql || 0) + (p.dml || 0) + (p.callout || 0);
+      if (!has) continue; // no timing or counters
       const kind = kindFromActor(fr.actor);
       const name = fr.actor.split(':').slice(1).join(':') || fr.actor;
-      const cur = map.get(fr.actor) || { kind, name, soql: 0, dml: 0, callout: 0, cpuMs: 0, heapBytes: 0 };
+      const cur =
+        map.get(fr.actor) ||
+        { kind, name, soql: 0, dml: 0, callout: 0, timeMs: 0, soqlTimeMs: 0, dmlTimeMs: 0, calloutTimeMs: 0 };
       cur.soql += p.soql || 0;
       cur.dml += p.dml || 0;
       cur.callout += p.callout || 0;
-      cur.cpuMs += p.cpuMs || 0;
-      cur.heapBytes += p.heapBytes || 0;
+      cur.timeMs += p.timeMs || 0;
+      cur.soqlTimeMs += p.soqlTimeMs || 0;
+      cur.dmlTimeMs += p.dmlTimeMs || 0;
+      cur.calloutTimeMs += p.calloutTimeMs || 0;
       map.set(fr.actor, cur);
     }
     const arr = Array.from(map.entries()).map(([actor, v]) => ({ actor, ...v }));
-    arr.sort((a, b) => (b.cpuMs - a.cpuMs) || (b.soql + b.dml + b.callout - (a.soql + a.dml + a.callout)) || a.name.localeCompare(b.name));
+    arr.sort((a, b) => (b.timeMs - a.timeMs) || (b.soql + b.dml + b.callout - (a.soql + a.dml + a.callout)) || a.name.localeCompare(b.name));
     return arr;
   }, [frames]);
 
@@ -255,15 +270,26 @@ function ProfilingSidebar({
         <div key={it.actor} className="item">
           <span className="title">{it.name}</span>
           <span className="meta">
-            {it.cpuMs ? `CPU ${it.cpuMs}ms` : ''}
-            {it.cpuMs && (it.heapBytes || it.soql || it.dml || it.callout) ? ' • ' : ''}
-            {it.heapBytes ? `Heap ${humanBytes(it.heapBytes)}` : ''}
-            {(it.heapBytes && (it.soql || it.dml || it.callout)) ? ' • ' : ''}
-            {it.soql ? `S${it.soql}` : ''}
+            {it.timeMs ? `Time ${it.timeMs}ms` : ''}
+            {it.timeMs && (it.soql || it.dml || it.callout) ? ' • ' : ''}
+            {it.soql ? `S${it.soql}${it.soqlTimeMs ? `(${it.soqlTimeMs}ms)` : ''}` : ''}
             {it.soql && (it.dml || it.callout) ? ' ' : ''}
-            {it.dml ? `D${it.dml}` : ''}
+            {it.dml ? `D${it.dml}${it.dmlTimeMs ? `(${it.dmlTimeMs}ms)` : ''}` : ''}
             {it.dml && it.callout ? ' ' : ''}
-            {it.callout ? `C${it.callout}` : ''}
+            {it.callout ? `C${it.callout}${it.calloutTimeMs ? `(${it.calloutTimeMs}ms)` : ''}` : ''}
+          </span>
+        </div>
+      ))}
+
+      <h3 style={{ marginTop: 12 }}>Log Issues</h3>
+      {issues.length === 0 && <div className="item" style={{ opacity: 0.7 }}>No issues detected.</div>}
+      {issues.map((it, idx) => (
+        <div key={`${it.code}-${idx}`} className="item">
+          <span className="title">{it.message}</span>
+          <span className="meta">
+            {it.severity.toUpperCase()} • {it.code}
+            {typeof it.line === 'number' ? ` • line ${it.line}` : ''}
+            {it.details ? ` — ${it.details}` : ''}
           </span>
         </div>
       ))}

--- a/src/webview/utils/diagramFilter.ts
+++ b/src/webview/utils/diagramFilter.ts
@@ -37,6 +37,10 @@ export function filterAndCollapse(
         if (f.profile.callout) prev.profile.callout = (prev.profile.callout || 0) + f.profile.callout;
         if (f.profile.cpuMs) prev.profile.cpuMs = (prev.profile.cpuMs || 0) + f.profile.cpuMs;
         if (f.profile.heapBytes) prev.profile.heapBytes = (prev.profile.heapBytes || 0) + f.profile.heapBytes;
+        if (f.profile.timeMs) prev.profile.timeMs = (prev.profile.timeMs || 0) + f.profile.timeMs;
+        if (f.profile.soqlTimeMs) prev.profile.soqlTimeMs = (prev.profile.soqlTimeMs || 0) + f.profile.soqlTimeMs;
+        if (f.profile.dmlTimeMs) prev.profile.dmlTimeMs = (prev.profile.dmlTimeMs || 0) + f.profile.dmlTimeMs;
+        if (f.profile.calloutTimeMs) prev.profile.calloutTimeMs = (prev.profile.calloutTimeMs || 0) + f.profile.calloutTimeMs;
       }
     } else {
       // Clone profile to avoid mutating the source graph when we merge repeats
@@ -47,4 +51,3 @@ export function filterAndCollapse(
 }
 
 export default filterAndCollapse;
-


### PR DESCRIPTION
Summary\n- Use log nanosecond timestamps to compute per-frame wall time (profile.timeMs).\n- Measure per-category durations from log lines: SOQL (BEGIN→END), DML (BEGIN→END), Callout (REQUEST→RESPONSE).\n- Show chips with Time Xms; sort sidebar by time; keep S/D/C counts.\n- Add log validator: detect missing/low log levels, missing timestamps, non-monotonic times, missing/unbalanced events, unclosed frames, open operations.\n\nDetails\n- Parser: track startNs/endNs on frames; compute timeMs; stacks for SOQL/DML/Callout timing; attach issues[].\n- Diagram: tooltip includes S/D/C with per-category timing; chips show Time; sidebar aggregates time + S/D/C timings.\n- Collapse: sums timeMs and per-category timing fields.\n- Docs: AGENTS.md updated with branching workflow (always use feature/fix branch and PR to main).\n\nVerification\n1) npm run build\n2) Open an Apex .log in VS Code and run the diagram command.\n3) Toggle Profiling chips and check Time labels.\n4) Check Profiling and Log Issues panels in the sidebar.\n\nTests\n- Unit: 54 passing locally.\n- Integration: 3 passing locally (extension presence, API version, findExistingLogFile).\n\nRisk / Rollback\n- UI shows Time instead of CPU/Heap in chips; tooltips still carry counters; CPU/Heap values still parsed but not displayed.\n- Rollback: revert this PR to restore prior profiling display.\n\nNotes\n- QUERY_MORE increments SOQL count but isn’t timed due to lack of an explicit END.\n- If BEGIN lacks END, duration for that operation is not counted.\n