### PR TITLE
feat: add error filter to log viewer

### DIFF
--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -79,7 +79,7 @@ describe('Log viewer components', () => {
         <LogViewerFilters
           active="all"
           onChange={next => calls.push(next)}
-          counts={{ total: 1234, debug: 12, soql: 5, dml: 3 }}
+          counts={{ total: 1234, debug: 12, errors: 2, soql: 5, dml: 3 }}
           locale="en-US"
         />
       );
@@ -89,6 +89,9 @@ describe('Log viewer components', () => {
 
       fireEvent.click(screen.getByText('SOQL'));
       expect(calls[1]).toBe('soql');
+
+      fireEvent.click(screen.getByText('Errors'));
+      expect(calls[2]).toBe('error');
 
       const showing = screen.getByText(/entries$/);
       expect(showing.textContent?.includes('1,234 entries')).toBe(true);
@@ -107,7 +110,7 @@ describe('Log viewer components', () => {
           <LogViewerFilters
             active="debug"
             onChange={() => {}}
-            counts={{ total: 999, debug: 456, soql: 0, dml: 0 }}
+            counts={{ total: 999, debug: 456, errors: 78, soql: 0, dml: 0 }}
             locale="zz-ZZ"
           />
         );
@@ -123,7 +126,7 @@ describe('Log viewer components', () => {
     it('renders metadata and formatted values', () => {
       render(
         <LogViewerStatusBar
-          counts={{ total: 2048, debug: 20, soql: 10, dml: 4 }}
+          counts={{ total: 2048, debug: 20, errors: 3, soql: 10, dml: 4 }}
           locale="en-US"
           metadata={{ sizeBytes: 1536, modifiedAt: '2025-09-21T17:30:00.000Z' }}
         />
@@ -131,6 +134,7 @@ describe('Log viewer components', () => {
 
       screen.getByText('Total Lines: 2,048');
       screen.getByText('Debug Statements: 20');
+      screen.getByText('Error Events: 3');
       screen.getByText('SOQL Queries: 10');
       screen.getByText('DML Operations: 4');
       screen.getByText('Size: 1.5 KB');
@@ -149,11 +153,12 @@ describe('Log viewer components', () => {
       try {
         render(
           <LogViewerStatusBar
-            counts={{ total: 12, debug: 1, soql: 2, dml: 3 }}
+            counts={{ total: 12, debug: 1, errors: 0, soql: 2, dml: 3 }}
             locale="bad-locale"
             metadata={{ sizeBytes: 512, modifiedAt: 'not-a-date' }}
           />
         );
+        screen.getByText('Error Events: 0');
         expect(screen.queryByText(/Updated:/)).toBeNull();
         screen.getByText('Size: 512 B');
       } finally {
@@ -182,7 +187,7 @@ describe('Log viewer components', () => {
       expect(screen.getByText('Context info')).toBeInTheDocument();
     });
 
-    it.each(['debug', 'soql', 'dml', 'code', 'limit', 'system', 'other'] as LogCategory[])(
+    it.each(['debug', 'soql', 'dml', 'code', 'limit', 'system', 'error', 'other'] as LogCategory[])(
       'applies visuals for %s entries',
       category => {
         const entry = { ...baseEntry, category, type: category.toUpperCase(), details: undefined };

--- a/src/webview/components/log-viewer/LogEntryRow.tsx
+++ b/src/webview/components/log-viewer/LogEntryRow.tsx
@@ -2,7 +2,7 @@ import React, { useLayoutEffect, useRef } from 'react';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/utils';
 import type { LogCategory, ParsedLogEntry } from '../../utils/logViewerParser';
-import { Bug, Database, Edit3, Settings, Info, AlertTriangle, Cpu } from 'lucide-react';
+import { Bug, Database, Edit3, Settings, Info, AlertTriangle, AlertOctagon, Cpu } from 'lucide-react';
 
 interface Props {
   entry: ParsedLogEntry;
@@ -133,6 +133,12 @@ function getCategoryVisuals(category: LogCategory) {
         badgeClass: 'border-yellow-500/40 bg-yellow-500/15 text-yellow-200',
         icon: AlertTriangle,
         iconClass: 'text-yellow-400'
+      };
+    case 'error':
+      return {
+        badgeClass: 'border-red-500/40 bg-red-500/15 text-red-200',
+        icon: AlertOctagon,
+        iconClass: 'text-red-400'
       };
     case 'system':
       return {

--- a/src/webview/components/log-viewer/LogViewerFilters.tsx
+++ b/src/webview/components/log-viewer/LogViewerFilters.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
-import { Bug, Database, Edit3, Filter, Eye } from 'lucide-react';
+import { AlertOctagon, Bug, Database, Edit3, Filter, Eye } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/utils';
 
-export type LogFilter = 'all' | 'debug' | 'soql' | 'dml';
+export type LogFilter = 'all' | 'debug' | 'error' | 'soql' | 'dml';
 
 interface Props {
   active: LogFilter;
@@ -12,6 +12,7 @@ interface Props {
   counts: {
     total: number;
     debug: number;
+    errors: number;
     soql: number;
     dml: number;
   };
@@ -30,11 +31,13 @@ export function LogViewerFilters({ active, onChange, counts, locale }: Props) {
   const showing =
     active === 'debug'
       ? counts.debug
-      : active === 'soql'
-        ? counts.soql
-        : active === 'dml'
-          ? counts.dml
-          : counts.total;
+      : active === 'error'
+        ? counts.errors
+        : active === 'soql'
+          ? counts.soql
+          : active === 'dml'
+            ? counts.dml
+            : counts.total;
 
   return (
     <div className="flex flex-wrap items-center justify-between gap-3 border-b border-border/60 bg-background/40 px-5 py-3 text-sm">
@@ -54,6 +57,20 @@ export function LogViewerFilters({ active, onChange, counts, locale }: Props) {
         >
           <Bug className="h-3.5 w-3.5" />
           Debug Only
+        </Button>
+        <Button
+          size="sm"
+          variant={active === 'error' ? 'default' : 'ghost'}
+          onClick={() => onChange(active === 'error' ? 'all' : 'error')}
+          className={cn(
+            'flex items-center gap-2',
+            active === 'error'
+              ? 'bg-rose-600 text-white hover:bg-rose-700'
+              : 'text-muted-foreground hover:text-foreground'
+          )}
+        >
+          <AlertOctagon className="h-3.5 w-3.5" />
+          Errors
         </Button>
         <Button
           size="sm"

--- a/src/webview/components/log-viewer/LogViewerStatusBar.tsx
+++ b/src/webview/components/log-viewer/LogViewerStatusBar.tsx
@@ -5,6 +5,7 @@ interface Props {
   counts: {
     total: number;
     debug: number;
+    errors: number;
     soql: number;
     dml: number;
   };
@@ -30,6 +31,7 @@ export function LogViewerStatusBar({ counts, locale, metadata }: Props) {
       <div className="flex flex-wrap items-center gap-4">
         <span>Total Lines: {formatNumber(counts.total, locale)}</span>
         <span>Debug Statements: {formatNumber(counts.debug, locale)}</span>
+        <span>Error Events: {formatNumber(counts.errors, locale)}</span>
         <span>SOQL Queries: {formatNumber(counts.soql, locale)}</span>
         <span>DML Operations: {formatNumber(counts.dml, locale)}</span>
       </div>

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -19,6 +19,8 @@ function mapFilterToCategory(filter: LogFilter): LogCategory | undefined {
   switch (filter) {
     case 'debug':
       return 'debug';
+    case 'error':
+      return 'error';
     case 'soql':
       return 'soql';
     case 'dml':
@@ -122,12 +124,16 @@ export function LogViewerApp({
 
   const counts = useMemo(() => {
     let debug = 0;
+    let errors = 0;
     let soql = 0;
     let dml = 0;
     for (const entry of entries) {
       switch (entry.category) {
         case 'debug':
           debug++;
+          break;
+        case 'error':
+          errors++;
           break;
         case 'soql':
           soql++;
@@ -140,6 +146,7 @@ export function LogViewerApp({
     return {
       total: entries.length,
       debug,
+      errors,
       soql,
       dml
     };
@@ -150,6 +157,9 @@ export function LogViewerApp({
       switch (filter) {
         case 'debug':
           if (entry.category !== 'debug') return false;
+          break;
+        case 'error':
+          if (entry.category !== 'error') return false;
           break;
         case 'soql':
           if (entry.category !== 'soql') return false;

--- a/src/webview/utils/logViewerParser.ts
+++ b/src/webview/utils/logViewerParser.ts
@@ -1,4 +1,4 @@
-export type LogCategory = 'debug' | 'soql' | 'dml' | 'code' | 'limit' | 'system' | 'other';
+export type LogCategory = 'debug' | 'soql' | 'dml' | 'code' | 'limit' | 'system' | 'error' | 'other';
 
 export interface ParsedLogEntry {
   id: number;
@@ -100,6 +100,20 @@ function parseLogLine(raw: string, index: number): ParsedLogEntry | undefined {
 
 function categorize(type: string): LogCategory {
   const upper = type.toUpperCase();
+  const tokens = upper.split(/[^A-Z]+/).filter(Boolean);
+  if (
+    tokens.some(token =>
+      token === 'EXCEPTION' ||
+      token === 'ERROR' ||
+      token === 'FATAL' ||
+      token === 'FAIL' ||
+      token === 'FAILED' ||
+      token === 'FAILURE' ||
+      token === 'FAULT'
+    )
+  ) {
+    return 'error';
+  }
   if (upper === 'USER_DEBUG') {
     return 'debug';
   }


### PR DESCRIPTION
## Summary
- add an 'error' category to the log parser when EXCEPTION/ERROR tokens appear
- expose an Errors filter toggle with counts across filters, list highlighting, and status bar
- extend component coverage to validate error visuals and stats

## Linked Issues
- n/a

## Screenshots / GIFs (UI)
- n/a

## Verification Steps
- `npm run test:webview`

## Risk / Rollback
- Low; revert commit `feat(log-viewer): add error filter toggle`

## Checklist
- [ ] `npm run build` passes
- [ ] `npm test` (or `npm run test:all`) passes; integration tests prefixed with `integration`
- [ ] Lint/Types: `npm run lint` and `npm run check-types`
- [ ] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added
