### PR TITLE
style(webview): align toolbar control heights

### DIFF
--- a/src/webview/components/LabeledSelect.tsx
+++ b/src/webview/components/LabeledSelect.tsx
@@ -77,7 +77,7 @@ export function LabeledSelect({
           onChange={e => onChange(e.target.value)}
           disabled={disabled}
           className={cn(
-            'min-w-[160px] rounded-md border border-input bg-input px-3 py-2 text-sm text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+            'min-w-[160px] rounded-md border border-input bg-input px-3 py-1 text-[13px] text-foreground shadow-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background',
             triggerClassName
           )}
         >

--- a/src/webview/components/ui/button.tsx
+++ b/src/webview/components/ui/button.tsx
@@ -4,22 +4,22 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { cn } from '../../lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center gap-1.5 whitespace-nowrap rounded-md text-[13px] font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground shadow hover:bg-primary/90',
-        secondary: 'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
-        outline: 'border border-border bg-transparent shadow-sm hover:bg-muted/70',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        outline: 'border border-border bg-transparent hover:bg-muted/70',
         ghost: 'hover:bg-muted/60 hover:text-foreground',
-        destructive: 'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
         link: 'text-primary underline-offset-4 hover:underline'
       },
       size: {
-        default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-6 text-base',
-        icon: 'h-9 w-9'
+        default: 'min-h-[28px] px-3 py-0',
+        sm: 'min-h-[26px] rounded-md px-2.5 text-xs',
+        lg: 'min-h-[30px] rounded-md px-4 text-sm',
+        icon: 'min-h-[28px] w-[28px] px-0'
       }
     },
     defaultVariants: {

--- a/src/webview/components/ui/input.tsx
+++ b/src/webview/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(({ className, type 
     <input
       type={type}
       className={cn(
-        'flex h-9 w-full rounded-md border border-input bg-input px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
+        'flex min-h-[28px] w-full rounded-md border border-input bg-input px-3 py-1 text-[13px] shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50',
         className
       )}
       ref={ref}

--- a/src/webview/components/ui/select.tsx
+++ b/src/webview/components/ui/select.tsx
@@ -14,7 +14,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-9 w-full items-center justify-between rounded-md border border-input bg-input px-3 py-2 text-sm ring-offset-background transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      'flex min-h-[28px] w-full items-center justify-between rounded-md border border-input bg-input px-3 py-1 text-[13px] ring-offset-background transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 disabled:cursor-not-allowed disabled:opacity-50',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary
- align shared input and select controls with the updated button min-height so the toolbar sits flush row-wide
- update fallback native select to match the Radix trigger styling when the webview falls back to plain HTML controls

## Testing
- not run (UI only)