### PR TITLE
feat(traceflags): cache debug levels

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,12 @@
           "minimum": 0,
           "markdownDescription": "%configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description%"
         },
+        "electivus.apexLogs.cliCache.debugLevelsTtlSeconds": {
+          "type": "number",
+          "default": 300,
+          "minimum": 0,
+          "markdownDescription": "%configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description%"
+        },
         "sfLogs.pageSize": {
           "type": "number",
           "default": 100,
@@ -167,6 +173,13 @@
           "minimum": 0,
           "markdownDescription": "%configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description%",
           "deprecationMessage": "Deprecated: use electivus.apexLogs.cliCache.authPersistentTtlSeconds"
+        },
+        "sfLogs.cliCache.debugLevelsTtlSeconds": {
+          "type": "number",
+          "default": 300,
+          "minimum": 0,
+          "markdownDescription": "%configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description%",
+          "deprecationMessage": "Deprecated: use electivus.apexLogs.cliCache.debugLevelsTtlSeconds"
         }
       }
     },

--- a/package.nls.json
+++ b/package.nls.json
@@ -18,5 +18,6 @@
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL in seconds for cached results of 'sf org list'. Set 0 to disable. Large TTLs keep results longer but may be stale.",
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "Short-lived in-memory TTL (seconds) for cached auth tokens acquired via CLI. Tokens are NOT persisted. Larger values reduce CLI calls but increase the reuse window.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "Persistent TTL in seconds for cached results of 'sf org display'. Stores the token in VS Code storage to avoid repeated CLI calls across reloads. Larger values reduce CLI calls but keep cached auth longer; set 0 to disable.",
+  "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL in seconds for cached DebugLevel queries. Set 0 to disable. Large TTLs reduce API calls but may serve stale data.",
   "tailSaveFailed": "Tail: failed to save log to workspace (best-effort)."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -18,5 +18,6 @@
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL em segundos para o cache do resultado de 'sf org list'. Defina 0 para desativar. TTLs grandes mantêm resultados por mais tempo, porém podem ficar desatualizados.",
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "TTL curto em memória (segundos) para cachear credenciais obtidas via CLI. Tokens NÃO são persistidos. Valores maiores reduzem chamadas ao CLI, mas aumentam a janela de reutilização.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "TTL persistente (segundos) para o cache de 'sf org display'. Armazena o token no VS Code para evitar chamadas repetidas entre recarregamentos. Valores maiores reduzem chamadas ao CLI, mas mantêm o auth em cache por mais tempo; defina 0 para desativar.",
+  "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL em segundos para o cache de consultas DebugLevel. Defina 0 para desativar. TTLs grandes reduzem chamadas à API, mas podem servir dados desatualizados.",
   "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço)."
 }

--- a/src/test/listDebugLevels.test.ts
+++ b/src/test/listDebugLevels.test.ts
@@ -1,12 +1,18 @@
 import assert from 'assert/strict';
 import { EventEmitter } from 'events';
+import { workspace } from 'vscode';
 import { listDebugLevels } from '../salesforce/traceflags';
 import { __setHttpsRequestImplForTests, __resetHttpsRequestImplForTests } from '../salesforce/http';
+import { CacheManager } from '../utils/cacheManager';
 import type { OrgAuth } from '../salesforce/types';
 
 suite('listDebugLevels', () => {
-  teardown(() => {
+  const originalGetConfiguration = workspace.getConfiguration;
+
+  teardown(async () => {
     __resetHttpsRequestImplForTests();
+    (workspace.getConfiguration as any) = originalGetConfiguration;
+    await CacheManager.delete();
   });
 
   test('parses developer names from response', async () => {
@@ -41,5 +47,58 @@ suite('listDebugLevels', () => {
 
     const levels = await listDebugLevels(auth);
     assert.deepEqual(levels, ['DL1', 'DL2']);
+  });
+
+  test('reuses cached debug levels', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    const auth: OrgAuth = { accessToken: 't', instanceUrl: 'https://example.com' } as OrgAuth;
+    let called = 0;
+    __setHttpsRequestImplForTests((opts: any, cb: any) => {
+      called++;
+      const req = new EventEmitter() as any;
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.end = () => {
+        const res = new EventEmitter() as any;
+        res.statusCode = 200;
+        res.headers = {};
+        res.on = function (event: string, listener: any) {
+          EventEmitter.prototype.on.call(this, event, listener);
+          return this;
+        };
+        res.setEncoding = () => {};
+        res.req = req;
+        cb(res);
+        process.nextTick(() => {
+          res.emit('data', Buffer.from(JSON.stringify({ records: [{ DeveloperName: 'DL1' }] })));
+          res.emit('end');
+        });
+      };
+      return req;
+    });
+
+    const memento = {
+      _s: new Map<string, unknown>(),
+      get(key: string) {
+        return this._s.get(key);
+      },
+      update(key: string, value: unknown) {
+        if (value === undefined) {
+          this._s.delete(key);
+        } else {
+          this._s.set(key, value);
+        }
+        return Promise.resolve();
+      }
+    } as any;
+    CacheManager.init(memento);
+
+    const first = await listDebugLevels(auth);
+    const second = await listDebugLevels(auth);
+    assert.deepEqual(first, ['DL1']);
+    assert.deepEqual(second, ['DL1']);
+    assert.equal(called, 1, 'expected single HTTP request');
   });
 });


### PR DESCRIPTION
## Summary
- cache DebugLevel query results per org using CacheManager
- add `sfLogs.cliCache.debugLevelsTtlSeconds` setting to control cache TTL
- test that repeated DebugLevel requests are served from cache

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc760ee008323b5c40cd7ae5b0620