### PR TITLE
chore: configure dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,58 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      salesforce-sdk:
+        patterns:
+          - "@salesforce/*"
+      vscode-platform:
+        patterns:
+          - "@vscode/*"
+          - "vscode-nls"
+          - "vscode-nls-dev"
+      react-ui:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-window"
+          - "lucide-react"
+          - "@radix-ui/*"
+      linting-and-formatting:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "lint-staged"
+          - "husky"
+      testing:
+        patterns:
+          - "mocha"
+          - "jsdom"
+          - "@types/mocha"
+          - "@types/jsdom"
+          - "@testing-library/*"
+      types:
+        patterns:
+          - "@types/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "tailwindcss-animate"
+          - "@tailwindcss/*"
+          - "autoprefixer"
+          - "postcss"
+      tooling:
+        patterns:
+          - "esbuild"
+          - "typescript"
+          - "npm-run-all"
+          - "sharp"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@
 - `npm run lint` / `npm run format` – enforce ESLint (`eslint.config.mjs`) and Prettier across sources.
 - `npm run test` – compile and execute the default Mocha suite; use `npm run test:unit`, `npm run test:integration`, or `npm run test:all` for targeted scopes.
 
+## Dependency Management
+- Dependabot groups live in `.github/dependabot.yml`; when adding or upgrading dependencies, confirm the new package is matched by an existing group pattern.
+- If the dependency belongs to a new technology area, create a dedicated group (or expand an existing one) so related packages are updated together.
+- Ensure each dependency maps to exactly one group; avoid overlapping patterns when adding catch-all buckets.
+
 ## Coding Style & Naming Conventions
 - TypeScript strict mode, 2-space indent, semicolons, and single quotes. Prettier is the source of truth for formatting.
 - Keep ESLint clean; avoid disabling rules without justification in-code.


### PR DESCRIPTION
## Summary
- group Dependabot updates by stack and tooling buckets
- document that new dependencies should keep the groups current

## Testing
- n/a