### PR TITLE
feat: add command to open Apex logs in viewer and implement CodeLens …

### DIFF
--- a/package.json
+++ b/package.json
@@ -257,8 +257,7 @@
       {
         "id": "apexlog",
         "aliases": ["ApexLog", "Salesforce Apex Log"],
-        "firstLine": "^\\d{2}\\.\\d{2}.+?APEX_CODE,\\w.+$",
-        "filenamePatterns": ["**/apexlogs/*.log", "**/apexlogs/*.txt"]
+        "firstLine": "^\\d{2}\\.\\d{2}.+?APEX_CODE,\\w.+$"
       }
     ],
     "menus": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
     "onCommand:sfLogs.selectOrg",
     "onCommand:sfLogs.tail",
     "onCommand:sfLogs.showOutput",
-    "onCommand:sfLogs.resetCliCache"
+    "onCommand:sfLogs.resetCliCache",
+    "onCommand:sfLogs.openLogInViewer",
+    "onLanguage:apexlog"
   ],
   "extensionDependencies": [],
   "main": "./dist/extension.js",
@@ -236,6 +238,11 @@
         "category": "Electivus Apex Logs"
       },
       {
+        "command": "sfLogs.openLogInViewer",
+        "title": "%command.openLogInViewer.title%",
+        "category": "Electivus Apex Logs"
+      },
+      {
         "command": "sfLogs.showOutput",
         "title": "Show Extension Output",
         "category": "Electivus Apex Logs"
@@ -244,6 +251,14 @@
         "command": "sfLogs.resetCliCache",
         "title": "Reset CLI Cache",
         "category": "Electivus Apex Logs"
+      }
+    ],
+    "languages": [
+      {
+        "id": "apexlog",
+        "aliases": ["ApexLog", "Salesforce Apex Log"],
+        "firstLine": "^\\d{2}\\.\\d{2}.+?APEX_CODE,\\w.+$",
+        "filenamePatterns": ["**/apexlogs/*.log", "**/apexlogs/*.txt"]
       }
     ],
     "menus": {
@@ -259,7 +274,14 @@
           "group": "navigation@99"
         }
       ],
-      "editor/title": []
+      "editor/title": [
+        {
+          "command": "sfLogs.openLogInViewer",
+          "when": "resourceLangId == apexlog",
+          "group": "navigation@50",
+          "icon": "$(open-preview)"
+        }
+      ]
     }
   },
   "scripts": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,7 @@
   "command.refresh.title": "Refresh Logs",
   "command.selectOrg.title": "Select Org",
   "command.tail.title": "Tail Logs",
+  "command.openLogInViewer.title": "Open in Apex Log Viewer",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page (effective maximum: 200). Higher values fetch more per request but may slow the UI or increase API load.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",
@@ -18,5 +19,10 @@
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "Short-lived in-memory TTL (seconds) for cached auth tokens acquired via CLI. Tokens are NOT persisted. Larger values reduce CLI calls but increase the reuse window.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "Persistent TTL in seconds for cached results of 'sf org display'. Stores the token in VS Code storage to avoid repeated CLI calls across reloads. Larger values reduce CLI calls but keep cached auth longer; set 0 to disable.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL in seconds for cached DebugLevel queries. Set 0 to disable. Large TTLs reduce API calls but may serve stale data.",
-  "tailSaveFailed": "Tail: failed to save log to workspace (best-effort)."
+  "tailSaveFailed": "Tail: failed to save log to workspace (best-effort).",
+  "openLogInViewer.noDocument": "Electivus Apex Logs: No Apex log is active.",
+  "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Unable to open Apex logs from this location.",
+  "openLogInViewer.notApex": "Electivus Apex Logs: The active document is not recognized as a Salesforce Apex log.",
+  "openLogInViewer.failed": "Failed to open Apex log: {0}",
+  "openLogInViewer.codeLensTitle": "Open in Apex Log Viewer"
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -8,6 +8,7 @@
   "command.refresh.title": "Atualizar Logs",
   "command.selectOrg.title": "Selecionar Org",
   "command.tail.title": "Tail de Logs",
+  "command.openLogInViewer.title": "Abrir no Apex Log Viewer",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página (máximo efetivo: 200). Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",
@@ -18,5 +19,10 @@
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "TTL curto em memória (segundos) para cachear credenciais obtidas via CLI. Tokens NÃO são persistidos. Valores maiores reduzem chamadas ao CLI, mas aumentam a janela de reutilização.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "TTL persistente (segundos) para o cache de 'sf org display'. Armazena o token no VS Code para evitar chamadas repetidas entre recarregamentos. Valores maiores reduzem chamadas ao CLI, mas mantêm o auth em cache por mais tempo; defina 0 para desativar.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL em segundos para o cache de consultas DebugLevel. Defina 0 para desativar. TTLs grandes reduzem chamadas à API, mas podem servir dados desatualizados.",
-  "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço)."
+  "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço).",
+  "openLogInViewer.noDocument": "Electivus Apex Logs: Nenhum log Apex está ativo.",
+  "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Não é possível abrir logs Apex a partir desta origem.",
+  "openLogInViewer.notApex": "Electivus Apex Logs: O documento ativo não é reconhecido como um log Apex do Salesforce.",
+  "openLogInViewer.failed": "Falha ao abrir log Apex: {0}",
+  "openLogInViewer.codeLensTitle": "Abrir no Apex Log Viewer"
 }

--- a/src/provider/ApexLogCodeLensProvider.ts
+++ b/src/provider/ApexLogCodeLensProvider.ts
@@ -1,0 +1,25 @@
+import * as vscode from 'vscode';
+import { isApexLogDocument } from '../utils/workspace';
+import { localize } from '../utils/localize';
+
+export class ApexLogCodeLensProvider implements vscode.CodeLensProvider {
+  private readonly onDidChangeEmitter = new vscode.EventEmitter<void>();
+
+  readonly onDidChangeCodeLenses = this.onDidChangeEmitter.event;
+
+  provideCodeLenses(document: vscode.TextDocument, token: vscode.CancellationToken): vscode.CodeLens[] {
+    if (token.isCancellationRequested || !isApexLogDocument(document)) {
+      return [];
+    }
+    const command: vscode.Command = {
+      title: localize('openLogInViewer.codeLensTitle', 'Open in Apex Log Viewer'),
+      command: 'sfLogs.openLogInViewer',
+      arguments: [document.uri]
+    };
+    return [new vscode.CodeLens(new vscode.Range(0, 0, 0, 0), command)];
+  }
+
+  dispose(): void {
+    this.onDidChangeEmitter.dispose();
+  }
+}


### PR DESCRIPTION
This pull request adds a new "Open in Apex Log Viewer" feature for Salesforce Apex log files in the Electivus Apex Logs extension. Users can now open Apex logs in a dedicated viewer via a command, menu item, or inline CodeLens above log files. The changes include command registration, UI integration, and localization support.

**Apex Log Viewer Feature Integration**

* Added a new command `sfLogs.openLogInViewer` to open Apex logs in a custom viewer, including command registration and error handling in `src/extension.ts`.
* Introduced `ApexLogCodeLensProvider` to show an inline "Open in Apex Log Viewer" CodeLens above Apex log files, improving discoverability and user experience. [[1]](diffhunk://#diff-45c5a1d404243834f8cd5300be50d273691b06d04c9e3145c5924ae1433ed094R1-R25) [[2]](diffhunk://#diff-04bba6a35cad1c794cbbe677678a51de13441b7a6ee8592b7b50be1f05c6f626R17-R18)

**Extension Manifest and UI Updates**

* Updated `package.json` to declare the new command, add the Apex log language definition, register the CodeLens provider, and add a menu item for the viewer in the editor title bar when viewing Apex logs. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L58-R60) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R240-R244) [[3]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R256-R263) [[4]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L262-R284)

**Localization Enhancements**

* Added localization strings for the new command and error messages in both English and Brazilian Portuguese (`package.nls.json`, `package.nls.pt-br.json`). [[1]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0R11) [[2]](diffhunk://#diff-9b29d8b47a74097a04da353b72a8632d485d658282457b97b4caf26575a42dd0L21-R27) [[3]](diffhunk://#diff-1c00b49de937c38f14bea3726b44809387fcf96f15c2d5e4b8c3f2fa5d860034R11) [[4]](diffhunk://#diff-1c00b49de937c38f14bea3726b44809387fcf96f15c2d5e4b8c3f2fa5d860034L21-R27)