### PR TITLE
refactor(telemetry): add safe send helper

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,7 @@ import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger 
 import { detectReplayDebuggerAvailable } from './utils/warmup';
 import { localize } from './utils/localize';
 import { ApexLogDiagramPanelManager } from './provider/ApexLogDiagramPanel';
-import { activateTelemetry, sendEvent, sendException, disposeTelemetry } from './shared/telemetry';
+import { activateTelemetry, safeSendEvent, safeSendException, disposeTelemetry } from './shared/telemetry';
 import { CacheManager } from './utils/cacheManager';
 import { getBooleanConfig, affectsConfiguration } from './utils/config';
 import { listOrgs, getOrgAuth } from './salesforce/cli';
@@ -27,14 +27,14 @@ export async function activate(context: vscode.ExtensionContext) {
   // Initialize telemetry (no-op if no key/conn configured)
   try {
     activateTelemetry(context);
-    sendEvent('extension.activate', {
-      vscodeVersion: vscode.version,
-      platform: process.platform,
-      hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
-    });
   } catch {
-    // ignore telemetry errors
+    // ignore telemetry init errors
   }
+  safeSendEvent('extension.activate', {
+    vscodeVersion: vscode.version,
+    platform: process.platform,
+    hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
+  });
   // Avoid @salesforce/core attempting to spawn Pino transports that fail when bundled
   try {
     if (!process.env.SF_DISABLE_LOG_FILE) process.env.SF_DISABLE_LOG_FILE = 'true';
@@ -117,9 +117,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.refresh', () => {
-      try {
-        sendEvent('command.refresh');
-      } catch {}
+      safeSendEvent('command.refresh');
       return provider.refresh();
     })
   );
@@ -140,29 +138,23 @@ export async function activate(context: vscode.ExtensionContext) {
         });
         if (!picked) {
           logInfo('Select org cancelled.');
-          try {
-            sendEvent('command.selectOrg', { outcome: 'cancel' });
-          } catch {}
+          safeSendEvent('command.selectOrg', { outcome: 'cancel' });
           return;
         }
         const username = picked.username;
         provider.setSelectedOrg(username);
         logInfo('Selected org:', username);
-        try {
-          const count = orgs.length;
-          const bucket = count === 0 ? '0' : count === 1 ? '1' : count <= 5 ? '2-5' : count <= 10 ? '6-10' : '10+';
-          const hasDefault = String(orgs.some(o => o.isDefaultUsername));
-          sendEvent('command.selectOrg', { outcome: 'picked', orgs: bucket, hasDefault });
-        } catch {}
+        const count = orgs.length;
+        const bucket = count === 0 ? '0' : count === 1 ? '1' : count <= 5 ? '2-5' : count <= 10 ? '6-10' : '10+';
+        const hasDefault = String(orgs.some(o => o.isDefaultUsername));
+        safeSendEvent('command.selectOrg', { outcome: 'picked', orgs: bucket, hasDefault });
         await provider.sendOrgs();
         await provider.refresh();
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
         logError('Failed listing orgs ->', msg);
         vscode.window.showErrorMessage(localize('selectOrgError', 'Electivus Apex Logs: Failed to list orgs'));
-        try {
-          sendException('command.selectOrg', { error: msg });
-        } catch {}
+        safeSendException('command.selectOrg', { error: msg });
       }
     })
   );
@@ -170,9 +162,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.tail', async () => {
       logInfo('Command sfLogs.tail invoked. Opening Tail view and starting…');
-      try {
-        sendEvent('command.tail');
-      } catch {}
+      safeSendEvent('command.tail');
       await provider.tailLogs();
     })
   );
@@ -183,9 +173,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.showDiagram', async () => {
       logInfo('Command sfLogs.showDiagram invoked.');
-      try {
-        sendEvent('command.showDiagram');
-      } catch {}
+      safeSendEvent('command.showDiagram');
       await diagramPanel.showForActiveEditor();
     })
   );
@@ -194,9 +182,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Convenience: command to show the output channel
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.showOutput', () => {
-      try {
-        sendEvent('command.showOutput');
-      } catch {}
+      safeSendEvent('command.showOutput');
       showOutput(true);
     })
   );

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { TelemetryReporter } from '@vscode/extension-telemetry';
+import { logWarn } from '../utils/logger';
 
 let reporter: TelemetryReporter | undefined;
 
@@ -9,7 +10,8 @@ function getConnectionString(context: vscode.ExtensionContext): string | undefin
   if (envConn) return envConn;
   // Fallback to packaged field set by CI (non-legacy): package.json.telemetryConnectionString
   const anyPkg = context.extension.packageJSON as any;
-  const conn: string | undefined = anyPkg && typeof anyPkg.telemetryConnectionString === 'string' ? anyPkg.telemetryConnectionString : undefined;
+  const conn: string | undefined =
+    anyPkg && typeof anyPkg.telemetryConnectionString === 'string' ? anyPkg.telemetryConnectionString : undefined;
   return conn;
 }
 
@@ -50,18 +52,32 @@ export function sendEvent(
   properties?: Record<string, string>,
   measurements?: Record<string, number>
 ): void {
-  try {
-    reporter?.sendTelemetryEvent(name, properties, measurements);
-  } catch {
-    // ignore
-  }
+  reporter?.sendTelemetryEvent(name, properties, measurements);
 }
 
 export function sendException(name: string, properties?: Record<string, string>): void {
+  // Avoid sending raw messages/stacks; send only a coarse-grained name/code.
+  reporter?.sendTelemetryErrorEvent(name, properties);
+}
+
+export function safeSendEvent(
+  name: string,
+  properties?: Record<string, string>,
+  measurements?: Record<string, number>
+): void {
   try {
-    // Avoid sending raw messages/stacks; send only a coarse-grained name/code.
-    reporter?.sendTelemetryErrorEvent(name, properties);
-  } catch {
-    // ignore
+    sendEvent(name, properties, measurements);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logWarn('Failed sending telemetry ->', msg);
+  }
+}
+
+export function safeSendException(name: string, properties?: Record<string, string>): void {
+  try {
+    sendException(name, properties);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    logWarn('Failed sending telemetry ->', msg);
   }
 }

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -6,7 +6,7 @@ suite('cli telemetry', () => {
     const calls: any[] = [];
     const { getOrgAuth, __setExecFileImplForTests, __resetExecFileImplForTests } = proxyquire('../salesforce/cli', {
       '../shared/telemetry': {
-        sendException: (name: string, properties: Record<string, string>) => {
+        safeSendException: (name: string, properties: Record<string, string>) => {
           calls.push({ name, properties });
         }
       }
@@ -28,7 +28,7 @@ suite('cli telemetry', () => {
     const calls: any[] = [];
     const { getOrgAuth, __setExecFileImplForTests, __resetExecFileImplForTests } = proxyquire('../salesforce/cli', {
       '../shared/telemetry': {
-        sendException: (name: string, properties: Record<string, string>) => {
+        safeSendException: (name: string, properties: Record<string, string>) => {
           calls.push({ name, properties });
         }
       }


### PR DESCRIPTION
## Summary
- add safeSendEvent and safeSendException helpers to log and swallow telemetry send errors
- replace scattered try/catch blocks in extension and CLI with the safe helpers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6de2038832380dea2883388306f