### PR TITLE
Refactor org persistence to remove global state dependency

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,7 +4,7 @@ import { SfLogTailViewProvider } from './provider/SfLogTailViewProvider';
 import type { OrgItem } from './shared/types';
 import * as path from 'path';
 import { promises as fs } from 'fs';
-import { setApiVersion, getApiVersion } from './salesforce/http';
+import { setApiVersion, getApiVersion, clearListCache } from './salesforce/http';
 import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger } from './utils/logger';
 import { detectReplayDebuggerAvailable } from './utils/warmup';
 import { localize } from './utils/localize';
@@ -28,6 +28,10 @@ export async function activate(context: vscode.ExtensionContext) {
   try {
     CacheManager.init(context.globalState);
     await CacheManager.clearExpired();
+    await CacheManager.delete('cli');
+  } catch {}
+  try {
+    clearListCache();
   } catch {}
   // Initialize telemetry (no-op if no key/conn configured)
   try {
@@ -131,7 +135,6 @@ export async function activate(context: vscode.ExtensionContext) {
         const orgs: OrgItem[] = await listOrgs(true);
         const items: OrgQuickPick[] = orgs.map(o => ({
           label: o.alias ?? o.username,
-          description: o.isDefaultUsername ? localize('selectOrgDefault', 'Default') : undefined,
           detail: o.instanceUrl || undefined,
           username: o.username
         }));

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -9,7 +9,7 @@ import { safeSendEvent } from '../shared/telemetry';
 import { warmUpReplayDebugger, ensureReplayDebuggerAvailable } from '../utils/warmup';
 import { buildWebviewHtml } from '../utils/webviewHtml';
 import { TailService } from '../utils/tailService';
-import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from '../utils/orgs';
+import { pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
 import { LogViewerPanel } from '../panel/LogViewerPanel';
@@ -22,11 +22,6 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   private tailService = new TailService(m => this.post(m));
 
   constructor(private readonly context: vscode.ExtensionContext) {
-    const persisted = restoreSelectedOrg(this.context);
-    if (persisted) {
-      this.selectedOrg = persisted;
-      logInfo('Tail: restored selected org from globalState:', this.selectedOrg || '(default)');
-    }
     this.tailService.setOrg(this.selectedOrg);
 
     // React to tail buffer size changes live
@@ -194,7 +189,6 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
 
   private setSelectedOrg(username?: string): void {
     this.selectedOrg = username;
-    persistSelectedOrg(this.context, username);
   }
 
   private async sendDebugLevels(): Promise<void> {

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -38,10 +38,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     private readonly orgManager = new OrgManager(context),
     private readonly configManager = new ConfigManager(5, 100)
   ) {
-    const org = this.orgManager.getSelectedOrg();
-    if (org) {
-      logInfo('Logs: restored selected org from globalState:', org || '(default)');
-    }
     this.logService.setHeadConcurrency(this.configManager.getHeadConcurrency());
     this.messageHandler = new LogsMessageHandler(
       () => this.refresh(),

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,2 +1,0 @@
-export const SELECTED_ORG_KEY = 'electivus.apexLogs.selectedOrg';
-export const LEGACY_SELECTED_ORG_KEY = 'sfLogs.selectedOrg';

--- a/src/test/fetchApexLogs.test.ts
+++ b/src/test/fetchApexLogs.test.ts
@@ -14,7 +14,7 @@ suite('fetchApexLogs', () => {
     clearListCache();
   });
 
-  test('uses cache for repeated calls', async () => {
+  test('performs network request for repeated calls', async () => {
     const auth: OrgAuth = {
       accessToken: 'tok',
       instanceUrl: 'https://example.com',
@@ -49,8 +49,8 @@ suite('fetchApexLogs', () => {
 
     const first = await fetchApexLogs(auth, 50, 0);
     const second = await fetchApexLogs(auth, 50, 0);
-    assert.deepEqual(second, first, 'cached result should match');
-    assert.equal(calls, 1, 'network should be called once due to cache');
+    assert.deepEqual(second, first, 'second call returns matching payload');
+    assert.equal(calls, 2, 'network should be called for each request');
   });
 
   test('respects limit and offset', async () => {

--- a/src/test/orgManager.test.ts
+++ b/src/test/orgManager.test.ts
@@ -3,28 +3,22 @@ import proxyquire from 'proxyquire';
 import type * as vscode from 'vscode';
 
 suite('OrgManager', () => {
-  test('setSelectedOrg persists value', () => {
-    let saved: string | undefined;
+  test('setSelectedOrg keeps value in memory', () => {
     const { OrgManager } = proxyquire('../utils/orgManager', {
       './orgs': {
-        persistSelectedOrg: (_ctx: vscode.ExtensionContext, val?: string) => {
-          saved = val;
-        },
-        restoreSelectedOrg: () => undefined,
         pickSelectedOrg: () => undefined
       },
       '../salesforce/cli': { listOrgs: async () => [] }
     });
-    const mgr = new OrgManager({} as any);
+    const mgr = new OrgManager({} as vscode.ExtensionContext);
+    assert.equal(mgr.getSelectedOrg(), undefined);
     mgr.setSelectedOrg('user1');
-    assert.equal(saved, 'user1');
+    assert.equal(mgr.getSelectedOrg(), 'user1');
   });
 
   test('list returns orgs and selected', async () => {
     const { OrgManager } = proxyquire('../utils/orgManager', {
       './orgs': {
-        persistSelectedOrg: () => {},
-        restoreSelectedOrg: () => 'u1',
         pickSelectedOrg: () => 'u1'
       },
       '../salesforce/cli': {

--- a/src/test/persistedState.test.ts
+++ b/src/test/persistedState.test.ts
@@ -3,7 +3,6 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
 import { SfLogTailViewProvider } from '../provider/SfLogTailViewProvider';
-import { SELECTED_ORG_KEY } from '../shared/constants';
 
 function makeContext() {
   let capturedGetKey: string | undefined;
@@ -25,25 +24,23 @@ function makeContext() {
 }
 
 suite('Persisted org state', () => {
-  test('SfLogsViewProvider restores and persists selected org', () => {
+  test('SfLogsViewProvider no longer touches globalState for org persistence', () => {
     const { context, capturedGetKey, updates } = makeContext();
     const provider = new SfLogsViewProvider(context);
-    assert.equal(capturedGetKey(), SELECTED_ORG_KEY);
-    assert.equal((provider as any).orgManager.getSelectedOrg(), 'persisted-org');
+    assert.equal(capturedGetKey(), undefined);
+    assert.equal((provider as any).orgManager.getSelectedOrg(), undefined);
     provider.setSelectedOrg('next-org');
-    assert.equal(updates[0]?.key, SELECTED_ORG_KEY);
-    assert.equal(updates[0]?.value, 'next-org');
+    assert.equal(updates.length, 0);
     assert.equal((provider as any).orgManager.getSelectedOrg(), 'next-org');
   });
 
-  test('SfLogTailViewProvider restores and persists selected org', () => {
+  test('SfLogTailViewProvider keeps org selection in-memory only', () => {
     const { context, capturedGetKey, updates } = makeContext();
     const provider = new SfLogTailViewProvider(context);
-    assert.equal(capturedGetKey(), SELECTED_ORG_KEY);
-    assert.equal((provider as any).selectedOrg, 'persisted-org');
+    assert.equal(capturedGetKey(), undefined);
+    assert.equal((provider as any).selectedOrg, undefined);
     (provider as any).setSelectedOrg('next-org');
-    assert.equal(updates[0]?.key, SELECTED_ORG_KEY);
-    assert.equal(updates[0]?.value, 'next-org');
+    assert.equal(updates.length, 0);
     assert.equal((provider as any).selectedOrg, 'next-org');
   });
 });

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -1,12 +1,13 @@
 import type * as vscode from 'vscode';
-import { persistSelectedOrg, restoreSelectedOrg, pickSelectedOrg } from './orgs';
+import { pickSelectedOrg } from './orgs';
 import { listOrgs } from '../salesforce/cli';
 import type { OrgItem } from '../shared/types';
 
 export class OrgManager {
   private selectedOrg: string | undefined;
-  constructor(private readonly context: vscode.ExtensionContext) {
-    this.selectedOrg = restoreSelectedOrg(this.context) || undefined;
+  constructor(context?: vscode.ExtensionContext) {
+    void context;
+    this.selectedOrg = undefined;
   }
 
   getSelectedOrg(): string | undefined {
@@ -15,7 +16,6 @@ export class OrgManager {
 
   setSelectedOrg(org?: string): void {
     this.selectedOrg = org;
-    persistSelectedOrg(this.context, org);
   }
 
   async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {

--- a/src/utils/orgs.ts
+++ b/src/utils/orgs.ts
@@ -1,29 +1,8 @@
-import * as vscode from 'vscode';
 import type { OrgItem } from '../shared/types';
-import { SELECTED_ORG_KEY, LEGACY_SELECTED_ORG_KEY } from '../shared/constants';
 
-/** Restore previously selected org username from globalState, if any. */
-export function restoreSelectedOrg(context: vscode.ExtensionContext): string | undefined {
-  try {
-    const cur = (context as any)?.globalState?.get?.(SELECTED_ORG_KEY) as string | undefined;
-    if (cur !== undefined) return cur;
-    // Fallback to legacy key for backward compatibility
-    return (context as any)?.globalState?.get?.(LEGACY_SELECTED_ORG_KEY) as string | undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-/** Persist selected org username to globalState (best-effort). */
-export function persistSelectedOrg(context: vscode.ExtensionContext, username?: string): void {
-  try {
-    void (context as any)?.globalState?.update?.(SELECTED_ORG_KEY, username);
-  } catch {
-    // ignore in tests or headless
-  }
-}
-
-/** Pick a selected org given the list and an optional current value. */
+/**
+ * Pick a selected org given the list and an optional current value.
+ */
 export function pickSelectedOrg(orgs: OrgItem[], current?: string): string | undefined {
   const match = current ? orgs.find(o => o.username === current) : undefined;
   if (match) {

--- a/src/webview/__tests__/OrgSelect.test.tsx
+++ b/src/webview/__tests__/OrgSelect.test.tsx
@@ -16,10 +16,14 @@ describe('OrgSelect', () => {
     globalDoc.DocumentFragment = undefined;
     try {
       render(
-        <OrgSelect label="Org" orgs={orgs} selected={undefined} onChange={v => changes.push(v)} disabled={false} />
+        <OrgSelect label="Org" orgs={orgs} selected="u1" onChange={v => changes.push(v)} disabled={false} />
       );
       const select = screen.getByRole('combobox') as HTMLSelectElement;
       expect(select.value).toBe('u1');
+
+      // Ensure no default marker is appended
+      const options = Array.from(select.options).map(o => o.textContent);
+      expect(options).toEqual(['Org One', 'Two']);
 
       fireEvent.change(select, { target: { value: 'u2' } });
       expect(changes).toEqual(['u2']);

--- a/src/webview/components/OrgSelect.tsx
+++ b/src/webview/components/OrgSelect.tsx
@@ -19,7 +19,7 @@ export function OrgSelect({
 }) {
   const options = orgs.map(o => ({
     value: o.username,
-    label: `${o.alias ?? o.username}${o.isDefaultUsername ? ' *' : ''}`
+    label: o.alias ?? o.username
   }));
   const value = selected ?? '';
   return (


### PR DESCRIPTION
Eliminate the use of global state for org persistence, simplifying the OrgManager and related components. Adjust tests to reflect the in-memory management of selected orgs without relying on persisted state.