### PR TITLE
refactor: centralize error message handling

### DIFF
--- a/src/provider/ApexLogDiagramPanel.ts
+++ b/src/provider/ApexLogDiagramPanel.ts
@@ -3,6 +3,7 @@ import { parseApexLogToGraph } from '../shared/apexLogParser';
 import type { DiagramWebviewToExtensionMessage } from '../shared/diagramMessages';
 import { buildWebviewHtml } from '../utils/webviewHtml';
 import { logInfo, logWarn } from '../utils/logger';
+import { getErrorMessage } from '../utils/error';
 
 export class ApexLogDiagramPanelManager implements vscode.Disposable {
   private panel?: vscode.WebviewPanel;
@@ -65,7 +66,7 @@ export class ApexLogDiagramPanelManager implements vscode.Disposable {
             const graph = parseApexLogToGraph(doc.getText(), 100000);
             this.panel?.webview.postMessage({ type: 'graph', graph });
           } catch (e) {
-            logWarn('Diagram panel: parse failed ->', e instanceof Error ? e.message : String(e));
+            logWarn('Diagram panel: parse failed ->', getErrorMessage(e));
           }
         }
       });
@@ -78,7 +79,7 @@ export class ApexLogDiagramPanelManager implements vscode.Disposable {
           const graph = parseApexLogToGraph(e.document.getText(), 100000);
           this.panel.webview.postMessage({ type: 'graph', graph });
         } catch (e2) {
-          logWarn('Diagram panel: update parse failed ->', e2 instanceof Error ? e2.message : String(e2));
+          logWarn('Diagram panel: update parse failed ->', getErrorMessage(e2));
         }
       }
     });
@@ -88,7 +89,7 @@ export class ApexLogDiagramPanelManager implements vscode.Disposable {
       const graph = parseApexLogToGraph(doc.getText(), 100000);
       this.panel.webview.postMessage({ type: 'graph', graph });
     } catch (e) {
-      logWarn('Diagram panel: initial parse failed ->', e instanceof Error ? e.message : String(e));
+      logWarn('Diagram panel: initial parse failed ->', getErrorMessage(e));
     }
     this.panel.reveal(vscode.ViewColumn.Beside, true);
   }

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -10,6 +10,7 @@ import { buildWebviewHtml } from '../utils/webviewHtml';
 import { TailService } from '../utils/tailService';
 import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
+import { getErrorMessage } from '../utils/error';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
@@ -54,7 +55,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     try {
       setTimeout(() => void warmUpReplayDebugger(), 0);
     } catch (e) {
-      logWarn('Tail: warm-up of Apex Replay Debugger failed ->', e instanceof Error ? e.message : String(e));
+      logWarn('Tail: warm-up of Apex Replay Debugger failed ->', getErrorMessage(e));
     }
 
     this.context.subscriptions.push(
@@ -78,7 +79,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       });
       this.context.subscriptions.push(d);
     } catch (e) {
-      logWarn('Tail: window state tracking failed ->', e instanceof Error ? e.message : String(e));
+      logWarn('Tail: window state tracking failed ->', getErrorMessage(e));
     }
 
     webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
@@ -185,7 +186,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       const selected = pickSelectedOrg(orgs, this.selectedOrg);
       this.post({ type: 'orgs', data: orgs, selected });
     } catch (e) {
-      logWarn('Tail: sendOrgs failed ->', e instanceof Error ? e.message : String(e));
+      logWarn('Tail: sendOrgs failed ->', getErrorMessage(e));
       this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
     }
   }
@@ -201,7 +202,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     try {
       auth = await getOrgAuth(this.selectedOrg);
     } catch (e) {
-      logWarn('Tail: could not load auth for debug levels ->', e instanceof Error ? e.message : String(e));
+      logWarn('Tail: could not load auth for debug levels ->', getErrorMessage(e));
       this.post({ type: 'debugLevels', data: [] });
       return;
     }
@@ -236,7 +237,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       await vscode.window.showTextDocument(doc, { preview: true });
       logInfo('Tail: opened log', logId);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
+      const msg = getErrorMessage(e);
       logWarn('Tail: openLog failed ->', msg);
       this.post({ type: 'error', message: msg });
     } finally {
@@ -262,14 +263,14 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
           try {
             await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', uri);
           } catch (e) {
-            logWarn('Tail: sf.launch.replay.debugger.logfile failed ->', e instanceof Error ? e.message : String(e));
+            logWarn('Tail: sf.launch.replay.debugger.logfile failed ->', getErrorMessage(e));
             await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
           }
         }
       );
       logInfo('Tail: replay requested for', logId);
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
+      const msg = getErrorMessage(e);
       logWarn('Tail: replay failed ->', msg);
       this.post({ type: 'error', message: msg });
     }

--- a/src/salesforce/streaming.ts
+++ b/src/salesforce/streaming.ts
@@ -3,6 +3,7 @@ import { Duration } from '@salesforce/kit';
 import type { AnyJson, JsonMap } from '@salesforce/ts-types';
 import type { OrgAuth } from './types';
 import { logWarn } from '../utils/logger';
+import { getErrorMessage } from '../utils/error';
 
 export type { StreamingClient };
 
@@ -30,7 +31,7 @@ export async function createLoggingStreamingClient(
   try {
     options.setSubscribeTimeout(Duration.minutes(30));
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    const msg = getErrorMessage(e);
     logWarn('Failed to set StreamingClient timeout ->', msg);
   }
   // For system topics, DefaultOptions will force API 36.0 automatically.

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,10 @@
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  try {
+    return String(err);
+  } catch {
+    return 'Unknown error';
+  }
+}

--- a/src/utils/warmup.ts
+++ b/src/utils/warmup.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { logInfo, logWarn } from './logger';
 import { localize } from './localize';
+import { getErrorMessage } from './error';
 
 /**
  * Warm up the Apex Replay Debugger by activating its extension(s).
@@ -23,7 +24,7 @@ export async function warmUpReplayDebugger(): Promise<void> {
         logInfo('Warmed up extension:', id);
         return;
       } catch (e) {
-        logWarn('Warm-up failed for', id, '->', e instanceof Error ? e.message : String(e));
+        logWarn('Warm-up failed for', id, '->', getErrorMessage(e));
       }
     }
   } catch {
@@ -44,7 +45,7 @@ export async function ensureReplayDebuggerAvailable(): Promise<boolean> {
       return true;
     }
   } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
+    const msg = getErrorMessage(e);
     logWarn('Failed to check Replay Debugger commands ->', msg);
   }
   const openExt = localize('replayMissingExtOpen', 'Open Extensions');
@@ -57,7 +58,7 @@ export async function ensureReplayDebuggerAvailable(): Promise<boolean> {
     try {
       await vscode.commands.executeCommand('workbench.extensions.search', '@id:salesforce.salesforcedx-vscode');
     } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
+      const msg = getErrorMessage(e);
       logWarn('Failed to open extensions search ->', msg);
     }
   }


### PR DESCRIPTION
## Summary
- add `getErrorMessage` helper for consistent unknown error formatting
- use `getErrorMessage` across warm-up logic, tail service, log providers, extension activation, and streaming client

## Testing
- `npm run lint`
- `npm test` *(fails: requires installing @salesforce/cli globally)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc746c0ec832384394297d2a8c4cc