### PR TITLE
refactor(provider): extract shared webview view base

### DIFF
--- a/src/provider/BaseWebviewViewProvider.ts
+++ b/src/provider/BaseWebviewViewProvider.ts
@@ -1,0 +1,61 @@
+import * as vscode from 'vscode';
+import type { ExtensionToWebviewMessage } from '../shared/messages';
+import { warmUpReplayDebugger } from '../utils/warmup';
+import { logInfo, logWarn } from '../utils/logger';
+import { getErrorMessage } from '../utils/error';
+
+/**
+ * Shared base class for WebviewView providers with common warm-up and
+ * disposal behavior.
+ */
+export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvider {
+  protected view?: vscode.WebviewView;
+  protected disposed = false;
+
+  protected constructor(protected readonly context: vscode.ExtensionContext, private readonly name: string) {}
+
+  resolveWebviewView(webviewView: vscode.WebviewView): void {
+    this.view = webviewView;
+    this.disposed = false;
+    webviewView.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
+    };
+    webviewView.webview.html = this.getHtmlForWebview(webviewView.webview);
+    logInfo(`${this.name} webview resolved.`);
+
+    try {
+      setTimeout(() => void warmUpReplayDebugger(), 0);
+    } catch (e) {
+      logWarn(`${this.name}: warm-up of Apex Replay Debugger failed ->`, getErrorMessage(e));
+    }
+
+    this.subscribe(
+      webviewView.onDidDispose(() => {
+        this.disposed = true;
+        this.view = undefined;
+        this.onDisposed();
+        logInfo(`${this.name} webview disposed.`);
+      })
+    );
+
+    this.onResolve(webviewView);
+  }
+
+  protected abstract getHtmlForWebview(webview: vscode.Webview): string;
+
+  /** Hooks for subclasses to wire up additional behavior once the view is resolved. */
+  protected onResolve(_webviewView: vscode.WebviewView): void {}
+
+  /** Called when the view is disposed. */
+  protected onDisposed(): void {}
+
+  protected post(msg: ExtensionToWebviewMessage): void {
+    this.view?.webview.postMessage(msg);
+  }
+
+  protected subscribe(disposable: vscode.Disposable): void {
+    this.context.subscriptions.push(disposable);
+  }
+}
+

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -3,24 +3,25 @@ import { localize } from '../utils/localize';
 import { listOrgs, getOrgAuth } from '../salesforce/cli';
 import { listDebugLevels, getActiveUserDebugLevel } from '../salesforce/traceflags';
 import type { OrgAuth } from '../salesforce/types';
-import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
+import type { WebviewToExtensionMessage } from '../shared/messages';
 import { logInfo, logWarn } from '../utils/logger';
 import { safeSendEvent } from '../shared/telemetry';
-import { warmUpReplayDebugger, ensureReplayDebuggerAvailable } from '../utils/warmup';
+import { ensureReplayDebuggerAvailable } from '../utils/warmup';
 import { buildWebviewHtml } from '../utils/webviewHtml';
 import { TailService } from '../utils/tailService';
 import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
 
-export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
+import { BaseWebviewViewProvider } from './BaseWebviewViewProvider';
+
+export class SfLogTailViewProvider extends BaseWebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
-  private view?: vscode.WebviewView;
-  private disposed = false;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
 
-  constructor(private readonly context: vscode.ExtensionContext) {
+  constructor(context: vscode.ExtensionContext) {
+    super(context, 'Tail');
     const persisted = restoreSelectedOrg(this.context);
     if (persisted) {
       this.selectedOrg = persisted;
@@ -29,7 +30,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     this.tailService.setOrg(this.selectedOrg);
 
     // React to tail buffer size changes live
-    this.context.subscriptions.push(
+    this.subscribe(
       vscode.workspace.onDidChangeConfiguration(e => {
         if (affectsConfiguration(e, 'sfLogs.tailBufferSize')) {
           try {
@@ -43,32 +44,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     );
   }
 
-  resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
-    this.view = webviewView;
-    this.disposed = false;
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
-    };
-    webviewView.webview.html = this.getHtmlForWebview(webviewView.webview);
-    logInfo('Tail webview resolved.');
-    // Fire-and-forget warm-up of Replay Debugger when the Tail view opens
-    try {
-      setTimeout(() => void warmUpReplayDebugger(), 0);
-    } catch (e) {
-      logWarn('Tail: warm-up of Apex Replay Debugger failed ->', getErrorMessage(e));
-    }
-
-    this.context.subscriptions.push(
-      webviewView.onDidDispose(() => {
-        this.disposed = true;
-        this.view = undefined;
-        // Stop timers and clear caches, but keep TailService reusable when the view reopens
-        this.tailService.stop();
-        logInfo('Tail webview disposed; stopped tail.');
-      })
-    );
-
+  protected override onResolve(webviewView: vscode.WebviewView): void {
     // Track window activity to adapt polling cadence (requires VS Code 1.89+; @types 1.90)
     try {
       this.tailService.setWindowActive(vscode.window.state?.active ?? true);
@@ -78,17 +54,18 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
           this.tailService.promptPoll();
         }
       });
-      this.context.subscriptions.push(d);
+      this.subscribe(d);
     } catch (e) {
       logWarn('Tail: window state tracking failed ->', getErrorMessage(e));
     }
 
-    webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
-      const t = (message as any)?.type;
-      if (t) {
-        logInfo('Tail: received message from webview:', t);
-      }
-      if (message?.type === 'ready') {
+    this.subscribe(
+      webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
+        const t = (message as any)?.type;
+        if (t) {
+          logInfo('Tail: received message from webview:', t);
+        }
+        if (message?.type === 'ready') {
         // Show loading while bootstrapping orgs and debug levels
         this.post({ type: 'loading', value: true });
         await this.sendOrgs();
@@ -160,20 +137,22 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         this.post({ type: 'tailReset' });
         return;
       }
-    });
+      })
+    );
   }
 
-  private getHtmlForWebview(webview: vscode.Webview): string {
+  protected override onDisposed(): void {
+    // Stop timers and clear caches, but keep TailService reusable when the view reopens
+    this.tailService.stop();
+  }
+
+  protected getHtmlForWebview(webview: vscode.Webview): string {
     return buildWebviewHtml(
       webview,
       this.context.extensionUri,
       'tail.js',
       localize('salesforce.tail.view.name', 'Electivus Apex Logs Tail')
     );
-  }
-
-  private post(msg: ExtensionToWebviewMessage): void {
-    this.view?.webview.postMessage(msg);
   }
 
   private getTailBufferSize(): number {


### PR DESCRIPTION
## Summary
- add `BaseWebviewViewProvider` with shared resolve and warm-up logic
- update logs and tail providers to extend the base and forward subscriptions

## Testing
- `npm run lint`
- `npm run check-types`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5842bdd448323834c2b5055e9f320