### PR TITLE
feat(telemetry): add coarse performance timings and avoid error message PII

### DIFF
--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -5,6 +5,7 @@ This extension uses the official `@vscode/extension-telemetry` module to emit mi
 What we collect
 
 - Activation and command usage counts (e.g. `command.refresh`, `command.tail`).
+- Coarse performance timings (e.g., activation duration, log refresh time, diagram parse time).
 - Coarse environment info (platform, VS Code version) to understand compatibility.
 - Non‑PII error categories (e.g. error names like `ETIMEDOUT`, not full messages or stacks).
 


### PR DESCRIPTION
This PR improves telemetry privacy and usefulness by adding coarse performance timing metrics and removing a potential PII leak in one error path.\n\nChanges\n- Add performance timings (ms) for: activation, org listing (Logs/Tail), logs refresh/loadMore, log open, replay (Logs/Tail), debug levels load, and initial diagram parse.\n- Replace raw error message with coarse code in command.selectOrg telemetry.\n- Update docs/TELEMETRY.md to mention performance telemetry.\n\nPrivacy & Security\n- No PII: no usernames, org IDs, instance URLs, file paths, messages or stacks.\n- Only low-cardinality properties (view, outcome, phase) and numeric measurements (durationMs, count, pageSize).\n- Telemetry disabled in Dev/Test and when no connection string present; respects telemetry.telemetryLevel.\n\nValidation\n- npm run lint: pass\n- npm run check-types: pass\n- npm run build: pass\n- npm test: 70 passing\n\nNotes\n- Let me know if you prefer sampling for any event or additional buckets.\n