### PR TITLE
refactor(provider): extract log services and handlers

### DIFF
--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -1,0 +1,63 @@
+import type { WebviewToExtensionMessage } from '../shared/messages';
+import { logInfo } from '../utils/logger';
+
+export class LogsMessageHandler {
+  constructor(
+    private readonly refresh: () => Promise<void>,
+    private readonly sendOrgs: () => Promise<void>,
+    private readonly setSelectedOrg: (org?: string) => void,
+    private readonly openLog: (logId: string) => Promise<void>,
+    private readonly debugLog: (logId: string) => Promise<void>,
+    private readonly loadMore: () => Promise<void>,
+    private readonly setLoading: (val: boolean) => void
+  ) {}
+
+  async handle(message: WebviewToExtensionMessage): Promise<void> {
+    if (!message?.type) {
+      return;
+    }
+    switch (message.type) {
+      case 'ready':
+        logInfo('Logs: message ready');
+        this.setLoading(true);
+        await this.sendOrgs();
+        await this.refresh();
+        this.setLoading(false);
+        break;
+      case 'refresh':
+        logInfo('Logs: message refresh');
+        await this.refresh();
+        break;
+      case 'getOrgs':
+        logInfo('Logs: message getOrgs');
+        this.setLoading(true);
+        try {
+          await this.sendOrgs();
+        } finally {
+          this.setLoading(false);
+        }
+        break;
+      case 'selectOrg':
+        this.setSelectedOrg(typeof message.target === 'string' ? message.target.trim() : undefined);
+        logInfo('Logs: selected org set');
+        await this.refresh();
+        break;
+      case 'openLog':
+        if (message.logId) {
+          logInfo('Logs: openLog', message.logId);
+          await this.openLog(message.logId);
+        }
+        break;
+      case 'replay':
+        if (message.logId) {
+          logInfo('Logs: replay', message.logId);
+          await this.debugLog(message.logId);
+        }
+        break;
+      case 'loadMore':
+        logInfo('Logs: loadMore');
+        await this.loadMore();
+        break;
+    }
+  }
+}

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,0 +1,142 @@
+import * as vscode from 'vscode';
+import { promises as fs } from 'fs';
+import { createLimiter, type Limiter } from '../utils/limiter';
+import { getOrgAuth } from '../salesforce/cli';
+import {
+  fetchApexLogs,
+  fetchApexLogHead,
+  fetchApexLogBody,
+  extractCodeUnitStartedFromLines
+} from '../salesforce/http';
+import type { ApexLogCursor } from '../salesforce/http';
+import type { OrgAuth } from '../salesforce/types';
+import type { ApexLogRow } from '../shared/types';
+import { getLogFilePathWithUsername, findExistingLogFile } from '../utils/workspace';
+import { ensureReplayDebuggerAvailable } from '../utils/warmup';
+import { getErrorMessage } from '../utils/error';
+import { logWarn } from '../utils/logger';
+
+export class LogService {
+  private headLimiter: Limiter;
+  private headConcurrency: number;
+
+  constructor(headConcurrency = 5) {
+    this.headConcurrency = headConcurrency;
+    this.headLimiter = createLimiter(this.headConcurrency);
+  }
+
+  setHeadConcurrency(conc: number): void {
+    if (conc !== this.headConcurrency) {
+      this.headConcurrency = conc;
+      this.headLimiter = createLimiter(this.headConcurrency);
+    }
+  }
+
+  async fetchLogs(
+    auth: OrgAuth,
+    limit: number,
+    offset: number,
+    signal?: AbortSignal,
+    cursor?: ApexLogCursor
+  ): Promise<ApexLogRow[]> {
+    return fetchApexLogs(auth, limit, offset, undefined, undefined, signal, cursor);
+  }
+
+  loadLogHeads(
+    logs: ApexLogRow[],
+    auth: OrgAuth,
+    token: number,
+    post: (logId: string, codeUnit: string) => void,
+    signal?: AbortSignal
+  ): void {
+    for (const log of logs) {
+      void this.headLimiter(async () => {
+        if (signal?.aborted) {
+          return;
+        }
+        try {
+          const headLines = await fetchApexLogHead(
+            auth,
+            log.Id,
+            10,
+            typeof log.LogLength === 'number' ? log.LogLength : undefined,
+            undefined,
+            signal
+          );
+          if (signal?.aborted) {
+            return;
+          }
+          const codeUnit = extractCodeUnitStartedFromLines(headLines);
+          if (codeUnit) {
+            post(log.Id, codeUnit);
+          }
+        } catch (e) {
+          logWarn('LogService: loadLogHead failed for', log.Id, '->', e);
+        }
+      });
+    }
+  }
+
+  private async ensureLogFile(logId: string, selectedOrg?: string): Promise<string> {
+    const existing = await findExistingLogFile(logId);
+    if (existing) {
+      return existing;
+    }
+    const auth = await getOrgAuth(selectedOrg);
+    const { filePath } = await getLogFilePathWithUsername(auth.username, logId);
+    const body = await fetchApexLogBody(auth, logId);
+    await fs.writeFile(filePath, body, 'utf8');
+    return filePath;
+  }
+
+  async openLog(logId: string, selectedOrg?: string): Promise<void> {
+    const targetPath = await this.ensureLogFile(logId, selectedOrg);
+    const uri = vscode.Uri.file(targetPath);
+    const doc = await vscode.workspace.openTextDocument(uri);
+    await vscode.window.showTextDocument(doc, { preview: true });
+  }
+
+  async debugLog(logId: string, selectedOrg?: string): Promise<void> {
+    await vscode.window.withProgress(
+      {
+        location: vscode.ProgressLocation.Notification,
+        title: 'Starting Apex Replay Debugger…',
+        cancellable: true
+      },
+      async (_progress, ct) => {
+        const controller = new AbortController();
+        ct.onCancellationRequested(() => controller.abort());
+        const ok = await ensureReplayDebuggerAvailable();
+        if (!ok || ct.isCancellationRequested) {
+          return;
+        }
+        let targetPath = await findExistingLogFile(logId);
+        if (!targetPath) {
+          const auth = await getOrgAuth(selectedOrg, undefined, controller.signal);
+          if (ct.isCancellationRequested) {
+            return;
+          }
+          const { filePath } = await getLogFilePathWithUsername(auth.username, logId);
+          const body = await fetchApexLogBody(auth, logId, undefined, controller.signal);
+          if (ct.isCancellationRequested) {
+            return;
+          }
+          await fs.writeFile(filePath, body, 'utf8');
+          targetPath = filePath;
+        }
+        if (ct.isCancellationRequested) {
+          return;
+        }
+        const uri = vscode.Uri.file(targetPath);
+        try {
+          await vscode.commands.executeCommand('sf.launch.replay.debugger.logfile', uri);
+        } catch (e) {
+          if (!controller.signal.aborted) {
+            logWarn('LogService: sf.launch.replay.debugger.logfile failed ->', getErrorMessage(e));
+            await vscode.commands.executeCommand('sfdx.launch.replay.debugger.logfile', uri);
+          }
+        }
+      }
+    );
+  }
+}

--- a/src/test/logService.test.ts
+++ b/src/test/logService.test.ts
@@ -1,0 +1,54 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+import type { OrgAuth } from '../salesforce/types';
+import type { ApexLogRow } from '../shared/types';
+
+suite('LogService', () => {
+  test('fetchLogs delegates to fetchApexLogs', async () => {
+    const calls: any[] = [];
+    const { LogService } = proxyquire('../services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: (auth: OrgAuth, limit: number, offset: number) => {
+          calls.push({ auth, limit, offset });
+          return Promise.resolve([{ Id: '1' }] as ApexLogRow[]);
+        },
+        fetchApexLogHead: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => ''
+      },
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async () => ({ dir: '', filePath: '' }),
+        findExistingLogFile: async () => undefined
+      }
+    });
+    const svc = new LogService();
+    const auth: OrgAuth = { accessToken: 't', instanceUrl: 'url', username: 'u' };
+    const res = await svc.fetchLogs(auth, 2, 0);
+    assert.equal(res.length, 1);
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], { auth, limit: 2, offset: 0 });
+  });
+
+  test('loadLogHeads posts code units', async () => {
+    const { LogService } = proxyquire('../services/logService', {
+      '../salesforce/http': {
+        fetchApexLogHead: async () => ['line'],
+        extractCodeUnitStartedFromLines: () => 'Unit',
+        fetchApexLogs: async () => [],
+        fetchApexLogBody: async () => ''
+      },
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async () => ({ dir: '', filePath: '' }),
+        findExistingLogFile: async () => undefined
+      }
+    });
+    const svc = new LogService(1);
+    const logs: ApexLogRow[] = [{ Id: '1', LogLength: 10 } as any];
+    const seen: any[] = [];
+    svc.loadLogHeads(logs, {} as OrgAuth, 0, (id: string, code: string) => {
+      seen.push({ id, code });
+    });
+    await new Promise(r => setTimeout(r, 10));
+    assert.deepEqual(seen, [{ id: '1', code: 'Unit' }]);
+  });
+});

--- a/src/test/orgManager.test.ts
+++ b/src/test/orgManager.test.ts
@@ -1,0 +1,39 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+import type * as vscode from 'vscode';
+
+suite('OrgManager', () => {
+  test('setSelectedOrg persists value', () => {
+    let saved: string | undefined;
+    const { OrgManager } = proxyquire('../utils/orgManager', {
+      './orgs': {
+        persistSelectedOrg: (_ctx: vscode.ExtensionContext, val?: string) => {
+          saved = val;
+        },
+        restoreSelectedOrg: () => undefined,
+        pickSelectedOrg: () => undefined
+      },
+      '../salesforce/cli': { listOrgs: async () => [] }
+    });
+    const mgr = new OrgManager({} as any);
+    mgr.setSelectedOrg('user1');
+    assert.equal(saved, 'user1');
+  });
+
+  test('list returns orgs and selected', async () => {
+    const { OrgManager } = proxyquire('../utils/orgManager', {
+      './orgs': {
+        persistSelectedOrg: () => {},
+        restoreSelectedOrg: () => 'u1',
+        pickSelectedOrg: () => 'u1'
+      },
+      '../salesforce/cli': {
+        listOrgs: async () => [{ username: 'u1' }]
+      }
+    });
+    const mgr = new OrgManager({} as any);
+    const res = await mgr.list();
+    assert.equal(res.selected, 'u1');
+    assert.equal(res.orgs.length, 1);
+  });
+});

--- a/src/test/persistedState.test.ts
+++ b/src/test/persistedState.test.ts
@@ -29,11 +29,11 @@ suite('Persisted org state', () => {
     const { context, capturedGetKey, updates } = makeContext();
     const provider = new SfLogsViewProvider(context);
     assert.equal(capturedGetKey(), SELECTED_ORG_KEY);
-    assert.equal((provider as any).selectedOrg, 'persisted-org');
-    (provider as any).setSelectedOrg('next-org');
+    assert.equal((provider as any).orgManager.getSelectedOrg(), 'persisted-org');
+    provider.setSelectedOrg('next-org');
     assert.equal(updates[0]?.key, SELECTED_ORG_KEY);
     assert.equal(updates[0]?.value, 'next-org');
-    assert.equal((provider as any).selectedOrg, 'next-org');
+    assert.equal((provider as any).orgManager.getSelectedOrg(), 'next-org');
   });
 
   test('SfLogTailViewProvider restores and persists selected org', () => {

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -1,0 +1,22 @@
+import { getNumberConfig, affectsConfiguration } from './config';
+import type * as vscode from 'vscode';
+
+export class ConfigManager {
+  constructor(private headConcurrency: number, private pageLimit: number) {}
+
+  handleChange(e: vscode.ConfigurationChangeEvent): void {
+    if (affectsConfiguration(e, 'sfLogs.headConcurrency')) {
+      this.headConcurrency = getNumberConfig('sfLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
+    }
+  }
+
+  getHeadConcurrency(): number {
+    return this.headConcurrency;
+  }
+
+  getPageLimit(): number {
+    const configuredLimit = getNumberConfig('sfLogs.pageSize', this.pageLimit, 10, Number.MAX_SAFE_INTEGER);
+    this.pageLimit = Math.min(configuredLimit, 200);
+    return this.pageLimit;
+  }
+}

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -1,0 +1,26 @@
+import type * as vscode from 'vscode';
+import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from './orgs';
+import { listOrgs } from '../salesforce/cli';
+import type { OrgItem } from '../shared/types';
+
+export class OrgManager {
+  private selectedOrg: string | undefined;
+  constructor(private readonly context: vscode.ExtensionContext) {
+    this.selectedOrg = restoreSelectedOrg(this.context) || undefined;
+  }
+
+  getSelectedOrg(): string | undefined {
+    return this.selectedOrg;
+  }
+
+  setSelectedOrg(org?: string): void {
+    this.selectedOrg = org;
+    persistSelectedOrg(this.context, org);
+  }
+
+  async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {
+    const orgs = await listOrgs(forceRefresh, signal);
+    const selected = pickSelectedOrg(orgs, this.selectedOrg);
+    return { orgs, selected };
+  }
+}


### PR DESCRIPTION
## Summary
- modularize webview messaging via `LogsMessageHandler`
- centralize log operations in new `LogService`
- introduce `OrgManager` and `ConfigManager` utilities with unit tests

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c06a9d92148323a227119266aa57a6