### PR TITLE
fix(tail): reset row heights on filter change

### DIFF
--- a/src/test/TailList.test.tsx
+++ b/src/test/TailList.test.tsx
@@ -24,6 +24,8 @@ suite('TailList', () => {
     const captured: any = {};
     const List = (props: any) => {
       captured.overscanCount = props.overscanCount;
+      captured.rowHeight = props.rowHeight;
+      captured.rowComponent = props.rowComponent;
       return (
         <div
           ref={el => {
@@ -42,7 +44,8 @@ suite('TailList', () => {
     });
 
     const listRef = React.createRef<any>();
-    render(
+    let current = { lines, filteredIndexes, onAtBottomChange };
+    const rendered = render(
       <TailList
         lines={lines}
         filteredIndexes={filteredIndexes}
@@ -55,6 +58,22 @@ suite('TailList', () => {
         onAtBottomChange={onAtBottomChange}
       />
     );
+    captured.rerender = (next: { lines?: string[]; filteredIndexes?: number[] }) => {
+      current = { ...current, ...next };
+      rendered.rerender(
+        <TailList
+          lines={current.lines}
+          filteredIndexes={current.filteredIndexes}
+          selectedIndex={undefined}
+          onSelectIndex={() => {}}
+          colorize={false}
+          running={true}
+          listRef={listRef}
+          t={t}
+          onAtBottomChange={current.onAtBottomChange}
+        />
+      );
+    };
     return captured as { el: HTMLDivElement; overscanCount: number } & Record<string, any>;
   }
 
@@ -107,15 +126,15 @@ suite('TailList', () => {
     // wait for rAF-computed callback
     return new Promise<void>(resolve => setTimeout(resolve, 0)).then(() => {
       assert.equal(calls.length > 0, true, 'initial atBottom computed');
-    assert.equal(calls[calls.length - 1], true, 'initial state is atBottom');
+      assert.equal(calls[calls.length - 1], true, 'initial state is atBottom');
 
-    // Scroll up enough to exit bottom zone
+      // Scroll up enough to exit bottom zone
       el.scrollTop = 500;
       fireEvent.scroll(el);
       return new Promise<void>(r => setTimeout(r, 0)).then(() => {
         assert.equal(calls[calls.length - 1], false, 'leaving bottom triggers false');
 
-    // Return to bottom zone
+        // Return to bottom zone
         el.scrollTop = 1000 - 300 - 1;
         fireEvent.scroll(el);
         return new Promise<void>(r => setTimeout(r, 0)).then(() => {
@@ -123,5 +142,21 @@ suite('TailList', () => {
         });
       });
     });
+  });
+
+  test('recomputes row heights after filter changes', () => {
+    const lines = ['short', 'long line'];
+    const captured = mountWithStubbedList({ lines, filteredIndexes: [0, 1] });
+
+    const row1 = captured.rowComponent({ index: 1, style: {} });
+    row1.props.onMeasured(50);
+    assert.equal(captured.rowHeight(1), 50, 'initial measurement stored');
+
+    captured.rerender({ filteredIndexes: [1] });
+    assert.equal(captured.rowHeight(0), 18, 'row heights reset after filter change');
+
+    const row0 = captured.rowComponent({ index: 0, style: {} });
+    row0.props.onMeasured(70);
+    assert.equal(captured.rowHeight(0), 70, 'new measurement applied after reset');
   });
 });

--- a/src/webview/components/tail/TailList.tsx
+++ b/src/webview/components/tail/TailList.tsx
@@ -58,6 +58,10 @@ export function TailList({
     }
   };
 
+  React.useEffect(() => {
+    rowHeightsRef.current = {};
+  }, [filteredIndexes, lines]);
+
   // Auto-size list to fit viewport similarly to LogsTable
   useLayoutEffect(() => {
     const recompute = () => {


### PR DESCRIPTION
## Summary
- reset cached row heights when tail lines or filters change
- test TailList row height recalculation on filter updates

## Testing
- `npm test` *(fails: hangs after dependency setup)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda8dd22408323b1f66e073acff56b