### PR TITLE
refactor: use ConfigManager for tail buffer size

### DIFF
--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -2,11 +2,18 @@ import { getNumberConfig, affectsConfiguration } from './config';
 import type * as vscode from 'vscode';
 
 export class ConfigManager {
-  constructor(private headConcurrency: number, private pageLimit: number) {}
+  constructor(
+    private headConcurrency: number,
+    private pageLimit: number,
+    private tailBufferSize = 10000
+  ) {}
 
   handleChange(e: vscode.ConfigurationChangeEvent): void {
     if (affectsConfiguration(e, 'sfLogs.headConcurrency')) {
       this.headConcurrency = getNumberConfig('sfLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
+    }
+    if (affectsConfiguration(e, 'sfLogs.tailBufferSize')) {
+      this.getTailBufferSize();
     }
   }
 
@@ -18,5 +25,10 @@ export class ConfigManager {
     const configuredLimit = getNumberConfig('sfLogs.pageSize', this.pageLimit, 10, Number.MAX_SAFE_INTEGER);
     this.pageLimit = Math.min(configuredLimit, 200);
     return this.pageLimit;
+  }
+
+  getTailBufferSize(): number {
+    this.tailBufferSize = getNumberConfig('sfLogs.tailBufferSize', this.tailBufferSize, 1000, Number.MAX_SAFE_INTEGER);
+    return this.tailBufferSize;
   }
 }


### PR DESCRIPTION
## Summary
- reuse ConfigManager in SfLogTailViewProvider to manage tail buffer configuration
- expose tailBufferSize getter on ConfigManager
- adjust tests to cover tail buffer configuration via ConfigManager

## Testing
- `npm run lint`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5842976388323a3d85af891e689e5