### PR TITLE
test(runner): skip SF CLI on unit and reuse VS Code cache

### DIFF
--- a/scripts/clean-vscode-test.js
+++ b/scripts/clean-vscode-test.js
@@ -12,7 +12,12 @@ function safeRm(p) {
 }
 
 const cwd = process.cwd();
-safeRm(join(cwd, '.vscode-test'));
+const cleanCache = /^1|true$/i.test(String(process.env.CLEAN_VSCODE_CACHE || ''));
+if (cleanCache) {
+  safeRm(join(cwd, '.vscode-test'));
+} else {
+  console.log('[test-clean] Skipping removal of .vscode-test cache. Set CLEAN_VSCODE_CACHE=true to purge.');
+}
 safeRm(join(tmpdir(), 'alv-user-data'));
 safeRm(join(tmpdir(), 'alv-extensions'));
-console.log('[test-clean] Cleaned .vscode-test and temp VS Code dirs.');
+console.log('[test-clean] Cleaned temp VS Code dirs.');


### PR DESCRIPTION
This PR updates the test runner to make unit tests faster and more hermetic.\n\nChanges\n- Skip Salesforce CLI/Dev Hub auth and scratch org creation when running with `--scope=unit`.\n- Prefer VS Code `stable` for unit runs to maximize cache reuse and avoid Insiders re-downloads.\n- Preserve `.vscode-test` cache by default; allow explicit purge via `CLEAN_VSCODE_CACHE=true`.\n\nRationale\n- Unit tests should not depend on Dev Hub or scratch orgs.\n- Using stable reduces download churn.\n- Keeping the cache speeds up repeated local and CI runs.\n\nValidation\n- Lint and type-check pass locally.\n- Build succeeds.\n\nNotes\n- No behavioral changes to integration tests. They continue to install dependencies and use Insiders by default.\n