### PR TITLE
Implement log ID extraction and fix stale closure in LogsTable

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { LogViewerPanel } from './panel/LogViewerPanel';
 import { getBooleanConfig, affectsConfiguration } from './utils/config';
 import { getErrorMessage } from './utils/error';
 import { listOrgs, getOrgAuth } from './salesforce/cli';
-import { isApexLogDocument } from './utils/workspace';
+import { isApexLogDocument, getLogIdFromLogFilePath } from './utils/workspace';
 import { ApexLogCodeLensProvider } from './provider/ApexLogCodeLensProvider';
 
 interface OrgQuickPick extends vscode.QuickPickItem {
@@ -212,7 +212,7 @@ export async function activate(context: vscode.ExtensionContext) {
           return;
         }
         const filePath = doc.uri.fsPath;
-        const logId = path.basename(filePath).replace(/\.log$/i, '');
+        const logId = getLogIdFromLogFilePath(filePath) ?? path.parse(filePath).name;
         await LogViewerPanel.show({ logId, filePath });
         logInfo('Command sfLogs.openLogInViewer opened log viewer for', logId);
       } catch (e) {

--- a/src/test/getLogIdFromLogFilePath.test.ts
+++ b/src/test/getLogIdFromLogFilePath.test.ts
@@ -1,0 +1,35 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+
+const workspaceModule: typeof import('../utils/workspace') = proxyquire('../utils/workspace', {
+  vscode: {
+    workspace: { workspaceFolders: undefined },
+    Range: class {
+      constructor(
+        public readonly startLine: number,
+        public readonly startCharacter: number,
+        public readonly endLine: number,
+        public readonly endCharacter: number
+      ) {}
+    }
+  }
+});
+
+const { getLogIdFromLogFilePath } = workspaceModule;
+
+suite('getLogIdFromLogFilePath', () => {
+  test('extracts log id from username-prefixed filenames', () => {
+    const result = getLogIdFromLogFilePath('/tmp/default_07L000000000001AA.log');
+    assert.equal(result, '07L000000000001AA');
+  });
+
+  test('extracts log id from legacy filenames', () => {
+    const result = getLogIdFromLogFilePath('/tmp/07L000000000001AA.log');
+    assert.equal(result, '07L000000000001AA');
+  });
+
+  test('returns undefined for non-matching filenames', () => {
+    const result = getLogIdFromLogFilePath('/tmp/custom.log.txt');
+    assert.equal(result, undefined);
+  });
+});

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -93,6 +93,11 @@ function extractLogIdFromFileName(fileName: string): string | undefined {
   return match ? match[1] : undefined;
 }
 
+export function getLogIdFromLogFilePath(filePath: string): string | undefined {
+  const fileName = path.basename(filePath);
+  return extractLogIdFromFileName(fileName);
+}
+
 export async function purgeSavedLogs(options: {
   keepIds?: Set<string>;
   maxAgeMs?: number;

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -85,6 +85,7 @@ export function LogsTable({
   const hasMoreRef = useRef<boolean>(hasMore);
   const loadingRef = useRef<boolean>(loading);
   const autoLoadRef = useRef<boolean>(autoLoadEnabled);
+  const loadMoreRef = useRef(onLoadMore);
   const lastLoadTsRef = useRef<number>(0);
   const gridTemplate =
     'minmax(160px,1fr) minmax(140px,1fr) minmax(200px,1.2fr) minmax(200px,1fr) minmax(110px,0.6fr) minmax(120px,0.8fr) minmax(260px,1.4fr) minmax(90px,0.6fr) minmax(320px,1.6fr) 96px';
@@ -202,6 +203,9 @@ export function LogsTable({
   useEffect(() => {
     autoLoadRef.current = autoLoadEnabled;
   }, [autoLoadEnabled]);
+  useEffect(() => {
+    loadMoreRef.current = onLoadMore;
+  }, [onLoadMore]);
 
   // Adaptive overscan based on scroll velocity
   useEffect(() => {
@@ -241,7 +245,7 @@ export function LogsTable({
         if (remaining <= defaultRowHeight * 2) {
           if (now - lastLoadTsRef.current > 300) {
             lastLoadTsRef.current = now;
-            onLoadMore();
+            loadMoreRef.current();
           }
         }
       }


### PR DESCRIPTION
Introduce a new function for extracting log IDs from file paths and add corresponding tests. Update the LogsTable component to prevent stale closure issues by correctly referencing the load more function.