### PR TITLE
ci(telemetry): use Actions variables for telemetry connection string

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,14 +136,14 @@ jobs:
           echo "PRE_RELEASE=$PRE_RELEASE" >> $GITHUB_ENV
           if [ "$PRE_RELEASE" = "true" ]; then echo "CHANNEL_SUFFIX=pre" >> $GITHUB_ENV; else echo "CHANNEL_SUFFIX=stable" >> $GITHUB_ENV; fi
 
-      - name: Ensure telemetry secret present
+      - name: Ensure telemetry variable present
         if: startsWith(github.ref, 'refs/tags/v') || github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.tag_name != '')
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           set -euo pipefail
           if [ -z "${APPLICATIONINSIGHTS_CONNECTION_STRING:-}" ]; then
-            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING secret. Refusing to package without telemetry." >&2
+            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING variable. Refusing to package without telemetry." >&2
             exit 1
           fi
 
@@ -164,7 +164,7 @@ jobs:
 
       - name: Create VSIX
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           if [ "${PRE_RELEASE}" = "true" ]; then
             echo "Packaging pre-release VSIX (${VERSION})"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -99,13 +99,13 @@ jobs:
       - name: Build for packaging
         run: npm run package
 
-      - name: Ensure telemetry secret present
+      - name: Ensure telemetry variable present
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           set -euo pipefail
           if [ -z "${APPLICATIONINSIGHTS_CONNECTION_STRING:-}" ]; then
-            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING secret. Refusing to package nightly without telemetry." >&2
+            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING variable. Refusing to package nightly without telemetry." >&2
             exit 1
           fi
 
@@ -141,7 +141,7 @@ jobs:
 
       - name: Package VSIX (pre-release)
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: npm run vsce:package:pre
 
       - name: Rename VSIX with timestamp

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,19 +101,19 @@ jobs:
           echo "PRE_RELEASE=$PRE_RELEASE" >> $GITHUB_ENV
           if [ "$PRE_RELEASE" = "true" ]; then echo "CHANNEL_SUFFIX=pre" >> $GITHUB_ENV; else echo "CHANNEL_SUFFIX=stable" >> $GITHUB_ENV; fi
 
-      - name: Ensure telemetry secret present
+      - name: Ensure telemetry variable present
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           set -euo pipefail
           if [ -z "${APPLICATIONINSIGHTS_CONNECTION_STRING:-}" ]; then
-            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING secret. Refusing to package without telemetry." >&2
+            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING variable. Refusing to package without telemetry." >&2
             exit 1
           fi
 
       - name: Create VSIX
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           if [ "${PRE_RELEASE}" = "true" ]; then
             echo "Packaging pre-release VSIX (${VERSION})"

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -33,8 +33,8 @@ For maintainers
 
 GitHub Actions integration
 
-- Add a repository secret named `APPLICATIONINSIGHTS_CONNECTION_STRING` contendo sua Application Insights connection string.
-- Export it as an environment variable in your workflow before packaging. The scripts will inject it into `package.json` for the duration of the packaging step and then remove it.
+- Adicione uma variável de repositório (Actions → Variables) chamada `APPLICATIONINSIGHTS_CONNECTION_STRING` contendo sua Application Insights connection string (não sensível segundo a documentação da Microsoft).
+- Exporte-a como variável de ambiente no workflow antes do empacotamento. Os scripts irão injetá-la em `package.json` durante o empacotamento e removê-la depois.
 
 Example job snippet:
 
@@ -50,19 +50,19 @@ jobs:
       - run: npm ci
       - name: Build (extension + webview)
         run: npm run package
-      - name: Ensure telemetry secret present
+      - name: Ensure telemetry variable present
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
         run: |
           if [ -z "${APPLICATIONINSIGHTS_CONNECTION_STRING:-}" ]; then
-            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING secret. Refusing to package without telemetry." >&2
+            echo "Missing APPLICATIONINSIGHTS_CONNECTION_STRING variable. Refusing to package without telemetry." >&2
             exit 1
           fi
 
       - name: Package VSIX
         run: npm run vsce:package
         env:
-          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}
       # Optionally upload the VSIX artifact here
 ```
 


### PR DESCRIPTION
Switch workflows to use GitHub Actions repository variables (`${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}`) for the Application Insights connection string, per Microsoft guidance that the connection string is not sensitive.

- Replace `${{ secrets.APPLICATIONINSIGHTS_CONNECTION_STRING }}` with `${{ vars.APPLICATIONINSIGHTS_CONNECTION_STRING }}` in release, prerelease and CI workflows.
- Early-fail steps now check the variable presence (not secret).
- Docs (docs/TELEMETRY.md) updated with the variable-based setup and workflow snippet.

No code changes in the extension; this PR only adjusts CI and docs.
