### PR TITLE
fix(webview): allow worker-src in CSP to prevent service worker registration error

### DIFF
--- a/src/utils/webviewHtml.ts
+++ b/src/utils/webviewHtml.ts
@@ -10,7 +10,12 @@ export function buildWebviewHtml(
   title: string
 ): string {
   const scriptUri = webview.asWebviewUri(vscode.Uri.joinPath(extensionUri, 'media', scriptFile));
-  const csp = `default-src 'none'; img-src ${webview.cspSource} https:; script-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline';`;
+  // Allow service/worker scripts from the webview source. VS Code registers
+  // an internal service worker to serve local resources. Without an explicit
+  // worker-src, the default-src ('none') can cause registration to fail on
+  // some platforms, leading to sporadic "Could not register service worker"
+  // errors. Keeping other directives tight.
+  const csp = `default-src 'none'; img-src ${webview.cspSource} https:; script-src ${webview.cspSource}; style-src ${webview.cspSource} 'unsafe-inline'; worker-src ${webview.cspSource};`;
   return `<!DOCTYPE html>
       <html lang="en">
       <head>
@@ -43,4 +48,3 @@ export function buildWebviewHtml(
       </body>
       </html>`;
 }
-


### PR DESCRIPTION
This PR fixes intermittent webview load failures:

- Error: "Could not register service worker: InvalidStateError: The document is in an invalid state"

Root cause
- Our CSP used `default-src 'none'` without an explicit `worker-src`, so Chromium applied `default-src` to worker/service worker scripts and blocked VS Code’s internal service worker for webviews.

Change
- Update `src/utils/webviewHtml.ts` to include `worker-src ${webview.cspSource}`, keeping all other directives restrictive.

Validation
- Ran `npm run lint`, `npm run check-types`, `npm run build`, and `npm test` — all pass locally.

Impact
- Applies to all panels using `buildWebviewHtml` (Logs, Tail, Diagram, Call Tree).
- No functional changes beyond CSP; mitigates the error toast users reported.

Notes
- If anyone still sees the error on very old VS Code versions, try "Developer: Reload Window" or update VS Code.
