### PR TITLE
fix(cli): handle sync errors in execCommand

### DIFF
--- a/src/test/salesforce.exec.test.ts
+++ b/src/test/salesforce.exec.test.ts
@@ -53,4 +53,17 @@ suite('salesforce exec safety', () => {
       return true;
     });
   });
+
+  test('cleans up cache when exec throws synchronously', async () => {
+    let callCount = 0;
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, _cb: any) => {
+      callCount++;
+      throw new Error('sync fail');
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined), /sync fail/);
+    const first = callCount;
+    await assert.rejects(getOrgAuth(undefined), /sync fail/);
+    assert.equal(callCount, first * 2);
+  });
 });


### PR DESCRIPTION
## Summary
- handle synchronous throws in CLI execCommand
- ensure cache entry removed on sync errors and add regression test

## Testing
- `npm test` *(fails: TestRunFailedError: Test run failed with code 1)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda84f470083239dfafe66ef419a95