### PR TITLE
ci: stabilize smoke VSIX and skip Codex on Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,12 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 20
+    ignore:
+      - dependency-name: "@types/vscode"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:

--- a/.github/workflows/codex-review-auto-comment.yml
+++ b/.github/workflows/codex-review-auto-comment.yml
@@ -9,7 +9,6 @@ permissions:
 
 jobs:
   request-codex-review:
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       CODEX_REVIEW_COMMENTER_TOKEN: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN }}

--- a/.github/workflows/codex-review-auto-comment.yml
+++ b/.github/workflows/codex-review-auto-comment.yml
@@ -9,6 +9,7 @@ permissions:
 
 jobs:
   request-codex-review:
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     env:
       CODEX_REVIEW_COMMENTER_TOKEN: ${{ secrets.CODEX_REVIEW_COMMENTER_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "@types/proxyquire": "^1.3.4",
         "@types/react": "^19.2.2",
         "@types/react-dom": "^19.2.0",
-        "@types/vscode": "^1.105.0",
+        "@types/vscode": "1.90.0",
         "@typescript-eslint/eslint-plugin": "^8.50.1",
         "@typescript-eslint/parser": "^8.46.3",
         "@vscode/test-electron": "^2.5.2",
@@ -346,7 +346,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1381,7 +1380,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1425,7 +1423,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -5488,7 +5485,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5654,7 +5652,6 @@
       "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -5678,7 +5675,6 @@
       "integrity": "sha512-6mDvHUFSjyT2B2yeNx2nUgMxh9LtOWvkhIU3uePn2I2oyNymUAX1NIsdgviM4CH+JSrp2D2hsMvJOkxY+0wNRA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -5689,7 +5685,6 @@
       "integrity": "sha512-brtBs0MnE9SMx7px208g39lRmC5uHZs96caOJfTjFcYSLHNamvaSMfJNagChVNkup2SdtOxKX1FDBkRSJe1ZAg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5715,9 +5710,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.105.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.105.0.tgz",
-      "integrity": "sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==",
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
+      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -5773,7 +5768,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -6699,7 +6693,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7335,7 +7328,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001741",
@@ -8641,7 +8633,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9091,7 +9084,6 @@
       "integrity": "sha512-BhHmn2yNOFA9H9JmmIVKJmd288g9hrVRDkdoIgRCRuSySRUHH7r/DI6aAXW9T1WwUuY3DFgrcaqB+deURBLR5g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11302,7 +11294,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12527,7 +12518,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -13509,6 +13499,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15214,7 +15205,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15291,6 +15281,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15306,6 +15297,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15316,6 +15308,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15532,7 +15525,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
       "integrity": "sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15542,7 +15534,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.0.tgz",
       "integrity": "sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15555,7 +15546,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -17180,8 +17172,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17410,7 +17401,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17577,8 +17567,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -17733,7 +17722,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -351,7 +351,7 @@
     "@types/proxyquire": "^1.3.4",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.0",
-    "@types/vscode": "^1.105.0",
+    "@types/vscode": "1.90.0",
     "@typescript-eslint/eslint-plugin": "^8.50.1",
     "@typescript-eslint/parser": "^8.46.3",
     "@vscode/test-electron": "^2.5.2",

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,6 +1,6 @@
 const { spawn, execFile, spawnSync } = require('child_process');
 const { platform, tmpdir } = require('os');
-const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require('fs');
+const { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } = require('fs');
 const { join, resolve } = require('path');
 const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
 const { cleanVsCodeTest } = require('./clean-vscode-test.js');
@@ -158,17 +158,38 @@ async function whichSf() {
   }
 }
 
+async function resolveGlobalNpmBin() {
+  const attempts = [
+    ['npm', ['bin', '-g'], bin => bin],
+    ['npm', ['prefix', '-g'], prefix => (platform() === 'win32' ? prefix : join(prefix, 'bin'))],
+    ['npm', ['config', 'get', 'prefix'], prefix => (platform() === 'win32' ? prefix : join(prefix, 'bin'))]
+  ];
+  for (const [cmd, args, mapper] of attempts) {
+    try {
+      const { stdout } = await execFileAsync(cmd, args);
+      const raw = (stdout || '').trim();
+      if (raw) {
+        return mapper(raw);
+      }
+    } catch {
+      // try next option
+    }
+  }
+  return '';
+}
+
 async function addGlobalBinToPath() {
   try {
-    const { stdout } = await execFileAsync('npm', ['bin', '-g']);
-    const bin = (stdout || '').trim();
+    const bin = await resolveGlobalNpmBin();
     if (bin) {
       const sep = platform() === 'win32' ? ';' : ':';
       const pathNow = process.env.PATH || '';
       if (!pathNow.split(sep).includes(bin)) {
         process.env.PATH = bin + sep + pathNow;
       }
+      return;
     }
+    console.warn('Failed to locate global npm bin; continuing without it.');
   } catch (e) {
     console.warn('Failed to add global npm bin to PATH:', e && e.message ? e.message : e);
   }
@@ -316,7 +337,9 @@ async function ensureDefaultScratch(cli, { alias, durationDays, definitionJson, 
   }
 }
 
-async function pretestSetup(scope = 'all') {
+async function pretestSetup(scope = 'all', opts = {}) {
+  const smokeVsix = !!opts.smokeVsix;
+  const normalizedScope = String(scope || '').trim().toLowerCase();
   const devhubAuthUrl = process.env.SF_DEVHUB_AUTH_URL || process.env.SFDX_AUTH_URL;
   const devhubAlias = process.env.SF_DEVHUB_ALIAS || 'DevHub';
   const scratchAlias = process.env.SF_SCRATCH_ALIAS || 'ALV_Test_Scratch';
@@ -325,7 +348,7 @@ async function pretestSetup(scope = 'all') {
   // When running unit tests, skip any Salesforce CLI/Dev Hub setup.
   // Keep only the temporary workspace preparation below.
   let cleanup = async () => {};
-  if (String(scope) !== 'unit') {
+  if (normalizedScope !== 'unit' && !smokeVsix) {
     const cli = await ensureSfCliInstalled();
     if (!cli) {
       console.warn('[test-setup] Salesforce CLI not found; skipping org setup.');
@@ -336,7 +359,7 @@ async function pretestSetup(scope = 'all') {
         await ensureDevHub(cli, { authUrl: devhubAuthUrl, alias: devhubAlias });
       }
 
-      const toggle = process.env.SF_SETUP_SCRATCH || process.env.CI || devhubAuthUrl;
+      const toggle = process.env.SF_SETUP_SCRATCH || devhubAuthUrl;
       if (toggle) {
         const res = await ensureDefaultScratch(cli, {
           alias: scratchAlias,
@@ -438,7 +461,7 @@ async function run() {
     }
   }
 
-  const { cleanup } = await pretestSetup(args.scope);
+  const { cleanup } = await pretestSetup(args.scope, { smokeVsix: args.smokeVsix });
 
   // Hint Electron to avoid GPU issues in headless envs
   process.env.ELECTRON_DISABLE_GPU = process.env.ELECTRON_DISABLE_GPU || '1';
@@ -538,7 +561,17 @@ async function run() {
       await execFileAsync('npm', ['run', '-s', 'nls:write']);
     } catch {}
     // Create the VSIX (this will also run vscode:prepublish)
-    await execFileAsync('npx', ['--no-install', 'vsce', 'package', '--no-yarn']);
+    const localVsce = join(
+      process.cwd(),
+      'node_modules',
+      '.bin',
+      platform() === 'win32' ? 'vsce.cmd' : 'vsce'
+    );
+    if (existsSync(localVsce)) {
+      await execFileAsync(localVsce, ['package', '--no-yarn']);
+    } else {
+      await execFileAsync('npx', ['--yes', '@vscode/vsce', 'package', '--no-yarn']);
+    }
     const vsix = require('fs')
       .readdirSync(process.cwd())
       .find(f => /\.vsix$/.test(f));


### PR DESCRIPTION
## Summary
- skip Codex auto-comment job for Dependabot PRs to avoid token failures
- harden smoke VSIX packaging to use local vsce or npx fallback
- avoid Salesforce CLI/scratch org setup during smoke VSIX runs
- improve global npm bin resolution when npm bin -g is unavailable

## Testing
- not run (CI will validate)