### PR TITLE
chore(devcontainer): add VS Code dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,4 @@
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:20
+
+# Install Salesforce CLI globally for the node user.
+RUN npm install -g @salesforce/cli

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,26 @@
+{
+  "name": "Apex Log Viewer Dev",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "."
+  },
+  "remoteUser": "node",
+  "updateRemoteUserUID": true,
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "salesforce.salesforcedx-vscode"
+      ],
+      "settings": {
+        "npm.packageManager": "npm",
+        "editor.formatOnSave": true
+      }
+    }
+  },
+  "postCreateCommand": "bash -lc \"INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh && npm install\"",
+  "containerEnv": {
+    "FORCE_COLOR": "1"
+  }
+}


### PR DESCRIPTION
## Summary
- add \.devcontainer/devcontainer.json to build the workspace container locally
- install the Salesforce CLI in \.devcontainer/Dockerfile to replace the unavailable GHCR feature

## Testing
- not run (container definition only)
