### PR TITLE
chore(ci): restrict workflow permissions

### DIFF
--- a/.github/workflows/forbid-sensitive-files.yml
+++ b/.github/workflows/forbid-sensitive-files.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check-forbidden:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- add an explicit permissions block to the forbid-sensitive-files workflow so the GITHUB_TOKEN stays read-only
- resolve CodeQL security alert #14 (actions/missing-workflow-permissions)

## Testing
- not run (workflow change only)
