### PR TITLE
feat(logs): add cancellation support to progress operations

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -246,32 +246,43 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
 
   private async replayLog(logId: string): Promise<void> {
     try {
-      const ok = await ensureReplayDebuggerAvailable();
-      if (!ok) {
-        return;
-      }
-      const filePath = await this.tailService.ensureLogSaved(logId);
-      const uri = vscode.Uri.file(filePath);
-      // Keep loading visible and show a notification while launching Replay
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: localize('replayStarting', 'Starting Apex Replay Debugger…')
+          title: localize('replayStarting', 'Starting Apex Replay Debugger…'),
+          cancellable: true
         },
-        async () => {
+        async (_progress, ct) => {
+          const controller = new AbortController();
+          ct.onCancellationRequested(() => controller.abort());
+          const ok = await ensureReplayDebuggerAvailable();
+          if (!ok || ct.isCancellationRequested) {
+            return;
+          }
+          const filePath = await this.tailService.ensureLogSaved(logId, controller.signal);
+          if (ct.isCancellationRequested) {
+            return;
+          }
+          const uri = vscode.Uri.file(filePath);
           try {
             await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', uri);
           } catch (e) {
-            logWarn('Tail: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
-            await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
+            if (!controller.signal.aborted) {
+              logWarn('Tail: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
+              await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
+            }
           }
         }
       );
       logInfo('Tail: replay requested for', logId);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      logWarn('Tail: replay failed ->', msg);
-      this.post({ type: 'error', message: msg });
+      if (e instanceof Error && e.message === 'aborted') {
+        // cancellation; no error message
+      } else {
+        const msg = e instanceof Error ? e.message : String(e);
+        logWarn('Tail: replay failed ->', msg);
+        this.post({ type: 'error', message: msg });
+      }
     }
   }
 }

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -150,9 +150,12 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: localize('refreshingLogs', 'Refreshing logs…')
+        title: localize('refreshingLogs', 'Refreshing logs…'),
+        cancellable: true
       },
-      async () => {
+      async (_progress, ct) => {
+        const controller = new AbortController();
+        ct.onCancellationRequested(() => controller.abort());
         this.post({ type: 'loading', value: true });
         try {
           clearListCache();
@@ -166,9 +169,22 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
             this.headConcurrency = nextConc;
             this.headLimiter = createLimiter(this.headConcurrency);
           }
-          const auth = await getOrgAuth(this.selectedOrg);
+          const auth = await getOrgAuth(this.selectedOrg, undefined, controller.signal);
+          if (ct.isCancellationRequested) {
+            return;
+          }
           this.currentOffset = 0;
-          const logs: ApexLogRow[] = await fetchApexLogs(auth, this.pageLimit, this.currentOffset);
+          const logs: ApexLogRow[] = await fetchApexLogs(
+            auth,
+            this.pageLimit,
+            this.currentOffset,
+            undefined,
+            undefined,
+            controller.signal
+          );
+          if (ct.isCancellationRequested) {
+            return;
+          }
           logInfo('Logs: fetched', logs.length, 'rows (pageSize =', this.pageLimit, ')');
           this.currentOffset += logs.length;
           if (token !== this.refreshToken || this.disposed) {
@@ -178,11 +194,13 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
           const hasMore = logs.length === this.pageLimit;
           this.post({ type: 'logs', data: logs, hasMore });
           // Limited parallel fetch of log heads
-          this.loadLogHeads(logs, auth, token);
+          this.loadLogHeads(logs, auth, token, controller.signal);
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
-          logWarn('Logs: refresh failed ->', msg);
-          this.post({ type: 'error', message: msg });
+          if (!controller.signal.aborted) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logWarn('Logs: refresh failed ->', msg);
+            this.post({ type: 'error', message: msg });
+          }
         } finally {
           this.post({ type: 'loading', value: false });
         }
@@ -216,16 +234,24 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private loadLogHeads(logs: ApexLogRow[], auth: OrgAuth, token: number): void {
+  private loadLogHeads(logs: ApexLogRow[], auth: OrgAuth, token: number, signal?: AbortSignal): void {
     for (const log of logs) {
       void this.headLimiter(async () => {
+        if (signal?.aborted) {
+          return;
+        }
         try {
           const headLines = await fetchApexLogHead(
             auth,
             log.Id,
             10,
-            typeof log.LogLength === 'number' ? log.LogLength : undefined
+            typeof log.LogLength === 'number' ? log.LogLength : undefined,
+            undefined,
+            signal
           );
+          if (signal?.aborted) {
+            return;
+          }
           const codeUnit = extractCodeUnitStartedFromLines(headLines);
           if (codeUnit && token === this.refreshToken && !this.disposed) {
             this.post({ type: 'logHead', logId: log.Id, codeUnitStarted: codeUnit });
@@ -266,44 +292,60 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
   }
 
   private async debugLog(logId: string) {
+    this.post({ type: 'loading', value: true });
     try {
-      // Ensure Replay Debugger is available before doing work
-      const ok = await ensureReplayDebuggerAvailable();
-      if (!ok) {
-        return;
-      }
-      this.post({ type: 'loading', value: true });
-      // Use existing file if present; otherwise fetch and save with username prefix
-      let targetPath = await this.findExistingLogFile(logId);
-      if (!targetPath) {
-        const auth = await getOrgAuth(this.selectedOrg);
-        const { filePath } = await this.getLogFilePathWithUsername(auth.username, logId);
-        const body = await fetchApexLogBody(auth, logId);
-        await fs.writeFile(filePath, body, 'utf8');
-        targetPath = filePath;
-      }
-      const uri = vscode.Uri.file(targetPath);
-      // Keep loading visible for the user-triggered launch and show a notification
       await vscode.window.withProgress(
         {
           location: vscode.ProgressLocation.Notification,
-          title: localize('replayStarting', 'Starting Apex Replay Debugger…')
+          title: localize('replayStarting', 'Starting Apex Replay Debugger…'),
+          cancellable: true
         },
-        async () => {
+        async (_progress, ct) => {
+          const controller = new AbortController();
+          ct.onCancellationRequested(() => controller.abort());
+          const ok = await ensureReplayDebuggerAvailable();
+          if (!ok || ct.isCancellationRequested) {
+            return;
+          }
+          // Use existing file if present; otherwise fetch and save with username prefix
+          let targetPath = await this.findExistingLogFile(logId);
+          if (!targetPath) {
+            const auth = await getOrgAuth(this.selectedOrg, undefined, controller.signal);
+            if (ct.isCancellationRequested) {
+              return;
+            }
+            const { filePath } = await this.getLogFilePathWithUsername(auth.username, logId);
+            const body = await fetchApexLogBody(auth, logId, undefined, controller.signal);
+            if (ct.isCancellationRequested) {
+              return;
+            }
+            await fs.writeFile(filePath, body, 'utf8');
+            targetPath = filePath;
+          }
+          if (ct.isCancellationRequested) {
+            return;
+          }
+          const uri = vscode.Uri.file(targetPath);
           try {
             await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', uri);
           } catch (e) {
-            logWarn('Logs: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
-            await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
+            if (!controller.signal.aborted) {
+              logWarn('Logs: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
+              await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
+            }
           }
         }
       );
     } catch (e) {
-      vscode.window.showErrorMessage(
-        localize('replayError', 'Failed to launch Apex Replay Debugger: ') +
-          (e instanceof Error ? e.message : String(e))
-      );
-      logWarn('Logs: replay failed ->', e instanceof Error ? e.message : String(e));
+      if (e instanceof Error && e.message === 'aborted') {
+        // silent cancellation
+      } else {
+        vscode.window.showErrorMessage(
+          localize('replayError', 'Failed to launch Apex Replay Debugger: ') +
+            (e instanceof Error ? e.message : String(e))
+        );
+        logWarn('Logs: replay failed ->', e instanceof Error ? e.message : String(e));
+      }
     } finally {
       this.post({ type: 'loading', value: false });
     }
@@ -322,18 +364,26 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: localize('listingOrgs', 'Listing Salesforce orgs…')
+        title: localize('listingOrgs', 'Listing Salesforce orgs…'),
+        cancellable: true
       },
-      async () => {
+      async (_progress, ct) => {
+        const controller = new AbortController();
+        ct.onCancellationRequested(() => controller.abort());
         try {
-          const orgs = await listOrgs(forceRefresh);
+          const orgs = await listOrgs(forceRefresh, controller.signal);
+          if (ct.isCancellationRequested) {
+            return;
+          }
           const selected = pickSelectedOrg(orgs, this.selectedOrg);
           this.post({ type: 'orgs', data: orgs, selected });
         } catch (e) {
-          const msg = e instanceof Error ? e.message : String(e);
-          logError('Logs: list orgs failed ->', msg);
-          void vscode.window.showErrorMessage(localize('sendOrgsFailed', 'Failed to list Salesforce orgs: {0}', msg));
-          this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
+          if (!controller.signal.aborted) {
+            const msg = e instanceof Error ? e.message : String(e);
+            logError('Logs: list orgs failed ->', msg);
+            void vscode.window.showErrorMessage(localize('sendOrgsFailed', 'Failed to list Salesforce orgs: {0}', msg));
+            this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
+          }
         }
       }
     );

--- a/src/test/getOrgAuth.cancel.dedup.test.ts
+++ b/src/test/getOrgAuth.cancel.dedup.test.ts
@@ -1,0 +1,60 @@
+import assert from 'assert/strict';
+import { getOrgAuth, __setExecFileImplForTests, __resetExecFileImplForTests } from '../salesforce/cli';
+
+suite('getOrgAuth cancellation + dedupe', () => {
+  teardown(() => {
+    __resetExecFileImplForTests();
+  });
+
+  test('cancelling one caller does not abort shared exec', async () => {
+    let spawnCount = 0;
+    let capturedCb: ((err: any, stdout: string, stderr: string) => void) | undefined;
+    let readyResolve: (() => void) | undefined;
+    const ready = new Promise<void>(res => (readyResolve = res));
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      spawnCount++;
+      capturedCb = cb as any;
+      // Let the test know the fake exec has been spawned
+      readyResolve?.();
+      // Do not invoke the callback yet; the test will resolve it later
+      return undefined as any;
+    }) as any);
+
+    const c1 = new AbortController();
+    const c2 = new AbortController();
+
+    // Two concurrent calls for same target (default org) should dedupe
+    const p1 = getOrgAuth(undefined, undefined, c1.signal);
+    const p2 = getOrgAuth(undefined, undefined, c2.signal);
+
+    // Wait until the underlying fake exec was spawned
+    await ready;
+
+    // Cancel only the first caller
+    c1.abort();
+
+    // Complete the fake CLI call with valid org display JSON
+    const stdout = JSON.stringify({
+      result: {
+        accessToken: 'token',
+        instanceUrl: 'https://example.my.salesforce.com',
+        username: 'user@example.com'
+      }
+    });
+    capturedCb?.(null, stdout, '');
+
+    // First caller should reject due to cancellation
+    await assert.rejects(p1, (e: any) => /aborted/i.test(String(e?.message || e)));
+
+    // Second caller resolves successfully
+    const auth = await p2;
+    assert.equal(auth.instanceUrl, 'https://example.my.salesforce.com');
+    assert.equal(auth.accessToken, 'token');
+    assert.equal(auth.username, 'user@example.com');
+
+    // Only one spawn should have occurred (deduped)
+    assert.equal(spawnCount, 1);
+  });
+});
+

--- a/src/test/listOrgs.cancel.dedup.test.ts
+++ b/src/test/listOrgs.cancel.dedup.test.ts
@@ -1,0 +1,72 @@
+import assert from 'assert/strict';
+import {
+  listOrgs,
+  __setExecFileImplForTests,
+  __resetExecFileImplForTests,
+  __resetListOrgsCacheForTests
+} from '../salesforce/cli';
+
+suite('listOrgs cancellation + dedupe', () => {
+  teardown(() => {
+    __resetExecFileImplForTests();
+    __resetListOrgsCacheForTests();
+  });
+
+  test('cancelling one caller does not abort shared exec', async () => {
+    __resetListOrgsCacheForTests();
+
+    let spawnCount = 0;
+    let capturedCb: ((err: any, stdout: string, stderr: string) => void) | undefined;
+    let readyResolve: (() => void) | undefined;
+    const ready = new Promise<void>(res => (readyResolve = res));
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      spawnCount++;
+      capturedCb = cb as any;
+      // Signal that the fake process has been spawned and we captured the callback
+      readyResolve?.();
+      // Do not invoke the callback yet; the test will trigger it
+      return undefined as any;
+    }) as any);
+
+    const c1 = new AbortController();
+    const c2 = new AbortController();
+
+    // Fire two concurrent requests that should dedupe to a single spawn
+    const p1 = listOrgs(false, c1.signal);
+    const p2 = listOrgs(false, c2.signal);
+
+    // Wait until the underlying fake exec has been created
+    await ready;
+
+    // Cancel only the first caller
+    c1.abort();
+
+    // Now complete the fake exec with a valid JSON payload
+    const stdout = JSON.stringify({
+      result: {
+        orgs: [
+          {
+            username: 'user@example.com',
+            alias: 'alias1',
+            isDefaultUsername: true
+          }
+        ]
+      }
+    });
+    capturedCb?.(null, stdout, '');
+
+    // First caller should reject with an aborted error
+    await assert.rejects(p1, (e: any) => /aborted/i.test(String(e?.message || e)));
+
+    // Second caller should resolve successfully with parsed results
+    const res2 = await p2;
+    assert.ok(Array.isArray(res2));
+    assert.equal(res2.length, 1);
+    assert.equal(res2[0]?.username, 'user@example.com');
+
+    // Only one spawn should have occurred due to in-flight dedupe
+    assert.equal(spawnCount, 1);
+  });
+});
+

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -393,14 +393,14 @@ export class TailService {
     }
   }
 
-  async ensureLogSaved(logId: string): Promise<string> {
+  async ensureLogSaved(logId: string, signal?: AbortSignal): Promise<string> {
     const existing = this.logIdToPath.get(logId);
     if (existing) {
       return existing;
     }
-    const auth = this.currentAuth ?? (await getOrgAuth(this.selectedOrg));
+    const auth = this.currentAuth ?? (await getOrgAuth(this.selectedOrg, undefined, signal));
     this.currentAuth = auth;
-    const body = await fetchApexLogBody(auth, logId);
+    const body = await fetchApexLogBody(auth, logId, undefined, signal);
     const { filePath } = await this.getLogFilePathWithUsername(auth.username, logId);
     await fs.writeFile(filePath, body, 'utf8');
     this.addLogPath(logId, filePath);


### PR DESCRIPTION
## Summary
- make log refresh and org listing cancellable
- cancel replay debugger launches and tail fetches
- add AbortSignal support to CLI and HTTP helpers

## Testing
- `npm run lint`
- `npm test` *(fails: Salesforce CLI auth missing)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bdc68fdce48323a7b92d593f71f675