### PR TITLE
feat(webview): add log filters hook

### DIFF
--- a/src/test/useLogFilters.test.ts
+++ b/src/test/useLogFilters.test.ts
@@ -1,0 +1,49 @@
+import assert from 'assert/strict';
+import { renderHook, act } from '@testing-library/react';
+import useLogFilters from '../webview/hooks/useLogFilters';
+
+suite('useLogFilters', () => {
+  test('updates filters and sorting', () => {
+    const { result } = renderHook(() => useLogFilters());
+    act(() => {
+      result.current.setQuery('abc');
+      result.current.setFilterUser('user1');
+      result.current.setFilterOperation('op1');
+      result.current.setFilterStatus('success');
+      result.current.setFilterCodeUnit('MyClass');
+      result.current.onSort('user');
+    });
+    assert.equal(result.current.query, 'abc');
+    assert.equal(result.current.filterUser, 'user1');
+    assert.equal(result.current.filterOperation, 'op1');
+    assert.equal(result.current.filterStatus, 'success');
+    assert.equal(result.current.filterCodeUnit, 'MyClass');
+    assert.equal(result.current.sortBy, 'user');
+    assert.equal(result.current.sortDir, 'asc');
+    act(() => {
+      result.current.onSort('user');
+    });
+    assert.equal(result.current.sortDir, 'desc');
+  });
+
+  test('resets filters without changing sort', () => {
+    const { result } = renderHook(() => useLogFilters());
+    act(() => {
+      result.current.setQuery('abc');
+      result.current.setFilterUser('user1');
+      result.current.setFilterOperation('op1');
+      result.current.setFilterStatus('success');
+      result.current.setFilterCodeUnit('MyClass');
+      result.current.onSort('user');
+      result.current.clearFilters();
+    });
+    assert.equal(result.current.query, '');
+    assert.equal(result.current.filterUser, '');
+    assert.equal(result.current.filterOperation, '');
+    assert.equal(result.current.filterStatus, '');
+    assert.equal(result.current.filterCodeUnit, '');
+    assert.equal(result.current.sortBy, 'user');
+    assert.equal(result.current.sortDir, 'asc');
+  });
+});
+

--- a/src/webview/hooks/useLogFilters.ts
+++ b/src/webview/hooks/useLogFilters.ts
@@ -1,0 +1,91 @@
+import { useReducer } from 'react';
+
+export type SortKey =
+  | 'user'
+  | 'application'
+  | 'operation'
+  | 'time'
+  | 'duration'
+  | 'status'
+  | 'size'
+  | 'codeUnit';
+
+interface State {
+  query: string;
+  filterUser: string;
+  filterOperation: string;
+  filterStatus: string;
+  filterCodeUnit: string;
+  sortBy: SortKey;
+  sortDir: 'asc' | 'desc';
+}
+
+const initialState: State = {
+  query: '',
+  filterUser: '',
+  filterOperation: '',
+  filterStatus: '',
+  filterCodeUnit: '',
+  sortBy: 'time',
+  sortDir: 'desc'
+};
+
+const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case 'setQuery':
+      return { ...state, query: action.value };
+    case 'setFilterUser':
+      return { ...state, filterUser: action.value };
+    case 'setFilterOperation':
+      return { ...state, filterOperation: action.value };
+    case 'setFilterStatus':
+      return { ...state, filterStatus: action.value };
+    case 'setFilterCodeUnit':
+      return { ...state, filterCodeUnit: action.value };
+    case 'sort':
+      if (action.key === state.sortBy) {
+        return { ...state, sortDir: state.sortDir === 'asc' ? 'desc' : 'asc' };
+      }
+      return {
+        ...state,
+        sortBy: action.key,
+        sortDir: action.key === 'time' || action.key === 'size' || action.key === 'duration' ? 'desc' : 'asc'
+      };
+    case 'reset':
+      return {
+        ...state,
+        query: '',
+        filterUser: '',
+        filterOperation: '',
+        filterStatus: '',
+        filterCodeUnit: ''
+      };
+    default:
+      return state;
+  }
+};
+
+type Action =
+  | { type: 'setQuery'; value: string }
+  | { type: 'setFilterUser'; value: string }
+  | { type: 'setFilterOperation'; value: string }
+  | { type: 'setFilterStatus'; value: string }
+  | { type: 'setFilterCodeUnit'; value: string }
+  | { type: 'sort'; key: SortKey }
+  | { type: 'reset' };
+
+export default function useLogFilters() {
+  const [state, dispatch] = useReducer(reducer, initialState);
+
+  return {
+    ...state,
+    setQuery: (value: string) => dispatch({ type: 'setQuery', value }),
+    setFilterUser: (value: string) => dispatch({ type: 'setFilterUser', value }),
+    setFilterOperation: (value: string) => dispatch({ type: 'setFilterOperation', value }),
+    setFilterStatus: (value: string) => dispatch({ type: 'setFilterStatus', value }),
+    setFilterCodeUnit: (value: string) => dispatch({ type: 'setFilterCodeUnit', value }),
+    onSort: (key: SortKey) => dispatch({ type: 'sort', key }),
+    clearFilters: () => dispatch({ type: 'reset' })
+  };
+}
+


### PR DESCRIPTION
## Summary
- use a reducer-based hook to manage webview log filters and sort order
- refactor main webview to use the new hook
- add unit tests for filter updates and reset behavior

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58501f91c8323b1d79c0e9bbfad25