### PR TITLE
feat(webview): add keyboard handlers to log row

### DIFF
--- a/src/test/LogRow.test.tsx
+++ b/src/test/LogRow.test.tsx
@@ -43,5 +43,16 @@ suite('LogRow', () => {
     fireEvent.click(getByRole('button', { name: 'Replay' }));
     assert.equal(opened, '1');
     assert.equal(replayed, '1');
+
+    opened = undefined;
+    replayed = undefined;
+    const rowEl = getByRole('row');
+    fireEvent.keyDown(rowEl, { key: 'Enter' });
+    assert.equal(opened, '1');
+    opened = undefined;
+    fireEvent.keyDown(rowEl, { key: ' ' });
+    assert.equal(opened, '1');
+    fireEvent.keyDown(rowEl, { key: 'Enter', shiftKey: true });
+    assert.equal(replayed, '1');
   });
 });

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -67,8 +67,26 @@ export function LogRow({
     wordBreak: 'break-word'
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      if (e.shiftKey) {
+        onReplay(r.Id);
+      } else {
+        onOpen(r.Id);
+      }
+    }
+  };
+
   return (
-    <div role="row" style={{ ...style }}>
+    <div
+      role="row"
+      tabIndex={0}
+      onKeyDown={handleKeyDown}
+      onFocus={e => (e.currentTarget.style.outline = '1px solid var(--vscode-focusBorder)')}
+      onBlur={e => (e.currentTarget.style.outline = 'none')}
+      style={{ ...style, outline: 'none' }}
+    >
       <div
         ref={contentRef}
         style={{

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -68,6 +68,9 @@ export function LogRow({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    // Only handle keys when the event originates on the row itself.
+    // This avoids hijacking keyboard interactions of inner buttons.
+    if (e.currentTarget !== e.target) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       if (e.shiftKey) {


### PR DESCRIPTION
## Summary
- allow LogRow to be focused via keyboard and handle Enter/Space/Shift+Enter
- show a focus outline for focused rows
- test keyboard interactions invoke open and replay callbacks

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bdc7690cec832396dd16fe15b6ff38