### PR TITLE
Revert default setting for full log search to false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Logs: enable full log search by default so the list view always loads log bodies for content filtering, removed the legacy `sfLogs.enableFullLogSearch` setting in favor of `electivus.apexLogs.enableFullLogSearch`, and surface a highlighted match snippet in the table when search results come from log content.
+- Logs: keep header-only loading by default again—`electivus.apexLogs.enableFullLogSearch` now defaults to false, but you can opt in to download full log bodies for content filtering. The highlighted match snippet in the table still appears when full content search is enabled.
 
 ## [0.12.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.10.0...v0.12.0) (2025-09-20)
 

--- a/package.json
+++ b/package.json
@@ -123,8 +123,8 @@
           "markdownDescription": "%configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description%"
         },
         "electivus.apexLogs.enableFullLogSearch": {
-          "type": "boolean",
-          "default": true,
+        "type": "boolean",
+        "default": false,
           "markdownDescription": "%configuration.electivus.apexLogs.enableFullLogSearch.description%"
         },
         "sfLogs.pageSize": {

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -5,7 +5,7 @@ export class ConfigManager {
   private enableFullLogSearch: boolean;
 
   constructor(private headConcurrency: number, private pageLimit: number) {
-    this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', true);
+    this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', false);
   }
 
   handleChange(e: vscode.ConfigurationChangeEvent): void {


### PR DESCRIPTION
Restore the default behavior for full log search to false, allowing users to opt-in for full log body downloads while maintaining the highlighted match snippet feature in search results. Update the changelog accordingly.