### PR TITLE
feat(telemetry): report CLI errors

### DIFF
--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -1,0 +1,48 @@
+import assert from 'assert/strict';
+const proxyquire: any = require('proxyquire');
+
+suite('cli telemetry', () => {
+  test('sends telemetry on ENOENT', async () => {
+    const calls: any[] = [];
+    const { getOrgAuth, __setExecFileImplForTests, __resetExecFileImplForTests } = proxyquire('../salesforce/cli', {
+      '../shared/telemetry': {
+        sendException: (name: string, properties: Record<string, string>) => {
+          calls.push({ name, properties });
+        }
+      }
+    });
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      const err: any = new Error('not found');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(calls.some(c => c.properties?.code === 'ENOENT'));
+  });
+
+  test('sends telemetry on ETIMEDOUT', async () => {
+    const calls: any[] = [];
+    const { getOrgAuth, __setExecFileImplForTests, __resetExecFileImplForTests } = proxyquire('../salesforce/cli', {
+      '../shared/telemetry': {
+        sendException: (name: string, properties: Record<string, string>) => {
+          calls.push({ name, properties });
+        }
+      }
+    });
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      const err: any = new Error('timeout');
+      err.code = 'ETIMEDOUT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(calls.some(c => c.properties?.code === 'ETIMEDOUT'));
+  });
+});


### PR DESCRIPTION
## Summary
- capture CLI error telemetry using `sendException`
- emit telemetry when `getOrgAuth` fails to resolve credentials
- test telemetry is sent on ENOENT and ETIMEDOUT failures

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcd1cb7af883238cf5baad7990711f