### PR TITLE
fix: sync org selection when listing orgs

### DIFF
--- a/src/test/orgManager.test.ts
+++ b/src/test/orgManager.test.ts
@@ -29,5 +29,23 @@ suite('OrgManager', () => {
     const res = await mgr.list();
     assert.equal(res.selected, 'u1');
     assert.equal(res.orgs.length, 1);
+    assert.equal(mgr.getSelectedOrg(), 'u1');
+  });
+
+  test('list clears selected org when none returned', async () => {
+    const { OrgManager } = proxyquire('../utils/orgManager', {
+      './orgs': {
+        pickSelectedOrg: () => undefined
+      },
+      '../salesforce/cli': {
+        listOrgs: async () => []
+      }
+    });
+    const mgr = new OrgManager({} as any);
+    mgr.setSelectedOrg('existing');
+    const res = await mgr.list();
+    assert.equal(res.selected, undefined);
+    assert.equal(res.orgs.length, 0);
+    assert.equal(mgr.getSelectedOrg(), undefined);
   });
 });

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -21,6 +21,7 @@ export class OrgManager {
   async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {
     const orgs = await listOrgs(forceRefresh, signal);
     const selected = pickSelectedOrg(orgs, this.selectedOrg);
+    this.selectedOrg = selected;
     return { orgs, selected };
   }
 }


### PR DESCRIPTION
## Summary
- persist the OrgManager list selection back to internal state
- cover selected org updates in the orgManager tests for populated and empty org lists

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68db1c60d89483239fd459a76abb2ce4