### PR TITLE
Update LogsTable to always display code unit column

### DIFF
--- a/src/webview/__tests__/LogsTable.test.tsx
+++ b/src/webview/__tests__/LogsTable.test.tsx
@@ -198,10 +198,10 @@ describe('LogsTable', () => {
     (performance as any).now = originalNow;
   });
 
-  it('shows match column and hides code unit when full log search is enabled', () => {
+  it('shows match column while keeping code unit when full log search is enabled', () => {
     const captured: CapturedList = {};
     renderTable({ captured, fullLogSearchEnabled: true });
-    expect(screen.queryByText('Code Unit')).toBeNull();
+    expect(screen.getByText('Code Unit')).toBeInTheDocument();
     expect(screen.getByText('Match')).toBeInTheDocument();
   });
 

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -92,7 +92,7 @@ export function LogsTable({
   const onLoadMoreRef = useRef(onLoadMore);
   const lastLoadTsRef = useRef<number>(0);
   const showMatchColumn = fullLogSearchEnabled;
-  const showCodeUnitColumn = !fullLogSearchEnabled;
+  const showCodeUnitColumn = true;
   const gridTemplate = useMemo(() => {
     const columns = [
       'minmax(160px,1fr)',

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -158,13 +158,6 @@ export function LogsApp({
     }
   };
 
-  useEffect(() => {
-    if (fullLogSearchEnabled && sortBy === 'codeUnit') {
-      setSortBy('time');
-      setSortDir('desc');
-    }
-  }, [fullLogSearchEnabled, sortBy]);
-
   const clearFilters = () => {
     updateQuery('');
     setFilterUser('');


### PR DESCRIPTION
Ensure the code unit column remains visible in the LogsTable regardless of the full log search setting, and adjust related test expectations accordingly.