### PR TITLE
fix(ci): prerelease tags use v<version> + USER_DEBUG TraceFlag

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,7 +33,8 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          LAST_TAG=$(git tag --list 'pre-*' --sort=-v:refname | head -n 1)
+          # Consider the latest tag with odd minor version (vX.Y.Z where Y is odd)
+          LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]*[13579]\.[0-9]+$' | head -n 1)
           if [ -z "$LAST_TAG" ]; then
             echo "No pre-release tags found; proceeding"
             echo "has_changes=true" >> $GITHUB_OUTPUT
@@ -159,8 +160,8 @@ jobs:
           mv "$FILE" "$NEW_NAME"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "file=$NEW_NAME" >> $GITHUB_OUTPUT
-          # Use version-based tag so each release is unique and time-correct
-          echo "tag=pre-${VERSION}" >> $GITHUB_OUTPUT
+          # Use standard v* tag, mark release as pre-release via flag
+          echo "tag=v${VERSION}" >> $GITHUB_OUTPUT
 
       - name: Upload VSIX artifact for publish
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -33,15 +33,26 @@ jobs:
         id: check
         run: |
           set -euo pipefail
-          # Consider the latest tag with odd minor version (vX.Y.Z where Y is odd)
+          # If HEAD already points at a release/pre-release tag, skip
+          HEAD_SHA=$(git rev-parse HEAD)
+          AT_HEAD=$(git tag --points-at "$HEAD_SHA" | grep -E '^(v[0-9]+\.[0-9]+\.[0-9]+|pre-[0-9]+\.[0-9]+\.[0-9]+)$' || true)
+          if [ -n "$AT_HEAD" ]; then
+            echo "HEAD already tagged: $AT_HEAD (skipping nightly)"
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Consider the latest odd-minor tag (vX.Y.Z where Y is odd); fallback to legacy pre-* tags
           LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]*[13579]\.[0-9]+$' | head -n 1)
+          if [ -z "$LAST_TAG" ]; then
+            LAST_TAG=$(git tag --list 'pre-*' --sort=-v:refname | head -n 1)
+          fi
           if [ -z "$LAST_TAG" ]; then
             echo "No pre-release tags found; proceeding"
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
             echo "Latest pre-release tag: $LAST_TAG"
             TAG_SHA=$(git rev-list -n1 "$LAST_TAG")
-            HEAD_SHA=$(git rev-parse HEAD)
             if [ "$TAG_SHA" = "$HEAD_SHA" ]; then
               echo "No changes since last pre-release"
               echo "has_changes=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -43,7 +43,8 @@ jobs:
           fi
 
           # Consider the latest odd-minor tag (vX.Y.Z where Y is odd); fallback to legacy pre-* tags
-          LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | grep -E '^v[0-9]+\.[0-9]*[13579]\.[0-9]+$' | head -n 1)
+          # grep exits 1 when no match; with pipefail that would abort the job, so tolerate empty match
+          LAST_TAG=$(git tag --list 'v*' --sort=-v:refname | (grep -E '^v[0-9]+\.[0-9]*[13579]\.[0-9]+$' || true) | head -n 1)
           if [ -z "$LAST_TAG" ]; then
             LAST_TAG=$(git tag --list 'pre-*' --sort=-v:refname | head -n 1)
           fi

--- a/src/test/provider.logs.behavior.test.ts
+++ b/src/test/provider.logs.behavior.test.ts
@@ -1,0 +1,208 @@
+import assert from 'assert/strict';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs/promises';
+import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
+import * as cli from '../salesforce/cli';
+import * as http from '../salesforce/http';
+
+function makeContext() {
+  const context = {
+    extensionUri: vscode.Uri.file(path.resolve('.')),
+    subscriptions: [] as vscode.Disposable[]
+  } as unknown as vscode.ExtensionContext;
+  return context;
+}
+
+suite('SfLogsViewProvider behavior', () => {
+  const origGetOrgAuth = cli.getOrgAuth;
+  const origFetchLogs = http.fetchApexLogs;
+  const origFetchHead = http.fetchApexLogHead;
+  const origExtract = http.extractCodeUnitStartedFromLines;
+  const origOpenTextDocument = vscode.workspace.openTextDocument;
+  const origShowTextDocument = vscode.window.showTextDocument;
+  const origGetCommands = vscode.commands.getCommands;
+  const origExecCommand = vscode.commands.executeCommand;
+
+  teardown(() => {
+    (cli as any).getOrgAuth = origGetOrgAuth;
+    (http as any).fetchApexLogs = origFetchLogs;
+    (http as any).fetchApexLogHead = origFetchHead;
+    (http as any).extractCodeUnitStartedFromLines = origExtract;
+    (vscode.workspace as any).openTextDocument = origOpenTextDocument;
+    (vscode.window as any).showTextDocument = origShowTextDocument;
+    (vscode.commands as any).getCommands = origGetCommands;
+    (vscode.commands as any).executeCommand = origExecCommand;
+  });
+
+  test('refresh posts logs and logHead with code unit', async () => {
+    (cli as any).getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+    (http as any).fetchApexLogs = async () => [{ Id: '1', LogLength: 10 }, { Id: '2', LogLength: 20 }];
+    (http as any).fetchApexLogHead = async () => ['|CODE_UNIT_STARTED|Foo|MyClass.myMethod'];
+    (http as any).extractCodeUnitStartedFromLines = () => 'MyClass.myMethod';
+
+    const context = makeContext();
+    const posted: any[] = [];
+    const provider = new SfLogsViewProvider(context);
+    // Inject minimal view so refresh proceeds
+    (provider as any).view = {
+      webview: {
+        postMessage: (m: any) => {
+          posted.push(m);
+          return Promise.resolve(true);
+        }
+      }
+    } as any;
+
+    await provider.refresh();
+    // Allow head limiter tasks to complete
+    await new Promise(r => setTimeout(r, 20));
+
+    const init = posted.find(m => m?.type === 'init');
+    const logs = posted.find(m => m?.type === 'logs');
+    const heads = posted.filter(m => m?.type === 'logHead');
+    assert.ok(init, 'should post init');
+    assert.ok(logs, 'should post logs');
+    assert.equal((logs?.data || []).length, 2, 'should include two logs');
+    assert.equal(heads.length, 2, 'should post head for each log');
+    assert.equal(heads[0]?.codeUnitStarted, 'MyClass.myMethod');
+  });
+
+  test('loadMore appends logs', async () => {
+    (cli as any).getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+    let call = 0;
+    (http as any).fetchApexLogs = async () => {
+      call++;
+      return call === 1 ? [{ Id: '1', LogLength: 10 }] : [{ Id: '2', LogLength: 20 }];
+    };
+    (http as any).fetchApexLogHead = async () => ['|CODE_UNIT_STARTED|Foo|C.m'];
+    (http as any).extractCodeUnitStartedFromLines = () => 'C.m';
+
+    const context = makeContext();
+    const posted: any[] = [];
+    const provider = new SfLogsViewProvider(context);
+    (provider as any).view = {
+      webview: {
+        postMessage: (m: any) => {
+          posted.push(m);
+          return Promise.resolve(true);
+        }
+      }
+    } as any;
+
+    await provider.refresh();
+    await new Promise(r => setTimeout(r, 10));
+    await (provider as any).loadMore();
+    await new Promise(r => setTimeout(r, 10));
+
+    const append = posted.find(m => m?.type === 'appendLogs');
+    assert.ok(append, 'should post appendLogs');
+    assert.equal((append?.data || []).length, 1);
+    assert.equal(append.data[0]?.Id, '2');
+  });
+
+  test('openLog uses existing file when present', async () => {
+    const tmp = path.join(process.cwd(), 'apexlogs');
+    await fs.mkdir(tmp, { recursive: true });
+    const existing = path.join(tmp, 'existing.log');
+    await fs.writeFile(existing, 'body', 'utf8');
+
+    const context = makeContext();
+    const provider = new SfLogsViewProvider(context);
+    const opened: string[] = [];
+    (vscode.workspace as any).openTextDocument = async (uri: any) => {
+      opened.push(uri.fsPath || uri.path || String(uri));
+      return { uri } as any;
+    };
+    (vscode.window as any).showTextDocument = async () => undefined;
+
+    // Proper mock webview/view
+    class MockWebview implements vscode.Webview {
+      html = '';
+      options: vscode.WebviewOptions = {};
+      cspSource = 'vscode-resource://test';
+      private handler: ((e: any) => any) | undefined;
+      asWebviewUri(uri: vscode.Uri): vscode.Uri { return uri; }
+      postMessage(_message: any): Thenable<boolean> { return Promise.resolve(true); }
+      onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+        this.handler = listener; return { dispose() {} } as any;
+      }
+      emit(message: any) { return this.handler?.(message); }
+    }
+    class MockWebviewView implements vscode.WebviewView {
+      visible = true; title = 'Test'; viewType = 'sfLogViewer';
+      description?: string | undefined; badge?: { value: number; tooltip: string } | undefined;
+      webview: vscode.Webview; constructor(webview: vscode.Webview) { this.webview = webview; }
+      show(): void { /* noop */ }
+      onDidChangeVisibility: vscode.Event<void> = () => ({ dispose() {} } as any);
+      onDidDispose: vscode.Event<void> = () => ({ dispose() {} } as any);
+    }
+    const webview = new MockWebview();
+    const view = new MockWebviewView(webview);
+    await provider.resolveWebviewView(view);
+
+    // Bypass network: force existing file hit and ensure fetch not called
+    (provider as any).findExistingLogFile = async () => existing;
+    const origFetchBody = http.fetchApexLogBody;
+    (http as any).fetchApexLogBody = async () => {
+      throw new Error('should not fetch when existing file is present');
+    };
+
+    try {
+      await (webview as any).emit({ type: 'openLog', logId: 'ignored' });
+      assert.equal(opened[0], existing);
+    } finally {
+      (http as any).fetchApexLogBody = origFetchBody;
+    }
+  });
+
+  test('debugLog launches replay when available', async () => {
+    (vscode.commands as any).getCommands = async () => ['sf.launch.replay.debugger.logfile'];
+    const executed: Array<{ cmd: string; args: any[] }> = [];
+    (vscode.commands as any).executeCommand = async (cmd: string, ...args: any[]) => {
+      executed.push({ cmd, args });
+      return undefined;
+    };
+    const tmpDir = path.join(process.cwd(), 'apexlogs');
+    await fs.mkdir(tmpDir, { recursive: true });
+    const filePath = path.join(tmpDir, 'dbg.log');
+    await fs.writeFile(filePath, 'body', 'utf8');
+
+    const context = makeContext();
+    const provider = new SfLogsViewProvider(context);
+
+    class MockWebview implements vscode.Webview {
+      html = '';
+      options: vscode.WebviewOptions = {};
+      cspSource = 'vscode-resource://test';
+      private handler: ((e: any) => any) | undefined;
+      asWebviewUri(uri: vscode.Uri): vscode.Uri { return uri; }
+      postMessage(_message: any): Thenable<boolean> { return Promise.resolve(true); }
+      onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+        this.handler = listener; return { dispose() {} } as any;
+      }
+      emit(message: any) { return this.handler?.(message); }
+    }
+    class MockWebviewView implements vscode.WebviewView {
+      visible = true; title = 'Test'; viewType = 'sfLogViewer';
+      description?: string | undefined; badge?: { value: number; tooltip: string } | undefined;
+      webview: vscode.Webview; constructor(webview: vscode.Webview) { this.webview = webview; }
+      show(): void { /* noop */ }
+      onDidChangeVisibility: vscode.Event<void> = () => ({ dispose() {} } as any);
+      onDidDispose: vscode.Event<void> = () => ({ dispose() {} } as any);
+    }
+    const webview = new MockWebview();
+    const view = new MockWebviewView(webview);
+    await provider.resolveWebviewView(view);
+
+    // Make provider return an existing file to avoid network
+    (provider as any).findExistingLogFile = async () => filePath;
+
+    await (webview as any).emit({ type: 'replay', logId: 'abc' });
+
+    const call = executed.find(c => c.cmd === 'sf.launch.replay.debugger.logfile');
+    assert.ok(call, 'should execute replay command');
+    const uri = call?.args?.[0];
+    assert.ok(uri && typeof uri.fsPath === 'string' && uri.fsPath.endsWith('dbg.log'), 'should pass URI');
+  });
+});

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -94,21 +94,15 @@ export class TailService {
       this.logService = new (LogService as any)(this.connection as any);
 
       try {
-        // Prefer apex-node trace flag management
-        await (this.logService as any)?.prepareTraceFlag(debugLevel);
-        logInfo('Tail: TraceFlag ensured via apex-node with level', debugLevel);
-      } catch {
-        // Fall back to our helper if apex-node path fails
-        try {
-          const created = await ensureUserTraceFlag(auth, debugLevel);
-          if (created) {
-            logInfo('Tail: TraceFlag created for user with level', debugLevel);
-          } else {
-            logInfo('Tail: TraceFlag already active or unchanged');
-          }
-        } catch {
-          logWarn('Tail: ensure TraceFlag failed (continuing)');
+        // Ensure TraceFlag using USER_DEBUG and update existing if present
+        const created = await ensureUserTraceFlag(auth, debugLevel);
+        if (created) {
+          logInfo('Tail: TraceFlag created for user with level', debugLevel);
+        } else {
+          logInfo('Tail: TraceFlag updated or already matching for level', debugLevel);
         }
+      } catch {
+        logWarn('Tail: ensure TraceFlag failed (continuing)');
       }
 
       try {


### PR DESCRIPTION
Fix prerelease naming regression and Tail TraceFlag logic.

Changes
- prerelease.yml: use tag/title `vX.Y.Z` instead of `pre-X.Y.Z`; still mark as pre-release.
- prerelease.yml: detect last prerelease from odd-minor `v*` tags.
- traceflags/tail: ensure only USER_DEBUG TraceFlag; update existing flag when same DebugLevel, else create.
- tests: add SfLogsViewProvider behavior tests (refresh/loadMore/open/replay).

Rationale
- Align prerelease naming with stable (avoids breaking consumers and links).
- Avoid creating DEVELOPER_LOG flags that interfere with general settings and replay.

Validation
- npm run build; npm test: all green (74 passing locally).

After merge
- Nightly runs will produce GitHub releases like `v0.7.x` flagged as pre-release.
- Tail start will reuse/update USER_DEBUG flag for the user when possible.
