### PR TITLE
chore: split Dependabot type groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,9 +35,17 @@ updates:
           - "@types/mocha"
           - "@types/jsdom"
           - "@testing-library/*"
+      react-types:
+        patterns:
+          - "@types/react"
+          - "@types/react-dom"
+      vscode-types:
+        patterns:
+          - "@types/vscode"
       types:
         patterns:
-          - "@types/*"
+          - "@types/node"
+          - "@types/proxyquire"
       tailwind:
         patterns:
           - "tailwindcss"


### PR DESCRIPTION
## Summary
- split React and VS Code @types packages into dedicated groups
- keep remaining type packages in a generic bucket so updates stay batched sensibly

## Testing
- n/a