### PR TITLE
feat(logs): add duration column to Apex Logs view

### DIFF
--- a/src/shared/format.ts
+++ b/src/shared/format.ts
@@ -21,3 +21,14 @@ function formatUnit(value: number, unit: 'KB' | 'MB' | 'GB'): string {
   const trimmed = s.endsWith('.0') ? s.slice(0, -2) : s;
   return `${trimmed} ${unit}`;
 }
+
+export function formatDuration(ms: number): string {
+  const n = typeof ms === 'number' && isFinite(ms) ? Math.max(0, Math.floor(ms)) : 0;
+  if (n < 1000) {
+    return `${n} ms`;
+  }
+  const seconds = n / 1000;
+  const s = seconds.toFixed(1);
+  const trimmed = s.endsWith('.0') ? s.slice(0, -2) : s;
+  return `${trimmed} s`;
+}

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -29,9 +29,11 @@ export function LogsTable({
   locale: string;
   hasMore: boolean;
   onLoadMore: () => void;
-  sortBy: 'user' | 'application' | 'operation' | 'time' | 'status' | 'size' | 'codeUnit';
+  sortBy: 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit';
   sortDir: 'asc' | 'desc';
-  onSort: (key: 'user' | 'application' | 'operation' | 'time' | 'status' | 'size' | 'codeUnit') => void;
+  onSort: (
+    key: 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit'
+  ) => void;
 }) {
   const listRef = useRef<ListImperativeAPI | null>(null);
   const outerRef = useRef<HTMLDivElement | null>(null);
@@ -54,7 +56,7 @@ export function LogsTable({
   const loadingRef = useRef<boolean>(loading);
   const lastLoadTsRef = useRef<number>(0);
   const gridTemplate =
-    'minmax(160px,1fr) minmax(140px,1fr) minmax(200px,1.2fr) minmax(200px,1fr) minmax(120px,0.8fr) minmax(260px,1.4fr) minmax(90px,0.6fr) 72px';
+    'minmax(160px,1fr) minmax(140px,1fr) minmax(200px,1.2fr) minmax(200px,1fr) minmax(110px,0.6fr) minmax(120px,0.8fr) minmax(260px,1.4fr) minmax(90px,0.6fr) 72px';
   // Header is rendered by LogsHeader; keep container simple
 
   // autoPagingActivated will be flipped by the adaptive overscan listener below

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -1,7 +1,7 @@
 import React, { useLayoutEffect, useRef } from 'react';
 import type { ApexLogRow } from '../../../shared/types';
 import type { LogHeadMap } from '../LogsTable';
-import { formatBytes } from '../../utils/format';
+import { formatBytes, formatDuration } from '../../utils/format';
 import { OpenIcon } from '../icons/OpenIcon';
 import { ReplayIcon, SpinnerIcon } from '../icons/ReplayIcon';
 import { IconButton } from '../IconButton';
@@ -103,6 +103,7 @@ export function LogRow({
         <div style={baseCell}>{r.Application}</div>
         <div style={baseCell}>{r.Operation}</div>
         <div style={baseCell}>{new Date(r.StartTime).toLocaleString(locale)}</div>
+        <div style={baseCell}>{formatDuration(r.DurationMilliseconds)}</div>
         <div style={baseCell}>{r.Status}</div>
         <div style={baseCell} title={logHead[r.Id]?.codeUnitStarted ?? ''}>
           {logHead[r.Id]?.codeUnitStarted ?? ''}

--- a/src/webview/components/table/LogsHeader.tsx
+++ b/src/webview/components/table/LogsHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-type SortKey = 'user' | 'application' | 'operation' | 'time' | 'status' | 'size' | 'codeUnit';
+type SortKey = 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit';
 
 type Props = {
   t: any;
@@ -76,6 +76,15 @@ export const LogsHeader = React.forwardRef<HTMLDivElement, Props>(
         >
           {t.columns.time}
           {sortArrow('time')}
+        </div>
+        <div
+          role="columnheader"
+          style={sortableStyle}
+          aria-sort={sortBy === 'duration' ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'}
+          onClick={() => onSort('duration')}
+        >
+          {t.columns.duration}
+          {sortArrow('duration')}
         </div>
         <div
           role="columnheader"

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -39,6 +39,7 @@ export type Messages = {
     application: string;
     operation: string;
     time: string;
+    duration: string;
     status: string;
     size: string;
     codeUnitStarted: string;
@@ -86,6 +87,7 @@ const en: Messages = {
     application: 'Application',
     operation: 'Operation',
     time: 'Time',
+    duration: 'Duration',
     status: 'Status',
     size: 'Size',
     codeUnitStarted: 'Code Unit'
@@ -133,6 +135,7 @@ const ptBR: Messages = {
     application: 'Aplicação',
     operation: 'Operação',
     time: 'Tempo',
+    duration: 'Duração',
     status: 'Status',
     size: 'Tamanho',
     codeUnitStarted: 'Code Unit'

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -18,7 +18,7 @@ declare global {
 
 const vscode = acquireVsCodeApi<WebviewToExtensionMessage>();
 
-type SortKey = 'user' | 'application' | 'operation' | 'time' | 'status' | 'size' | 'codeUnit';
+type SortKey = 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit';
 
 function App() {
   const [locale, setLocale] = useState('en');
@@ -104,7 +104,7 @@ function App() {
     } else {
       setSortBy(key);
       // sensible defaults
-      setSortDir(key === 'time' || key === 'size' ? 'desc' : 'asc');
+      setSortDir(key === 'time' || key === 'size' || key === 'duration' ? 'desc' : 'asc');
     }
   };
 
@@ -171,6 +171,9 @@ function App() {
           break;
         case 'time':
           cmp = new Date(a.StartTime).getTime() - new Date(b.StartTime).getTime();
+          break;
+        case 'duration':
+          cmp = (a.DurationMilliseconds || 0) - (b.DurationMilliseconds || 0);
           break;
         case 'status':
           cmp = (a.Status || '').localeCompare(b.Status || '');

--- a/src/webview/utils/format.ts
+++ b/src/webview/utils/format.ts
@@ -1,1 +1,1 @@
-export { formatBytes } from '../../shared/format';
+export { formatBytes, formatDuration } from '../../shared/format';


### PR DESCRIPTION
This PR adds a new Duration column to the Apex Logs table.

Changes
- UI: add Duration column (header + cells) between Time and Status
- Sorting: support sorting by duration (default desc)
- i18n: en=Duration, pt-BR=Duração
- Format: formatDuration(ms) utility (ms < 1000 → 'NN ms'; otherwise seconds with 1 decimal)

Validation
- npm run build
- npm test (all passing)

Notes
- No Salesforce org required; this is a purely UI + wiring change.