### PR TITLE
refactor(tail): extract message handler

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -3,7 +3,7 @@ import { localize } from '../utils/localize';
 import { listOrgs, getOrgAuth } from '../salesforce/cli';
 import { listDebugLevels, getActiveUserDebugLevel } from '../salesforce/traceflags';
 import type { OrgAuth } from '../salesforce/types';
-import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
+import type { ExtensionToWebviewMessage } from '../shared/messages';
 import { logInfo, logWarn } from '../utils/logger';
 import { safeSendEvent } from '../shared/telemetry';
 import { warmUpReplayDebugger, ensureReplayDebuggerAvailable } from '../utils/warmup';
@@ -12,6 +12,7 @@ import { TailService } from '../utils/tailService';
 import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
+import { TailMessageHandler } from './tailMessageHandler';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
@@ -19,6 +20,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   private disposed = false;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
+  private messageHandler: TailMessageHandler;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     const persisted = restoreSelectedOrg(this.context);
@@ -27,6 +29,23 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logInfo('Tail: restored selected org from globalState:', this.selectedOrg || '(default)');
     }
     this.tailService.setOrg(this.selectedOrg);
+
+    this.messageHandler = new TailMessageHandler(
+      () => this.sendOrgs(),
+      () => this.sendDebugLevels(),
+      id => this.openLog(id),
+      id => this.replayLog(id),
+      org => this.setSelectedOrg(org),
+      () => this.selectedOrg,
+      org => this.tailService.setOrg(org),
+      level => this.tailService.start(level),
+      () => this.tailService.stop(),
+      () => this.tailService.clearLogPaths(),
+      () => this.tailService.isRunning(),
+      () => this.getTailBufferSize(),
+      m => this.post(m),
+      v => this.post({ type: 'loading', value: v })
+    );
 
     // React to tail buffer size changes live
     this.context.subscriptions.push(
@@ -83,84 +102,11 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logWarn('Tail: window state tracking failed ->', getErrorMessage(e));
     }
 
-    webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
-      const t = (message as any)?.type;
-      if (t) {
-        logInfo('Tail: received message from webview:', t);
-      }
-      if (message?.type === 'ready') {
-        // Show loading while bootstrapping orgs and debug levels
-        this.post({ type: 'loading', value: true });
-        await this.sendOrgs();
-        await this.sendDebugLevels();
-        this.post({ type: 'init', locale: vscode.env.language });
-        // Send tail buffer size configuration
-        this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() });
-        this.post({ type: 'tailStatus', running: this.tailService.isRunning() });
-        this.post({ type: 'loading', value: false });
-        return;
-      }
-      if (message?.type === 'getOrgs') {
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.sendOrgs();
-          await this.sendDebugLevels();
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'selectOrg') {
-        const target = typeof message.target === 'string' ? message.target.trim() : undefined;
-        const next = target || undefined;
-        const prev = this.selectedOrg;
-        this.setSelectedOrg(next);
-        this.tailService.setOrg(next);
-        if (prev !== next) {
-          this.tailService.stop();
-        }
-        logInfo('Tail: selected org set to', next || '(none)');
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.sendOrgs();
-          await this.sendDebugLevels();
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'openLog' && (message as any).logId) {
-        const id = (message as any).logId;
-        logInfo('Tail: openLog requested for', id);
-        await this.openLog(id);
-        return;
-      }
-      if (message?.type === 'replay' && (message as any).logId) {
-        const id = (message as any).logId;
-        logInfo('Tail: replay requested for', id);
-        await this.replayLog(id);
-        return;
-      }
-      if (message?.type === 'tailStart') {
-        // Surface loading while ensuring TraceFlag and priming tail
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.tailService.start(typeof message.debugLevel === 'string' ? message.debugLevel.trim() : undefined);
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
-      if (message?.type === 'tailStop') {
-        this.tailService.stop();
-        return;
-      }
-      if (message?.type === 'tailClear') {
-        this.tailService.clearLogPaths();
-        this.post({ type: 'tailReset' });
-        return;
-      }
-    });
+    this.context.subscriptions.push(
+      webviewView.webview.onDidReceiveMessage(message => {
+        void this.messageHandler.handle(message);
+      })
+    );
   }
 
   private getHtmlForWebview(webview: vscode.Webview): string {

--- a/src/provider/tailMessageHandler.ts
+++ b/src/provider/tailMessageHandler.ts
@@ -1,0 +1,96 @@
+import * as vscode from 'vscode';
+import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
+import { logInfo } from '../utils/logger';
+
+export class TailMessageHandler {
+  constructor(
+    private readonly sendOrgs: () => Promise<void>,
+    private readonly sendDebugLevels: () => Promise<void>,
+    private readonly openLog: (logId: string) => Promise<void>,
+    private readonly replayLog: (logId: string) => Promise<void>,
+    private readonly setSelectedOrg: (org?: string) => void,
+    private readonly getSelectedOrg: () => string | undefined,
+    private readonly setTailOrg: (org?: string) => void,
+    private readonly startTail: (debugLevel?: string) => Promise<void>,
+    private readonly stopTail: () => void,
+    private readonly clearTail: () => void,
+    private readonly isTailRunning: () => boolean,
+    private readonly getTailBufferSize: () => number,
+    private readonly post: (msg: ExtensionToWebviewMessage) => void,
+    private readonly setLoading: (val: boolean) => void
+  ) {}
+
+  async handle(message: WebviewToExtensionMessage): Promise<void> {
+    if (!message?.type) {
+      return;
+    }
+    logInfo('Tail: message', message.type);
+    switch (message.type) {
+      case 'ready':
+        this.setLoading(true);
+        await this.sendOrgs();
+        await this.sendDebugLevels();
+        this.post({ type: 'init', locale: vscode.env.language });
+        this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() });
+        this.post({ type: 'tailStatus', running: this.isTailRunning() });
+        this.setLoading(false);
+        break;
+      case 'getOrgs':
+        this.setLoading(true);
+        try {
+          await this.sendOrgs();
+          await this.sendDebugLevels();
+        } finally {
+          this.setLoading(false);
+        }
+        break;
+      case 'selectOrg':
+        {
+          const target = typeof message.target === 'string' ? message.target.trim() : undefined;
+          const next = target || undefined;
+          const prev = this.getSelectedOrg();
+          this.setSelectedOrg(next);
+          this.setTailOrg(next);
+          if (prev !== next) {
+            this.stopTail();
+          }
+          this.setLoading(true);
+          try {
+            await this.sendOrgs();
+            await this.sendDebugLevels();
+          } finally {
+            this.setLoading(false);
+          }
+        }
+        break;
+      case 'openLog':
+        if (message.logId) {
+          await this.openLog(message.logId);
+        }
+        break;
+      case 'replay':
+        if (message.logId) {
+          await this.replayLog(message.logId);
+        }
+        break;
+      case 'tailStart':
+        this.setLoading(true);
+        try {
+          await this.startTail(
+            typeof message.debugLevel === 'string' ? message.debugLevel.trim() : undefined
+          );
+        } finally {
+          this.setLoading(false);
+        }
+        break;
+      case 'tailStop':
+        this.stopTail();
+        break;
+      case 'tailClear':
+        this.clearTail();
+        this.post({ type: 'tailReset' });
+        break;
+    }
+  }
+}
+

--- a/src/test/tailMessageHandler.test.ts
+++ b/src/test/tailMessageHandler.test.ts
@@ -1,0 +1,133 @@
+import assert from 'assert/strict';
+import { TailMessageHandler } from '../provider/tailMessageHandler';
+
+suite('TailMessageHandler', () => {
+  test('ready posts init and loads orgs and debug levels', async () => {
+    let orgs = 0;
+    let levels = 0;
+    const posts: any[] = [];
+    const loading: boolean[] = [];
+    const handler = new TailMessageHandler(
+      async () => {
+        orgs++;
+      },
+      async () => {
+        levels++;
+      },
+      async () => {},
+      async () => {},
+      () => {},
+      () => undefined,
+      () => {},
+      async () => {},
+      () => {},
+      () => {},
+      () => false,
+      () => 123,
+      m => posts.push(m),
+      v => loading.push(v)
+    );
+    await handler.handle({ type: 'ready' });
+    assert.equal(orgs, 1, 'sendOrgs should be called');
+    assert.equal(levels, 1, 'sendDebugLevels should be called');
+    assert.deepEqual(loading, [true, false]);
+    assert.ok(posts.find(m => m.type === 'init'), 'should post init');
+    assert.ok(posts.find(m => m.type === 'tailConfig'), 'should post tailConfig');
+    assert.ok(posts.find(m => m.type === 'tailStatus'), 'should post tailStatus');
+  });
+
+  test('selectOrg updates org and stops tail when changed', async () => {
+    let selected: string | undefined = 'old';
+    let stopped = 0;
+    let setOrgArg: string | undefined;
+    let orgs = 0;
+    let levels = 0;
+    const loading: boolean[] = [];
+    const handler = new TailMessageHandler(
+      async () => {
+        orgs++;
+      },
+      async () => {
+        levels++;
+      },
+      async () => {},
+      async () => {},
+      org => {
+        selected = org;
+      },
+      () => selected,
+      org => {
+        setOrgArg = org;
+      },
+      async () => {},
+      () => {
+        stopped++;
+      },
+      () => {},
+      () => false,
+      () => 123,
+      () => {},
+      v => loading.push(v)
+    );
+    await handler.handle({ type: 'selectOrg', target: ' new ' });
+    assert.equal(selected, 'new');
+    assert.equal(setOrgArg, 'new');
+    assert.equal(stopped, 1);
+    assert.equal(orgs, 1);
+    assert.equal(levels, 1);
+    assert.deepEqual(loading, [true, false]);
+  });
+
+  test('tailStart starts tail with debug level', async () => {
+    let started: string | undefined;
+    const loading: boolean[] = [];
+    const handler = new TailMessageHandler(
+      async () => {},
+      async () => {},
+      async () => {},
+      async () => {},
+      () => {},
+      () => undefined,
+      () => {},
+      async level => {
+        started = level;
+      },
+      () => {},
+      () => {},
+      () => false,
+      () => 123,
+      () => {},
+      v => loading.push(v)
+    );
+    await handler.handle({ type: 'tailStart', debugLevel: '  DL  ' });
+    assert.equal(started, 'DL');
+    assert.deepEqual(loading, [true, false]);
+  });
+
+  test('tailClear clears tail and posts reset', async () => {
+    let cleared = 0;
+    const posts: any[] = [];
+    const handler = new TailMessageHandler(
+      async () => {},
+      async () => {},
+      async () => {},
+      async () => {},
+      () => {},
+      () => undefined,
+      () => {},
+      async () => {},
+      () => {},
+      () => {
+        cleared++;
+      },
+      () => false,
+      () => 123,
+      m => posts.push(m),
+      () => {}
+    );
+    await handler.handle({ type: 'tailClear' });
+    assert.equal(cleared, 1);
+    assert.ok(posts.find(m => m.type === 'tailReset'));
+  });
+});
+


### PR DESCRIPTION
## Summary
- create TailMessageHandler to centralize tail view message routing
- delegate SfLogTailViewProvider messages to TailMessageHandler
- add unit tests for TailMessageHandler covering init, org selection, tail start/clear

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c584df11d0832383761b511bec5e9c