### PR TITLE
feat(webview): simplify log table scroll handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "@types/proxyquire": "^1.3.4",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.0.2",
+        "@types/react-window-infinite-loader": "^1.0.9",
         "@types/vscode": "^1.90.0",
         "@typescript-eslint/eslint-plugin": "^8.43.0",
         "@typescript-eslint/parser": "^8.42.0",
@@ -43,6 +44,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-window": "^2.1.0",
+        "react-window-infinite-loader": "^1.0.10",
         "sharp": "^0.34.3",
         "typescript": "^5.9.2",
         "vscode-nls-dev": "^4.0.4"
@@ -2502,6 +2504,27 @@
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@types/react-window": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@types/react-window/-/react-window-1.8.8.tgz",
+      "integrity": "sha512-8Ls660bHR1AUA2kuRvVG9D/4XpRC6wjAaPT9dil7Ckc76eP9TKWZwwmgfq8Q1LANX3QNDnoU4Zp48A3w+zK69Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-window-infinite-loader": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/react-window-infinite-loader/-/react-window-infinite-loader-1.0.9.tgz",
+      "integrity": "sha512-gEInTjQwURCnDOFyIEK2+fWB5gTjqwx30O62QfxA9stE5aiB6EWkGj4UMhc0axq7/FV++Gs/TGW8FtgEx0S6Tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*",
+        "@types/react-window": "*"
       }
     },
     "node_modules/@types/sarif": {
@@ -9690,6 +9713,20 @@
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
         "react-dom": "^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/react-window-infinite-loader": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/react-window-infinite-loader/-/react-window-infinite-loader-1.0.10.tgz",
+      "integrity": "sha512-NO/csdHlxjWqA2RJZfzQgagAjGHspbO2ik9GtWZb0BY1Nnapq0auG8ErI+OhGCzpjYJsCYerqUlK6hkq9dfAAA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.3.0 || ^16.0.0-alpha || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read": {

--- a/package.json
+++ b/package.json
@@ -235,7 +235,6 @@
         "title": "%command.tail.title%",
         "category": "Electivus Apex Logs"
       },
-      
       {
         "command": "sfLogs.showOutput",
         "title": "Show Extension Output",
@@ -323,6 +322,7 @@
     "@types/proxyquire": "^1.3.4",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.0.2",
+    "@types/react-window-infinite-loader": "^1.0.9",
     "@types/vscode": "^1.90.0",
     "@typescript-eslint/eslint-plugin": "^8.43.0",
     "@typescript-eslint/parser": "^8.42.0",
@@ -341,6 +341,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-window": "^2.1.0",
+    "react-window-infinite-loader": "^1.0.10",
     "sharp": "^0.34.3",
     "typescript": "^5.9.2",
     "vscode-nls-dev": "^4.0.4"


### PR DESCRIPTION
## Summary
- replace manual overscan & scroll listeners with `react-window`'s `InfiniteLoader`
- add unit tests covering slow and fast scroll load-more scenarios
- include `react-window-infinite-loader` dependency

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test` *(fails: Test run terminated with signal SIGTRAP)*

------
https://chatgpt.com/codex/tasks/task_e_68c5842e987c83238282a70f541250c5