### PR TITLE
ci: force bash in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,7 @@ jobs:
         run: npm ci
 
       - name: Verify tag matches package.json version
+        shell: bash
         run: |
           set -euo pipefail
           PKG_VERSION=$(node -p "require('./package.json').version")
@@ -189,6 +190,7 @@ jobs:
         run: npm ci
 
       - name: Verify tag matches package.json version
+        shell: bash
         run: |
           set -euo pipefail
           PKG_VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary
- set shell to bash for the tag/version check so Windows runners execute the right syntax

## Testing
- not run