### PR TITLE
refactor: remove CLI cache reset on activation

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,14 +21,17 @@ interface OrgQuickPick extends vscode.QuickPickItem {
   username: string;
 }
 
+async function initializePersistentCache(context: vscode.ExtensionContext): Promise<void> {
+  CacheManager.init(context.globalState);
+  await CacheManager.clearExpired();
+}
+
 export async function activate(context: vscode.ExtensionContext) {
   const activationStart = Date.now();
   LogViewerPanel.initialize(context);
   // Init TTL cache (best-effort; no-op if unavailable)
   try {
-    CacheManager.init(context.globalState);
-    await CacheManager.clearExpired();
-    await CacheManager.delete('cli');
+    await initializePersistentCache(context);
   } catch {}
   try {
     clearListCache();
@@ -326,3 +329,7 @@ export function deactivate() {
     // ignore
   }
 }
+
+export const __test__ = {
+  initializePersistentCache
+};


### PR DESCRIPTION
## Summary
- stop invoking versioned CLI cache resets during activation while still clearing expired entries
- update the listOrgs cache tests to cover activation persistence and manual cache clearing without reset flags

## Testing
- npm run lint
- CI=1 npm test

------
https://chatgpt.com/codex/tasks/task_e_68db1eeb06888323adedc5e026047b02