### PR TITLE
fix: avoid duplicate org listings on ready

### DIFF
--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -101,16 +101,6 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         this.post({ type: 'loading', value: false });
         return;
       }
-      if (message?.type === 'getOrgs') {
-        this.post({ type: 'loading', value: true });
-        try {
-          await this.sendOrgs();
-          await this.sendDebugLevels();
-        } finally {
-          this.post({ type: 'loading', value: false });
-        }
-        return;
-      }
       if (message?.type === 'selectOrg') {
         const target = typeof message.target === 'string' ? message.target.trim() : undefined;
         const next = target || undefined;

--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -28,15 +28,6 @@ export class LogsMessageHandler {
         logInfo('Logs: message refresh');
         await this.refresh();
         break;
-      case 'getOrgs':
-        logInfo('Logs: message getOrgs');
-        this.setLoading(true);
-        try {
-          await this.sendOrgs();
-        } finally {
-          this.setLoading(false);
-        }
-        break;
       case 'selectOrg':
         this.setSelectedOrg(typeof message.target === 'string' ? message.target.trim() : undefined);
         logInfo('Logs: selected org set');

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -4,7 +4,6 @@ import type { ApexLogRow, OrgItem } from './types';
 export type WebviewToExtensionMessage =
   | { type: 'ready' }
   | { type: 'refresh' }
-  | { type: 'getOrgs' }
   | { type: 'selectOrg'; target: string }
   | { type: 'openLog'; logId: string }
   | { type: 'replay'; logId: string }

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -83,7 +83,6 @@ function App() {
     };
     window.addEventListener('message', onMsg);
     vscode.postMessage({ type: 'ready' });
-    vscode.postMessage({ type: 'getOrgs' });
     return () => window.removeEventListener('message', onMsg);
   }, []);
 

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -94,7 +94,6 @@ function App() {
     };
     window.addEventListener('message', handler);
     vscode.postMessage({ type: 'ready' });
-    vscode.postMessage({ type: 'getOrgs' });
     return () => window.removeEventListener('message', handler);
   }, []);
 


### PR DESCRIPTION
## Summary
- rely on the existing ready handshake in the logs webview to load org data
- do the same for the tail webview so it no longer sends an extra getOrgs request
- remove now-unused getOrgs message plumbing from shared message types and handlers

## Testing
- npm run lint
- npm run test > /tmp/npm-test.log 2>&1

------
https://chatgpt.com/codex/tasks/task_e_68cdeceb7b8c8323bcbc68de6ce4a00f