### PR TITLE
ci: fix codex review workflow guard

### DIFF
--- a/.github/workflows/dependabot-codex-review.yml
+++ b/.github/workflows/dependabot-codex-review.yml
@@ -11,17 +11,30 @@ jobs:
   request-codex-review:
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     runs-on: ubuntu-latest
+    env:
+      CODEX_REVIEW_COMMENTER_TOKEN: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN }}
     steps:
       - name: Skip when PAT secret missing
-        if: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN == '' }}
+        if: env.CODEX_REVIEW_COMMENTER_TOKEN == ''
         run: |
           echo "Dependabot Codex review trigger skipped: set CODEX_REVIEW_COMMENTER_TOKEN secret to enable @codex review comments." >&2
+      - name: Find existing Codex review comment
+        if: env.CODEX_REVIEW_COMMENTER_TOKEN != ''
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          token: ${{ env.CODEX_REVIEW_COMMENTER_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body-includes: '<!-- codex:dependabot-auto -->'
       - name: Ensure Codex review comment
-        if: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN != '' }}
+        if: env.CODEX_REVIEW_COMMENTER_TOKEN != ''
         uses: peter-evans/create-or-update-comment@v4
         with:
-          token: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN }}
+          token: ${{ env.CODEX_REVIEW_COMMENTER_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: '@codex review'
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          body: |-
+            @codex review
+
+            <!-- codex:dependabot-auto -->
           edit-mode: replace
-          body-includes: '@codex review'


### PR DESCRIPTION
## Summary
- load CODEX_REVIEW_COMMENTER_TOKEN into job env scope
- use env-based if checks so workflow validates on GitHub
- reuse env token when creating the comment