### PR TITLE
chore(logs): warn on log head fetch errors

### DIFF
--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -230,8 +230,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
           if (codeUnit && token === this.refreshToken && !this.disposed) {
             this.post({ type: 'logHead', logId: log.Id, codeUnitStarted: codeUnit });
           }
-        } catch {
-          // ignore per-log error
+        } catch (e) {
+          logWarn('Logs: loadLogHead failed for', log.Id, '->', e);
         }
       });
     }


### PR DESCRIPTION
## Summary
- log warnings with log ID and error object when loading log heads fails

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc6f4f3b8832388136409fcc1492e