### PR TITLE
Chore/dependabot groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,58 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      salesforce-sdk:
+        patterns:
+          - "@salesforce/*"
+      vscode-platform:
+        patterns:
+          - "@vscode/*"
+          - "vscode-nls"
+          - "vscode-nls-dev"
+      react-ui:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-window"
+          - "lucide-react"
+          - "@radix-ui/*"
+      linting-and-formatting:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "lint-staged"
+          - "husky"
+      testing:
+        patterns:
+          - "mocha"
+          - "jsdom"
+          - "@types/mocha"
+          - "@types/jsdom"
+          - "@testing-library/*"
+      types:
+        patterns:
+          - "@types/*"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "tailwindcss-animate"
+          - "@tailwindcss/*"
+          - "autoprefixer"
+          - "postcss"
+      tooling:
+        patterns:
+          - "esbuild"
+          - "typescript"
+          - "npm-run-all"
+          - "sharp"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,66 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      salesforce-sdk:
+        patterns:
+          - "@salesforce/*"
+      vscode-platform:
+        patterns:
+          - "@vscode/*"
+          - "vscode-nls"
+          - "vscode-nls-dev"
+      react-ui:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "react-window"
+          - "lucide-react"
+          - "@radix-ui/*"
+      linting-and-formatting:
+        patterns:
+          - "eslint*"
+          - "@typescript-eslint/*"
+          - "prettier"
+          - "lint-staged"
+          - "husky"
+      testing:
+        patterns:
+          - "mocha"
+          - "jsdom"
+          - "@types/mocha"
+          - "@types/jsdom"
+          - "@testing-library/*"
+      react-types:
+        patterns:
+          - "@types/react"
+          - "@types/react-dom"
+      vscode-types:
+        patterns:
+          - "@types/vscode"
+      types:
+        patterns:
+          - "@types/node"
+          - "@types/proxyquire"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "tailwindcss-animate"
+          - "@tailwindcss/*"
+          - "autoprefixer"
+          - "postcss"
+      tooling:
+        patterns:
+          - "esbuild"
+          - "typescript"
+          - "npm-run-all"
+          - "sharp"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    groups:
+      actions-all:
+        patterns:
+          - "*"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,11 @@
 - `npm run lint` / `npm run format` – enforce ESLint (`eslint.config.mjs`) and Prettier across sources.
 - `npm run test` – compile and execute the default Mocha suite; use `npm run test:unit`, `npm run test:integration`, or `npm run test:all` for targeted scopes.
 
+## Dependency Management
+- Dependabot groups live in `.github/dependabot.yml`; when adding or upgrading dependencies, confirm the new package is matched by an existing group pattern.
+- If the dependency belongs to a new technology area, create a dedicated group (or expand an existing one) so related packages are updated together.
+- Ensure each dependency maps to exactly one group; avoid overlapping patterns when adding catch-all buckets.
+
 ## Coding Style & Naming Conventions
 - TypeScript strict mode, 2-space indent, semicolons, and single quotes. Prettier is the source of truth for formatting.
 - Keep ESLint clean; avoid disabling rules without justification in-code.


### PR DESCRIPTION
This pull request introduces improvements to how dependencies are managed and updated in the project. The main change is the addition of grouped updates for dependencies in Dependabot, making it easier to keep related packages up-to-date together. Documentation has also been updated to explain the new grouping system and best practices for managing dependency groups.

**Dependency Management Improvements**

* Added multiple dependency groups in `.github/dependabot.yml` for npm packages, such as `salesforce-sdk`, `vscode-platform`, `react-ui`, `linting-and-formatting`, `testing`, `react-types`, `vscode-types`, `types`, `tailwind`, and `tooling`, each with specific patterns to group related packages for updates.
* Added an `actions-all` group for GitHub Actions dependencies to update all actions together.

**Documentation Updates**

* Updated `AGENTS.md` to document the new Dependabot group system, including guidance on matching new dependencies to existing groups, creating new groups for new technology areas, and avoiding overlapping patterns.