### PR TITLE
feat(webview): add error boundary

### DIFF
--- a/src/test/webview/ErrorBoundary.test.tsx
+++ b/src/test/webview/ErrorBoundary.test.tsx
@@ -1,0 +1,20 @@
+import assert from 'assert/strict';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { ErrorBoundary } from '../../webview/components/ErrorBoundary';
+
+suite('ErrorBoundary', () => {
+  test('renders fallback UI on error with reload', () => {
+    const Boom = () => {
+      throw new Error('Boom');
+    };
+    const { getByText } = render(
+      <ErrorBoundary showReload>
+        <Boom />
+      </ErrorBoundary>
+    );
+    assert.ok(getByText(/Something went wrong/i));
+    assert.ok(getByText(/Reload/i));
+  });
+});
+

--- a/src/webview/components/ErrorBoundary.tsx
+++ b/src/webview/components/ErrorBoundary.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+interface ErrorBoundaryProps {
+  children: React.ReactNode;
+  showReload?: boolean;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  message?: string;
+}
+
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  override state: ErrorBoundaryState = { hasError: false, message: undefined };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { hasError: true, message: error.message };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error(error, errorInfo);
+  }
+
+  private handleReload = () => {
+    window.location.reload();
+  };
+
+  override render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" style={{ padding: 16 }}>
+          <p>Something went wrong.</p>
+          {this.state.message && <pre>{this.state.message}</pre>}
+          {this.props.showReload && (
+            <button type="button" onClick={this.handleReload}>
+              Reload
+            </button>
+          )}
+        </div>
+      );
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -6,6 +6,7 @@ import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../sh
 import { Toolbar } from './components/Toolbar';
 import { LogsTable } from './components/LogsTable';
 import { LoadingOverlay } from './components/LoadingOverlay';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 declare global {
   // Provided by VS Code webview runtime
@@ -241,4 +242,8 @@ function App() {
 }
 
 const root = createRoot(document.getElementById('root')!);
-root.render(<App />);
+root.render(
+  <ErrorBoundary showReload>
+    <App />
+  </ErrorBoundary>
+);

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -7,6 +7,7 @@ import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../sh
 import { TailToolbar } from './components/tail/TailToolbar';
 import { TailList } from './components/tail/TailList';
 import { LoadingOverlay } from './components/LoadingOverlay';
+import { ErrorBoundary } from './components/ErrorBoundary';
 
 declare global {
   var acquireVsCodeApi: <T = unknown>() => {
@@ -271,4 +272,8 @@ function App() {
 }
 
 const container = document.getElementById('root')!;
-createRoot(container).render(<App />);
+createRoot(container).render(
+  <ErrorBoundary showReload>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- add class-based `ErrorBoundary` component with optional reload fallback
- wrap main and tail webview roots with the boundary
- test that the boundary renders fallback UI on errors

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c584df0d1083238b4f359b67dc4654