### PR TITLE
feat(settings): add HTTP and CLI timeout options

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Why developers like it
 - `electivus.apexLogs.headConcurrency`: Max concurrent requests to fetch log headers (>= 1; default 5). Very high values can overload APIs.
 - `electivus.apexLogs.saveDirName`: Folder name used when saving logs to disk (default `apexlogs`).
 - `electivus.apexLogs.trace`: Enable verbose trace logging of CLI and HTTP calls.
+- `electivus.apexLogs.httpTimeoutMs`: Timeout in milliseconds for Salesforce HTTP requests (1000–600000; default 120000).
+- `electivus.apexLogs.cliTimeoutMs`: Timeout in milliseconds for Salesforce CLI commands (1000–600000; default 120000).
 
 See [docs/SETTINGS.md](docs/SETTINGS.md) for more details on configuration.
 
@@ -136,6 +138,7 @@ See docs/TESTING.md for how to run unit and integration tests (`npm run test:uni
 To help improve quality and performance, the extension may emit minimal, anonymized usage and error telemetry (for example: command invocation counts, non‑PII error categories like `ENOENT`/`ETIMEDOUT`, and coarse performance timings). We never include source code, Apex log content, access tokens, usernames, org IDs, or instance URLs in telemetry. Telemetry is disabled automatically in Development and Test modes (Extension Development Host and automated tests).
 
 Respecting your preferences:
+
 - VS Code’s `telemetry.telemetryLevel` setting controls whether telemetry is sent (values: `off`, `crash`, `error`, `all`). If set to `off`, the extension does not send telemetry.
 
 For details and implementer guidance, see `docs/TELEMETRY.md`.

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -7,7 +7,9 @@ The Electivus Apex Log Viewer extension exposes several settings under the `Elec
 "electivus.apexLogs.headConcurrency": 5,
 "electivus.apexLogs.saveDirName": "apexlogs",
 "electivus.apexLogs.trace": false,
-"electivus.apexLogs.tailBufferSize": 10000
+"electivus.apexLogs.tailBufferSize": 10000,
+"electivus.apexLogs.httpTimeoutMs": 120000,
+"electivus.apexLogs.cliTimeoutMs": 120000
 ```
 
 ## `electivus.apexLogs.pageSize`
@@ -40,6 +42,18 @@ The Electivus Apex Log Viewer extension exposes several settings under the `Elec
 - Default: `10000`
 - Number of lines retained in the Tail view's rolling buffer. Higher values keep more history visible to filters and search, at the cost of additional memory and CPU.
 - Changes take effect immediately in an open Tail view; no reload required.
+
+## `electivus.apexLogs.httpTimeoutMs`
+
+- Type: number (1000–600000)
+- Default: `120000`
+- Timeout in milliseconds for Salesforce HTTP requests. Values outside the range are clamped.
+
+## `electivus.apexLogs.cliTimeoutMs`
+
+- Type: number (1000–600000)
+- Default: `120000`
+- Timeout in milliseconds for Salesforce CLI commands. Values outside the range are clamped.
 
 ## Applying changes
 

--- a/package.json
+++ b/package.json
@@ -85,6 +85,18 @@
           "minimum": 1000,
           "markdownDescription": "%configuration.electivus.apexLogs.tailBufferSize.description%"
         },
+        "electivus.apexLogs.httpTimeoutMs": {
+          "type": "number",
+          "default": 120000,
+          "minimum": 1000,
+          "markdownDescription": "%configuration.electivus.apexLogs.httpTimeoutMs.description%"
+        },
+        "electivus.apexLogs.cliTimeoutMs": {
+          "type": "number",
+          "default": 120000,
+          "minimum": 1000,
+          "markdownDescription": "%configuration.electivus.apexLogs.cliTimeoutMs.description%"
+        },
         "electivus.apexLogs.cliCache.enabled": {
           "type": "boolean",
           "default": true,

--- a/package.nls.json
+++ b/package.nls.json
@@ -14,6 +14,8 @@
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",
   "configuration.electivus.apexLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'.",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Lines kept in the Tail view's rolling buffer. Larger buffers use more memory and CPU.",
+  "configuration.electivus.apexLogs.httpTimeoutMs.description": "Timeout in milliseconds for Salesforce HTTP requests. Values outside 1000–600000 are clamped.",
+  "configuration.electivus.apexLogs.cliTimeoutMs.description": "Timeout in milliseconds for Salesforce CLI commands. Values outside 1000–600000 are clamped.",
   "configuration.electivus.apexLogs.cliCache.enabled.description": "Enable persistent caching for Salesforce CLI calls (org list, etc.).",
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL in seconds for cached results of 'sf org list'. Set 0 to disable. Large TTLs keep results longer but may be stale.",
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "Short-lived in-memory TTL (seconds) for cached auth tokens acquired via CLI. Tokens are NOT persisted. Larger values reduce CLI calls but increase the reuse window.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -14,6 +14,8 @@
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",
   "configuration.electivus.apexLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'.",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Quantidade de linhas mantidas no buffer do Tail. Buffers maiores consomem mais memória e CPU.",
+  "configuration.electivus.apexLogs.httpTimeoutMs.description": "Tempo limite em milissegundos para requisições HTTP ao Salesforce. Valores fora de 1000–600000 são ajustados.",
+  "configuration.electivus.apexLogs.cliTimeoutMs.description": "Tempo limite em milissegundos para comandos do Salesforce CLI. Valores fora de 1000–600000 são ajustados.",
   "configuration.electivus.apexLogs.cliCache.enabled.description": "Ativa cache persistente para chamadas do Salesforce CLI (lista de orgs, etc.).",
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL em segundos para o cache do resultado de 'sf org list'. Defina 0 para desativar. TTLs grandes mantêm resultados por mais tempo, porém podem ficar desatualizados.",
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "TTL curto em memória (segundos) para cachear credenciais obtidas via CLI. Tokens NÃO são persistidos. Valores maiores reduzem chamadas ao CLI, mas aumentam a janela de reutilização.",

--- a/src/test/timeoutConfig.test.ts
+++ b/src/test/timeoutConfig.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert/strict';
+import { workspace } from 'vscode';
+import { getCliTimeoutMs } from '../salesforce/cli';
+import { getHttpTimeoutMs } from '../salesforce/http';
+
+suite('timeout settings', () => {
+  const original = workspace.getConfiguration;
+
+  teardown(() => {
+    (workspace.getConfiguration as any) = original;
+  });
+
+  test('CLI timeout clamped to range', () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => 5 });
+    assert.equal(getCliTimeoutMs(), 1000);
+    (workspace.getConfiguration as any) = () => ({ get: () => 9999999 });
+    assert.equal(getCliTimeoutMs(), 600000);
+  });
+
+  test('HTTP timeout clamped to range', () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => 5 });
+    assert.equal(getHttpTimeoutMs(), 1000);
+    (workspace.getConfiguration as any) = () => ({ get: () => 9999999 });
+    assert.equal(getHttpTimeoutMs(), 600000);
+  });
+});


### PR DESCRIPTION
## Summary
- add `electivus.apexLogs.httpTimeoutMs` and `electivus.apexLogs.cliTimeoutMs` settings
- apply configurable timeouts in Salesforce HTTP and CLI helpers
- document new timeout settings and add clamping tests

## Testing
- `npm run lint`
- `npm test` *(fails: Failed to check existing scratch org 'ALV_Test_Scratch': Command failed: sf org display -o ALV_Test_Scratch --json)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc77f11608323a8dbc453d505e2d0