### PR TITLE
fix(webview): handle zero-length regex in highlightContent

### DIFF
--- a/src/test/highlightContent.test.ts
+++ b/src/test/highlightContent.test.ts
@@ -1,0 +1,11 @@
+import assert from 'assert/strict';
+import { highlightContent } from '../webview/utils/tail';
+
+suite('highlightContent', () => {
+  test('handles zero-length regex', () => {
+    const rules = [{ regex: /(?:)/g, style: {} }];
+    const segs = highlightContent('abc', rules);
+    assert.equal(segs.length, 1);
+    assert.equal(segs[0]?.text, 'abc');
+  });
+});

--- a/src/webview/utils/tail.ts
+++ b/src/webview/utils/tail.ts
@@ -228,6 +228,12 @@ export function highlightContent(
         if (start > lastIndex) {
           next.push({ text: seg.text.slice(lastIndex, start) });
         }
+        // Avoid infinite loops on zero-length matches by advancing lastIndex
+        if (m[0].length === 0) {
+          regex.lastIndex++;
+          lastIndex = start;
+          continue;
+        }
         next.push({ text: m[0], style: rule.style });
         lastIndex = end;
       }

--- a/src/webview/utils/tail.ts
+++ b/src/webview/utils/tail.ts
@@ -224,15 +224,14 @@ export function highlightContent(
       let m: RegExpExecArray | null;
       while ((m = regex.exec(seg.text)) !== null) {
         const start = m.index;
-        const end = m.index + m[0].length;
-        if (start > lastIndex) {
-          next.push({ text: seg.text.slice(lastIndex, start) });
-        }
-        // Avoid infinite loops on zero-length matches by advancing lastIndex
+        const end = start + m[0].length;
+        // Skip zero-length matches up-front to avoid fragmentation
         if (m[0].length === 0) {
           regex.lastIndex++;
-          lastIndex = start;
           continue;
+        }
+        if (start > lastIndex) {
+          next.push({ text: seg.text.slice(lastIndex, start) });
         }
         next.push({ text: m[0], style: rule.style });
         lastIndex = end;


### PR DESCRIPTION
## Summary
- prevent infinite loops in `highlightContent` by advancing `regex.lastIndex` when a zero-length match is detected
- add unit test for zero-length regex

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to add global npm bin to PATH)*

------
https://chatgpt.com/codex/tasks/task_e_68bda8e29a908323a1c0e966470b6eb0