### PR TITLE
chore(release): prepare 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+## [0.20.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.18.0...v0.20.0) (2025-10-22)
+
+### Features
+
+- Logs: add an error filter toggle to spotlight entries with error-level log lines. ([#351](https://github.com/Electivus/Apex-Log-Viewer/pull/351)) ([5a03c2c](https://github.com/Electivus/Apex-Log-Viewer/commit/5a03c2c))
+- Logs: support in-log navigation controls so search results can jump between matches. ([#350](https://github.com/Electivus/Apex-Log-Viewer/pull/350)) ([dd5203d](https://github.com/Electivus/Apex-Log-Viewer/commit/dd5203d))
+
 ## [0.18.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.17.0...v0.18.0) (2025-10-16)
 
 ### Miscellaneous

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.18.0",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-select": "^2.2.6",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.18.0",
+  "version": "0.20.0",
   "publisher": "electivus",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- bump the VS Code extension version to 0.20.0 as the next stable channel release
- capture the recent log viewer features in the changelog for 0.20.0

## Linked Issues
- n/a

## Screenshots / GIFs (UI)
- n/a

## Verification Steps
- 
> apex-log-viewer@0.20.0 lint
> eslint src *(fails: local environment missing the eslint binary; dependencies not installed yet)*

## Risk / Rollback
- Low; revert commit 8bc4c3a if the release prep needs to be undone.

## Checklist
- [ ] 
> apex-log-viewer@0.20.0 prebuild
> npm run clean


> apex-log-viewer@0.20.0 clean
> node -e "const fs=require('fs');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/webview.css']){try{fs.unlinkSync(f)}catch{}}"


> apex-log-viewer@0.20.0 build
> npm run build:extension && npm run build:webview


> apex-log-viewer@0.20.0 build:extension
> esbuild src/extension.ts --bundle --platform=node --format=cjs --outfile=dist/extension.js --minify --sourcemap --external:vscode --external:@vscode/ripgrep --alias:bfj=./src/shims/bfj.ts passes
- [ ] 
> apex-log-viewer@0.20.0 pretest
> npm run test:clean && npm run test:linux-deps && npm run compile && npm run build:extension && npm run compile-tests


> apex-log-viewer@0.20.0 test:clean
> node scripts/clean-vscode-test.js

[test-clean] Removed .vscode-test cache.
[test-clean] Cleaned temp VS Code dirs.

> apex-log-viewer@0.20.0 test:linux-deps
> bash scripts/install-linux-deps.sh


> apex-log-viewer@0.20.0 compile
> npm run lint && tsc -p tsconfig.extension.json --noEmit


> apex-log-viewer@0.20.0 lint
> eslint src (or 
> apex-log-viewer@0.20.0 test:all
> npm run test:webview && npm run pretest && bash scripts/run-tests.sh --scope=all


> apex-log-viewer@0.20.0 test:webview
> jest --config jest.config.webview.cjs) passes; integration tests prefixed with 
- [ ] Lint/Types: 
> apex-log-viewer@0.20.0 lint
> eslint src and 
> apex-log-viewer@0.20.0 check-types
> tsc --noEmit -p tsconfig.extension.json
- [ ] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added