### PR TITLE
fix(tail): set running flag before async ops

### DIFF
--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -78,6 +78,7 @@ export class TailService {
       logWarn('Tail: start aborted; no debug level selected.');
       return;
     }
+    this.tailRunning = true;
     this.seenLogIds.clear();
     this.logIdToPath.clear();
     this.currentDebugLevel = debugLevel;
@@ -121,7 +122,6 @@ export class TailService {
         logWarn('Tail: prime recent logs failed; proceeding with empty seen set');
       }
 
-      this.tailRunning = true;
       this.post({ type: 'tailStatus', running: true });
       logInfo('Tail: started; subscribing to /systemTopic/Logging…');
 

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -84,6 +84,10 @@ export class TailService {
     this.currentDebugLevel = debugLevel;
     try {
       const auth = await getOrgAuth(this.selectedOrg);
+      if (!this.tailRunning || this.disposed) {
+        logWarn('Tail: start aborted while awaiting auth');
+        return;
+      }
       this.currentAuth = auth;
       logInfo('Tail: acquired auth for', auth.username || '(default)', 'at', auth.instanceUrl);
 
@@ -120,6 +124,11 @@ export class TailService {
         }
       } catch {
         logWarn('Tail: prime recent logs failed; proceeding with empty seen set');
+      }
+
+      if (!this.tailRunning || this.disposed) {
+        logWarn('Tail: start aborted after priming');
+        return;
       }
 
       this.post({ type: 'tailStatus', running: true });


### PR DESCRIPTION
## Summary
- set tailRunning flag before awaiting auth in tail service
- reset running flag if tail startup fails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda976952c8323b3e72b8d6aef7a32