### PR TITLE
chore(ci): prevent vsce from packaging workspace root

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -228,12 +228,45 @@ jobs:
           node <<'NODE'
           const { spawnSync } = require('child_process');
           const fs = require('fs');
+          const os = require('os');
+          const path = require('path');
           const target = process.env.MATRIX_TARGET;
           const version = process.env.VERSION;
           const suffix = process.env.CHANNEL_SUFFIX;
           const outName = `apex-log-viewer-${version}-${suffix}-${target}.vsix`;
+          const whichCmd = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = spawnSync(whichCmd, ['npm'], { encoding: 'utf8' });
+          const realNpm = (whichResult.stdout || '').split(/\r?\n/).find(Boolean) || 'npm';
+          const wrapperDir = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-wrapper-'));
+          const npmWrapper = path.join(wrapperDir, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+          const wrapperBody = process.platform === 'win32'
+            ? [
+              '@echo off',
+              'if /I \"%1\"==\"ls\" goto withflag',
+              'if /I \"%1\"==\"list\" goto withflag',
+              '\"%REAL_NPM%\" %*',
+              'exit /b %ERRORLEVEL%',
+              ':withflag',
+              '\"%REAL_NPM%\" %* --workspaces=false',
+              'exit /b %ERRORLEVEL%'
+            ].join('\r\n')
+            : [
+              '#!/usr/bin/env bash',
+              'set -euo pipefail',
+              'cmd=\"${1:-}\"',
+              'if [[ \"$cmd\" == \"ls\" || \"$cmd\" == \"list\" ]]; then',
+              '  exec \"$REAL_NPM\" \"$@\" --workspaces=false',
+              'fi',
+              'exec \"$REAL_NPM\" \"$@\"'
+            ].join('\n');
+          fs.writeFileSync(npmWrapper, wrapperBody, { mode: 0o755 });
+          const env = {
+            ...process.env,
+            PATH: `${wrapperDir}${path.delimiter}${process.env.PATH ?? ''}`,
+            REAL_NPM: realNpm
+          };
           const args = ['--yes', '@vscode/vsce', 'package', '--no-yarn', '--target', target, '--out', outName, '--pre-release'];
-          const result = spawnSync('npx', args, { stdio: 'inherit', shell: process.platform === 'win32' });
+          const result = spawnSync('npx', args, { stdio: 'inherit', shell: process.platform === 'win32', env });
           if (result.status !== 0) {
             process.exit(result.status ?? 1);
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,16 +149,49 @@ jobs:
           node <<'NODE'
           const { spawnSync } = require('child_process');
           const fs = require('fs');
+          const os = require('os');
+          const path = require('path');
           const target = process.env.MATRIX_TARGET;
           const version = process.env.VERSION;
           const suffix = process.env.CHANNEL_SUFFIX;
           const preRelease = process.env.PRE_RELEASE === 'true';
           const outName = `apex-log-viewer-${version}-${suffix}-${target}.vsix`;
+          const whichCmd = process.platform === 'win32' ? 'where' : 'which';
+          const whichResult = spawnSync(whichCmd, ['npm'], { encoding: 'utf8' });
+          const realNpm = (whichResult.stdout || '').split(/\r?\n/).find(Boolean) || 'npm';
+          const wrapperDir = fs.mkdtempSync(path.join(os.tmpdir(), 'npm-wrapper-'));
+          const npmWrapper = path.join(wrapperDir, process.platform === 'win32' ? 'npm.cmd' : 'npm');
+          const wrapperBody = process.platform === 'win32'
+            ? [
+              '@echo off',
+              'if /I \"%1\"==\"ls\" goto withflag',
+              'if /I \"%1\"==\"list\" goto withflag',
+              '\"%REAL_NPM%\" %*',
+              'exit /b %ERRORLEVEL%',
+              ':withflag',
+              '\"%REAL_NPM%\" %* --workspaces=false',
+              'exit /b %ERRORLEVEL%'
+            ].join('\r\n')
+            : [
+              '#!/usr/bin/env bash',
+              'set -euo pipefail',
+              'cmd=\"${1:-}\"',
+              'if [[ \"$cmd\" == \"ls\" || \"$cmd\" == \"list\" ]]; then',
+              '  exec \"$REAL_NPM\" \"$@\" --workspaces=false',
+              'fi',
+              'exec \"$REAL_NPM\" \"$@\"'
+            ].join('\n');
+          fs.writeFileSync(npmWrapper, wrapperBody, { mode: 0o755 });
+          const env = {
+            ...process.env,
+            PATH: `${wrapperDir}${path.delimiter}${process.env.PATH ?? ''}`,
+            REAL_NPM: realNpm
+          };
           const args = ['--yes', '@vscode/vsce', 'package', '--no-yarn', '--target', target, '--out', outName];
           if (preRelease) {
             args.push('--pre-release');
           }
-          const result = spawnSync('npx', args, { stdio: 'inherit', shell: process.platform === 'win32' });
+          const result = spawnSync('npx', args, { stdio: 'inherit', shell: process.platform === 'win32', env });
           if (result.status !== 0) {
             process.exit(result.status ?? 1);
           }

--- a/docs/plans/2026-01-24-fix-vsce-packaging.md
+++ b/docs/plans/2026-01-24-fix-vsce-packaging.md
@@ -1,0 +1,82 @@
+# VSCE Packaging No-Dependencies Fix Implementation Plan
+
+> **For the agent:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Prevent VSCE packaging from pulling the workspace root into the extension VSIX so the nightly packaging jobs stop failing.
+
+**Architecture:** Update the GitHub Actions packaging steps to invoke `vsce package` with `--no-dependencies`, which skips dependency auto-detection that drags in workspace root files. Mirror the same flag in local `vsce:package` scripts for consistency.
+
+**Tech Stack:** GitHub Actions, Node.js, @vscode/vsce.
+
+### Task 1: Reproduce the packaging scope issue locally
+
+**Files:**
+- None
+
+**Step 1: Run VSCE listing with dependencies (expected to show parent entry)**
+
+Run: `cd apps/vscode-extension && npx --yes @vscode/vsce ls --tree --no-yarn`
+Expected: Output includes a `../` entry (or similar parent path) indicating workspace root files are being pulled in.
+
+**Step 2: Run VSCE listing without dependencies**
+
+Run: `cd apps/vscode-extension && npx --yes @vscode/vsce ls --tree --no-yarn --no-dependencies`
+Expected: Output shows only extension files (no `../` entry).
+
+### Task 2: Update nightly packaging workflow
+
+**Files:**
+- Modify: `.github/workflows/prerelease.yml`
+
+**Step 1: Add `--no-dependencies` to the VSCE package args**
+
+Update the Node packaging step to include the new flag:
+
+```js
+const args = ['--yes', '@vscode/vsce', 'package', '--no-yarn', '--no-dependencies', '--target', target, '--out', outName, '--pre-release'];
+```
+
+**Step 2: Save and format (YAML only)**
+
+### Task 3: Update release packaging workflow
+
+**Files:**
+- Modify: `.github/workflows/release.yml`
+
+**Step 1: Add `--no-dependencies` to the VSCE package args**
+
+```js
+const args = ['--yes', '@vscode/vsce', 'package', '--no-yarn', '--no-dependencies', '--target', target, '--out', outName];
+```
+
+### Task 4: Align local VSCE scripts
+
+**Files:**
+- Modify: `apps/vscode-extension/package.json`
+
+**Step 1: Update scripts to include `--no-dependencies`**
+
+```json
+"vsce:package": "vsce package --no-dependencies",
+"vsce:package:pre": "vsce package --pre-release --no-dependencies"
+```
+
+### Task 5: Verify packaging command locally
+
+**Files:**
+- None
+
+**Step 1: Run a targeted package command**
+
+Run: `cd apps/vscode-extension && npx --yes @vscode/vsce package --no-yarn --no-dependencies --target linux-x64 --out /tmp/apex-log-viewer-no-deps.vsix --pre-release`
+Expected: Command completes without `invalid relative path` errors and creates the VSIX.
+
+### Task 6: Commit
+
+**Step 1: Stage changes**
+
+Run: `git add .github/workflows/prerelease.yml .github/workflows/release.yml apps/vscode-extension/package.json`
+
+**Step 2: Commit**
+
+Run: `git commit -m "chore(ci): disable vsce dependency packaging"`


### PR DESCRIPTION
## Summary
- wrap npm in VSCE packaging steps to force --workspaces=false
- keep VSIX contents scoped to apps/vscode-extension

## Test Plan
- npm run ext:test:unit