### PR TITLE
feat(traceflags): cache current user id

### DIFF
--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -52,7 +52,8 @@ export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefine
   if (!username) {
     return undefined;
   }
-  const cached = userIdCache.get(username);
+  const key = `${auth.instanceUrl || ''}::${username}`;
+  const cached = userIdCache.get(key);
   if (cached) {
     return cached;
   }
@@ -66,7 +67,7 @@ export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefine
   const userJson = JSON.parse(userBody);
   const userId: string | undefined = Array.isArray(userJson.records) ? userJson.records[0]?.Id : undefined;
   if (userId) {
-    userIdCache.set(username, userId);
+    userIdCache.set(key, userId);
   }
   return userId;
 }

--- a/src/test/getCurrentUserId.cache.test.ts
+++ b/src/test/getCurrentUserId.cache.test.ts
@@ -1,0 +1,52 @@
+import assert from 'assert/strict';
+import { EventEmitter } from 'events';
+import { getCurrentUserId, __resetUserIdCacheForTests } from '../salesforce/traceflags';
+import { __setHttpsRequestImplForTests, __resetHttpsRequestImplForTests } from '../salesforce/http';
+import type { OrgAuth } from '../salesforce/types';
+
+suite('getCurrentUserId caching', () => {
+  teardown(() => {
+    __resetHttpsRequestImplForTests();
+    __resetUserIdCacheForTests();
+  });
+
+  test('reuses cached user id', async () => {
+    const auth: OrgAuth = {
+      accessToken: 't',
+      instanceUrl: 'https://example.com',
+      username: 'a@example.com'
+    } as OrgAuth;
+    let called = 0;
+    __setHttpsRequestImplForTests((opts: any, cb: any) => {
+      called++;
+      const req = new EventEmitter() as any;
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.end = () => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.headers = {};
+        res.on = function (event: string, listener: any) {
+          EventEmitter.prototype.on.call(this, event, listener);
+          return this;
+        };
+        res.setEncoding = () => {};
+        res.req = req;
+        cb(res);
+        process.nextTick(() => {
+          res.emit('data', Buffer.from(JSON.stringify({ records: [{ Id: '005xx0000012345' }] })));
+          res.emit('end');
+        });
+      };
+      return req;
+    });
+
+    const first = await getCurrentUserId(auth);
+    const second = await getCurrentUserId(auth);
+    assert.equal(first, '005xx0000012345');
+    assert.equal(second, '005xx0000012345');
+    assert.equal(called, 1, 'expected single HTTP request');
+  });
+});


### PR DESCRIPTION
## Summary
- cache resolved user IDs by username to avoid repeated lookups
- use cached IDs in `getActiveUserDebugLevel`
- test that repeated lookups hit the cache

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda756c4c08323a7847938c053aeb6