### PR TITLE
fix(tail): clean up resources on start error

### DIFF
--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -241,16 +241,17 @@ export class TailService {
         }
       }
     } catch (e) {
+      this.stop();
       const msg = e instanceof Error ? e.message : String(e);
       logError('Tail: start failed ->', msg);
       this.post({ type: 'error', message: msg });
       showOutput(true);
       this.post({ type: 'tailStatus', running: false });
-      this.tailRunning = false;
     }
   }
 
   stop(): void {
+    const wasRunning = this.tailRunning;
     this.tailRunning = false;
     try {
       if (this.streamingClient) {
@@ -301,8 +302,10 @@ export class TailService {
     }
     this.seenLogIds.clear();
     this.logIdToPath.clear();
-    this.post({ type: 'tailStatus', running: false });
-    logInfo('Tail: stopped.');
+    if (wasRunning) {
+      this.post({ type: 'tailStatus', running: false });
+      logInfo('Tail: stopped.');
+    }
   }
 
   clearLogPaths(): void {


### PR DESCRIPTION
## Summary
- ensure tail cleanup on start errors
- guard tail stop to avoid unnecessary recursion

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bcd29677f88323b0f11f487e352524