### PR TITLE
feat: enable find-in-log navigation

### DIFF
--- a/src/webview/__tests__/Input.test.tsx
+++ b/src/webview/__tests__/Input.test.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { Input } from '../components/ui/input';
+
+describe('Input component', () => {
+  it('renders default text input', () => {
+    render(<Input placeholder="Default" />);
+    const input = screen.getByPlaceholderText('Default') as HTMLInputElement;
+    expect(input.type).toBe('text');
+  });
+
+  it('respects provided type attribute', () => {
+    render(<Input placeholder="Search" type="search" />);
+    const input = screen.getByPlaceholderText('Search') as HTMLInputElement;
+    expect(input.type).toBe('search');
+  });
+});

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -72,9 +72,13 @@ describe('Log Viewer App', () => {
     fireEvent.click(screen.getByText('Debug Only'));
     fireEvent.click(screen.getByText('Debug Only'));
 
-    fireEvent.change(screen.getByPlaceholderText('Search entries…'), { target: { value: 'sem resultado' } });
-    await screen.findByText('No entries match the current filters.');
-    fireEvent.change(screen.getByPlaceholderText('Search entries…'), { target: { value: '' } });
+    const searchInput = screen.getByPlaceholderText('Search entries…');
+    fireEvent.change(searchInput, { target: { value: 'sem resultado' } });
+    await screen.findByText('Olá Mundo | Detalhe');
+    screen.getByText('0/0');
+    expect(screen.getByLabelText('Next match')).toBeDisabled();
+    fireEvent.change(searchInput, { target: { value: '' } });
+    await waitFor(() => expect(screen.queryByText('0/0')).toBeNull());
 
     fireEvent.click(screen.getByText('View Raw'));
 

--- a/src/webview/components/log-viewer/LogViewerHeader.tsx
+++ b/src/webview/components/log-viewer/LogViewerHeader.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { FileText, Search } from 'lucide-react';
+import { ChevronDown, ChevronUp, FileText, Search } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { cn } from '../../lib/utils';
@@ -10,9 +10,28 @@ interface Props {
   onSearchChange: (value: string) => void;
   onViewRaw: () => void;
   disabled?: boolean;
+  matchCount?: number;
+  activeMatchIndex?: number;
+  onNextMatch?: () => void;
+  onPreviousMatch?: () => void;
 }
 
-export function LogViewerHeader({ fileName, search, onSearchChange, onViewRaw, disabled }: Props) {
+export function LogViewerHeader({
+  fileName,
+  search,
+  onSearchChange,
+  onViewRaw,
+  disabled,
+  matchCount = 0,
+  activeMatchIndex,
+  onNextMatch,
+  onPreviousMatch
+}: Props) {
+  const hasQuery = search.trim().length > 0;
+  const totalMatches = matchCount;
+  const currentMatch = activeMatchIndex !== undefined && activeMatchIndex !== null && activeMatchIndex >= 0 ? activeMatchIndex + 1 : 0;
+  const matchLabel = hasQuery ? `${currentMatch}/${totalMatches}` : '';
+
   return (
     <header className="flex items-center justify-between gap-4 border-b border-border/60 bg-card/40 px-5 py-3">
       <div className="flex min-w-0 items-center gap-3">
@@ -23,15 +42,56 @@ export function LogViewerHeader({ fileName, search, onSearchChange, onViewRaw, d
         </div>
       </div>
       <div className="flex items-center gap-2">
-        <div className="relative">
-          <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input
-            value={search}
-            onChange={event => onSearchChange(event.target.value)}
-            placeholder="Search entries…"
-            className={cn('w-64 pl-8 text-sm', disabled && 'opacity-70')}
-            disabled={disabled}
-          />
+        <div className="flex items-center gap-1.5">
+          <div className="relative">
+            <Search className="absolute left-2 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              value={search}
+              onChange={event => onSearchChange(event.target.value)}
+              onKeyDown={event => {
+                if (!hasQuery) return;
+                if (event.key === 'Enter') {
+                  event.preventDefault();
+                  if (event.shiftKey) {
+                    onPreviousMatch?.();
+                  } else {
+                    onNextMatch?.();
+                  }
+                }
+              }}
+              placeholder="Search entries…"
+              className={cn('w-64 pl-8 text-sm', disabled && 'opacity-70')}
+              disabled={disabled}
+              type="search"
+            />
+          </div>
+          {hasQuery && (
+            <div className="flex items-center gap-1 rounded-md border border-border/60 bg-background/60 px-1.5 py-1 text-[11px] text-muted-foreground">
+              <span className="min-w-[42px] text-center tabular-nums">{matchLabel || '0/0'}</span>
+              <div className="flex items-center gap-1">
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onPreviousMatch?.()}
+                  disabled={disabled || totalMatches === 0}
+                  className="h-6 w-6"
+                  aria-label="Previous match"
+                >
+                  <ChevronUp className="h-3.5 w-3.5" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => onNextMatch?.()}
+                  disabled={disabled || totalMatches === 0}
+                  className="h-6 w-6"
+                  aria-label="Next match"
+                >
+                  <ChevronDown className="h-3.5 w-3.5" />
+                </Button>
+              </div>
+            </div>
+          )}
         </div>
         <Button variant="outline" size="sm" onClick={onViewRaw} disabled={disabled} className="text-sm">
           <FileText className="mr-2 h-4 w-4" />


### PR DESCRIPTION
## Summary
- add match navigation controls to the log viewer header with keyboard support
- highlight individual matches and auto-scroll to the active occurrence
- cover new behaviour with updated component tests and input coverage

## Testing
- npm run test -- logViewerComponents