### PR TITLE
feat: add Open VSX publishing support to workflows and documentation

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -326,7 +326,7 @@ jobs:
           done
 
   marketplace:
-    name: Publish to Marketplace (pre-release channel)
+    name: Publish to Marketplaces (pre-release channel)
     needs: [assemble_release, prepare, check_changes]
     if: github.repository == 'Electivus/Apex-Log-Viewer' && needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
@@ -374,4 +374,25 @@ jobs:
           for FILE in "${FILES[@]}"; do
             echo "Publishing ${FILE}"
             npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
+          done
+
+      - name: Publish pre-release to Open VSX from VSIX
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${OVSX_PAT}" ]; then
+            echo "OVSX_PAT not set; skipping Open VSX publish."
+            exit 0
+          fi
+          shopt -s nullglob
+          FILES=( *.vsix )
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No VSIX found to publish" >&2
+            exit 1
+          fi
+          for FILE in "${FILES[@]}"; do
+            echo "Publishing ${FILE} to Open VSX"
+            npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release
           done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -169,7 +169,7 @@ jobs:
           if-no-files-found: error
 
   publish:
-    name: Publish to Marketplace
+    name: Publish to Marketplaces
     if: github.repository == 'Electivus/Apex-Log-Viewer'
     needs: package
     runs-on: ubuntu-latest
@@ -298,6 +298,34 @@ jobs:
             else
               echo "Publishing stable ${VERSION} from ${FILE}"
               npx --yes @vscode/vsce publish --packagePath "${FILE}"
+            fi
+          done
+
+      - name: Publish to Open VSX from VSIX artifact
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          PRE_RELEASE: ${{ steps.determine_channel.outputs.pre_release }}
+          VERSION: ${{ steps.determine_channel.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${OVSX_PAT}" ]; then
+            echo "OVSX_PAT not set; skipping Open VSX publish."
+            exit 0
+          fi
+          shopt -s nullglob
+          FILES=( *.vsix )
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No VSIX found to publish" >&2
+            exit 1
+          fi
+          for FILE in "${FILES[@]}"; do
+            if [ "${PRE_RELEASE}" = "true" ]; then
+              echo "Publishing pre-release ${VERSION} to Open VSX from ${FILE}"
+              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release
+            else
+              echo "Publishing stable ${VERSION} to Open VSX from ${FILE}"
+              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}"
             fi
           done
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Build
+
+- Workflows: publish VSIX artifacts to Open VSX when `OVSX_PAT` is configured.
+
 ## [0.20.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.18.0...v0.20.0) (2025-10-22)
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,12 +47,14 @@ docs: improve README with Marketplace badges and usage
 - Merge PRs to `main` using Conventional Commits.
 - Update `CHANGELOG.md` manually for the new version (follow SemVer; include notable changes and any BREAKING CHANGES).
 - Bump `package.json` to the release version and push a tag `vX.Y.Z` pointing to that commit.
-- The Release workflow (on tag push) builds, packages, and publishes automatically to the Marketplace (when `VSCE_PAT` is configured).
+- The Release workflow (on tag push) builds, packages, and publishes automatically to the Marketplace (`VSCE_PAT`) and Open VSX (`OVSX_PAT`) when configured.
 
 Manual packaging (rare):
 
 - Stable: `npm run vsce:package` then `npm run vsce:publish`.
 - Pre‑release: `npm run vsce:package:pre` then `npm run vsce:publish:pre`.
+- Open VSX (stable): `npx --yes ovsx publish --pat <token>`.
+- Open VSX (pre‑release): `npx --yes ovsx publish --pat <token> --pre-release`.
 
 ## Pull Request Checklist
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -3,8 +3,8 @@
 This repository uses GitHub Actions to build, test, package, and publish the extension.
 
 - Workflow CI (`.github/workflows/ci.yml`): build/test only on `push` and `pull_request`. Manual `workflow_dispatch` allows choosing the test scope (`unit`, `integration`, or `all`).
-- Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace automatically (if `VSCE_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
-- Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace pre‑release channel (when `VSCE_PAT` is set).
+- Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
+- Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 
 Build & Test basics:
 
@@ -19,17 +19,23 @@ Standard releases are driven by git tags `v*`.
 
 1. Merge PRs using Conventional Commits (e.g., `feat:`, `fix:`, `docs:`).
 2. Bump the version in `package.json` and push a tag `vX.Y.Z` for that commit.
-3. On tag push, the Release workflow packages and publishes to the Marketplace automatically (when `VSCE_PAT` is configured).
+3. On tag push, the Release workflow packages and publishes to the Marketplace (`VSCE_PAT`) and Open VSX (`OVSX_PAT`) automatically.
 4. The changelog (`CHANGELOG.md`) is maintained manually. Update it as part of preparing the release commit.
 
-Pre‑releases: nightly builds run daily and are published automatically to the Marketplace pre‑release channel when `VSCE_PAT` is configured; the VSIX is also attached to a GitHub pre‑release.
+Pre‑releases: nightly builds run daily and are published automatically to the Marketplace (`VSCE_PAT`) and Open VSX (`OVSX_PAT`) pre‑release channels; the VSIX is also attached to a GitHub pre‑release.
 
-See also: `docs/PUBLISHING.md` for the full Marketplace publishing flow and guidance.
+See also: `docs/PUBLISHING.md` for the full Marketplace/Open VSX publishing flow and guidance.
 
 ## Setup `VSCE_PAT`
 
 - Create a Personal Access Token with publish rights for the Visual Studio Marketplace.
 - Add it as a GitHub secret named `VSCE_PAT` in the repository (Settings → Secrets and variables → Actions → New repository secret).
+- Publishing is optional; without the secret, the workflow still builds, tests, and attaches the VSIX artifact to the run.
+
+## Setup `OVSX_PAT`
+
+- Create a Personal Access Token with publish rights for your Open VSX namespace.
+- Add it as a GitHub secret named `OVSX_PAT` in the repository (Settings → Secrets and variables → Actions → New repository secret).
 - Publishing is optional; without the secret, the workflow still builds, tests, and attaches the VSIX artifact to the run.
 
 ## Release Channels

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -3,11 +3,12 @@
 Maintainer quick start
 
 1. Create a Marketplace publisher and PAT, add secret `VSCE_PAT` in GitHub.
-2. For standard releases, update `CHANGELOG.md` manually, bump `package.json`, and push a tag `vX.Y.Z`.
-3. The Release workflow on the tag builds, attaches the `.vsix`, and—if `VSCE_PAT` exists—publishes automatically.
-4. Alternatively, publish locally with `npm run vsce:publish` (or `:pre`).
+2. Create an Open VSX namespace + PAT, add secret `OVSX_PAT` in GitHub.
+3. For standard releases, update `CHANGELOG.md` manually, bump `package.json`, and push a tag `vX.Y.Z`.
+4. The Release workflow on the tag builds, attaches the `.vsix`, and—if `VSCE_PAT`/`OVSX_PAT` exist—publishes automatically.
+5. Alternatively, publish locally with `npm run vsce:publish` (or `:pre`) and `npx --yes ovsx publish`.
 
-This repository includes an automated publish flow for the Visual Studio Code Marketplace with first‑class support for pre‑releases. It uses GitHub Actions and `vsce` and follows a simple semver convention:
+This repository includes automated publish flows for the Visual Studio Code Marketplace and Open VSX with first‑class support for pre‑releases. It uses GitHub Actions, `vsce`, and `ovsx` and follows a simple semver convention:
 
 - Stable: even minor versions (e.g., 0.6.0, 0.6.1).
 - Pre‑release: odd minor versions (e.g., 0.7.0, 0.7.1).
@@ -18,6 +19,8 @@ Prerequisites
 
 - Create a publisher and PAT on the VS Code Marketplace.
 - Add the PAT as the repository secret `VSCE_PAT` (Settings → Secrets and variables → Actions).
+- Create a namespace + PAT on Open VSX.
+- Add the PAT as the repository secret `OVSX_PAT` (Settings → Secrets and variables → Actions).
 
 How it works
 
@@ -26,6 +29,7 @@ How it works
   - Odd minor → pre‑release → `vsce publish --pre-release`.
   - Even minor → stable → `vsce publish`.
 - If `VSCE_PAT` is present, it publishes to Marketplace; otherwise it only attaches the `.vsix` artifact to the workflow run.
+- If `OVSX_PAT` is present, it publishes the same VSIX artifacts to Open VSX.
 
 Quick recipes
 
@@ -43,6 +47,8 @@ Local packaging/publish
 - Package a VSIX (pre‑release flag): `npm run vsce:package:pre`
 - Publish to Marketplace (stable): `npm run vsce:publish`
 - Publish to Marketplace (pre‑release): `npm run vsce:publish:pre`
+- Publish to Open VSX (stable): `npx --yes ovsx publish --pat <token>`
+- Publish to Open VSX (pre‑release): `npx --yes ovsx publish --pat <token> --pre-release`
 
 Notes
 


### PR DESCRIPTION
Implement Open VSX publishing in the workflows, allowing for VSIX artifacts to be published to both the Visual Studio Marketplace and Open VSX when the appropriate tokens are configured. Update documentation to reflect these changes and provide guidance on setting up the necessary tokens.

