### PR TITLE
feat(cache): clear head cache on refresh and tail stop

### DIFF
--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -8,7 +8,8 @@ import {
   fetchApexLogBody,
   fetchApexLogHead,
   extractCodeUnitStartedFromLines,
-  clearListCache
+  clearListCache,
+  clearHeadCache
 } from '../salesforce/http';
 import type { ApexLogRow, OrgItem } from '../shared/types';
 import type { OrgAuth } from '../salesforce/types';
@@ -150,6 +151,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     this.post({ type: 'loading', value: true });
     try {
       clearListCache();
+      clearHeadCache();
       this.pageLimit = getNumberConfig('sfLogs.pageSize', this.pageLimit, 10, 200);
       const nextConc = getNumberConfig('sfLogs.headConcurrency', this.headConcurrency, 1, 20);
       if (nextConc !== this.headConcurrency) {

--- a/src/salesforce/http.ts
+++ b/src/salesforce/http.ts
@@ -154,6 +154,10 @@ export function clearListCache(): void {
   listCache.clear();
 }
 
+export function clearHeadCache(): void {
+  headCacheByLog.clear();
+}
+
 export async function fetchApexLogs(
   auth: OrgAuth,
   limit: number = 50,

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'fs';
-import { fetchApexLogs, fetchApexLogBody } from '../salesforce/http';
+import { fetchApexLogs, fetchApexLogBody, clearHeadCache } from '../salesforce/http';
 import { getOrgAuth } from '../salesforce/cli';
 import { ensureUserTraceFlag } from '../salesforce/traceflags';
 import type { OrgAuth } from '../salesforce/types';
@@ -301,6 +301,7 @@ export class TailService {
     }
     this.seenLogIds.clear();
     this.logIdToPath.clear();
+    clearHeadCache();
     this.post({ type: 'tailStatus', running: false });
     logInfo('Tail: stopped.');
   }


### PR DESCRIPTION
## Summary
- expose `clearHeadCache` to drop cached log heads
- clear cached log heads when tail service stops
- reset head cache on logs view refresh

## Testing
- `npm run lint -- src/salesforce/http.ts src/utils/tailService.ts src/provider/SfLogsViewProvider.ts`
- `npm test` *(fails: TestRunFailedError: Test run failed with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd36fc02c83239b0e5e240a442c4e