### PR TITLE
refactor(parser): modularize types, levels, graph; update imports; add unit tests

### DIFF
--- a/src/shared/apexLogParser/graph.ts
+++ b/src/shared/apexLogParser/graph.ts
@@ -1,0 +1,39 @@
+import type { GraphEdge, GraphNode, LogLevels, SequenceEvent } from './types';
+
+export function nodeId(kind: GraphNode['kind'], name: string): string {
+  return `${kind}:${name}`;
+}
+
+export function upsertNode(
+  nodesById: Map<string, GraphNode>,
+  kind: GraphNode['kind'],
+  name: string,
+  levels?: LogLevels
+): GraphNode {
+  const id = nodeId(kind, name);
+  const existing = nodesById.get(id);
+  if (existing) {
+    return existing;
+  }
+  const node: GraphNode = { id, label: name, kind, levels };
+  nodesById.set(id, node);
+  return node;
+}
+
+export function incEdge(edgesByKey: Map<string, GraphEdge>, from: string, to: string): GraphEdge | undefined {
+  if (from === to) return; // ignore self loops
+  const key = `${from}|${to}`;
+  const existing = edgesByKey.get(key);
+  if (existing) {
+    existing.count++;
+    return existing;
+  }
+  const edge: GraphEdge = { from, to, count: 1 };
+  edgesByKey.set(key, edge);
+  return edge;
+}
+
+export function addSequenceEvent(sequence: SequenceEvent[], event: SequenceEvent) {
+  sequence.push(event);
+}
+

--- a/src/shared/apexLogParser/levels.ts
+++ b/src/shared/apexLogParser/levels.ts
@@ -1,0 +1,28 @@
+import type { LogLevels } from './types';
+
+function normalizeLevel(level: string | undefined): string | undefined {
+  const l = (level || '').toUpperCase().trim();
+  const allowed = ['FINEST', 'FINER', 'FINE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'NONE'];
+  return allowed.includes(l) ? l : undefined;
+}
+
+// Parse a line like:
+//   "64.0 APEX_CODE,FINEST;APEX_PROFILING,INFO;DB,INFO;SYSTEM,DEBUG;..."
+export function parseDefaultLogLevels(headLines: string[]): LogLevels | undefined {
+  const first = headLines.find(l => /\bAPEX_CODE\b.*[,;]/.test(l));
+  if (!first) return undefined;
+  const map: LogLevels = {};
+  // Take the substring starting at the first category to avoid leading version numbers
+  const start = first.indexOf('APEX_');
+  const payload = start >= 0 ? first.slice(start) : first;
+  for (const part of payload.split(';')) {
+    const m = part.match(/([A-Z_]+)\s*,\s*([A-Z]+)/);
+    if (m) {
+      const [, key, lvl] = m as unknown as [string, string, string];
+      const norm = normalizeLevel(lvl);
+      if (norm) (map as Record<string, string>)[key] = norm;
+    }
+  }
+  return Object.keys(map).length ? map : undefined;
+}
+

--- a/src/shared/apexLogParser/types.ts
+++ b/src/shared/apexLogParser/types.ts
@@ -1,0 +1,73 @@
+export type LogLevels = Record<string, string>;
+
+export type GraphNode = {
+  id: string;
+  label: string;
+  kind: 'Trigger' | 'Class' | 'Flow' | 'Other';
+  levels?: LogLevels;
+};
+
+export type GraphEdge = {
+  from: string;
+  to: string;
+  count: number;
+};
+
+export type SequenceEvent = {
+  from?: string;
+  to: string;
+  label?: string;
+  time?: string;
+  nanos?: string;
+};
+
+export type FlowSpan = {
+  actor: string;
+  label: string;
+  start: number;
+  end?: number;
+  depth: number;
+  kind: 'unit' | 'method';
+  startNs?: number;
+  endNs?: number;
+};
+
+export type NestedFrame = {
+  actor: string;
+  label: string;
+  start: number;
+  end?: number;
+  depth: number;
+  kind: 'unit' | 'method';
+  profile?: {
+    soql?: number;
+    dml?: number;
+    callout?: number;
+    cpuMs?: number;
+    heapBytes?: number;
+    timeMs?: number;
+    soqlTimeMs?: number;
+    dmlTimeMs?: number;
+    calloutTimeMs?: number;
+  };
+  startNs?: number;
+  endNs?: number;
+};
+
+export type LogGraph = {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  sequence: SequenceEvent[];
+  flow: FlowSpan[];
+  nested: NestedFrame[];
+  issues?: LogIssue[];
+};
+
+export type LogIssue = {
+  severity: 'info' | 'warning' | 'error';
+  code: string;
+  message: string;
+  details?: string;
+  line?: number;
+};
+

--- a/src/shared/diagramMessages.ts
+++ b/src/shared/diagramMessages.ts
@@ -1,8 +1,7 @@
-import type { LogGraph } from './apexLogParser';
+import type { LogGraph } from './apexLogParser/types';
 
 // Messages sent from Webview -> Extension (diagram panel)
 export type DiagramWebviewToExtensionMessage = { type: 'ready' };
 
 // Messages sent from Extension -> Webview (diagram panel)
 export type DiagramExtensionToWebviewMessage = { type: 'graph'; graph: LogGraph };
-

--- a/src/test/unit/diagramFilter.test.ts
+++ b/src/test/unit/diagramFilter.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert/strict';
-import type { NestedFrame } from '../../shared/apexLogParser';
+import type { NestedFrame } from '../../shared/apexLogParser/types';
 import { filterAndCollapse } from '../../webview/utils/diagramFilter';
 
 suite('filterAndCollapse (diagram filter)', () => {

--- a/src/test/unit/graph.test.ts
+++ b/src/test/unit/graph.test.ts
@@ -1,0 +1,40 @@
+import assert from 'assert/strict';
+import { addSequenceEvent, incEdge, nodeId, upsertNode } from '../../shared/apexLogParser/graph';
+import type { GraphEdge, GraphNode } from '../../shared/apexLogParser/types';
+
+suite('graph utilities', () => {
+  test('nodeId composes kind and name', () => {
+    assert.equal(nodeId('Class', 'MyClass'), 'Class:MyClass');
+  });
+
+  test('upsertNode creates and memoizes nodes', () => {
+    const nodes = new Map<string, GraphNode>();
+    const n1 = upsertNode(nodes, 'Class', 'Svc', { APEX_CODE: 'FINEST' });
+    const n2 = upsertNode(nodes, 'Class', 'Svc', { APEX_CODE: 'DEBUG' });
+    assert.equal(n1, n2);
+    assert.equal(nodes.size, 1);
+    assert.equal(n1.id, 'Class:Svc');
+    assert.equal(n1.label, 'Svc');
+  });
+
+  test('incEdge adds and increments; ignores self loops', () => {
+    const edges = new Map<string, GraphEdge>();
+    const a = 'Class:A';
+    const b = 'Class:B';
+    assert.equal(incEdge(edges, a, a), undefined); // self-loop ignored
+    const e1 = incEdge(edges, a, b)!;
+    assert.equal(e1.count, 1);
+    const e2 = incEdge(edges, a, b)!;
+    assert.equal(e2.count, 2);
+    assert.equal(edges.size, 1);
+  });
+
+  test('addSequenceEvent pushes even when owner is missing (incomplete log)', () => {
+    const sequence: any[] = [];
+    addSequenceEvent(sequence, { to: 'Class:Target', label: 'METHOD_ENTRY' });
+    assert.equal(sequence.length, 1);
+    assert.equal(sequence[0].from, undefined);
+    assert.equal(sequence[0].to, 'Class:Target');
+  });
+});
+

--- a/src/test/unit/levels.test.ts
+++ b/src/test/unit/levels.test.ts
@@ -1,0 +1,27 @@
+import assert from 'assert/strict';
+import { parseDefaultLogLevels } from '../../shared/apexLogParser/levels';
+
+suite('parseDefaultLogLevels', () => {
+  test('parses levels from a typical header line', () => {
+    const head = ['64.0 APEX_CODE,FINEST;APEX_PROFILING,INFO;DB,INFO;SYSTEM,DEBUG'];
+    const levels = parseDefaultLogLevels(head);
+    assert.deepEqual(levels, {
+      APEX_CODE: 'FINEST',
+      APEX_PROFILING: 'INFO',
+      DB: 'INFO',
+      SYSTEM: 'DEBUG'
+    });
+  });
+
+  test('returns undefined if no APEX_CODE line is present', () => {
+    const levels = parseDefaultLogLevels(['Some other line', 'RANDOM']);
+    assert.equal(levels, undefined);
+  });
+
+  test('ignores invalid/partial categories and may return undefined', () => {
+    // First line contains APEX_CODE but no valid value; second line is ignored by design
+    const levels = parseDefaultLogLevels(['APEX_CODE,', 'DB,INFO']);
+    assert.equal(levels, undefined);
+  });
+});
+

--- a/src/webview/components/diagram/DiagramSvg.tsx
+++ b/src/webview/components/diagram/DiagramSvg.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import type { NestedFrame } from '../../../shared/apexLogParser';
+import type { NestedFrame } from '../../../shared/apexLogParser/types';
 
 type UnitFrame = NestedFrame & { kind: 'unit'; count?: number };
 type MethodFrame = NestedFrame & { kind: 'method'; count?: number };

--- a/src/webview/diagram.tsx
+++ b/src/webview/diagram.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import type { LogGraph, NestedFrame, LogIssue } from '../shared/apexLogParser';
+import type { LogGraph, NestedFrame, LogIssue } from '../shared/apexLogParser/types';
 import type { DiagramExtensionToWebviewMessage, DiagramWebviewToExtensionMessage } from '../shared/diagramMessages';
 import { DiagramToolbar } from './components/diagram/DiagramToolbar';
 import { DiagramSvg } from './components/diagram/DiagramSvg';

--- a/src/webview/utils/diagramFilter.ts
+++ b/src/webview/utils/diagramFilter.ts
@@ -1,4 +1,4 @@
-import type { NestedFrame } from '../../shared/apexLogParser';
+import type { NestedFrame } from '../../shared/apexLogParser/types';
 
 export function filterAndCollapse(
   frames: NestedFrame[] | undefined,


### PR DESCRIPTION
This PR consolidates and applies the best parts from #185, #186, #187, and #188 to implement the requested refactor with minimal churn:

What changed
- Moved type definitions to src/shared/apexLogParser/types.ts (LogNode, LogGraph, SequenceEvent, etc.)
- Isolated default log level parsing into src/shared/apexLogParser/levels.ts
- Extracted graph/sequence helpers into src/shared/apexLogParser/graph.ts (nodeId, upsertNode, incEdge, addSequenceEvent)
- Renamed src/shared/apexLogParser.ts -> src/shared/apexLogParser/index.ts to preserve existing imports for the parser (parseApexLogToGraph) while consuming helpers from graph.ts and levels.ts.
- Updated imports in consumers to reference types from src/shared/apexLogParser/types (diagram.tsx, DiagramSvg.tsx, diagramFilter.ts, diagramMessages.ts, and unit test).
- Added focused unit tests for levels.ts and graph.ts, including handling of incomplete/missing log info.

Notes on approach
- Kept parseApexLogToGraph in index.ts (as in #185/#187) to avoid changing provider imports, but factored out helpers to graph.ts as in the activity.
- Added addSequenceEvent helper (from #185/#187) to make sequence mutation explicit and easier to test.
- Consumers import types from the new types.ts module to reduce coupling and improve tree-shaking.

Validation
- npm run lint
- npm run check-types
- npm run build
- npm test (unit + existing suites)

All checks pass locally.

Closes: Implements the requested activity (modularization) and supersedes overlapping parts of #185–#188. If desired, we can close them in favor of this PR.
