### PR TITLE
refactor(webview): add messaging hook

### DIFF
--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -6,17 +6,7 @@ import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../sh
 import { Toolbar } from './components/Toolbar';
 import { LogsTable } from './components/LogsTable';
 import { LoadingOverlay } from './components/LoadingOverlay';
-
-declare global {
-  // Provided by VS Code webview runtime
-  var acquireVsCodeApi: <T = unknown>() => {
-    postMessage: (msg: T) => void;
-    getState: <S = any>() => S | undefined;
-    setState: (state: any) => void;
-  };
-}
-
-const vscode = acquireVsCodeApi<WebviewToExtensionMessage>();
+import { useVsCodeMessaging } from './utils/useVsCodeMessaging';
 
 type SortKey = 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit';
 
@@ -43,60 +33,55 @@ function App() {
   const [sortBy, setSortBy] = useState<SortKey>('time');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
+  const { postMessage } = useVsCodeMessaging<ExtensionToWebviewMessage, WebviewToExtensionMessage>(msg => {
+    switch (msg.type) {
+      case 'loading':
+        setLoading(!!msg.value);
+        break;
+      case 'error':
+        setError(msg.message);
+        break;
+      case 'init':
+        setLocale(msg.locale);
+        setT(getMessages(msg.locale));
+        break;
+      case 'logs':
+        setRows(msg.data || []);
+        setHasMore(!!msg.hasMore);
+        setError(undefined);
+        break;
+      case 'appendLogs':
+        setRows(prev => [...prev, ...(msg.data || [])]);
+        setHasMore(!!msg.hasMore);
+        break;
+      case 'logHead':
+        setLogHead(prev => ({
+          ...prev,
+          [msg.logId]: { codeUnitStarted: msg.codeUnitStarted }
+        }));
+        break;
+      case 'orgs':
+        setOrgs(msg.data || []);
+        setSelectedOrg(msg.selected);
+        break;
+    }
+  });
+
   useEffect(() => {
-    const onMsg = (event: MessageEvent) => {
-      const msg = event.data as ExtensionToWebviewMessage;
-      if (!msg || typeof msg !== 'object') {
-        return;
-      }
-      switch (msg.type) {
-        case 'loading':
-          setLoading(!!msg.value);
-          break;
-        case 'error':
-          setError(msg.message);
-          break;
-        case 'init':
-          setLocale(msg.locale);
-          setT(getMessages(msg.locale));
-          break;
-        case 'logs':
-          setRows(msg.data || []);
-          setHasMore(!!msg.hasMore);
-          setError(undefined);
-          break;
-        case 'appendLogs':
-          setRows(prev => [...prev, ...(msg.data || [])]);
-          setHasMore(!!msg.hasMore);
-          break;
-        case 'logHead':
-          setLogHead(prev => ({
-            ...prev,
-            [msg.logId]: { codeUnitStarted: msg.codeUnitStarted }
-          }));
-          break;
-        case 'orgs':
-          setOrgs(msg.data || []);
-          setSelectedOrg(msg.selected);
-          break;
-      }
-    };
-    window.addEventListener('message', onMsg);
-    vscode.postMessage({ type: 'ready' });
-    vscode.postMessage({ type: 'getOrgs' });
-    return () => window.removeEventListener('message', onMsg);
-  }, []);
+    postMessage({ type: 'ready' });
+    postMessage({ type: 'getOrgs' });
+  }, [postMessage]);
 
   const onRefresh = () => {
-    vscode.postMessage({ type: 'refresh' });
+    postMessage({ type: 'refresh' });
   };
   const onSelectOrg = (v: string) => {
     setSelectedOrg(v);
-    vscode.postMessage({ type: 'selectOrg', target: v });
+    postMessage({ type: 'selectOrg', target: v });
   };
-  const onOpen = (logId: string) => vscode.postMessage({ type: 'openLog', logId });
-  const onReplay = (logId: string) => vscode.postMessage({ type: 'replay', logId });
-  const onLoadMore = () => hasMore && vscode.postMessage({ type: 'loadMore' });
+  const onOpen = (logId: string) => postMessage({ type: 'openLog', logId });
+  const onReplay = (logId: string) => postMessage({ type: 'replay', logId });
+  const onLoadMore = () => hasMore && postMessage({ type: 'loadMore' });
 
   const onSort = (key: SortKey) => {
     if (key === sortBy) {

--- a/src/webview/utils/useVsCodeMessaging.ts
+++ b/src/webview/utils/useVsCodeMessaging.ts
@@ -1,0 +1,35 @@
+import { useEffect, useMemo } from 'react';
+
+// Minimal VS Code API interface
+interface VsCodeApi<T> {
+  postMessage: (msg: T) => void;
+  getState: <S = unknown>() => S | undefined;
+  setState: (state: any) => void;
+}
+
+declare global {
+  function acquireVsCodeApi<T = unknown>(): VsCodeApi<T>;
+}
+
+export function useVsCodeMessaging<Incoming, Outgoing = unknown>(
+  onMessage: (msg: Incoming) => void
+) {
+  const vscode = useMemo(() => acquireVsCodeApi<Outgoing>(), []);
+
+  useEffect(() => {
+    const listener = (event: MessageEvent) => {
+      const msg = event.data as Incoming;
+      if (!msg || typeof msg !== 'object') {
+        return;
+      }
+      onMessage(msg);
+    };
+    window.addEventListener('message', listener);
+    return () => window.removeEventListener('message', listener);
+  }, [onMessage]);
+
+  return {
+    postMessage: vscode.postMessage
+  };
+}
+


### PR DESCRIPTION
## Summary
- extract `useVsCodeMessaging` hook for webview messaging
- refactor main and tail webviews to use the hook

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run build:webview`


------
https://chatgpt.com/codex/tasks/task_e_68c584fe5db0832382bdf6db4b4e2bf3