### PR TITLE
refactor(webview): extract virtual list hook

### DIFF
--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useRef, useState, useLayoutEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { List, type ListImperativeAPI } from 'react-window';
 import type { ApexLogRow } from '../../shared/types';
 import { LogsHeader } from './table/LogsHeader';
 import { LogRow } from './table/LogRow';
+import { useVirtualList } from '../utils/useVirtualList';
 
 export type LogHeadMap = Record<string, { codeUnitStarted?: string }>;
 
@@ -36,21 +37,10 @@ export function LogsTable({
   ) => void;
 }) {
   const listRef = useRef<ListImperativeAPI | null>(null);
-  const outerRef = useRef<HTMLDivElement | null>(null);
   const headerRef = useRef<HTMLDivElement | null>(null);
-  // Previously we gated auto-paging until the first scroll; this
-  // prevented initial loads on small lists. After dependency updates,
-  // relying on that gate causes missed load-more events. Remove the gate
-  // and trigger based solely on visibility + hasMore/loading guards.
   const defaultRowHeight = 32;
-  const rowHeightsRef = useRef<Record<number, number>>({});
-  const [measuredListHeight, setMeasuredListHeight] = useState<number>(420);
-  const [overscanCount, setOverscanCount] = useState<number>(8);
-  const overscanBaseRef = useRef<number>(8);
-  const overscanLastTopRef = useRef<number>(0);
-  const overscanLastTsRef = useRef<number>(0);
-  const overscanDecayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const overscanLastSetRef = useRef<number>(8);
+  const { outerRef, height: measuredListHeight, setRowHeight, getItemSize, overscanCount } =
+    useVirtualList({ listRef, defaultRowHeight, headerRef });
   // Track latest paging flags for scroll handler without re-binding listeners
   const hasMoreRef = useRef<boolean>(hasMore);
   const loadingRef = useRef<boolean>(loading);
@@ -58,8 +48,6 @@ export function LogsTable({
   const gridTemplate =
     'minmax(160px,1fr) minmax(140px,1fr) minmax(200px,1.2fr) minmax(200px,1fr) minmax(110px,0.6fr) minmax(120px,0.8fr) minmax(260px,1.4fr) minmax(90px,0.6fr) 72px';
   // Header is rendered by LogsHeader; keep container simple
-
-  // autoPagingActivated will be flipped by the adaptive overscan listener below
 
   const handleRowsRendered = (props: { startIndex: number; stopIndex: number }) => {
     const { stopIndex: visibleStopIndex } = props;
@@ -71,52 +59,6 @@ export function LogsTable({
     }
   };
 
-  // Batch resetAfterIndex calls to once-per-frame
-  const rafRef = useRef<number | null>(null);
-  const [, forceRender] = useState(0);
-  const scheduleRerender = () => {
-    if (rafRef.current !== null) return;
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      forceRender(v => v + 1);
-    });
-  };
-  const setRowHeight = (index: number, size: number) => {
-    const current = rowHeightsRef.current[index] ?? defaultRowHeight;
-    const next = Math.max(defaultRowHeight, Math.ceil(size));
-    if (current !== next) {
-      rowHeightsRef.current[index] = next;
-      scheduleRerender();
-    }
-  };
-
-  const getItemSize = (index: number) => rowHeightsRef.current[index] ?? defaultRowHeight;
-
-  useLayoutEffect(() => {
-    const recompute = () => {
-      const outerRect = outerRef.current?.getBoundingClientRect();
-      const headerRect = headerRef.current?.getBoundingClientRect();
-      const top = outerRect?.top ?? 0;
-      const headerH = headerRect?.height ?? 0;
-      const available = Math.max(160, Math.floor(window.innerHeight - top - headerH - 12));
-      setMeasuredListHeight(available);
-    };
-    recompute();
-    const ro = new ResizeObserver(recompute);
-    if (outerRef.current) {
-      ro.observe(outerRef.current);
-    }
-    window.addEventListener('resize', recompute);
-    return () => {
-      try {
-        ro.disconnect();
-      } catch (e) {
-        console.warn('LogsTable: failed to disconnect ResizeObserver', e);
-      }
-      window.removeEventListener('resize', recompute);
-    };
-  }, []);
-
   // Keep refs synchronized with latest props for scroll safety net
   useEffect(() => {
     hasMoreRef.current = hasMore;
@@ -125,45 +67,21 @@ export function LogsTable({
     loadingRef.current = loading;
   }, [loading]);
 
-  // Adaptive overscan based on scroll velocity
+  // Trigger load-more when scrolled near the bottom as a safety net
   useEffect(() => {
     const el = listRef.current?.element;
     if (!el) return;
     const onScroll = () => {
-      const now = performance.now();
-      const dt = now - (overscanLastTsRef.current || now);
-      const dy = Math.abs(el.scrollTop - (overscanLastTopRef.current || 0));
-      if (dt > 16) {
-        const v = dy / dt; // px per ms
-        let next = overscanBaseRef.current;
-        if (v > 2) next = 22;
-        else if (v > 1) next = 14;
-        else if (v > 0.4) next = 10;
-        else next = overscanBaseRef.current; // idle/slow
-        if (next !== overscanLastSetRef.current) {
-          overscanLastSetRef.current = next;
-          setOverscanCount(next);
-        }
-        if (overscanDecayRef.current) clearTimeout(overscanDecayRef.current);
-        overscanDecayRef.current = setTimeout(() => {
-          if (overscanLastSetRef.current !== overscanBaseRef.current) {
-            overscanLastSetRef.current = overscanBaseRef.current;
-            setOverscanCount(overscanBaseRef.current);
-          }
-        }, 200);
-      }
-      // Also trigger load-more when very near the bottom, as a safety net
       if (hasMoreRef.current && !loadingRef.current) {
         const remaining = el.scrollHeight - (el.scrollTop + el.clientHeight);
         if (remaining <= defaultRowHeight * 2) {
+          const now = performance.now();
           if (now - lastLoadTsRef.current > 300) {
             lastLoadTsRef.current = now;
             onLoadMore();
           }
         }
       }
-      overscanLastTsRef.current = now;
-      overscanLastTopRef.current = el.scrollTop;
     };
     el.addEventListener('scroll', onScroll, { passive: true });
     return () => el.removeEventListener('scroll', onScroll);

--- a/src/webview/components/tail/TailList.tsx
+++ b/src/webview/components/tail/TailList.tsx
@@ -1,7 +1,8 @@
-import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useLayoutEffect, useRef } from 'react';
 import type { Messages } from '../../i18n';
 import { List, type ListImperativeAPI } from 'react-window';
 import { apexLineStyle, categoryStyle, contentHighlightRules, highlightContent, parseApexLine } from '../../utils/tail';
+import { useVirtualList } from '../../utils/useVirtualList';
 
 type TailListProps = {
   lines: string[];
@@ -27,60 +28,11 @@ export function TailList({
   onAtBottomChange
 }: TailListProps) {
   const defaultRowHeight = 18; // close to single-line height at default font
-  const rowHeightsRef = useRef<Record<number, number>>({});
-  const [height, setHeight] = useState(420);
-  const outerRef = useRef<HTMLDivElement | null>(null);
-  // Removed outerRef for List v2; use listRef.current.element instead
-  const [overscanCount, setOverscanCount] = useState<number>(8);
-  const overscanBaseRef = useRef<number>(8);
-  const overscanLastTopRef = useRef<number>(0);
-  const overscanLastTsRef = useRef<number>(0);
-  const overscanDecayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const overscanLastSetRef = useRef<number>(8);
+  const { outerRef, height, setRowHeight, getItemSize, overscanCount } = useVirtualList({
+    listRef,
+    defaultRowHeight
+  });
   const atBottomRef = useRef<boolean | null>(null);
-
-  const getItemSize = (index: number) => rowHeightsRef.current[index] ?? defaultRowHeight;
-  // Batch re-render to reflect updated row heights
-  const rafRef = useRef<number | null>(null);
-  const [, forceRender] = useState(0);
-  const scheduleRerender = () => {
-    if (rafRef.current !== null) return;
-    rafRef.current = requestAnimationFrame(() => {
-      rafRef.current = null;
-      forceRender(v => v + 1);
-    });
-  };
-  const setRowHeight = (index: number, size: number) => {
-    const next = Math.max(defaultRowHeight, Math.ceil(size));
-    if (rowHeightsRef.current[index] !== next) {
-      rowHeightsRef.current[index] = next;
-      scheduleRerender();
-    }
-  };
-
-  // Auto-size list to fit viewport similarly to LogsTable
-  useLayoutEffect(() => {
-    const recompute = () => {
-      const rect = outerRef.current?.getBoundingClientRect();
-      const top = rect?.top ?? 0;
-      const available = Math.max(160, Math.floor(window.innerHeight - top - 12));
-      setHeight(available);
-    };
-    recompute();
-    const ro = new ResizeObserver(recompute);
-    if (outerRef.current) ro.observe(outerRef.current);
-    window.addEventListener('resize', recompute);
-    return () => {
-      try {
-        ro.disconnect();
-      } catch (e) {
-        console.warn('TailList: failed to disconnect ResizeObserver', e);
-      }
-      window.removeEventListener('resize', recompute);
-    };
-  }, []);
-
-  const itemKey = (index: number) => filteredIndexes[index] ?? index;
 
   const sepStyle: React.CSSProperties = { opacity: 0.4 };
   const timeStyle: React.CSSProperties = { opacity: 0.6 };
@@ -133,39 +85,7 @@ export function TailList({
     return () => el.removeEventListener('scroll', onScroll);
   }, [onAtBottomChange, height, filteredIndexes.length]);
 
-  // Adaptive overscan based on scroll velocity
-  React.useEffect(() => {
-    const el = listRef.current?.element;
-    if (!el) return;
-    const onScroll = () => {
-      const now = performance.now();
-      const dt = now - (overscanLastTsRef.current || now);
-      const dy = Math.abs(el.scrollTop - (overscanLastTopRef.current || 0));
-      if (dt > 16) {
-        const v = dy / dt; // px per ms
-        let next = overscanBaseRef.current;
-        if (v > 2) next = 22;
-        else if (v > 1) next = 14;
-        else if (v > 0.4) next = 10;
-        else next = overscanBaseRef.current; // idle/slow
-        if (next !== overscanLastSetRef.current) {
-          overscanLastSetRef.current = next;
-          setOverscanCount(next);
-        }
-        if (overscanDecayRef.current) clearTimeout(overscanDecayRef.current);
-        overscanDecayRef.current = setTimeout(() => {
-          if (overscanLastSetRef.current !== overscanBaseRef.current) {
-            overscanLastSetRef.current = overscanBaseRef.current;
-            setOverscanCount(overscanBaseRef.current);
-          }
-        }, 200);
-      }
-      overscanLastTsRef.current = now;
-      overscanLastTopRef.current = el.scrollTop;
-    };
-    el.addEventListener('scroll', onScroll, { passive: true });
-    return () => el.removeEventListener('scroll', onScroll);
-  }, []);
+  // overscan and height handled by useVirtualList
 
   return (
     <div ref={outerRef} style={{ flex: '1 1 auto' }}>

--- a/src/webview/utils/useVirtualList.ts
+++ b/src/webview/utils/useVirtualList.ts
@@ -1,0 +1,103 @@
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import type { ListImperativeAPI } from 'react-window';
+
+export function useVirtualList({
+  listRef,
+  defaultRowHeight,
+  headerRef
+}: {
+  listRef: React.RefObject<ListImperativeAPI | null>;
+  defaultRowHeight: number;
+  headerRef?: React.RefObject<HTMLElement | null>;
+}) {
+  const outerRef = useRef<HTMLDivElement | null>(null);
+  const [height, setHeight] = useState<number>(420);
+
+  const rowHeightsRef = useRef<Record<number, number>>({});
+
+  const rafRef = useRef<number | null>(null);
+  const [, forceRender] = useState(0);
+  const scheduleRerender = () => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      forceRender(v => v + 1);
+    });
+  };
+
+  const setRowHeight = (index: number, size: number) => {
+    const current = rowHeightsRef.current[index] ?? defaultRowHeight;
+    const next = Math.max(defaultRowHeight, Math.ceil(size));
+    if (current !== next) {
+      rowHeightsRef.current[index] = next;
+      scheduleRerender();
+    }
+  };
+
+  const getItemSize = (index: number) => rowHeightsRef.current[index] ?? defaultRowHeight;
+
+  useLayoutEffect(() => {
+    const recompute = () => {
+      const outerRect = outerRef.current?.getBoundingClientRect();
+      const top = outerRect?.top ?? 0;
+      const headerH = headerRef?.current?.getBoundingClientRect().height ?? 0;
+      const available = Math.max(160, Math.floor(window.innerHeight - top - headerH - 12));
+      setHeight(available);
+    };
+    recompute();
+    const ro = new ResizeObserver(recompute);
+    if (outerRef.current) ro.observe(outerRef.current);
+    window.addEventListener('resize', recompute);
+    return () => {
+      try {
+        ro.disconnect();
+      } catch (e) {
+        console.warn('useVirtualList: failed to disconnect ResizeObserver', e);
+      }
+      window.removeEventListener('resize', recompute);
+    };
+  }, [headerRef]);
+
+  const [overscanCount, setOverscanCount] = useState<number>(8);
+  const overscanBaseRef = useRef<number>(8);
+  const overscanLastTopRef = useRef<number>(0);
+  const overscanLastTsRef = useRef<number>(0);
+  const overscanDecayRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const overscanLastSetRef = useRef<number>(8);
+
+  useEffect(() => {
+    const el = listRef.current?.element;
+    if (!el) return;
+    const onScroll = () => {
+      const now = performance.now();
+      const dt = now - (overscanLastTsRef.current || now);
+      const dy = Math.abs(el.scrollTop - (overscanLastTopRef.current || 0));
+      if (dt > 16) {
+        const v = dy / dt;
+        let next = overscanBaseRef.current;
+        if (v > 2) next = 22;
+        else if (v > 1) next = 14;
+        else if (v > 0.4) next = 10;
+        else next = overscanBaseRef.current;
+        if (next !== overscanLastSetRef.current) {
+          overscanLastSetRef.current = next;
+          setOverscanCount(next);
+        }
+        if (overscanDecayRef.current) clearTimeout(overscanDecayRef.current);
+        overscanDecayRef.current = setTimeout(() => {
+          if (overscanLastSetRef.current !== overscanBaseRef.current) {
+            overscanLastSetRef.current = overscanBaseRef.current;
+            setOverscanCount(overscanBaseRef.current);
+          }
+        }, 200);
+      }
+      overscanLastTsRef.current = now;
+      overscanLastTopRef.current = el.scrollTop;
+    };
+    el.addEventListener('scroll', onScroll, { passive: true });
+    return () => el.removeEventListener('scroll', onScroll);
+  }, [listRef]);
+
+  return { outerRef, height, setRowHeight, getItemSize, overscanCount };
+}
+


### PR DESCRIPTION
## Summary
- add reusable `useVirtualList` hook with height measurement and adaptive overscan
- refactor log and tail views to consume `useVirtualList`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58423972483238419449ba95766bb