### PR TITLE
feat(calltree): add Call Tree + Flame Graph for Apex logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:sfLogs.showDiagram"
+    "onCommand:sfLogs.showDiagram",
+    "onCommand:sfLogs.showCallTree"
   ],
   "extensionDependencies": [],
   "main": "./dist/extension.js",
@@ -236,6 +237,12 @@
         "icon": "$(graph)"
       },
       {
+        "command": "sfLogs.showCallTree",
+        "title": "%command.showCallTree.title%",
+        "category": "Electivus Apex Logs",
+        "icon": "$(list-tree)"
+      },
+      {
         "command": "sfLogs.showOutput",
         "title": "Show Extension Output",
         "category": "Electivus Apex Logs"
@@ -265,12 +272,18 @@
           "when": "resourceExtname == .log",
           "group": "navigation@100"
         }
+        ,
+        {
+          "command": "sfLogs.showCallTree",
+          "when": "resourceExtname == .log",
+          "group": "navigation@101"
+        }
       ]
     }
   },
   "scripts": {
     "test:clean": "node scripts/clean-vscode-test.js",
-    "clean": "node -e \"const fs=require('fs');const p=require('path');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/diagram.js','media/diagram.js.map']){try{fs.unlinkSync(f)}catch{}}\"",
+    "clean": "node -e \"const fs=require('fs');const p=require('path');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/diagram.js','media/diagram.js.map','media/calltree.js','media/calltree.js.map']){try{fs.unlinkSync(f)}catch{}}\"",
     "prebuild": "npm run clean",
     "vscode:prepublish": "npm run build && npm run nls:write",
     "check-types": "tsc --noEmit -p tsconfig.extension.json",
@@ -278,9 +291,9 @@
     "watch": "npm-run-all -p watch:*",
     "watch:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --sourcemap --external:vscode --alias:bfj=./src/shims/bfj.ts --watch",
     "watch:tsc": "tsc -p tsconfig.extension.json --watch --noEmit",
-    "watch:webview": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/diagram.tsx --bundle --outdir=media --platform=browser --format=iife --sourcemap --watch",
+    "watch:webview": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/diagram.tsx src/webview/calltree.tsx --bundle --outdir=media --platform=browser --format=iife --sourcemap --watch",
     "build:extension": "esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --minify --external:vscode --alias:bfj=./src/shims/bfj.ts",
-    "build:webview": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/diagram.tsx --bundle --outdir=media --platform=browser --format=iife --minify",
+    "build:webview": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/diagram.tsx src/webview/calltree.tsx --bundle --outdir=media --platform=browser --format=iife --minify",
     "build": "npm run build:extension && npm run build:webview",
     "build:icon": "node scripts/gen-icon.mjs",
     "build:assets": "node scripts/gen-assets.mjs",
@@ -361,6 +374,7 @@
     "dist/**",
     "media/main.js",
     "media/diagram.js",
+    "media/calltree.js",
     "media/tail.js",
     "media/icon.png",
     "README.md",

--- a/package.nls.json
+++ b/package.nls.json
@@ -9,6 +9,7 @@
   "command.selectOrg.title": "Select Org",
   "command.tail.title": "Tail Logs",
   "command.showDiagram.title": "Show Log Diagram",
+  "command.showCallTree.title": "Show Call Tree",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page (effective maximum: 200). Higher values fetch more per request but may slow the UI or increase API load.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -9,6 +9,7 @@
   "command.selectOrg.title": "Selecionar Org",
   "command.tail.title": "Tail de Logs",
   "command.showDiagram.title": "Mostrar Diagrama do Log",
+  "command.showCallTree.title": "Mostrar Árvore de Chamadas",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página (máximo efetivo: 200). Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,7 @@ import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger 
 import { detectReplayDebuggerAvailable } from './utils/warmup';
 import { localize } from './utils/localize';
 import { ApexLogDiagramPanelManager } from './provider/ApexLogDiagramPanel';
+import { ApexLogCallTreePanelManager } from './provider/ApexLogCallTreePanel';
 import { activateTelemetry, safeSendEvent, safeSendException, disposeTelemetry } from './shared/telemetry';
 import { CacheManager } from './utils/cacheManager';
 import { getBooleanConfig, affectsConfiguration } from './utils/config';
@@ -178,6 +179,17 @@ export async function activate(context: vscode.ExtensionContext) {
     })
   );
   // No auto-overlay; the diagram opens via the editor title button/command.
+
+  // Call Tree panel command
+  const callTreePanel = new ApexLogCallTreePanelManager(context);
+  context.subscriptions.push(callTreePanel);
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sfLogs.showCallTree', async () => {
+      logInfo('Command sfLogs.showCallTree invoked.');
+      safeSendEvent('command.showCallTree');
+      await callTreePanel.showForActiveEditor();
+    })
+  );
 
   // Convenience: command to show the output channel
   context.subscriptions.push(

--- a/src/shared/callTree/build.ts
+++ b/src/shared/callTree/build.ts
@@ -1,0 +1,203 @@
+import type { NestedFrame } from '../apexLogParser/types';
+import { signatureFromLabel } from './types';
+import type { BuildOptions, CallTreeModel, CallTreeNode } from './types';
+
+function safeTimeMs(fr: NestedFrame): number {
+  const p = fr.profile || {};
+  if (typeof p.timeMs === 'number') return Math.max(0, p.timeMs);
+  // Fallback from ns when available
+  if (typeof fr.startNs === 'number' && typeof fr.endNs === 'number') {
+    const raw = Math.round(Math.max(0, fr.endNs - fr.startNs) / 1_000_000);
+    return raw;
+  }
+  // Fallback from sequence index
+  const delta = (fr.end ?? fr.start + 1) - fr.start;
+  return Math.max(0, delta);
+}
+
+export function buildCallTree(frames: NestedFrame[], opts?: BuildOptions): CallTreeModel {
+  const options = { occurrences: true, ...(opts || {}) };
+  // Only method frames participate in the call tree
+  const methods = frames.filter(f => f.kind === 'method').slice().sort((a, b) => a.start - b.start || a.depth - b.depth);
+  const stack: CallTreeNode[] = [];
+  const all = new Map<string, CallTreeNode>();
+  const roots: CallTreeNode[] = [];
+  const bySignature = new Map<string, CallTreeNode[]>();
+  const parentsBySignature = new Map<string, Set<string>>();
+
+  for (const fr of methods) {
+    // Maintain nesting based on start/end
+    while (stack.length && (stack[stack.length - 1]!.end ?? Number.POSITIVE_INFINITY) <= fr.start) {
+      stack.pop();
+    }
+    const { className, method, sig } = signatureFromLabel(fr.actor, fr.label);
+
+    const metrics = {
+      totalTimeMs: safeTimeMs(fr),
+      ownTimeMs: 0,
+      soql: fr.profile?.soql || 0,
+      dml: fr.profile?.dml || 0,
+      callout: fr.profile?.callout || 0,
+      soqlTimeMs: fr.profile?.soqlTimeMs || 0,
+      dmlTimeMs: fr.profile?.dmlTimeMs || 0,
+      calloutTimeMs: fr.profile?.calloutTimeMs || 0,
+      cpuMs: fr.profile?.cpuMs || 0,
+      heapBytes: fr.profile?.heapBytes || 0
+    };
+    const node: CallTreeNode = {
+      id: `${fr.actor}:${fr.start}`,
+      ref: { className, method, label: fr.label },
+      children: [],
+      metrics,
+      start: fr.start,
+      end: fr.end,
+      depth: fr.depth,
+      actor: fr.actor
+    };
+    all.set(node.id, node);
+    // Index for search / merging
+    const arr = bySignature.get(sig) || [];
+    arr.push(node);
+    bySignature.set(sig, arr);
+
+    if (stack.length) {
+      const parent = stack[stack.length - 1]!;
+      (node.parents ||= []).push(parent);
+      parent.children.push(node);
+      // Track signature parentage for backtraces
+      const pSig = signatureFromLabel(parent.actor!, parent.ref.label).sig;
+      const set = parentsBySignature.get(sig) || new Set<string>();
+      set.add(pSig);
+      parentsBySignature.set(sig, set);
+    } else {
+      roots.push(node);
+    }
+    stack.push(node);
+  }
+
+  // Compute own time = total - sum(children.total)
+  function computeOwnTimes(n: CallTreeNode): number {
+    const childrenTotal = n.children.reduce((m, c) => m + computeOwnTimes(c), 0);
+    const own = Math.max(0, n.metrics.totalTimeMs - childrenTotal);
+    n.metrics.ownTimeMs = own;
+    return n.metrics.totalTimeMs;
+  }
+  for (const r of roots) computeOwnTimes(r);
+
+  const totalTime = roots.reduce((m, r) => m + r.metrics.totalTimeMs, 0);
+  const model: CallTreeModel = { roots, all, bySignature, parentsBySignature, totals: { totalTimeMs: totalTime } };
+  return model;
+}
+
+export function mergeOccurrences(model: CallTreeModel, signature: string): CallTreeModel {
+  // When merging, treat the selected signature as root. Aggregate all its occurrences and their subtrees.
+  const occ = model.bySignature.get(signature) || [];
+  const bySig = new Map<string, CallTreeNode>();
+  const makeNode = (sig: string, sample?: CallTreeNode): CallTreeNode => {
+    const existing = bySig.get(sig);
+    if (existing) return existing;
+    // Parse parts from a sample occurrence or fall back to sig splitting
+    const className = sample?.ref.className || sig.split('#')[0] || '';
+    const method = sample?.ref.method || sig.split('#')[1] || '';
+    const n: CallTreeNode = {
+      id: `merged:${sig}`,
+      ref: { className, method, label: `${className}.${method}` },
+      children: [],
+      metrics: { totalTimeMs: 0, ownTimeMs: 0, count: 0 }
+    };
+    bySig.set(sig, n);
+    return n;
+  };
+
+  // DFS across each occurrence to aggregate into the merged tree
+  for (const rootOcc of occ) {
+    const rootSig = signatureFromLabel(rootOcc.actor!, rootOcc.ref.label).sig;
+    const root = makeNode(rootSig, rootOcc);
+    root.metrics.count = (root.metrics.count || 0) + 1;
+    root.metrics.totalTimeMs += rootOcc.metrics.totalTimeMs;
+    root.metrics.ownTimeMs += rootOcc.metrics.ownTimeMs;
+    root.metrics.soql = (root.metrics.soql || 0) + (rootOcc.metrics.soql || 0);
+    root.metrics.dml = (root.metrics.dml || 0) + (rootOcc.metrics.dml || 0);
+    root.metrics.callout = (root.metrics.callout || 0) + (rootOcc.metrics.callout || 0);
+    root.metrics.soqlTimeMs = (root.metrics.soqlTimeMs || 0) + (rootOcc.metrics.soqlTimeMs || 0);
+    root.metrics.dmlTimeMs = (root.metrics.dmlTimeMs || 0) + (rootOcc.metrics.dmlTimeMs || 0);
+    root.metrics.calloutTimeMs = (root.metrics.calloutTimeMs || 0) + (rootOcc.metrics.calloutTimeMs || 0);
+
+    const stack: Array<{ occ: CallTreeNode; merged: CallTreeNode }> = [{ occ: rootOcc, merged: root }];
+    while (stack.length) {
+      const { occ, merged } = stack.pop()!;
+      for (const childOcc of occ.children) {
+        const cSig = signatureFromLabel(childOcc.actor!, childOcc.ref.label).sig;
+        const childMerged = makeNode(cSig, childOcc);
+        // Link if not already linked
+        if (!merged.children.includes(childMerged)) merged.children.push(childMerged);
+        // Aggregate metrics
+        childMerged.metrics.count = (childMerged.metrics.count || 0) + 1;
+        childMerged.metrics.totalTimeMs += childOcc.metrics.totalTimeMs;
+        childMerged.metrics.ownTimeMs += childOcc.metrics.ownTimeMs;
+        childMerged.metrics.soql = (childMerged.metrics.soql || 0) + (childOcc.metrics.soql || 0);
+        childMerged.metrics.dml = (childMerged.metrics.dml || 0) + (childOcc.metrics.dml || 0);
+        childMerged.metrics.callout = (childMerged.metrics.callout || 0) + (childOcc.metrics.callout || 0);
+        childMerged.metrics.soqlTimeMs = (childMerged.metrics.soqlTimeMs || 0) + (childOcc.metrics.soqlTimeMs || 0);
+        childMerged.metrics.dmlTimeMs = (childMerged.metrics.dmlTimeMs || 0) + (childOcc.metrics.dmlTimeMs || 0);
+        childMerged.metrics.calloutTimeMs = (childMerged.metrics.calloutTimeMs || 0) + (childOcc.metrics.calloutTimeMs || 0);
+        stack.push({ occ: childOcc, merged: childMerged });
+      }
+    }
+  }
+
+  const mergedRoots = [bySig.get(signature)!].filter(Boolean) as CallTreeNode[];
+  const all = new Map<string, CallTreeNode>(Array.from(bySig.entries()).map(([k, v]) => [v.id, v]));
+  const totals = { totalTimeMs: mergedRoots.reduce((m, r) => m + r.metrics.totalTimeMs, 0) };
+  // Build backlinks for backtraces navigation
+  for (const n of bySig.values()) for (const c of n.children) (c.parents ||= []).push(n);
+  return { roots: mergedRoots, all, bySignature: model.bySignature, parentsBySignature: model.parentsBySignature, totals };
+}
+
+export function invertForSignature(model: CallTreeModel, signature: string): CallTreeModel {
+  // Build callers tree (backtraces) for the given signature using the parentsBySignature index.
+  const seen = new Set<string>();
+  const makeNode = (sig: string): CallTreeNode => {
+    const sample = (model.bySignature.get(sig) || [])[0];
+    const className = sample?.ref.className || sig.split('#')[0] || '';
+    const method = sample?.ref.method || sig.split('#')[1] || '';
+    const n: CallTreeNode = {
+      id: `back:${sig}`,
+      ref: { className, method, label: `${className}.${method}` },
+      children: [],
+      metrics: { totalTimeMs: 0, ownTimeMs: 0 }
+    };
+    // Aggregate totals from occurrences
+    for (const occ of model.bySignature.get(sig) || []) {
+      n.metrics.totalTimeMs += occ.metrics.totalTimeMs;
+      n.metrics.ownTimeMs += occ.metrics.ownTimeMs;
+    }
+    return n;
+  };
+  const root = makeNode(signature);
+  const nodes = new Map<string, CallTreeNode>([[signature, root]]);
+  const queue: string[] = [signature];
+  seen.add(signature);
+  while (queue.length) {
+    const cur = queue.shift()!;
+    const parents = Array.from(model.parentsBySignature.get(cur) || []);
+    for (const p of parents) {
+      let pn = nodes.get(p);
+      if (!pn) {
+        pn = makeNode(p);
+        nodes.set(p, pn);
+      }
+      // Link parent -> child (inverted: callers above)
+      pn.children.push(nodes.get(cur)!);
+      if (!seen.has(p)) {
+        seen.add(p);
+        queue.push(p);
+      }
+    }
+  }
+  const roots = [root];
+  const all = new Map<string, CallTreeNode>(Array.from(nodes.values()).map(n => [n.id, n]));
+  const totals = { totalTimeMs: root.metrics.totalTimeMs };
+  return { roots, all, bySignature: model.bySignature, parentsBySignature: model.parentsBySignature, totals };
+}
+

--- a/src/shared/callTree/index.ts
+++ b/src/shared/callTree/index.ts
@@ -1,0 +1,3 @@
+export * from './types';
+export * from './build';
+

--- a/src/shared/callTree/types.ts
+++ b/src/shared/callTree/types.ts
@@ -1,0 +1,68 @@
+export type CallTreeNodeId = string;
+
+export type CallTreeMetrics = {
+  totalTimeMs: number; // time including subtree
+  ownTimeMs: number; // total - sum(children.totalTimeMs)
+  soql?: number;
+  dml?: number;
+  callout?: number;
+  soqlTimeMs?: number;
+  dmlTimeMs?: number;
+  calloutTimeMs?: number;
+  cpuMs?: number;
+  heapBytes?: number;
+  count?: number; // for merged nodes
+};
+
+export type CallRef = {
+  className: string; // e.g., MyClass
+  method: string; // e.g., doWork(String)
+  label: string; // raw label from log
+};
+
+export type CallTreeNode = {
+  id: CallTreeNodeId; // unique per occurrence (start index) or per merged key
+  ref: CallRef;
+  children: CallTreeNode[];
+  parents?: CallTreeNode[]; // optional backlinks for backtraces (filled on model)
+  metrics: CallTreeMetrics;
+  // Optional linking back to the original nested frame for navigation
+  start?: number;
+  end?: number;
+  depth?: number;
+  actor?: string; // Class:Foo
+};
+
+export type CallTreeModel = {
+  roots: CallTreeNode[]; // top-level methods
+  all: Map<CallTreeNodeId, CallTreeNode>;
+  // Indexes for search and merge/backtraces
+  bySignature: Map<string, CallTreeNode[]>; // key: ClassName#methodSig (raw label)
+  parentsBySignature: Map<string, Set<string>>; // calleeSig -> set of caller signatures
+  totals: { totalTimeMs: number };
+};
+
+export type BuildOptions = {
+  // When true, treat every occurrence independently and compute parent/child relations by time nesting.
+  // When false, behavior is the same (this option is reserved for future variations).
+  occurrences?: boolean;
+};
+
+export function signatureFromLabel(actor: string, label: string): { className: string; method: string; sig: string } {
+  const raw = (label || '').trim();
+  const noArgs = raw.split("|")[0] || raw;
+  const beforeParen = noArgs.split("(")[0] || noArgs;
+  let className = '';
+  let method = beforeParen;
+  // Labels usually are like: "MyClass.myMethod(String)" or "ns__MyClass.do()"
+  const dot = beforeParen.lastIndexOf('.');
+  if (dot > 0) {
+    className = beforeParen.slice(0, dot);
+    method = raw.slice(dot + 1);
+  } else if (actor.startsWith('Class:')) {
+    className = actor.slice('Class:'.length);
+  }
+  const sig = `${className}#${method}`;
+  return { className, method, sig };
+}
+

--- a/src/test/unit/calltree.build.test.ts
+++ b/src/test/unit/calltree.build.test.ts
@@ -1,0 +1,49 @@
+import { strict as assert } from 'assert';
+import type { NestedFrame } from '../../shared/apexLogParser/types';
+import { buildCallTree } from '../../shared/callTree';
+
+suite('callTree.build', () => {
+  test('builds parent/child relations and own time', () => {
+    const nested: NestedFrame[] = [
+      // Unit frame (ignored by builder)
+      {
+        actor: 'Class:Top',
+        label: 'Class.Top.start',
+        start: 0,
+        end: 5,
+        depth: 0,
+        kind: 'unit'
+      },
+      // Method A
+      {
+        actor: 'Class:Top',
+        label: 'Top.entry()',
+        start: 1,
+        end: 5,
+        depth: 1,
+        kind: 'method',
+        profile: { timeMs: 50 }
+      },
+      // Method B (child)
+      {
+        actor: 'Class:Foo',
+        label: 'Foo.work()',
+        start: 2,
+        end: 4,
+        depth: 2,
+        kind: 'method',
+        profile: { timeMs: 20 }
+      }
+    ];
+    const model = buildCallTree(nested);
+    assert.equal(model.roots.length, 1);
+    const root = model.roots[0]!;
+    assert.equal(root.ref.className, 'Top');
+    assert.equal(root.children.length, 1);
+    const child = root.children[0]!;
+    assert.equal(child.ref.className, 'Foo');
+    assert.equal(root.metrics.totalTimeMs, 50);
+    assert.equal(child.metrics.totalTimeMs, 20);
+    assert.equal(root.metrics.ownTimeMs, 30);
+  });
+});

--- a/src/webview/calltree.tsx
+++ b/src/webview/calltree.tsx
@@ -1,0 +1,249 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { LogGraph } from '../shared/apexLogParser/types';
+import { buildCallTree, invertForSignature, mergeOccurrences } from '../shared/callTree';
+import type { CallTreeModel, CallTreeNode } from '../shared/callTree';
+
+declare global {
+  var acquireVsCodeApi: <T = unknown>() => {
+    postMessage: (msg: T) => void;
+    getState: <S = any>() => S | undefined;
+    setState: (state: any) => void;
+  };
+}
+
+type WebToExt = { type: 'ready' };
+type ExtToWeb = { type: 'graph'; graph: LogGraph };
+
+const vscode = acquireVsCodeApi<WebToExt>();
+
+function fmtMs(n: number | undefined): string {
+  if (!n || n <= 0) return '0 ms';
+  if (n < 1000) return `${n} ms`;
+  const s = n / 1000;
+  return `${s.toFixed(s >= 10 ? 0 : 1)} s`;
+}
+
+function percent(n: number, total: number): string {
+  if (!total) return '0%';
+  return `${((n / total) * 100).toFixed(n / total >= 0.1 ? 1 : 2)}%`;
+}
+
+function classShort(name: string): string {
+  const parts = (name || '').split('.');
+  return parts[parts.length - 1] || name;
+}
+
+type Mode = 'tree' | 'backtraces' | 'merged';
+
+function App() {
+  const [graph, setGraph] = useState<LogGraph | undefined>(undefined);
+  const [model, setModel] = useState<CallTreeModel | undefined>(undefined);
+  const [mode, setMode] = useState<Mode>('tree');
+  const [selectedSig, setSelectedSig] = useState<string | undefined>(undefined);
+  const [filter, setFilter] = useState('');
+  const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
+  const [history, setHistory] = useState<{ mode: Mode; sig?: string }[]>([]);
+
+  // Listen for messages and ask for initial data
+  useEffect(() => {
+    const onMsg = (event: MessageEvent) => {
+      const msg = event.data as ExtToWeb;
+      if (msg?.type === 'graph') {
+        setGraph(msg.graph);
+      }
+    };
+    window.addEventListener('message', onMsg);
+    vscode.postMessage({ type: 'ready' });
+    return () => window.removeEventListener('message', onMsg);
+  }, []);
+
+  // Build base model from nested frames
+  useEffect(() => {
+    if (!graph) return;
+    try {
+      const base = buildCallTree(graph.nested || []);
+      setModel(base);
+      setMode('tree');
+      setSelectedSig(undefined);
+      setCollapsed(new Set());
+    } catch (e) {
+      console.warn('CallTree: build failed', e);
+    }
+  }, [graph]);
+
+  // Derived view model depending on mode/selection
+  const viewModel: CallTreeModel | undefined = useMemo(() => {
+    if (!model) return undefined;
+    if (mode === 'tree' || !selectedSig) return model;
+    if (mode === 'backtraces') return invertForSignature(model, selectedSig);
+    if (mode === 'merged') return mergeOccurrences(model, selectedSig);
+    return model;
+  }, [model, mode, selectedSig]);
+
+  // Filter roots by search
+  const roots = useMemo(() => {
+    const r = viewModel?.roots || [];
+    if (!filter.trim()) return r;
+    const f = filter.trim().toLowerCase();
+    const matches = (n: CallTreeNode): boolean =>
+      n.ref.method.toLowerCase().includes(f) ||
+      n.ref.className.toLowerCase().includes(f) ||
+      `${n.ref.className}.${n.ref.method}`.toLowerCase().includes(f);
+    // If filter, show roots that match or that have any matching descendants
+    const filtered: CallTreeNode[] = [];
+    const visit = (n: CallTreeNode): boolean => {
+      const childHas = n.children?.some(visit) || false;
+      return matches(n) || childHas;
+    };
+    for (const r0 of r) if (visit(r0)) filtered.push(r0);
+    return filtered;
+  }, [viewModel, filter]);
+
+  const total = viewModel?.totals.totalTimeMs || 0;
+
+  const onToggle = (id: string) => {
+    setCollapsed(prev => {
+      const n = new Set(prev);
+      if (n.has(id)) n.delete(id);
+      else n.add(id);
+      return n;
+    });
+  };
+
+  const onScope = (n: CallTreeNode) => {
+    const sig = `${n.ref.className}#${n.ref.method}`;
+    setHistory(h => [...h, { mode, sig: selectedSig }]);
+    setSelectedSig(sig);
+    setMode('tree');
+    setCollapsed(new Set());
+  };
+
+  const onMerged = (n: CallTreeNode) => {
+    const sig = `${n.ref.className}#${n.ref.method}`;
+    setHistory(h => [...h, { mode, sig: selectedSig }]);
+    setSelectedSig(sig);
+    setMode('merged');
+    setCollapsed(new Set());
+  };
+
+  const onBacktraces = (n: CallTreeNode) => {
+    const sig = `${n.ref.className}#${n.ref.method}`;
+    setHistory(h => [...h, { mode, sig: selectedSig }]);
+    setSelectedSig(sig);
+    setMode('backtraces');
+    setCollapsed(new Set());
+  };
+
+  const canBack = history.length > 0;
+  const onBack = () => {
+    const prev = history[history.length - 1];
+    setHistory(h => h.slice(0, -1));
+    if (prev) {
+      setMode(prev.mode);
+      setSelectedSig(prev.sig);
+      setCollapsed(new Set());
+    }
+  };
+
+  return (
+    <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+      <style>{`
+        html, body, #root { height: 100%; }
+        body { margin: 0; }
+        .toolbar { display:flex; align-items:center; gap:8px; padding:6px 10px; }
+        .tree { padding: 4px 10px 20px; overflow:auto; flex: 1; }
+        .node { line-height: 1.6; }
+        .label { cursor: default; }
+        .dim { opacity: 0.7; }
+        .controls button { margin-left: 4px; }
+      `}</style>
+      <div className="toolbar">
+        <button type="button" disabled={!canBack} onClick={onBack} title="Back">◀</button>
+        <input
+          type="text"
+          placeholder="Find class or method…"
+          value={filter}
+          onChange={e => setFilter(e.target.value)}
+          style={{ flex: 1 }}
+        />
+        <span className="dim">Total: {fmtMs(total)}</span>
+        <span className="dim">Mode: {mode}</span>
+      </div>
+      <div className="tree">
+        {roots.map(r => (
+          <TreeNode
+            key={r.id}
+            node={r}
+            total={total}
+            collapsed={collapsed}
+            onToggle={onToggle}
+            onScope={onScope}
+            onMerged={onMerged}
+            onBacktraces={onBacktraces}
+          />
+        ))}
+        {roots.length === 0 && <div style={{ opacity: 0.8 }}>No calls.</div>}
+      </div>
+    </div>
+  );
+}
+
+function TreeNode({
+  node,
+  total,
+  collapsed,
+  onToggle,
+  onScope,
+  onMerged,
+  onBacktraces
+}: {
+  node: CallTreeNode;
+  total: number;
+  collapsed: Set<string>;
+  onToggle: (id: string) => void;
+  onScope: (n: CallTreeNode) => void;
+  onMerged: (n: CallTreeNode) => void;
+  onBacktraces: (n: CallTreeNode) => void;
+}) {
+  const id = node.id;
+  const isCollapsed = collapsed.has(id);
+  const own = node.metrics.ownTimeMs || 0;
+  const tot = node.metrics.totalTimeMs || 0;
+  const cls = classShort(node.ref.className);
+  const name = `${cls}.${node.ref.method}`;
+  const suffix = node.metrics.count && node.metrics.count > 1 ? ` ×${node.metrics.count}` : '';
+
+  return (
+    <div className="node" style={{ marginLeft: 12 }}>
+      <div className="label" onDoubleClick={() => onToggle(id)}>
+        <button type="button" onClick={() => onToggle(id)} style={{ width: 22 }}>
+          {node.children.length ? (isCollapsed ? '▸' : '▾') : '·'}
+        </button>
+        <strong>{name}</strong>
+        {suffix ? <span className="dim"> {suffix}</span> : null}
+        <span className="dim"> — own {fmtMs(own)} ({percent(own, total)}), total {fmtMs(tot)}</span>
+        <span className="controls">
+          <button type="button" onClick={() => onScope(node)} title="Scope to This (Ctrl+Enter)">Scope</button>
+          <button type="button" onClick={() => onMerged(node)} title="Merge occurrences (Ctrl+Shift+Enter)">Merge</button>
+          <button type="button" onClick={() => onBacktraces(node)} title="Backtraces">Backtraces</button>
+        </span>
+      </div>
+      {!isCollapsed && node.children.map(c => (
+        <TreeNode
+          key={c.id}
+          node={c}
+          total={total}
+          collapsed={collapsed}
+          onToggle={onToggle}
+          onScope={onScope}
+          onMerged={onMerged}
+          onBacktraces={onBacktraces}
+        />
+      ))}
+    </div>
+  );
+}
+
+const root = createRoot(document.getElementById('root')!);
+root.render(<App />);

--- a/src/webview/calltree.tsx
+++ b/src/webview/calltree.tsx
@@ -34,7 +34,7 @@ function classShort(name: string): string {
   return parts[parts.length - 1] || name;
 }
 
-type Mode = 'tree' | 'backtraces' | 'merged';
+type Mode = 'tree' | 'backtraces' | 'merged' | 'flame';
 
 function App() {
   const [graph, setGraph] = useState<LogGraph | undefined>(undefined);
@@ -44,6 +44,7 @@ function App() {
   const [filter, setFilter] = useState('');
   const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
   const [history, setHistory] = useState<{ mode: Mode; sig?: string }[]>([]);
+  const [selectedId, setSelectedId] = useState<string | undefined>(undefined);
 
   // Listen for messages and ask for initial data
   useEffect(() => {
@@ -67,6 +68,7 @@ function App() {
       setMode('tree');
       setSelectedSig(undefined);
       setCollapsed(new Set());
+      setSelectedId(undefined);
     } catch (e) {
       console.warn('CallTree: build failed', e);
     }
@@ -102,6 +104,24 @@ function App() {
 
   const total = viewModel?.totals.totalTimeMs || 0;
 
+  // Aggregate counters for subtitle
+  const agg = useMemo(() => {
+    const res = { soql: 0, dml: 0, callout: 0, soqlTimeMs: 0, dmlTimeMs: 0, calloutTimeMs: 0 };
+    if (!viewModel) return res;
+    const stack = [...(viewModel.roots || [])];
+    while (stack.length) {
+      const n = stack.pop()!;
+      res.soql += n.metrics.soql || 0;
+      res.dml += n.metrics.dml || 0;
+      res.callout += n.metrics.callout || 0;
+      res.soqlTimeMs += n.metrics.soqlTimeMs || 0;
+      res.dmlTimeMs += n.metrics.dmlTimeMs || 0;
+      res.calloutTimeMs += n.metrics.calloutTimeMs || 0;
+      for (const c of n.children) stack.push(c);
+    }
+    return res;
+  }, [viewModel]);
+
   const onToggle = (id: string) => {
     setCollapsed(prev => {
       const n = new Set(prev);
@@ -117,6 +137,7 @@ function App() {
     setSelectedSig(sig);
     setMode('tree');
     setCollapsed(new Set());
+    setSelectedId(undefined);
   };
 
   const onMerged = (n: CallTreeNode) => {
@@ -125,6 +146,7 @@ function App() {
     setSelectedSig(sig);
     setMode('merged');
     setCollapsed(new Set());
+    setSelectedId(undefined);
   };
 
   const onBacktraces = (n: CallTreeNode) => {
@@ -133,6 +155,7 @@ function App() {
     setSelectedSig(sig);
     setMode('backtraces');
     setCollapsed(new Set());
+    setSelectedId(undefined);
   };
 
   const canBack = history.length > 0;
@@ -144,6 +167,63 @@ function App() {
       setSelectedSig(prev.sig);
       setCollapsed(new Set());
     }
+  };
+
+  // Keyboard shortcuts
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      // Next Important Call: Ctrl+Shift+Right
+      if (e.ctrlKey && e.shiftKey && e.key === 'ArrowRight') {
+        e.preventDefault();
+        nextImportant();
+      }
+      // Scope to This: Ctrl+Enter
+      if (e.ctrlKey && !e.shiftKey && e.key === 'Enter') {
+        e.preventDefault();
+        const n = selectedNode();
+        if (n) onScope(n);
+      }
+      // Merge occurrences: Ctrl+Shift+Enter
+      if (e.ctrlKey && e.shiftKey && e.key === 'Enter') {
+        e.preventDefault();
+        const n = selectedNode();
+        if (n) onMerged(n);
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [selectedId, viewModel, mode, selectedSig]);
+
+  // Helpers for selection and important calls
+  const flatten = (nodes: CallTreeNode[]): CallTreeNode[] => {
+    const out: CallTreeNode[] = [];
+    const st = nodes.slice().reverse();
+    while (st.length) {
+      const n = st.pop()!;
+      out.push(n);
+      for (let i = n.children.length - 1; i >= 0; i--) st.push(n.children[i]!);
+    }
+    return out;
+  };
+  const selectedNode = (): CallTreeNode | undefined => {
+    if (!viewModel || !selectedId) return undefined;
+    return viewModel.all.get(selectedId);
+  };
+  const importantNodes = useMemo(() => {
+    if (!viewModel) return [] as CallTreeNode[];
+    const nodes = flatten(viewModel.roots);
+    const baseTotal = viewModel.totals.totalTimeMs || 0;
+    const threshold = Math.max(1, Math.round(baseTotal * 0.1)); // 10% of total
+    const filtered = nodes.filter(n => (n.metrics.ownTimeMs || 0) >= threshold);
+    // Fallback to top 10 by own time if none over threshold
+    const list = filtered.length ? filtered : nodes.sort((a, b) => (b.metrics.ownTimeMs || 0) - (a.metrics.ownTimeMs || 0)).slice(0, 10);
+    return list;
+  }, [viewModel]);
+  const nextImportant = () => {
+    if (!importantNodes.length) return;
+    const idx = importantNodes.findIndex(n => n.id === selectedId);
+    const nxt = importantNodes[(idx + 1) % importantNodes.length];
+    if (nxt) setSelectedId(nxt.id);
   };
 
   return (
@@ -167,24 +247,41 @@ function App() {
           onChange={e => setFilter(e.target.value)}
           style={{ flex: 1 }}
         />
+        <button type="button" onClick={() => setMode(mode === 'flame' ? 'tree' as Mode : 'flame')} title="Flame Graph">
+          {mode === 'flame' ? 'Tree' : 'Flame Graph'}
+        </button>
+        <button type="button" onClick={nextImportant} title="Next Important Call (Ctrl+Shift+Right)">Next Important</button>
         <span className="dim">Total: {fmtMs(total)}</span>
+        {(agg.soql || agg.dml || agg.callout) ? (
+          <span className="dim">
+            • S{agg.soql}{agg.soqlTimeMs ? `(${agg.soqlTimeMs}ms)` : ''}
+            {agg.dml ? ` D${agg.dml}${agg.dmlTimeMs ? `(${agg.dmlTimeMs}ms)` : ''}` : ''}
+            {agg.callout ? ` C${agg.callout}${agg.calloutTimeMs ? `(${agg.calloutTimeMs}ms)` : ''}` : ''}
+          </span>
+        ) : null}
         <span className="dim">Mode: {mode}</span>
       </div>
-      <div className="tree">
-        {roots.map(r => (
-          <TreeNode
-            key={r.id}
-            node={r}
-            total={total}
-            collapsed={collapsed}
-            onToggle={onToggle}
-            onScope={onScope}
-            onMerged={onMerged}
-            onBacktraces={onBacktraces}
-          />
-        ))}
-        {roots.length === 0 && <div style={{ opacity: 0.8 }}>No calls.</div>}
-      </div>
+      {mode === 'flame' ? (
+        <FlameGraph roots={roots} total={total} onSelect={n => setSelectedId(n.id)} onScope={onScope} selectedId={selectedId} />
+      ) : (
+        <div className="tree">
+          {roots.map(r => (
+            <TreeNode
+              key={r.id}
+              node={r}
+              total={total}
+              collapsed={collapsed}
+              onToggle={onToggle}
+              onScope={onScope}
+              onMerged={onMerged}
+              onBacktraces={onBacktraces}
+              selectedId={selectedId}
+              onSelect={n => setSelectedId(n.id)}
+            />
+          ))}
+          {roots.length === 0 && <div style={{ opacity: 0.8 }}>No calls.</div>}
+        </div>
+      )}
     </div>
   );
 }
@@ -196,7 +293,9 @@ function TreeNode({
   onToggle,
   onScope,
   onMerged,
-  onBacktraces
+  onBacktraces,
+  selectedId,
+  onSelect
 }: {
   node: CallTreeNode;
   total: number;
@@ -205,6 +304,8 @@ function TreeNode({
   onScope: (n: CallTreeNode) => void;
   onMerged: (n: CallTreeNode) => void;
   onBacktraces: (n: CallTreeNode) => void;
+  selectedId?: string;
+  onSelect?: (n: CallTreeNode) => void;
 }) {
   const id = node.id;
   const isCollapsed = collapsed.has(id);
@@ -213,16 +314,31 @@ function TreeNode({
   const cls = classShort(node.ref.className);
   const name = `${cls}.${node.ref.method}`;
   const suffix = node.metrics.count && node.metrics.count > 1 ? ` ×${node.metrics.count}` : '';
+  const selected = selectedId === id;
 
   return (
     <div className="node" style={{ marginLeft: 12 }}>
-      <div className="label" onDoubleClick={() => onToggle(id)}>
+      <div
+        className="label"
+        onDoubleClick={() => onToggle(id)}
+        onClick={() => onSelect?.(node)}
+        style={selected ? { background: 'var(--vscode-list-hoverBackground)', borderRadius: 4 } : undefined}
+      >
         <button type="button" onClick={() => onToggle(id)} style={{ width: 22 }}>
           {node.children.length ? (isCollapsed ? '▸' : '▾') : '·'}
         </button>
         <strong>{name}</strong>
         {suffix ? <span className="dim"> {suffix}</span> : null}
         <span className="dim"> — own {fmtMs(own)} ({percent(own, total)}), total {fmtMs(tot)}</span>
+        {(node.metrics.soql || node.metrics.dml || node.metrics.callout) && (
+          <span className="dim" style={{ marginLeft: 6 }}>
+            [
+            {node.metrics.soql ? `S${node.metrics.soql}${node.metrics.soqlTimeMs ? `(${node.metrics.soqlTimeMs}ms)` : ''}` : 'S0'}
+            {node.metrics.dml ? ` D${node.metrics.dml}${node.metrics.dmlTimeMs ? `(${node.metrics.dmlTimeMs}ms)` : ''}` : ''}
+            {node.metrics.callout ? ` C${node.metrics.callout}${node.metrics.calloutTimeMs ? `(${node.metrics.calloutTimeMs}ms)` : ''}` : ''}
+            ]
+          </span>
+        )}
         <span className="controls">
           <button type="button" onClick={() => onScope(node)} title="Scope to This (Ctrl+Enter)">Scope</button>
           <button type="button" onClick={() => onMerged(node)} title="Merge occurrences (Ctrl+Shift+Enter)">Merge</button>
@@ -239,8 +355,97 @@ function TreeNode({
           onScope={onScope}
           onMerged={onMerged}
           onBacktraces={onBacktraces}
+          selectedId={selectedId}
+          onSelect={onSelect}
         />
       ))}
+    </div>
+  );
+}
+
+function FlameGraph({
+  roots,
+  total,
+  onSelect,
+  onScope,
+  selectedId
+}: {
+  roots: CallTreeNode[];
+  total: number;
+  onSelect: (n: CallTreeNode) => void;
+  onScope: (n: CallTreeNode) => void;
+  selectedId?: string;
+}) {
+  const width = Math.max(600, Math.min(1400, (total || 1) * 4));
+  const rowH = 22;
+  const pad = 8;
+  const scale = (total || 1) > 0 ? (width - pad * 2) / (total || 1) : 1;
+  const blocks: Array<{ n: CallTreeNode; x: number; y: number; w: number; h: number }> = [];
+  const walk = (n: CallTreeNode, x: number, depth: number) => {
+    const w = Math.max(1, Math.round((n.metrics.totalTimeMs || 0) * scale));
+    const y = pad + depth * rowH;
+    blocks.push({ n, x, y, w, h: rowH - 4 });
+    let cx = x;
+    for (const c of n.children) {
+      const cw = Math.max(1, Math.round((c.metrics.totalTimeMs || 0) * scale));
+      walk(c, cx, depth + 1);
+      cx += cw;
+    }
+  };
+  let x0 = pad;
+  for (const r of roots) {
+    const w = Math.max(1, Math.round((r.metrics.totalTimeMs || 0) * scale));
+    walk(r, x0, 0);
+    x0 += w;
+  }
+  const maxDepth = blocks.reduce((m, b) => Math.max(m, (b.y - pad) / rowH), 0) as number;
+  const height = pad + (maxDepth + 1) * rowH + pad;
+
+  const textFor = (n: CallTreeNode) => {
+    const base = `${classShort(n.ref.className)}.${n.ref.method}`;
+    const counts = [
+      n.metrics.soql ? `S${n.metrics.soql}` : '',
+      n.metrics.dml ? `D${n.metrics.dml}` : '',
+      n.metrics.callout ? `C${n.metrics.callout}` : ''
+    ].filter(Boolean);
+    return counts.length && base.length < 32 ? `${base}  [${counts.join(' ')}]` : base;
+  };
+
+  return (
+    <div className="tree" style={{ overflow: 'auto' }}>
+      <svg width={width} height={height} viewBox={`0 0 ${width} ${height}`}>
+        {blocks.map(b => {
+          const selected = selectedId === b.n.id;
+          const label = textFor(b.n);
+          return (
+            <g key={`${b.n.id}`}>
+              <rect
+                x={b.x}
+                y={b.y}
+                width={b.w}
+                height={b.h}
+                rx={3}
+                ry={3}
+                fill={selected ? 'var(--vscode-editorHoverWidget-background)' : 'var(--vscode-editorCodeLens-foreground, rgba(148,163,184,0.25))'}
+                stroke={'var(--vscode-contrastBorder, rgba(148,163,184,0.35))'}
+                onClick={() => onSelect(b.n)}
+                onDoubleClick={() => onScope(b.n)}
+              />
+              {b.w > 40 && (
+                <text x={b.x + 6} y={b.y + b.h / 2 + 4} fontSize={12} fill={'var(--vscode-foreground)'}>
+                  {label}
+                </text>
+              )}
+              <title>
+                {label}\nOwn {fmtMs(b.n.metrics.ownTimeMs)} ({percent(b.n.metrics.ownTimeMs || 0, total)}), Total {fmtMs(b.n.metrics.totalTimeMs)}
+                {(b.n.metrics.soql || b.n.metrics.dml || b.n.metrics.callout) ? `\nS${b.n.metrics.soql || 0}${b.n.metrics.soqlTimeMs ? ` (${b.n.metrics.soqlTimeMs}ms)` : ''}` : ''}
+                {b.n.metrics.dml ? ` D${b.n.metrics.dml}${b.n.metrics.dmlTimeMs ? ` (${b.n.metrics.dmlTimeMs}ms)` : ''}` : ''}
+                {b.n.metrics.callout ? ` C${b.n.metrics.callout}${b.n.metrics.calloutTimeMs ? ` (${b.n.metrics.calloutTimeMs}ms)` : ''}` : ''}
+              </title>
+            </g>
+          );
+        })}
+      </svg>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
Adds a Call Tree panel for Apex logs, built from our existing nested frames produced by the parser. Includes Flame Graph view, keyboard shortcuts and S/D/C badges.

### Highlights
- New command: `sfLogs.showCallTree` (Editor Title when `.log`)
- Call Tree view:
  - own time and total time per method
  - Scope to This, Merge occurrences, Backtraces
  - Search by class/method
  - Badges per node: `S` (SOQL), `D` (DML), `C` (Callout) with optional timings
- Flame Graph view:
  - Bars proportional to total time, stacked by depth
  - Click to select; double‑click to scope
- Keyboard shortcuts:
  - Ctrl+Shift+Right → Next Important Call (by own time)
  - Ctrl+Enter → Scope to This
  - Ctrl+Shift+Enter → Merge occurrences

### Implementation
- Data model + builder
  - `src/shared/callTree/{types.ts, build.ts, index.ts}`
  - Builds tree from `nested` frames; computes `ownTimeMs`; indexes by signature for merge/backtraces
- Panel + webview
  - `src/provider/ApexLogCallTreePanel.ts`
  - `src/webview/calltree.tsx`: tree + flame graph + badges/shortcuts
- Wiring & bundle
  - `package.json`: command, menu (editor title), bundle entry and watch/build
  - `src/extension.ts`: registers `sfLogs.showCallTree`
  - i18n strings updated

### Tests
- Unit: `src/test/unit/calltree.build.test.ts` verifies parent/child and own time
- All existing tests pass locally

### Screens / Notes
- Works with current parser; counters/time come from `NestedFrame.profile`
- No changes in existing diagram panel

### Follow-ups (optional)
- Add a UI toggle to show/hide timings in badges
- Expose threshold settings for “Next Important Call”

