### PR TITLE
Update head concurrency to use electivus namespace

### DIFF
--- a/src/test/configManager.test.ts
+++ b/src/test/configManager.test.ts
@@ -1,0 +1,33 @@
+import assert from 'assert/strict';
+import { workspace } from 'vscode';
+import { ConfigManager } from '../utils/configManager';
+
+suite('ConfigManager', () => {
+  const originalGetConfiguration = workspace.getConfiguration;
+
+  teardown(() => {
+    (workspace.getConfiguration as any) = originalGetConfiguration;
+  });
+
+  test('reads head concurrency from electivus namespace on construction', () => {
+    const values = new Map<string, unknown>([['electivus.apexLogs.headConcurrency', 3]]);
+    (workspace.getConfiguration as any) = () => ({
+      get: (key: string) => values.get(key)
+    });
+
+    const manager = new ConfigManager(5, 100);
+
+    assert.equal(manager.getHeadConcurrency(), 3);
+  });
+
+  test('falls back to legacy namespace for head concurrency', () => {
+    const values = new Map<string, unknown>([['sfLogs.headConcurrency', 7]]);
+    (workspace.getConfiguration as any) = () => ({
+      get: (key: string) => values.get(key)
+    });
+
+    const manager = new ConfigManager(5, 100);
+
+    assert.equal(manager.getHeadConcurrency(), 7);
+  });
+});

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -5,12 +5,18 @@ export class ConfigManager {
   private enableFullLogSearch: boolean;
 
   constructor(private headConcurrency: number, private pageLimit: number) {
+    this.headConcurrency = getNumberConfig('electivus.apexLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
     this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', false);
   }
 
   handleChange(e: vscode.ConfigurationChangeEvent): void {
-    if (affectsConfiguration(e, 'sfLogs.headConcurrency')) {
-      this.headConcurrency = getNumberConfig('sfLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
+    if (affectsConfiguration(e, 'electivus.apexLogs.headConcurrency')) {
+      this.headConcurrency = getNumberConfig(
+        'electivus.apexLogs.headConcurrency',
+        this.headConcurrency,
+        1,
+        Number.MAX_SAFE_INTEGER
+      );
     }
     if (affectsConfiguration(e, 'electivus.apexLogs.enableFullLogSearch')) {
       this.enableFullLogSearch = getBooleanConfig(


### PR DESCRIPTION
Refactor the ConfigManager to read head concurrency from the electivus namespace, with a fallback to the legacy namespace.