### PR TITLE
chore: bump version to 0.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.14.0",
+      "version": "0.14.1",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "publisher": "electivus",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump package.json and package-lock.json to 0.14.1 so the release tag matches package metadata

## Testing
- not run