### PR TITLE
fix(webview): guard tail auto-scroll with empty filters

### DIFF
--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -122,7 +122,8 @@ function App() {
   // Auto-scroll to the last visible (filtered) item when enabled
   useEffect(() => {
     if (!autoScroll) return;
-    const last = filteredIndexes.length > 0 ? filteredIndexes.length - 1 : 0;
+    if (filteredIndexes.length === 0) return;
+    const last = filteredIndexes.length - 1;
     listRef.current?.scrollToRow({ index: last, align: 'end', behavior: 'auto' });
   }, [lines, autoScroll, filteredIndexes.length]);
 


### PR DESCRIPTION
## Summary
- avoid calling `scrollToRow` when tail has no matching entries

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda984d9108323b7428498b04e7f1a