### PR TITLE
feat: enable full log search by default

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
         },
         "electivus.apexLogs.enableFullLogSearch": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "markdownDescription": "%configuration.electivus.apexLogs.enableFullLogSearch.description%"
         },
         "sfLogs.pageSize": {

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -142,7 +142,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
             return;
           }
           this.preloadFullLogBodies(logs, controller.signal);
-          this.post({ type: 'init', locale: vscode.env.language });
+          this.post({
+            type: 'init',
+            locale: vscode.env.language,
+            fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies()
+          });
           const hasMore = logs.length === this.pageLimit;
           this.post({ type: 'logs', data: logs, hasMore });
           this.currentLogs = logs.slice();

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -18,7 +18,7 @@ export type WebviewToExtensionMessage =
 export type ExtensionToWebviewMessage =
   | { type: 'loading'; value: boolean }
   | { type: 'error'; message: string }
-  | { type: 'init'; locale: string }
+  | { type: 'init'; locale: string; fullLogSearchEnabled?: boolean }
   | { type: 'logs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'appendLogs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'logHead'; logId: string; codeUnitStarted?: string }

--- a/src/test/provider.logs.behavior.test.ts
+++ b/src/test/provider.logs.behavior.test.ts
@@ -59,6 +59,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
+    (provider as any).configManager.shouldLoadFullLogBodies = () => false;
     // Inject minimal view so refresh proceeds
     (provider as any).view = {
       webview: {

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -6,7 +6,7 @@ export class ConfigManager {
 
   constructor(private headConcurrency: number, private pageLimit: number) {
     this.headConcurrency = getNumberConfig('electivus.apexLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
-    this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', false);
+    this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', true);
   }
 
   handleChange(e: vscode.ConfigurationChangeEvent): void {

--- a/src/webview/__tests__/logsApp.test.tsx
+++ b/src/webview/__tests__/logsApp.test.tsx
@@ -31,7 +31,7 @@ describe('Logs webview App', () => {
 
     expect(posted[0]).toEqual({ type: 'ready' });
 
-    sendMessage(bus, { type: 'init', locale: 'pt-BR' });
+    sendMessage(bus, { type: 'init', locale: 'pt-BR', fullLogSearchEnabled: true });
     await screen.findByText('Atualizar');
 
     sendMessage(bus, { type: 'loading', value: true });

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -10,6 +10,8 @@ type Props = {
   r: ApexLogRow;
   logHead: LogHeadMap;
   matchSnippet?: { text: string; ranges: [number, number][] };
+  showCodeUnitColumn: boolean;
+  showMatchColumn: boolean;
   locale: string;
   t: any;
   loading: boolean;
@@ -25,6 +27,8 @@ export function LogRow({
   r,
   logHead,
   matchSnippet,
+  showCodeUnitColumn,
+  showMatchColumn,
   locale,
   t,
   loading,
@@ -58,7 +62,15 @@ export function LogRow({
         console.warn('LogRow: failed to disconnect ResizeObserver', e);
       }
     };
-  }, [index, setRowHeight, logHead[r.Id]?.codeUnitStarted, matchSnippet?.text, r]);
+  }, [
+    index,
+    setRowHeight,
+    logHead[r.Id]?.codeUnitStarted,
+    matchSnippet?.text,
+    r,
+    showCodeUnitColumn,
+    showMatchColumn
+  ]);
 
   const cellClass =
     'min-w-0 px-3 py-2 text-sm leading-relaxed text-foreground/90 transition-colors break-words';
@@ -145,17 +157,21 @@ export function LogRow({
         <div className={cellClass}>{new Date(r.StartTime).toLocaleString(locale)}</div>
         <div className={cellClass}>{formatDuration(r.DurationMilliseconds)}</div>
         <div className={cellClass}>{r.Status}</div>
-        <div className={cellClass} title={logHead[r.Id]?.codeUnitStarted ?? ''}>
-          {logHead[r.Id]?.codeUnitStarted ?? ''}
-        </div>
+        {showCodeUnitColumn && (
+          <div className={cellClass} title={logHead[r.Id]?.codeUnitStarted ?? ''}>
+            {logHead[r.Id]?.codeUnitStarted ?? ''}
+          </div>
+        )}
         <div className={cn(cellClass, 'text-right font-medium tabular-nums text-foreground')}>
           {formatBytes(r.LogLength)}
         </div>
-        <div className={cn(cellClass, 'text-muted-foreground/90')} title={matchSnippet?.text ?? ''}>
-          <span className="block max-h-[4.5rem] overflow-hidden whitespace-pre-wrap text-left text-sm leading-relaxed">
-            {renderSnippet}
-          </span>
-        </div>
+        {showMatchColumn && (
+          <div className={cn(cellClass, 'text-muted-foreground/90')} title={matchSnippet?.text ?? ''}>
+            <span className="block max-h-[4.5rem] overflow-hidden whitespace-pre-wrap text-left text-sm leading-relaxed">
+              {renderSnippet}
+            </span>
+          </div>
+        )}
         <div className={cn(cellClass, 'flex items-center justify-center gap-2 text-center')}>
           <div className="flex items-center gap-2">
             {actionButton(

--- a/src/webview/components/table/LogsHeader.tsx
+++ b/src/webview/components/table/LogsHeader.tsx
@@ -10,10 +10,12 @@ type Props = {
   sortDir: 'asc' | 'desc';
   onSort: (key: SortKey) => void;
   gridTemplate: string;
+  showCodeUnitColumn: boolean;
+  showMatchColumn: boolean;
 };
 
 export const LogsHeader = React.forwardRef<HTMLDivElement, Props>(
-  ({ t, sortBy, sortDir, onSort, gridTemplate }, ref) => {
+  ({ t, sortBy, sortDir, onSort, gridTemplate, showCodeUnitColumn, showMatchColumn }, ref) => {
     const renderSortIcon = (key: SortKey) => {
       if (sortBy !== key) {
         return <ChevronsUpDown className="h-3.5 w-3.5 opacity-50" aria-hidden="true" />;
@@ -66,11 +68,13 @@ export const LogsHeader = React.forwardRef<HTMLDivElement, Props>(
         {renderHeader('time', t.columns.time)}
         {renderHeader('duration', t.columns.duration)}
         {renderHeader('status', t.columns.status)}
-        {renderHeader('codeUnit', t.columns.codeUnitStarted)}
+        {showCodeUnitColumn && renderHeader('codeUnit', t.columns.codeUnitStarted)}
         {renderHeader('size', t.columns.size, 'end')}
-        <div className={cn(headerClass, 'justify-start text-left text-muted-foreground')} role="columnheader">
-          <span className="truncate">{t.columns.match ?? 'Match'}</span>
-        </div>
+        {showMatchColumn && (
+          <div className={cn(headerClass, 'justify-start text-left text-muted-foreground')} role="columnheader">
+            <span className="truncate">{t.columns.match ?? 'Match'}</span>
+          </div>
+        )}
         <div aria-hidden="true" />
       </div>
     );

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -33,6 +33,7 @@ export function LogsApp({
   const [logHead, setLogHead] = useState<Record<string, { codeUnitStarted?: string }>>({});
   const [matchingIds, setMatchingIds] = useState<Set<string>>(new Set());
   const [matchSnippets, setMatchSnippets] = useState<Record<string, { text: string; ranges: [number, number][] }>>({});
+  const [fullLogSearchEnabled, setFullLogSearchEnabled] = useState(false);
   const queryRef = useRef('');
   const [searchStatus, setSearchStatus] = useState<'idle' | 'loading'>('idle');
 
@@ -67,6 +68,7 @@ export function LogsApp({
         case 'init':
           setLocale(msg.locale);
           setT(getMessages(msg.locale));
+          setFullLogSearchEnabled(!!msg.fullLogSearchEnabled);
           break;
         case 'logs':
           setRows(msg.data || []);
@@ -155,6 +157,13 @@ export function LogsApp({
       setSortDir(key === 'time' || key === 'size' || key === 'duration' ? 'desc' : 'asc');
     }
   };
+
+  useEffect(() => {
+    if (fullLogSearchEnabled && sortBy === 'codeUnit') {
+      setSortBy('time');
+      setSortDir('desc');
+    }
+  }, [fullLogSearchEnabled, sortBy]);
 
   const clearFilters = () => {
     updateQuery('');
@@ -300,6 +309,7 @@ export function LogsApp({
           sortDir={sortDir}
           onSort={onSort}
           matchSnippets={matchSnippets}
+          fullLogSearchEnabled={fullLogSearchEnabled}
           autoLoadEnabled={!hasFilters}
         />
         {hasFilters && hasMore && (


### PR DESCRIPTION
## Summary
- set the full log search configuration default to true and preload full bodies accordingly
- pipe the config state into the logs webview so we show match snippets and hide code unit columns when appropriate
- update unit tests for the provider and webview to cover the new layout logic

## Testing
- npm run test -- LogsTable
