### PR TITLE
fix: clamp logs page size to 200

### DIFF
--- a/package.nls.json
+++ b/package.nls.json
@@ -10,7 +10,7 @@
   "command.tail.title": "Tail Logs",
   "command.showDiagram.title": "Show Log Diagram",
   "configuration.title": "Electivus Apex Logs",
-  "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page. Higher values fetch more per request but may slow the UI or increase API load.",
+  "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page (effective maximum: 200). Higher values fetch more per request but may slow the UI or increase API load.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",
   "configuration.electivus.apexLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'.",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Lines kept in the Tail view's rolling buffer. Larger buffers use more memory and CPU.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -10,7 +10,7 @@
   "command.tail.title": "Tail de Logs",
   "command.showDiagram.title": "Mostrar Diagrama do Log",
   "configuration.title": "Electivus Apex Logs",
-  "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página. Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
+  "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página (máximo efetivo: 200). Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",
   "configuration.electivus.apexLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'.",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Quantidade de linhas mantidas no buffer do Tail. Buffers maiores consomem mais memória e CPU.",


### PR DESCRIPTION
## Summary
- clamp `sfLogs.pageSize` to 200 and warn when exceeded
- compute `hasMore` using clamped page size in refresh and loadMore

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda92a60c883239685c621f686bd92