### PR TITLE
feat(webview): add message hook

### DIFF
--- a/src/test/useVsCodeMessages.test.ts
+++ b/src/test/useVsCodeMessages.test.ts
@@ -1,0 +1,32 @@
+import assert from 'assert/strict';
+import { renderHook } from '@testing-library/react';
+import { useVsCodeMessages } from '../webview/utils/useVsCodeMessages';
+
+type Outgoing = { type: 'out'; };
+type Incoming = { type: 'in'; };
+
+suite('useVsCodeMessages', () => {
+  test('dispatches messages', async () => {
+    const sent: Outgoing[] = [];
+    (globalThis as any).acquireVsCodeApi = () => ({
+      postMessage: (msg: Outgoing) => {
+        sent.push(msg);
+      },
+      getState: () => undefined,
+      setState: () => {}
+    });
+
+    const { result } = renderHook(() => useVsCodeMessages<Outgoing, Incoming>());
+    const received: Incoming[] = [];
+    const dispose = result.current.addMessageListener(msg => received.push(msg));
+
+    result.current.postMessage({ type: 'out' });
+    assert.deepEqual(sent, [{ type: 'out' }]);
+
+    window.postMessage({ type: 'in' }, '*');
+    await new Promise(r => setTimeout(r, 0));
+    assert.deepEqual(received, [{ type: 'in' }]);
+
+    dispose();
+  });
+});

--- a/src/webview/utils/useVsCodeMessages.ts
+++ b/src/webview/utils/useVsCodeMessages.ts
@@ -1,0 +1,29 @@
+import { useCallback, useMemo } from 'react';
+
+declare global {
+  // Provided by VS Code webview runtime
+  var acquireVsCodeApi: <T = unknown>() => {
+    postMessage: (msg: T) => void;
+    getState: <S = any>() => S | undefined;
+    setState: (state: any) => void;
+  };
+}
+
+export function useVsCodeMessages<Send, Receive>() {
+  const vscode = useMemo(() => acquireVsCodeApi<Send>(), []);
+  const postMessage = useCallback((msg: Send) => {
+    vscode.postMessage(msg);
+  }, [vscode]);
+  const addMessageListener = useCallback((listener: (msg: Receive) => void) => {
+    const handler = (event: MessageEvent) => {
+      const msg = event.data as Receive;
+      if (!msg || typeof msg !== 'object') {
+        return;
+      }
+      listener(msg);
+    };
+    window.addEventListener('message', handler);
+    return () => window.removeEventListener('message', handler);
+  }, []);
+  return { postMessage, addMessageListener };
+}


### PR DESCRIPTION
## Summary
- add useVsCodeMessages hook to wrap VS Code messaging API
- refactor main and tail webviews to use the hook
- test hook message dispatch

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5842192648323abc0a88b8dc3979a