### PR TITLE
refactor: enforce exhaustive message handling

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -3,7 +3,7 @@ import { localize } from '../utils/localize';
 import { listOrgs, getOrgAuth } from '../salesforce/cli';
 import { listDebugLevels, getActiveUserDebugLevel } from '../salesforce/traceflags';
 import type { OrgAuth } from '../salesforce/types';
-import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
+import type { ExtensionToWebviewMessage } from '../shared/messages';
 import { logInfo, logWarn } from '../utils/logger';
 import { safeSendEvent } from '../shared/telemetry';
 import { warmUpReplayDebugger, ensureReplayDebuggerAvailable } from '../utils/warmup';
@@ -12,6 +12,7 @@ import { TailService } from '../utils/tailService';
 import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
+import { TailMessageHandler, type TailMessage } from './tailMessageHandler';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
@@ -19,6 +20,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   private disposed = false;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
+  private messageHandler: TailMessageHandler;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     const persisted = restoreSelectedOrg(this.context);
@@ -27,6 +29,17 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logInfo('Tail: restored selected org from globalState:', this.selectedOrg || '(default)');
     }
     this.tailService.setOrg(this.selectedOrg);
+
+    this.messageHandler = new TailMessageHandler(
+      () => this.handleReady(),
+      () => this.handleGetOrgs(),
+      org => this.handleSelectOrg(org),
+      id => this.openLog(id),
+      id => this.replayLog(id),
+      debug => this.startTail(debug),
+      () => this.tailService.stop(),
+      () => this.clearTail()
+    );
 
     // React to tail buffer size changes live
     this.context.subscriptions.push(
@@ -83,84 +96,57 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logWarn('Tail: window state tracking failed ->', getErrorMessage(e));
     }
 
-    webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
-      const t = (message as any)?.type;
-      if (t) {
-        logInfo('Tail: received message from webview:', t);
-      }
-      if (message?.type === 'ready') {
-        // Show loading while bootstrapping orgs and debug levels
-        this.post({ type: 'loading', value: true });
-        await this.sendOrgs();
-        await this.sendDebugLevels();
-        this.post({ type: 'init', locale: vscode.env.language });
-        // Send tail buffer size configuration
-        this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() });
-        this.post({ type: 'tailStatus', running: this.tailService.isRunning() });
-        this.post({ type: 'loading', value: false });
-        return;
-      }
-      if (message?.type === 'getOrgs') {
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.sendOrgs();
-          await this.sendDebugLevels();
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'selectOrg') {
-        const target = typeof message.target === 'string' ? message.target.trim() : undefined;
-        const next = target || undefined;
-        const prev = this.selectedOrg;
-        this.setSelectedOrg(next);
-        this.tailService.setOrg(next);
-        if (prev !== next) {
-          this.tailService.stop();
-        }
-        logInfo('Tail: selected org set to', next || '(none)');
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.sendOrgs();
-          await this.sendDebugLevels();
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'openLog' && (message as any).logId) {
-        const id = (message as any).logId;
-        logInfo('Tail: openLog requested for', id);
-        await this.openLog(id);
-        return;
-      }
-      if (message?.type === 'replay' && (message as any).logId) {
-        const id = (message as any).logId;
-        logInfo('Tail: replay requested for', id);
-        await this.replayLog(id);
-        return;
-      }
-      if (message?.type === 'tailStart') {
-        // Surface loading while ensuring TraceFlag and priming tail
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.tailService.start(typeof message.debugLevel === 'string' ? message.debugLevel.trim() : undefined);
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'tailStop') {
-        this.tailService.stop();
-        return;
-      }
-      if (message?.type === 'tailClear') {
-        this.tailService.clearLogPaths();
-        this.post({ type: 'tailReset' });
-        return;
-      }
-    });
+    this.context.subscriptions.push(
+      webviewView.webview.onDidReceiveMessage(message => {
+        void this.messageHandler.handle(message as TailMessage);
+      })
+    );
+  }
+
+  private async handleReady(): Promise<void> {
+    this.post({ type: 'loading', value: true });
+    await this.sendOrgs();
+    await this.sendDebugLevels();
+    this.post({ type: 'init', locale: vscode.env.language });
+    this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() });
+    this.post({ type: 'tailStatus', running: this.tailService.isRunning() });
+    this.post({ type: 'loading', value: false });
+  }
+
+  private async handleGetOrgs(): Promise<void> {
+    this.post({ type: 'loading', value: true });
+    try {
+      await this.sendOrgs();
+      await this.sendDebugLevels();
+    } finally {
+      this.post({ type: 'loading', value: false });
+    }
+  }
+
+  private async handleSelectOrg(target: string): Promise<void> {
+    const next = target.trim() || undefined;
+    const prev = this.selectedOrg;
+    this.setSelectedOrg(next);
+    this.tailService.setOrg(next);
+    if (prev !== next) {
+      this.tailService.stop();
+    }
+    logInfo('Tail: selected org set to', next || '(none)');
+    await this.handleGetOrgs();
+  }
+
+  private async startTail(debugLevel?: string): Promise<void> {
+    this.post({ type: 'loading', value: true });
+    try {
+      await this.tailService.start(debugLevel ? debugLevel.trim() : undefined);
+    } finally {
+      this.post({ type: 'loading', value: false });
+    }
+  }
+
+  private clearTail(): void {
+    this.tailService.clearLogPaths();
+    this.post({ type: 'tailReset' });
   }
 
   private getHtmlForWebview(webview: vscode.Webview): string {

--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -1,6 +1,20 @@
 import type { WebviewToExtensionMessage } from '../shared/messages';
 import { logInfo } from '../utils/logger';
 
+export type LogsMessage = Extract<
+  WebviewToExtensionMessage,
+  {
+    type:
+      | 'ready'
+      | 'refresh'
+      | 'getOrgs'
+      | 'selectOrg'
+      | 'openLog'
+      | 'replay'
+      | 'loadMore';
+  }
+>;
+
 export class LogsMessageHandler {
   constructor(
     private readonly refresh: () => Promise<void>,
@@ -12,10 +26,7 @@ export class LogsMessageHandler {
     private readonly setLoading: (val: boolean) => void
   ) {}
 
-  async handle(message: WebviewToExtensionMessage): Promise<void> {
-    if (!message?.type) {
-      return;
-    }
+  async handle(message: LogsMessage): Promise<void> {
     switch (message.type) {
       case 'ready':
         logInfo('Logs: message ready');
@@ -38,26 +49,26 @@ export class LogsMessageHandler {
         }
         break;
       case 'selectOrg':
-        this.setSelectedOrg(typeof message.target === 'string' ? message.target.trim() : undefined);
+        this.setSelectedOrg(message.target.trim());
         logInfo('Logs: selected org set');
         await this.refresh();
         break;
       case 'openLog':
-        if (message.logId) {
-          logInfo('Logs: openLog', message.logId);
-          await this.openLog(message.logId);
-        }
+        logInfo('Logs: openLog', message.logId);
+        await this.openLog(message.logId);
         break;
       case 'replay':
-        if (message.logId) {
-          logInfo('Logs: replay', message.logId);
-          await this.debugLog(message.logId);
-        }
+        logInfo('Logs: replay', message.logId);
+        await this.debugLog(message.logId);
         break;
       case 'loadMore':
         logInfo('Logs: loadMore');
         await this.loadMore();
         break;
+      default: {
+        const _exhaustiveCheck: never = message;
+        return _exhaustiveCheck;
+      }
     }
   }
 }

--- a/src/provider/tailMessageHandler.ts
+++ b/src/provider/tailMessageHandler.ts
@@ -1,0 +1,71 @@
+import type { WebviewToExtensionMessage } from '../shared/messages';
+import { logInfo } from '../utils/logger';
+
+export type TailMessage = Extract<
+  WebviewToExtensionMessage,
+  {
+    type:
+      | 'ready'
+      | 'getOrgs'
+      | 'selectOrg'
+      | 'openLog'
+      | 'replay'
+      | 'tailStart'
+      | 'tailStop'
+      | 'tailClear';
+  }
+>;
+
+export class TailMessageHandler {
+  constructor(
+    private readonly onReady: () => Promise<void>,
+    private readonly onGetOrgs: () => Promise<void>,
+    private readonly onSelectOrg: (org: string) => Promise<void>,
+    private readonly openLog: (logId: string) => Promise<void>,
+    private readonly replayLog: (logId: string) => Promise<void>,
+    private readonly startTail: (debugLevel?: string) => Promise<void>,
+    private readonly stopTail: () => void,
+    private readonly clearTail: () => void
+  ) {}
+
+  async handle(message: TailMessage): Promise<void> {
+    switch (message.type) {
+      case 'ready':
+        logInfo('Tail: message ready');
+        await this.onReady();
+        break;
+      case 'getOrgs':
+        logInfo('Tail: message getOrgs');
+        await this.onGetOrgs();
+        break;
+      case 'selectOrg':
+        logInfo('Tail: message selectOrg', message.target);
+        await this.onSelectOrg(message.target);
+        break;
+      case 'openLog':
+        logInfo('Tail: message openLog', message.logId);
+        await this.openLog(message.logId);
+        break;
+      case 'replay':
+        logInfo('Tail: message replay', message.logId);
+        await this.replayLog(message.logId);
+        break;
+      case 'tailStart':
+        logInfo('Tail: message tailStart');
+        await this.startTail(message.debugLevel);
+        break;
+      case 'tailStop':
+        logInfo('Tail: message tailStop');
+        this.stopTail();
+        break;
+      case 'tailClear':
+        logInfo('Tail: message tailClear');
+        this.clearTail();
+        break;
+      default: {
+        const _exhaustiveCheck: never = message;
+        return _exhaustiveCheck;
+      }
+    }
+  }
+}

--- a/src/test/messages.types.test.ts
+++ b/src/test/messages.types.test.ts
@@ -1,0 +1,11 @@
+import type { WebviewToExtensionMessage } from '../shared/messages';
+import type { LogsMessage } from '../provider/logsMessageHandler';
+import type { TailMessage } from '../provider/tailMessageHandler';
+
+type AllHandled = LogsMessage | TailMessage;
+
+type Assert<T extends true> = T;
+type IsEqual<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false;
+type _check = Assert<IsEqual<AllHandled, WebviewToExtensionMessage>>;
+
+export {};

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -82,21 +82,36 @@ function App() {
       }
     };
     window.addEventListener('message', onMsg);
-    vscode.postMessage({ type: 'ready' });
-    vscode.postMessage({ type: 'getOrgs' });
+    const ready = { type: 'ready' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(ready);
+    const getOrgs = { type: 'getOrgs' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(getOrgs);
     return () => window.removeEventListener('message', onMsg);
   }, []);
 
   const onRefresh = () => {
-    vscode.postMessage({ type: 'refresh' });
+    const msg = { type: 'refresh' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
   };
   const onSelectOrg = (v: string) => {
     setSelectedOrg(v);
-    vscode.postMessage({ type: 'selectOrg', target: v });
+    const msg = { type: 'selectOrg', target: v } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
   };
-  const onOpen = (logId: string) => vscode.postMessage({ type: 'openLog', logId });
-  const onReplay = (logId: string) => vscode.postMessage({ type: 'replay', logId });
-  const onLoadMore = () => hasMore && vscode.postMessage({ type: 'loadMore' });
+  const onOpen = (logId: string) => {
+    const msg = { type: 'openLog', logId } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
+  };
+  const onReplay = (logId: string) => {
+    const msg = { type: 'replay', logId } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
+  };
+  const onLoadMore = () => {
+    if (hasMore) {
+      const msg = { type: 'loadMore' } as const satisfies WebviewToExtensionMessage;
+      vscode.postMessage(msg);
+    }
+  };
 
   const onSort = (key: SortKey) => {
     if (key === sortBy) {

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -93,8 +93,10 @@ function App() {
       }
     };
     window.addEventListener('message', handler);
-    vscode.postMessage({ type: 'ready' });
-    vscode.postMessage({ type: 'getOrgs' });
+    const ready = { type: 'ready' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(ready);
+    const getOrgs = { type: 'getOrgs' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(getOrgs);
     return () => window.removeEventListener('message', handler);
   }, []);
 
@@ -158,10 +160,17 @@ function App() {
       setError(t.tail?.selectDebugLevel ?? 'Select a debug level');
       return;
     }
-    vscode.postMessage({ type: 'tailStart', debugLevel });
+    const msg = { type: 'tailStart', debugLevel } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
   };
-  const stop = () => vscode.postMessage({ type: 'tailStop' });
-  const clear = () => vscode.postMessage({ type: 'tailClear' });
+  const stop = () => {
+    const msg = { type: 'tailStop' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
+  };
+  const clear = () => {
+    const msg = { type: 'tailClear' } as const satisfies WebviewToExtensionMessage;
+    vscode.postMessage(msg);
+  };
 
   // Infer selected logId by scanning up to nearest header line
   const selectedLogId: string | undefined = useMemo(() => {
@@ -201,12 +210,14 @@ function App() {
         disabled={loading}
         onOpenSelected={() => {
           if (selectedLogId) {
-            vscode.postMessage({ type: 'openLog', logId: selectedLogId });
+            const msg = { type: 'openLog', logId: selectedLogId } as const satisfies WebviewToExtensionMessage;
+            vscode.postMessage(msg);
           }
         }}
         onReplaySelected={() => {
           if (selectedLogId) {
-            vscode.postMessage({ type: 'replay', logId: selectedLogId });
+            const msg = { type: 'replay', logId: selectedLogId } as const satisfies WebviewToExtensionMessage;
+            vscode.postMessage(msg);
           }
         }}
         actionsEnabled={!!selectedLogId}
@@ -214,7 +225,8 @@ function App() {
         selectedOrg={selectedOrg}
         onSelectOrg={value => {
           setSelectedOrg(value);
-          vscode.postMessage({ type: 'selectOrg', target: value });
+          const msg = { type: 'selectOrg', target: value } as const satisfies WebviewToExtensionMessage;
+          vscode.postMessage(msg);
         }}
         query={query}
         onQueryChange={setQuery}


### PR DESCRIPTION
## Summary
- ensure LogsMessageHandler and new TailMessageHandler exhaustively switch on message types
- post webview messages via typed constants
- add compile-time test verifying all WebviewToExtensionMessage variants are handled

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c584e0aa34832393748b4694b421b4