### PR TITLE
feat(webview): introduce LabeledSelect; refactor selects and update toolbars

### DIFF
--- a/src/webview/components/FilterSelect.tsx
+++ b/src/webview/components/FilterSelect.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { LabeledSelect } from './LabeledSelect';
 
 type Props = {
   label: string;
@@ -10,25 +11,14 @@ type Props = {
 };
 
 export function FilterSelect({ label, value, onChange, options, allLabel = 'All', disabled = false }: Props) {
-  const selectStyle: React.CSSProperties = {
-    background: 'var(--vscode-dropdown-background, var(--vscode-input-background))',
-    color: 'var(--vscode-dropdown-foreground, var(--vscode-input-foreground))',
-    border: '1px solid var(--vscode-dropdown-border, var(--vscode-input-border))',
-    padding: '2px 6px',
-    borderRadius: 4
-  };
-
   return (
-    <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-      <span style={{ opacity: 0.8 }}>{label}:</span>
-      <select value={value} onChange={e => onChange(e.target.value)} style={selectStyle} disabled={disabled}>
-        <option value="">{allLabel}</option>
-        {options.map(o => (
-          <option key={o} value={o}>
-            {o}
-          </option>
-        ))}
-      </select>
-    </label>
+    <LabeledSelect
+      label={label}
+      value={value}
+      onChange={onChange}
+      options={options.map(o => ({ value: o, label: o }))}
+      placeholderLabel={allLabel}
+      disabled={disabled}
+    />
   );
 }

--- a/src/webview/components/LabeledSelect.tsx
+++ b/src/webview/components/LabeledSelect.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import type ReactNS from 'react';
+import { selectStyle as baseSelectStyle } from './styles';
+
+export type LabeledSelectOption = {
+  value: string;
+  label: string;
+};
+
+type LabeledSelectProps = {
+  label: string;
+  value: string;
+  onChange: (value: string) => void;
+  options: LabeledSelectOption[];
+  disabled?: boolean;
+  // When provided, renders a first option with empty value
+  // Useful for filters with an "All" choice
+  placeholderLabel?: string;
+  // If true and there are no options, render `emptyText` instead of a select
+  hideIfEmpty?: boolean;
+  emptyText?: string;
+  // Allow minor style overrides (e.g., minWidth)
+  selectStyleOverride?: ReactNS.CSSProperties;
+};
+
+export function LabeledSelect({
+  label,
+  value,
+  onChange,
+  options,
+  disabled = false,
+  placeholderLabel,
+  hideIfEmpty = false,
+  emptyText,
+  selectStyleOverride
+}: LabeledSelectProps) {
+  if (hideIfEmpty && options.length === 0) {
+    return (
+      <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <span style={{ opacity: 0.8 }}>{label}:</span>
+        <span style={{ opacity: 0.7 }} aria-live="polite">
+          {emptyText || 'No options available.'}
+        </span>
+      </label>
+    );
+  }
+
+  const selectStyle = { ...baseSelectStyle, ...(selectStyleOverride || {}) };
+
+  return (
+    <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+      <span style={{ opacity: 0.8 }}>{label}:</span>
+      <select
+        value={value}
+        onChange={e => onChange(e.target.value)}
+        disabled={disabled}
+        style={selectStyle}
+      >
+        {typeof placeholderLabel === 'string' && (
+          <option value="">{placeholderLabel}</option>
+        )}
+        {options.map(o => (
+          <option key={o.value} value={o.value}>
+            {o.label}
+          </option>
+        ))}
+      </select>
+    </label>
+  );
+}
+

--- a/src/webview/components/OrgSelect.tsx
+++ b/src/webview/components/OrgSelect.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { OrgItem } from '../../shared/types';
-import { selectStyle } from './styles';
+import { LabeledSelect } from './LabeledSelect';
 
 export function OrgSelect({
   label,
@@ -17,24 +17,20 @@ export function OrgSelect({
   disabled?: boolean;
   emptyText?: string;
 }) {
-  const value = selected ?? (orgs[0]?.username || '');
+  const options = orgs.map(o => ({
+    value: o.username,
+    label: (o.alias ?? o.username) + (o.isDefaultUsername ? ' *' : '')
+  }));
+  const value = selected ?? (options[0]?.value || '');
   return (
-    <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-      <span style={{ opacity: 0.8 }}>{label}:</span>
-      {orgs.length > 0 ? (
-        <select value={value} onChange={e => onChange(e.target.value)} disabled={disabled} style={selectStyle}>
-          {orgs.map(o => (
-            <option key={o.username} value={o.username}>
-              {(o.alias ?? o.username) + (o.isDefaultUsername ? ' *' : '')}
-            </option>
-          ))}
-        </select>
-      ) : (
-        <span style={{ opacity: 0.7 }} aria-live="polite">
-          {emptyText || 'No orgs detected.'}
-        </span>
-      )}
-    </label>
+    <LabeledSelect
+      label={label}
+      value={value}
+      onChange={onChange}
+      options={options}
+      disabled={disabled}
+      hideIfEmpty
+      emptyText={emptyText || 'No orgs detected.'}
+    />
   );
 }
-

--- a/src/webview/components/tail/TailToolbar.tsx
+++ b/src/webview/components/tail/TailToolbar.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { OrgItem } from '../../../shared/types';
-import { commonButtonStyle, inputStyle, selectStyle } from '../styles';
+import { commonButtonStyle, inputStyle } from '../styles';
+import { LabeledSelect } from '../LabeledSelect';
 import { OrgSelect } from '../OrgSelect';
 import { SpinnerIcon } from '../icons/ReplayIcon';
 
@@ -123,22 +124,15 @@ export function TailToolbar({
         />
         <span>{t.tail?.colorize ?? 'Color'}</span>
       </label>
-      <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
-        <span>{t.tail?.debugLevel ?? 'Debug level'}</span>
-        <select
-          value={debugLevel}
-          onChange={e => onDebugLevelChange(e.target.value)}
-          disabled={disabled}
-          style={{ ...selectStyle, minWidth: 140 }}
-        >
-          <option value="">{t.tail?.select ?? 'Select'}</option>
-          {debugLevels.map(level => (
-            <option key={level} value={level}>
-              {level}
-            </option>
-          ))}
-        </select>
-      </label>
+      <LabeledSelect
+        label={t.tail?.debugLevel ?? 'Debug level'}
+        value={debugLevel}
+        onChange={onDebugLevelChange}
+        disabled={disabled}
+        options={debugLevels.map(level => ({ value: level, label: level }))}
+        placeholderLabel={t.tail?.select ?? 'Select'}
+        selectStyleOverride={{ minWidth: 140 }}
+      />
       <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
         <input
           type="checkbox"


### PR DESCRIPTION
This PR introduces a shared webview select component and refactors existing selects to use it.\n\nChanges\n- Add LabeledSelect component using shared `selectStyle` from `styles.ts`\n- Refactor FilterSelect and OrgSelect to wrap LabeledSelect (remove inline styles)\n- Update TailToolbar to use LabeledSelect for debug level\n- Toolbar continues to use FilterSelect/OrgSelect wrappers (now backed by LabeledSelect)\n\nValidation\n- Lint: npm run lint — OK\n- Types: npm run check-types — OK\n- Build: npm run build — OK\n- Tests: npm test — 78 passing\n\nRationale\n- Consolidates label + select structure\n- Reduces duplication and ensures consistent styling across webviews\n\nNotes\n- No breaking changes to props for Toolbar/TailToolbar consumers.\n