### PR TITLE
refactor(tail): delegate org handling to OrgManager

### DIFF
--- a/src/test/persistedState.test.ts
+++ b/src/test/persistedState.test.ts
@@ -40,10 +40,10 @@ suite('Persisted org state', () => {
     const { context, capturedGetKey, updates } = makeContext();
     const provider = new SfLogTailViewProvider(context);
     assert.equal(capturedGetKey(), SELECTED_ORG_KEY);
-    assert.equal((provider as any).selectedOrg, 'persisted-org');
-    (provider as any).setSelectedOrg('next-org');
+    assert.equal((provider as any).orgManager.getSelectedOrg(), 'persisted-org');
+    (provider as any).orgManager.setSelectedOrg('next-org');
     assert.equal(updates[0]?.key, SELECTED_ORG_KEY);
     assert.equal(updates[0]?.value, 'next-org');
-    assert.equal((provider as any).selectedOrg, 'next-org');
+    assert.equal((provider as any).orgManager.getSelectedOrg(), 'next-org');
   });
 });


### PR DESCRIPTION
## Summary
- replace direct org persistence in tail provider with OrgManager
- list and select orgs through OrgManager
- update persisted state test to cover OrgManager usage

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c584282d308323bced10cafbda4e1e