### PR TITLE
test(provider): add message handling tests

### DIFF
--- a/src/test/logsMessageHandler.test.ts
+++ b/src/test/logsMessageHandler.test.ts
@@ -1,0 +1,88 @@
+import assert from 'assert/strict';
+import { LogsMessageHandler } from '../provider/logsMessageHandler';
+import type { WebviewToExtensionMessage } from '../shared/messages';
+
+suite('LogsMessageHandler', () => {
+  function makeHandler() {
+    const calls = {
+      refresh: 0,
+      sendOrgs: 0,
+      setSelectedOrg: [] as (string | undefined)[],
+      openLog: [] as string[],
+      debugLog: [] as string[],
+      loadMore: 0,
+      setLoading: [] as boolean[],
+    };
+    const handler = new LogsMessageHandler(
+      async () => {
+        calls.refresh++;
+      },
+      async () => {
+        calls.sendOrgs++;
+      },
+      (org?: string) => {
+        calls.setSelectedOrg.push(org);
+      },
+      async (logId: string) => {
+        calls.openLog.push(logId);
+      },
+      async (logId: string) => {
+        calls.debugLog.push(logId);
+      },
+      async () => {
+        calls.loadMore++;
+      },
+      (val: boolean) => {
+        calls.setLoading.push(val);
+      }
+    );
+    return { handler, calls };
+  }
+
+  test('handles ready message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'ready' } as WebviewToExtensionMessage);
+    assert.deepStrictEqual(calls.setLoading, [true, false]);
+    assert.equal(calls.sendOrgs, 1);
+    assert.equal(calls.refresh, 1);
+  });
+
+  test('handles selectOrg message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'selectOrg', target: ' foo ' } as WebviewToExtensionMessage);
+    assert.deepStrictEqual(calls.setSelectedOrg, ['foo']);
+    assert.equal(calls.refresh, 1);
+  });
+
+  test('handles loadMore message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'loadMore' } as WebviewToExtensionMessage);
+    assert.equal(calls.loadMore, 1);
+  });
+
+  test('handles openLog message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'openLog', logId: '123' } as WebviewToExtensionMessage);
+    assert.deepStrictEqual(calls.openLog, ['123']);
+  });
+
+  test('handles replay message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'replay', logId: 'xyz' } as WebviewToExtensionMessage);
+    assert.deepStrictEqual(calls.debugLog, ['xyz']);
+  });
+
+  test('handles getOrgs message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'getOrgs' } as WebviewToExtensionMessage);
+    assert.deepStrictEqual(calls.setLoading, [true, false]);
+    assert.equal(calls.sendOrgs, 1);
+  });
+
+  test('handles refresh message', async () => {
+    const { handler, calls } = makeHandler();
+    await handler.handle({ type: 'refresh' } as WebviewToExtensionMessage);
+    assert.equal(calls.refresh, 1);
+  });
+});
+

--- a/src/test/tailMessages.test.ts
+++ b/src/test/tailMessages.test.ts
@@ -1,0 +1,119 @@
+import assert from 'assert/strict';
+import * as vscode from 'vscode';
+import * as path from 'path';
+import { SfLogTailViewProvider } from '../provider/SfLogTailViewProvider';
+
+class MockDisposable implements vscode.Disposable {
+  dispose(): void {
+    /* noop */
+  }
+}
+
+class MockWebview implements vscode.Webview {
+  html = '';
+  options: vscode.WebviewOptions = {};
+  cspSource = 'vscode-resource://test';
+  private handler: ((e: any) => any) | undefined;
+  posts: any[] = [];
+  asWebviewUri(uri: vscode.Uri): vscode.Uri {
+    return uri;
+  }
+  postMessage(message: any): Thenable<boolean> {
+    this.posts.push(message);
+    return Promise.resolve(true);
+  }
+  onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+    this.handler = listener;
+    return new MockDisposable();
+  }
+  emit(message: any) {
+    return this.handler?.(message);
+  }
+}
+
+class MockWebviewView implements vscode.WebviewView {
+  visible = true;
+  title = 'Test';
+  viewType = 'sfLogTail';
+  description?: string | undefined;
+  badge?: { value: number; tooltip: string } | undefined;
+  webview: vscode.Webview;
+  constructor(webview: vscode.Webview) {
+    this.webview = webview;
+  }
+  show(_preserveFocus?: boolean | undefined): void {
+    /* noop */
+  }
+  onDidChangeVisibility: vscode.Event<void> = () => new MockDisposable();
+  onDidDispose: vscode.Event<void> = () => new MockDisposable();
+}
+
+suite('SfLogTailViewProvider tail messages', () => {
+  const origOnDidChangeWindowState = vscode.window.onDidChangeWindowState;
+  const origStateDescriptor = Object.getOwnPropertyDescriptor(vscode.window, 'state');
+  setup(() => {
+    Object.defineProperty(vscode.window, 'state', { value: { active: true }, configurable: true });
+    (vscode.window as any).onDidChangeWindowState = () => new MockDisposable();
+  });
+  teardown(() => {
+    if (origStateDescriptor) {
+      Object.defineProperty(vscode.window, 'state', origStateDescriptor);
+    }
+    (vscode.window as any).onDidChangeWindowState = origOnDidChangeWindowState;
+  });
+
+  function makeProvider() {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[],
+      globalState: {
+        get: () => undefined,
+        update: async () => {}
+      }
+    } as unknown as vscode.ExtensionContext;
+    const provider = new SfLogTailViewProvider(context);
+    const started: (string | undefined)[] = [];
+    let stopped = false;
+    let cleared = false;
+    (provider as any).tailService = {
+      start: async (level?: string) => {
+        started.push(level);
+      },
+      stop: () => {
+        stopped = true;
+      },
+      clearLogPaths: () => {
+        cleared = true;
+      },
+      setOrg: () => {},
+      setWindowActive: () => {},
+      isRunning: () => false,
+      promptPoll: () => {},
+    };
+    const webview = new MockWebview();
+    const view = new MockWebviewView(webview);
+    provider.resolveWebviewView(view);
+    return { webview, started, isStopped: () => stopped, isCleared: () => cleared };
+  }
+
+  test('tailStart starts tail service and toggles loading', async () => {
+    const { webview, started } = makeProvider();
+    await (webview as any).emit({ type: 'tailStart', debugLevel: 'FINE' });
+    assert.deepStrictEqual(started, ['FINE']);
+    const loading = (webview as MockWebview).posts.filter(p => p.type === 'loading').map(p => p.value);
+    assert.deepStrictEqual(loading, [true, false]);
+  });
+
+  test('tailStop stops tail service', async () => {
+    const { webview, isStopped } = makeProvider();
+    await (webview as any).emit({ type: 'tailStop' });
+    assert.equal(isStopped(), true);
+  });
+
+  test('tailClear clears paths and posts reset', async () => {
+    const { webview, isCleared } = makeProvider();
+    await (webview as any).emit({ type: 'tailClear' });
+    assert.equal(isCleared(), true);
+    assert.ok((webview as MockWebview).posts.find(p => p.type === 'tailReset'));
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for LogsMessageHandler messages
- ensure SfLogTailViewProvider reacts to tail start/stop/clear

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58509b0c48323ab798c937958b7c5