### PR TITLE
Add GITHUB_TOKEN to workflows environment variables

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -178,6 +178,7 @@ jobs:
       VERSION: ${{ needs.prepare.outputs.version }}
       PRE_RELEASE: 'true'
       CHANNEL_SUFFIX: pre
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,7 @@ jobs:
     env:
       TAG_NAME: ${{ github.ref_name }}
       GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
         uses: actions/checkout@v5


### PR DESCRIPTION
Enhance the prerelease and release workflows by adding the GITHUB_TOKEN to the environment variables, improving authentication for GitHub actions.