### PR TITLE
fix(tail): clear timers on start failure

### DIFF
--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -246,6 +246,14 @@ export class TailService {
       this.post({ type: 'error', message: msg });
       showOutput(true);
       this.post({ type: 'tailStatus', running: false });
+      if (this.tailTimer) {
+        clearTimeout(this.tailTimer);
+        this.tailTimer = undefined;
+      }
+      if (this.tailHardStopTimer) {
+        clearTimeout(this.tailHardStopTimer);
+        this.tailHardStopTimer = undefined;
+      }
       this.tailRunning = false;
     }
   }

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -26,7 +26,6 @@ import type { Connection } from '@salesforce/core';
  */
 export class TailService {
   private tailRunning = false;
-  private tailTimer: NodeJS.Timeout | undefined;
   private tailHardStopTimer: NodeJS.Timeout | undefined;
   private seenLogIds = new Set<string>();
   private currentAuth: OrgAuth | undefined;
@@ -58,9 +57,6 @@ export class TailService {
 
   promptPoll(): void {
     // No-op with Streaming API (kept for compatibility with older VS Code versions)
-    if (this.tailTimer) {
-      clearTimeout(this.tailTimer);
-    }
   }
 
   dispose(): void {
@@ -246,10 +242,6 @@ export class TailService {
       this.post({ type: 'error', message: msg });
       showOutput(true);
       this.post({ type: 'tailStatus', running: false });
-      if (this.tailTimer) {
-        clearTimeout(this.tailTimer);
-        this.tailTimer = undefined;
-      }
       if (this.tailHardStopTimer) {
         clearTimeout(this.tailHardStopTimer);
         this.tailHardStopTimer = undefined;
@@ -299,10 +291,6 @@ export class TailService {
     this.logService = undefined;
     this.currentAuth = undefined;
     this.lastReplayId = undefined;
-    if (this.tailTimer) {
-      clearTimeout(this.tailTimer);
-      this.tailTimer = undefined;
-    }
     if (this.tailHardStopTimer) {
       clearTimeout(this.tailHardStopTimer);
       this.tailHardStopTimer = undefined;


### PR DESCRIPTION
## Summary
- clear tail timers when `TailService.start` fails to prevent stray timeouts

## Testing
- `npm run lint`
- `npm run build`
- `npm test` *(fails: Installing @salesforce/cli globally via npm)*

------
https://chatgpt.com/codex/tasks/task_e_68bda97ffb188323962f0f767b01e360