### PR TITLE
refactor(webview): type tail messages

### DIFF
--- a/src/webview/components/tail/TailList.tsx
+++ b/src/webview/components/tail/TailList.tsx
@@ -1,5 +1,5 @@
 import React, { useLayoutEffect, useMemo, useRef, useState } from 'react';
-import type { Messages } from '../../i18n';
+import type { TailMessages } from '../../i18n';
 import { List, type ListImperativeAPI } from 'react-window';
 import { apexLineStyle, categoryStyle, contentHighlightRules, highlightContent, parseApexLine } from '../../utils/tail';
 
@@ -11,7 +11,7 @@ type TailListProps = {
   colorize: boolean;
   running: boolean;
   listRef: React.RefObject<ListImperativeAPI | null>;
-  t: Messages;
+  t?: TailMessages;
   onAtBottomChange?: (atBottom: boolean) => void;
 };
 
@@ -182,7 +182,7 @@ export function TailList({
       >
         {showEmpty ? (
           <div style={{ opacity: 0.7, padding: 8 }}>
-            {running ? (t.tail?.waiting ?? 'Waiting for logs…') : (t.tail?.pressStart ?? 'Press Start to tail logs.')}
+            {running ? (t?.waiting ?? 'Waiting for logs…') : (t?.pressStart ?? 'Press Start to tail logs.')}
           </div>
         ) : (
           <List
@@ -217,7 +217,7 @@ function RowContent({
   sepStyle: React.CSSProperties;
   timeStyle: React.CSSProperties;
   debugMsgStyle: React.CSSProperties;
-  t: Messages;
+  t?: TailMessages;
   onMeasured: (h: number) => void;
 }) {
   const ref = useRef<HTMLDivElement | null>(null);
@@ -300,7 +300,7 @@ function RowContent({
       )}
       {cat && cat.toUpperCase().includes('USER_DEBUG') && parsed.debugMessage ? (
         <>
-          <span style={{ opacity: 0.6 }}>[{t.tail?.debugTag ?? 'debug'}]</span>
+          <span style={{ opacity: 0.6 }}>[{t?.debugTag ?? 'debug'}]</span>
           <span style={sepStyle}> | </span>
           {highlightContent(parsed.debugMessage, contentHighlightRules).map((s, j) => (
             <span key={j} style={s.style ?? debugMsgStyle}>

--- a/src/webview/components/tail/TailToolbar.tsx
+++ b/src/webview/components/tail/TailToolbar.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import type { OrgItem } from '../../../shared/types';
+import type { TailMessages } from '../../i18n';
 import { commonButtonStyle, inputStyle } from '../styles';
 import { LabeledSelect } from '../LabeledSelect';
 import { OrgSelect } from '../OrgSelect';
@@ -30,7 +31,9 @@ type TailToolbarProps = {
   autoScroll: boolean;
   onToggleAutoScroll: (v: boolean) => void;
   error?: string;
-  t: any;
+  t?: TailMessages;
+  orgLabel: string;
+  noOrgsDetected?: string;
 };
 
 export function TailToolbar({
@@ -57,52 +60,54 @@ export function TailToolbar({
   autoScroll,
   onToggleAutoScroll,
   error,
-  t
+  t,
+  orgLabel,
+  noOrgsDetected
 }: TailToolbarProps) {
   return (
     <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
       <button onClick={running ? onStop : onStart} style={commonButtonStyle} disabled={disabled}>
-        {running ? (t.tail?.stop ?? 'Stop') : (t.tail?.start ?? 'Start')}
+        {running ? (t?.stop ?? 'Stop') : (t?.start ?? 'Start')}
       </button>
       <button onClick={onClear} style={commonButtonStyle} disabled={disabled}>
-        {t.tail?.clear ?? 'Clear'}
+        {t?.clear ?? 'Clear'}
       </button>
       <button
         onClick={onOpenSelected}
         style={commonButtonStyle}
         disabled={disabled || !actionsEnabled}
-        title={t.tail?.openSelectedLogTitle ?? 'Open selected log'}
+        title={t?.openSelectedLogTitle ?? 'Open selected log'}
       >
         {disabled && actionsEnabled ? (
           <span style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
             <SpinnerIcon />
-            {t.tail?.openLog ?? 'Open Log'}
+            {t?.openLog ?? 'Open Log'}
           </span>
         ) : (
-          t.tail?.openLog ?? 'Open Log'
+          t?.openLog ?? 'Open Log'
         )}
       </button>
       <button
         onClick={onReplaySelected}
         style={commonButtonStyle}
         disabled={disabled || !actionsEnabled}
-        title={t.tail?.replayDebuggerTitle ?? 'Apex Replay Debugger'}
+        title={t?.replayDebuggerTitle ?? 'Apex Replay Debugger'}
       >
-        {t.tail?.replayDebugger ?? 'Replay Debugger'}
+        {t?.replayDebugger ?? 'Replay Debugger'}
       </button>
       <OrgSelect
-        label={t.orgLabel}
+        label={orgLabel}
         orgs={orgs}
         selected={selectedOrg}
         onChange={onSelectOrg}
         disabled={disabled}
-        emptyText={t.noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}
+        emptyText={noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}
       />
       <input
         type="search"
         value={query}
         onChange={e => onQueryChange(e.target.value)}
-        placeholder={t.tail?.searchLivePlaceholder ?? 'Search live logs…'}
+        placeholder={t?.searchLivePlaceholder ?? 'Search live logs…'}
         disabled={disabled}
         style={{ ...inputStyle, flex: '1 1 220px', minWidth: 160 }}
       />
@@ -113,7 +118,7 @@ export function TailToolbar({
           onChange={e => onToggleOnlyUserDebug(e.target.checked)}
           disabled={disabled}
         />
-        <span>{t.tail?.debugOnly ?? 'Debug Only'}</span>
+        <span>{t?.debugOnly ?? 'Debug Only'}</span>
       </label>
       <label style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
         <input
@@ -122,15 +127,15 @@ export function TailToolbar({
           onChange={e => onToggleColorize(e.target.checked)}
           disabled={disabled}
         />
-        <span>{t.tail?.colorize ?? 'Color'}</span>
+        <span>{t?.colorize ?? 'Color'}</span>
       </label>
       <LabeledSelect
-        label={t.tail?.debugLevel ?? 'Debug level'}
+        label={t?.debugLevel ?? 'Debug level'}
         value={debugLevel}
         onChange={onDebugLevelChange}
         disabled={disabled}
         options={debugLevels.map(level => ({ value: level, label: level }))}
-        placeholderLabel={t.tail?.select ?? 'Select'}
+        placeholderLabel={t?.select ?? 'Select'}
         selectStyleOverride={{ minWidth: 140 }}
       />
       <label style={{ display: 'flex', alignItems: 'center', gap: 6, marginLeft: 'auto' }}>
@@ -140,7 +145,7 @@ export function TailToolbar({
           onChange={e => onToggleAutoScroll(e.target.checked)}
           disabled={disabled}
         />
-        <span>{t.tail?.autoScroll ?? 'Auto-scroll'}</span>
+        <span>{t?.autoScroll ?? 'Auto-scroll'}</span>
       </label>
       {error && <span style={{ color: 'var(--vscode-errorForeground)' }}>{error}</span>}
     </div>

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -1,3 +1,23 @@
+export interface TailMessages {
+  start: string;
+  stop: string;
+  clear: string;
+  openLog: string;
+  openSelectedLogTitle: string;
+  replayDebugger: string;
+  replayDebuggerTitle: string;
+  searchLivePlaceholder: string;
+  debugOnly: string;
+  colorize: string;
+  debugLevel: string;
+  select: string;
+  autoScroll: string;
+  waiting: string;
+  pressStart: string;
+  selectDebugLevel: string;
+  debugTag?: string;
+}
+
 export type Messages = {
   refresh: string;
   loading: string;
@@ -8,25 +28,7 @@ export type Messages = {
   defaultOrg: string;
   searchPlaceholder?: string;
   noOrgsDetected?: string;
-  tail?: {
-    start: string;
-    stop: string;
-    clear: string;
-    openLog: string;
-    openSelectedLogTitle: string;
-    replayDebugger: string;
-    replayDebuggerTitle: string;
-    searchLivePlaceholder: string;
-    debugOnly: string;
-    colorize: string;
-    debugLevel: string;
-    select: string;
-    autoScroll: string;
-    waiting: string;
-    pressStart: string;
-    selectDebugLevel: string;
-    debugTag?: string;
-  };
+  tail?: TailMessages;
   filters?: {
     user: string;
     operation: string;

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ListImperativeAPI } from 'react-window';
 import { createRoot } from 'react-dom/client';
-import { getMessages } from './i18n';
+import { getMessages, type TailMessages } from './i18n';
 import type { OrgItem } from '../shared/types';
 import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
 import { TailToolbar } from './components/tail/TailToolbar';
@@ -37,7 +37,8 @@ function App() {
   const [error, setError] = useState<string | undefined>(undefined);
   const [selectedIndex, setSelectedIndex] = useState<number | undefined>(undefined);
   const [loading, setLoading] = useState(false);
-  const t = getMessages(locale) as any;
+  const messages = getMessages(locale);
+  const t: TailMessages | undefined = messages.tail;
   const listRef = useRef<ListImperativeAPI | null>(null);
 
   useEffect(() => {
@@ -155,7 +156,7 @@ function App() {
   const start = () => {
     setError(undefined);
     if (!debugLevel) {
-      setError(t.tail?.selectDebugLevel ?? 'Select a debug level');
+      setError(t?.selectDebugLevel ?? 'Select a debug level');
       return;
     }
     vscode.postMessage({ type: 'tailStart', debugLevel });
@@ -192,7 +193,7 @@ function App() {
         position: 'relative'
       }}
     >
-      <LoadingOverlay show={loading} label={t.loading} />
+      <LoadingOverlay show={loading} label={messages.loading} />
       <TailToolbar
         running={running}
         onStart={start}
@@ -238,6 +239,8 @@ function App() {
         }}
         error={error}
         t={t}
+        orgLabel={messages.orgLabel}
+        noOrgsDetected={messages.noOrgsDetected}
       />
       <TailList
         lines={lines}


### PR DESCRIPTION
## Summary
- add TailMessages interface to i18n
- type TailToolbar and TailList with TailMessages
- use TailMessages in tail view instead of `any`

## Testing
- `npm run lint`
- `npm run check-types`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c58422e2348323af8559fe626394d4