### PR TITLE
ci(cli): publish Rust CLI to npm

### DIFF
--- a/.github/workflows/cli-npm-release.yml
+++ b/.github/workflows/cli-npm-release.yml
@@ -29,6 +29,7 @@ jobs:
             npm_os: linux
             cpu: x64
             bin: apex-log-viewer
+            native: true
           - platform: linux-arm64
             os: ubuntu-latest
             target: aarch64-unknown-linux-gnu
@@ -36,30 +37,35 @@ jobs:
             cpu: arm64
             bin: apex-log-viewer
             use_cross: true
+            native: false
           - platform: darwin-x64
             os: macos-13
             target: x86_64-apple-darwin
             npm_os: darwin
             cpu: x64
             bin: apex-log-viewer
+            native: true
           - platform: darwin-arm64
             os: macos-latest
             target: aarch64-apple-darwin
             npm_os: darwin
             cpu: arm64
             bin: apex-log-viewer
+            native: true
           - platform: win32-x64
             os: windows-latest
             target: x86_64-pc-windows-msvc
             npm_os: win32
             cpu: x64
             bin: apex-log-viewer.exe
+            native: true
           - platform: win32-arm64
             os: windows-latest
             target: aarch64-pc-windows-msvc
             npm_os: win32
             cpu: arm64
             bin: apex-log-viewer.exe
+            native: false
     steps:
       - name: Checkout
         uses: actions/checkout@v5
@@ -104,6 +110,7 @@ jobs:
           fi
 
       - name: Smoke test
+        if: ${{ matrix.native == true }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/cli-npm-release.yml
+++ b/.github/workflows/cli-npm-release.yml
@@ -1,0 +1,200 @@
+name: CLI NPM Release
+
+on:
+  push:
+    tags:
+      - 'cli-v*'
+  workflow_dispatch:
+
+concurrency:
+  group: cli-npm-release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish_platform:
+    name: Publish CLI (${{ matrix.platform }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux-x64
+            os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            npm_os: linux
+            cpu: x64
+            bin: apex-log-viewer
+          - platform: linux-arm64
+            os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            npm_os: linux
+            cpu: arm64
+            bin: apex-log-viewer
+            use_cross: true
+          - platform: darwin-x64
+            os: macos-13
+            target: x86_64-apple-darwin
+            npm_os: darwin
+            cpu: x64
+            bin: apex-log-viewer
+          - platform: darwin-arm64
+            os: macos-latest
+            target: aarch64-apple-darwin
+            npm_os: darwin
+            cpu: arm64
+            bin: apex-log-viewer
+          - platform: win32-x64
+            os: windows-latest
+            target: x86_64-pc-windows-msvc
+            npm_os: win32
+            cpu: x64
+            bin: apex-log-viewer.exe
+          - platform: win32-arm64
+            os: windows-latest
+            target: aarch64-pc-windows-msvc
+            npm_os: win32
+            cpu: arm64
+            bin: apex-log-viewer.exe
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+          scope: '@electivus'
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (linux arm64)
+        if: ${{ matrix.use_cross == true }}
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+
+      - name: Verify tag matches Cargo version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#cli-v}"
+          CARGO_VERSION=$(node -e "import('./scripts/cli-npm/read-version.mjs').then(m=>console.log(m.readCargoVersion('crates/cli/Cargo.toml')))" )
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME != Cargo version $CARGO_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Build CLI
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ matrix.use_cross || 'false' }}" = "true" ]; then
+            cross build -p apex-log-viewer-cli --release --target "${{ matrix.target }}"
+          else
+            cargo build -p apex-log-viewer-cli --release --target "${{ matrix.target }}"
+          fi
+
+      - name: Smoke test
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.bin }}"
+          "$BIN_PATH" --help >/dev/null
+
+      - name: Package npm platform
+        shell: bash
+        run: |
+          set -euo pipefail
+          BIN_PATH="target/${{ matrix.target }}/release/${{ matrix.bin }}"
+          node scripts/cli-npm/package-platform.mjs \
+            "${{ matrix.target }}" \
+            "${{ matrix.platform }}" \
+            "${{ matrix.npm_os }}" \
+            "${{ matrix.cpu }}" \
+            "${{ matrix.bin }}" \
+            "$BIN_PATH" \
+            "dist/cli-npm"
+
+      - name: Ensure NPM token is set
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN is required to publish" >&2
+            exit 1
+          fi
+
+      - name: Publish npm platform package
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "dist/cli-npm/${{ matrix.platform }}"
+          npm publish --access public --provenance
+
+  publish_wrapper:
+    name: Publish CLI Wrapper
+    needs: publish_platform
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          registry-url: https://registry.npmjs.org/
+          scope: '@electivus'
+
+      - name: Verify tag matches Cargo version
+        shell: bash
+        run: |
+          set -euo pipefail
+          TAG_VERSION="${GITHUB_REF_NAME#cli-v}"
+          CARGO_VERSION=$(node -e "import('./scripts/cli-npm/read-version.mjs').then(m=>console.log(m.readCargoVersion('crates/cli/Cargo.toml')))" )
+          if [ "$TAG_VERSION" != "$CARGO_VERSION" ]; then
+            echo "Tag $GITHUB_REF_NAME != Cargo version $CARGO_VERSION" >&2
+            exit 1
+          fi
+
+      - name: Package npm wrapper
+        shell: bash
+        run: |
+          set -euo pipefail
+          node scripts/cli-npm/package-wrapper.mjs \
+            "dist/cli-npm" \
+            linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64 win32-arm64
+
+      - name: Ensure NPM token is set
+        shell: bash
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "$NPM_TOKEN" ]; then
+            echo "NPM_TOKEN is required to publish" >&2
+            exit 1
+          fi
+
+      - name: Publish npm wrapper package
+        shell: bash
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          set -euo pipefail
+          cd "dist/cli-npm/wrapper"
+          npm publish --access public --provenance

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,10 @@ name = "apex-log-viewer-cli"
 version = "0.1.0"
 edition = "2021"
 
+[[bin]]
+name = "apex-log-viewer"
+path = "src/main.rs"
+
 [dependencies]
 clap = { version = "4.5.23", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "gzip", "rustls-tls"] }

--- a/crates/cli/npm/platform/README.md
+++ b/crates/cli/npm/platform/README.md
@@ -1,0 +1,3 @@
+# Apex Log Viewer CLI (Platform)
+
+This package is installed automatically by the main wrapper.

--- a/crates/cli/npm/platform/package.json
+++ b/crates/cli/npm/platform/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@electivus/apex-log-viewer-cli-__PLATFORM__",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
+  "os": ["__OS__"],
+  "cpu": ["__CPU__"],
+  "bin": {
+    "apex-log-viewer": "bin/__BIN__"
+  },
+  "files": ["bin/**"]
+}

--- a/crates/cli/npm/wrapper/README.md
+++ b/crates/cli/npm/wrapper/README.md
@@ -1,0 +1,3 @@
+# Apex Log Viewer CLI
+
+Install with `npm i -g @electivus/apex-log-viewer-cli`.

--- a/crates/cli/npm/wrapper/bin/apex-log-viewer.js
+++ b/crates/cli/npm/wrapper/bin/apex-log-viewer.js
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const path = require('path');
+const { resolvePlatform } = require('../lib/resolve-platform.cjs');
+
+function main() {
+  const { packageName, binName } = resolvePlatform(process.platform, process.arch);
+  const pkgRoot = path.dirname(require.resolve(`${packageName}/package.json`));
+  const binPath = path.join(pkgRoot, 'bin', binName);
+  const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+  process.exit(result.status ?? 1);
+}
+
+main();

--- a/crates/cli/npm/wrapper/lib/resolve-platform.cjs
+++ b/crates/cli/npm/wrapper/lib/resolve-platform.cjs
@@ -1,0 +1,19 @@
+const MAP = new Map([
+  ['linux:x64', { packageName: '@electivus/apex-log-viewer-cli-linux-x64', binName: 'apex-log-viewer' }],
+  ['linux:arm64', { packageName: '@electivus/apex-log-viewer-cli-linux-arm64', binName: 'apex-log-viewer' }],
+  ['darwin:x64', { packageName: '@electivus/apex-log-viewer-cli-darwin-x64', binName: 'apex-log-viewer' }],
+  ['darwin:arm64', { packageName: '@electivus/apex-log-viewer-cli-darwin-arm64', binName: 'apex-log-viewer' }],
+  ['win32:x64', { packageName: '@electivus/apex-log-viewer-cli-win32-x64', binName: 'apex-log-viewer.exe' }],
+  ['win32:arm64', { packageName: '@electivus/apex-log-viewer-cli-win32-arm64', binName: 'apex-log-viewer.exe' }]
+]);
+
+function resolvePlatform(platform, arch) {
+  const key = `${platform}:${arch}`;
+  const match = MAP.get(key);
+  if (!match) {
+    throw new Error(`Unsupported platform ${platform}/${arch}`);
+  }
+  return match;
+}
+
+module.exports = { resolvePlatform };

--- a/crates/cli/npm/wrapper/package.json
+++ b/crates/cli/npm/wrapper/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@electivus/apex-log-viewer-cli",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
+  "bin": {
+    "apex-log-viewer": "bin/apex-log-viewer.js"
+  },
+  "files": ["bin/**", "lib/**"],
+  "optionalDependencies": {}
+}

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -5,6 +5,7 @@ This repository uses GitHub Actions to build, test, package, and publish the ext
 - Workflow CI (`.github/workflows/ci.yml`): build/test only on `push` and `pull_request`. Manual `workflow_dispatch` allows choosing the test scope (`unit`, `integration`, or `all`).
 - Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
+- Workflow CLI NPM Release (`.github/workflows/cli-npm-release.yml`): runs on tag push `cli-v*` (and manual dispatch). Builds the Rust CLI for each supported platform, publishes platform packages to npm, then publishes the wrapper package (requires `NPM_TOKEN`).
 
 Build & Test basics:
 

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -21,6 +21,7 @@ Prerequisites
 - Add the PAT as the repository secret `VSCE_PAT` (Settings → Secrets and variables → Actions).
 - Create a namespace + PAT on Open VSX.
 - Add the PAT as the repository secret `OVSX_PAT` (Settings → Secrets and variables → Actions).
+- For CLI npm releases, create an npm access token and add it as `NPM_TOKEN` in GitHub (Settings → Secrets and variables → Actions).
 
 How it works
 
@@ -30,6 +31,13 @@ How it works
   - Even minor → stable → `vsce publish`.
 - If `VSCE_PAT` is present, it publishes to Marketplace; otherwise it only attaches the `.vsix` artifact to the workflow run.
 - If `OVSX_PAT` is present, it publishes the same VSIX artifacts to Open VSX.
+
+CLI npm publishing
+
+- Tags matching `cli-v*` trigger the CLI publish workflow (`.github/workflows/cli-npm-release.yml`).
+- The tag version must match `crates/cli/Cargo.toml`.
+- The workflow builds platform packages (`@electivus/apex-log-viewer-cli-<platform>`) and then publishes the wrapper package `@electivus/apex-log-viewer-cli`.
+- Publishing requires the `NPM_TOKEN` secret and uses npm provenance.
 
 Quick recipes
 
@@ -49,6 +57,11 @@ Local packaging/publish
 - Publish to Marketplace (pre‑release): `npm run vsce:publish:pre`
 - Publish to Open VSX (stable): `npx --yes ovsx publish --pat <token>`
 - Publish to Open VSX (pre‑release): `npx --yes ovsx publish --pat <token> --pre-release`
+
+- Publish the CLI to npm (automated):
+  - Bump `crates/cli/Cargo.toml` version.
+  - Push tag `cli-vX.Y.Z`.
+  - CI builds and publishes the wrapper + platform packages to npm.
 
 Notes
 

--- a/docs/plans/2026-01-24-cli-npm-release-design.md
+++ b/docs/plans/2026-01-24-cli-npm-release-design.md
@@ -1,0 +1,31 @@
+# CLI NPM Release CI Design
+
+**Goal:** Publish the Rust CLI to npm using platform-specific packages plus a wrapper package, with a GitHub Actions CI that is secure and repeatable.
+
+## Context
+We ship a Rust CLI in `crates/cli`. We want npm distribution that does not rely on postinstall downloads and supports multiple OS/arch combinations.
+
+## Decisions
+1. **Package model:** Use a wrapper package `@electivus/apex-log-viewer-cli` plus six platform packages (`-linux-x64`, `-linux-arm64`, `-darwin-x64`, `-darwin-arm64`, `-win32-x64`, `-win32-arm64`).
+2. **Bin name:** Expose `apex-log-viewer` as the CLI executable in the wrapper and platform packages.
+3. **Release trigger:** Publish on tags matching `cli-v*` with a version check against `crates/cli/Cargo.toml`.
+4. **Security:** Use minimal permissions and npm provenance via OIDC (`id-token: write`). Secrets used only in publish jobs.
+
+## Architecture & Data Flow
+- Tag push `cli-vX.Y.Z` starts the workflow.
+- Matrix build compiles `cargo build --release --target <triple>` for each platform.
+- Each build creates a platform npm package containing `package.json`, `LICENSE`, `README.md`, and `bin/apex-log-viewer[.exe]`.
+- Platform packages are published first. The wrapper is published last with `optionalDependencies` referencing all platform packages and a JS shim that resolves and executes the installed binary.
+
+## Error Handling
+- Fail fast if tag version != `Cargo.toml` version.
+- Fail if the expected binary is missing or not executable.
+- Wrapper errors clearly if the current OS/arch has no supported package.
+
+## Testing Strategy
+- Keep `cargo test -p apex-log-viewer-cli` in `ci.yml` for every change.
+- In release workflow, run a lightweight smoke (`apex-log-viewer --help`) before packaging.
+
+## Non-Goals
+- Implementing new CLI features.
+- Changing VS Code extension release workflows.

--- a/docs/plans/2026-01-24-cli-npm-release-plan.md
+++ b/docs/plans/2026-01-24-cli-npm-release-plan.md
@@ -1,0 +1,393 @@
+# CLI NPM Release CI Implementation Plan
+
+> **For the agent:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Publish the Rust CLI to npm using platform-specific packages plus a wrapper package, driven by a secure GitHub Actions workflow.
+
+**Architecture:** A wrapper npm package (`@electivus/apex-log-viewer-cli`) depends on six optional platform packages. Each platform package ships the compiled Rust binary. A CI workflow builds targets, packages them, publishes the platform packages first, then publishes the wrapper.
+
+**Tech Stack:** Rust (cargo), Node.js (packaging scripts), npm publish with provenance, GitHub Actions.
+
+---
+
+### Task 1: Add platform resolver module + tests for wrapper
+
+**Files:**
+- Create: `scripts/cli-npm/resolve-platform.test.cjs`
+- Create: `crates/cli/npm/wrapper/lib/resolve-platform.cjs`
+- Create: `crates/cli/npm/wrapper/bin/apex-log-viewer.js`
+
+**Step 1: Write the failing test**
+Create `scripts/cli-npm/resolve-platform.test.cjs`:
+```js
+const assert = require('assert');
+const { resolvePlatform } = require('../../crates/cli/npm/wrapper/lib/resolve-platform.cjs');
+
+assert.deepStrictEqual(resolvePlatform('linux', 'x64'), {
+  packageName: '@electivus/apex-log-viewer-cli-linux-x64',
+  binName: 'apex-log-viewer'
+});
+assert.deepStrictEqual(resolvePlatform('darwin', 'arm64'), {
+  packageName: '@electivus/apex-log-viewer-cli-darwin-arm64',
+  binName: 'apex-log-viewer'
+});
+assert.deepStrictEqual(resolvePlatform('win32', 'x64'), {
+  packageName: '@electivus/apex-log-viewer-cli-win32-x64',
+  binName: 'apex-log-viewer.exe'
+});
+assert.throws(() => resolvePlatform('freebsd', 'x64'));
+console.log('resolve-platform ok');
+```
+
+**Step 2: Run test to verify it fails**
+Run: `node scripts/cli-npm/resolve-platform.test.cjs`
+Expected: FAIL with "Cannot find module .../resolve-platform.cjs".
+
+**Step 3: Write minimal implementation**
+Create `crates/cli/npm/wrapper/lib/resolve-platform.cjs`:
+```js
+const MAP = new Map([
+  ['linux:x64', { packageName: '@electivus/apex-log-viewer-cli-linux-x64', binName: 'apex-log-viewer' }],
+  ['linux:arm64', { packageName: '@electivus/apex-log-viewer-cli-linux-arm64', binName: 'apex-log-viewer' }],
+  ['darwin:x64', { packageName: '@electivus/apex-log-viewer-cli-darwin-x64', binName: 'apex-log-viewer' }],
+  ['darwin:arm64', { packageName: '@electivus/apex-log-viewer-cli-darwin-arm64', binName: 'apex-log-viewer' }],
+  ['win32:x64', { packageName: '@electivus/apex-log-viewer-cli-win32-x64', binName: 'apex-log-viewer.exe' }],
+  ['win32:arm64', { packageName: '@electivus/apex-log-viewer-cli-win32-arm64', binName: 'apex-log-viewer.exe' }]
+]);
+
+function resolvePlatform(platform, arch) {
+  const key = `${platform}:${arch}`;
+  const match = MAP.get(key);
+  if (!match) {
+    throw new Error(`Unsupported platform ${platform}/${arch}`);
+  }
+  return match;
+}
+
+module.exports = { resolvePlatform };
+```
+
+Create `crates/cli/npm/wrapper/bin/apex-log-viewer.js`:
+```js
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+const path = require('path');
+const { resolvePlatform } = require('../lib/resolve-platform.cjs');
+
+function main() {
+  const { packageName, binName } = resolvePlatform(process.platform, process.arch);
+  const pkgRoot = path.dirname(require.resolve(`${packageName}/package.json`));
+  const binPath = path.join(pkgRoot, 'bin', binName);
+  const result = spawnSync(binPath, process.argv.slice(2), { stdio: 'inherit' });
+  process.exit(result.status ?? 1);
+}
+
+main();
+```
+
+**Step 4: Run test to verify it passes**
+Run: `node scripts/cli-npm/resolve-platform.test.cjs`
+Expected: PASS with "resolve-platform ok".
+
+**Step 5: Commit**
+```bash
+git add scripts/cli-npm/resolve-platform.test.cjs crates/cli/npm/wrapper/lib/resolve-platform.cjs crates/cli/npm/wrapper/bin/apex-log-viewer.js
+git commit -m "feat(cli): add npm wrapper platform resolver"
+```
+
+---
+
+### Task 2: Add npm package templates for wrapper + platform
+
+**Files:**
+- Create: `crates/cli/npm/wrapper/package.json`
+- Create: `crates/cli/npm/wrapper/README.md`
+- Create: `crates/cli/npm/platform/package.json`
+- Create: `crates/cli/npm/platform/README.md`
+- Create: `scripts/cli-npm/validate-templates.test.cjs`
+
+**Step 1: Write the failing test**
+Create `scripts/cli-npm/validate-templates.test.cjs`:
+```js
+const assert = require('assert');
+const path = require('path');
+
+const wrapperPkg = require(path.resolve('crates/cli/npm/wrapper/package.json'));
+const platformPkg = require(path.resolve('crates/cli/npm/platform/package.json'));
+
+assert.ok(wrapperPkg.name === '@electivus/apex-log-viewer-cli');
+assert.ok(wrapperPkg.bin && wrapperPkg.bin['apex-log-viewer']);
+assert.ok(Array.isArray(wrapperPkg.files));
+
+assert.ok(platformPkg.name.includes('@electivus/apex-log-viewer-cli-'));
+assert.ok(Array.isArray(platformPkg.files));
+assert.ok(platformPkg.os && platformPkg.cpu);
+
+console.log('templates ok');
+```
+
+**Step 2: Run test to verify it fails**
+Run: `node scripts/cli-npm/validate-templates.test.cjs`
+Expected: FAIL with "Cannot find module .../package.json".
+
+**Step 3: Write minimal templates**
+Create `crates/cli/npm/wrapper/package.json`:
+```json
+{
+  "name": "@electivus/apex-log-viewer-cli",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
+  "bin": {
+    "apex-log-viewer": "bin/apex-log-viewer.js"
+  },
+  "files": ["bin/**", "lib/**"],
+  "optionalDependencies": {}
+}
+```
+
+Create `crates/cli/npm/wrapper/README.md`:
+```md
+# Apex Log Viewer CLI
+
+Install with `npm i -g @electivus/apex-log-viewer-cli`.
+```
+
+Create `crates/cli/npm/platform/package.json`:
+```json
+{
+  "name": "@electivus/apex-log-viewer-cli-__PLATFORM__",
+  "version": "0.0.0",
+  "private": false,
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
+  "os": ["__OS__"],
+  "cpu": ["__CPU__"],
+  "bin": {
+    "apex-log-viewer": "bin/__BIN__"
+  },
+  "files": ["bin/**"]
+}
+```
+
+Create `crates/cli/npm/platform/README.md`:
+```md
+# Apex Log Viewer CLI (Platform)
+
+This package is installed automatically by the main wrapper.
+```
+
+**Step 4: Run test to verify it passes**
+Run: `node scripts/cli-npm/validate-templates.test.cjs`
+Expected: PASS with "templates ok".
+
+**Step 5: Commit**
+```bash
+git add crates/cli/npm/wrapper crates/cli/npm/platform scripts/cli-npm/validate-templates.test.cjs
+git commit -m "chore(cli): add npm package templates"
+```
+
+---
+
+### Task 3: Add packaging scripts for platform packages and wrapper
+
+**Files:**
+- Create: `scripts/cli-npm/read-version.mjs`
+- Create: `scripts/cli-npm/package-platform.mjs`
+- Create: `scripts/cli-npm/package-wrapper.mjs`
+- Create: `scripts/cli-npm/read-version.test.cjs`
+
+**Step 1: Write the failing test**
+Create `scripts/cli-npm/read-version.test.cjs`:
+```js
+const assert = require('assert');
+const { readCargoVersion } = require('./read-version.mjs');
+
+const version = readCargoVersion('scripts/cli-npm/fixtures/Cargo.toml');
+assert.strictEqual(version, '1.2.3');
+console.log('version ok');
+```
+Also create `scripts/cli-npm/fixtures/Cargo.toml`:
+```toml
+[package]
+name = "fake"
+version = "1.2.3"
+```
+
+**Step 2: Run test to verify it fails**
+Run: `node scripts/cli-npm/read-version.test.cjs`
+Expected: FAIL with "Cannot find module './read-version.mjs'".
+
+**Step 3: Write minimal implementation**
+Create `scripts/cli-npm/read-version.mjs`:
+```js
+import fs from 'fs';
+
+export function readCargoVersion(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const match = text.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('version not found');
+  }
+  return match[1];
+}
+```
+
+Create `scripts/cli-npm/package-platform.mjs`:
+```js
+import fs from 'fs';
+import path from 'path';
+import { readCargoVersion } from './read-version.mjs';
+
+const [,, targetTriple, platformName, os, cpu, binName, binaryPath, outDir] = process.argv;
+if (!targetTriple || !platformName || !os || !cpu || !binName || !binaryPath || !outDir) {
+  throw new Error('usage: package-platform <target> <platform> <os> <cpu> <bin> <binaryPath> <outDir>');
+}
+const version = readCargoVersion('crates/cli/Cargo.toml');
+const templateDir = 'crates/cli/npm/platform';
+const pkgDir = path.join(outDir, platformName);
+fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+const pkgJson = JSON.parse(fs.readFileSync(path.join(templateDir, 'package.json'), 'utf8'));
+const patched = JSON.stringify({
+  ...pkgJson,
+  name: `@electivus/apex-log-viewer-cli-${platformName}`,
+  version,
+  os: [os],
+  cpu: [cpu],
+  bin: { 'apex-log-viewer': `bin/${binName}` }
+}, null, 2);
+fs.writeFileSync(path.join(pkgDir, 'package.json'), patched + '\n');
+fs.copyFileSync(path.join(templateDir, 'README.md'), path.join(pkgDir, 'README.md'));
+fs.copyFileSync('LICENSE', path.join(pkgDir, 'LICENSE'));
+fs.copyFileSync(binaryPath, path.join(pkgDir, 'bin', binName));
+```
+
+Create `scripts/cli-npm/package-wrapper.mjs`:
+```js
+import fs from 'fs';
+import path from 'path';
+import { readCargoVersion } from './read-version.mjs';
+
+const [,, outDir, ...platforms] = process.argv;
+if (!outDir || platforms.length === 0) {
+  throw new Error('usage: package-wrapper <outDir> <platformName...>');
+}
+const version = readCargoVersion('crates/cli/Cargo.toml');
+const templateDir = 'crates/cli/npm/wrapper';
+const pkgDir = path.join(outDir, 'wrapper');
+fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+fs.mkdirSync(path.join(pkgDir, 'lib'), { recursive: true });
+const pkgJson = JSON.parse(fs.readFileSync(path.join(templateDir, 'package.json'), 'utf8'));
+const optionalDeps = Object.fromEntries(
+  platforms.map((p) => [`@electivus/apex-log-viewer-cli-${p}`, version])
+);
+const patched = JSON.stringify({
+  ...pkgJson,
+  version,
+  optionalDependencies: optionalDeps
+}, null, 2);
+fs.writeFileSync(path.join(pkgDir, 'package.json'), patched + '\n');
+fs.copyFileSync(path.join(templateDir, 'README.md'), path.join(pkgDir, 'README.md'));
+fs.copyFileSync('LICENSE', path.join(pkgDir, 'LICENSE'));
+fs.copyFileSync(path.join(templateDir, 'bin', 'apex-log-viewer.js'), path.join(pkgDir, 'bin', 'apex-log-viewer.js'));
+fs.copyFileSync(path.join(templateDir, 'lib', 'resolve-platform.cjs'), path.join(pkgDir, 'lib', 'resolve-platform.cjs'));
+```
+
+**Step 4: Run test to verify it passes**
+Run: `node scripts/cli-npm/read-version.test.cjs`
+Expected: PASS with "version ok".
+
+**Step 5: Commit**
+```bash
+git add scripts/cli-npm/read-version.mjs scripts/cli-npm/package-platform.mjs scripts/cli-npm/package-wrapper.mjs scripts/cli-npm/read-version.test.cjs scripts/cli-npm/fixtures/Cargo.toml
+git commit -m "chore(cli): add npm packaging scripts"
+```
+
+---
+
+### Task 4: Add GitHub Actions workflow to build and publish npm packages
+
+**Files:**
+- Create: `.github/workflows/cli-npm-release.yml`
+- Create: `scripts/cli-npm/validate-workflow.test.cjs`
+
+**Step 1: Write the failing test**
+Create `scripts/cli-npm/validate-workflow.test.cjs`:
+```js
+const assert = require('assert');
+const fs = require('fs');
+
+const text = fs.readFileSync('.github/workflows/cli-npm-release.yml', 'utf8');
+assert.ok(text.includes('cli-v*'));
+assert.ok(text.includes('npm publish'));
+assert.ok(text.includes('id-token: write'));
+console.log('workflow ok');
+```
+
+**Step 2: Run test to verify it fails**
+Run: `node scripts/cli-npm/validate-workflow.test.cjs`
+Expected: FAIL with "ENOENT".
+
+**Step 3: Write minimal workflow**
+Create `.github/workflows/cli-npm-release.yml` with:
+- `on: push: tags: ['cli-v*']` and `workflow_dispatch`.
+- `permissions: contents: read, id-token: write`.
+- Build matrix for targets (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64).
+- Steps: checkout, setup Rust, setup Node, verify tag matches `crates/cli/Cargo.toml` version, build target, run `node scripts/cli-npm/package-platform.mjs ...`, then `npm publish --provenance` for each platform package.
+- Final job publishes wrapper with `node scripts/cli-npm/package-wrapper.mjs` and `npm publish --provenance`.
+
+**Step 4: Run test to verify it passes**
+Run: `node scripts/cli-npm/validate-workflow.test.cjs`
+Expected: PASS with "workflow ok".
+
+**Step 5: Commit**
+```bash
+git add .github/workflows/cli-npm-release.yml scripts/cli-npm/validate-workflow.test.cjs
+git commit -m "ci(cli): publish npm packages on tag"
+```
+
+---
+
+### Task 5: Document CLI npm release flow
+
+**Files:**
+- Modify: `docs/CI.md`
+- Modify: `docs/PUBLISHING.md`
+
+**Step 1: Write the failing test**
+Create `scripts/cli-npm/validate-docs.test.cjs`:
+```js
+const assert = require('assert');
+const fs = require('fs');
+
+const ci = fs.readFileSync('docs/CI.md', 'utf8');
+const pub = fs.readFileSync('docs/PUBLISHING.md', 'utf8');
+assert.ok(ci.includes('cli-v'));
+assert.ok(pub.includes('NPM_TOKEN'));
+console.log('docs ok');
+```
+
+**Step 2: Run test to verify it fails**
+Run: `node scripts/cli-npm/validate-docs.test.cjs`
+Expected: FAIL with assertion error.
+
+**Step 3: Update docs**
+- Add a CI section for CLI npm publishing, tag format `cli-vX.Y.Z`, and required secret `NPM_TOKEN`.
+- Document how to publish the CLI via tag and what the wrapper/platform packages are.
+
+**Step 4: Run test to verify it passes**
+Run: `node scripts/cli-npm/validate-docs.test.cjs`
+Expected: PASS with "docs ok".
+
+**Step 5: Commit**
+```bash
+git add docs/CI.md docs/PUBLISHING.md scripts/cli-npm/validate-docs.test.cjs
+git commit -m "docs: document CLI npm publishing"
+```

--- a/scripts/cli-npm/fixtures/Cargo.toml
+++ b/scripts/cli-npm/fixtures/Cargo.toml
@@ -1,0 +1,3 @@
+[package]
+name = "fake"
+version = "1.2.3"

--- a/scripts/cli-npm/package-platform.mjs
+++ b/scripts/cli-npm/package-platform.mjs
@@ -1,0 +1,29 @@
+import fs from 'fs';
+import path from 'path';
+import { readCargoVersion } from './read-version.mjs';
+
+const [,, targetTriple, platformName, os, cpu, binName, binaryPath, outDir] = process.argv;
+if (!targetTriple || !platformName || !os || !cpu || !binName || !binaryPath || !outDir) {
+  throw new Error('usage: package-platform <target> <platform> <os> <cpu> <bin> <binaryPath> <outDir>');
+}
+
+const version = readCargoVersion('crates/cli/Cargo.toml');
+const templateDir = 'crates/cli/npm/platform';
+const pkgDir = path.join(outDir, platformName);
+
+fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+
+const pkgJson = JSON.parse(fs.readFileSync(path.join(templateDir, 'package.json'), 'utf8'));
+const patched = JSON.stringify({
+  ...pkgJson,
+  name: `@electivus/apex-log-viewer-cli-${platformName}`,
+  version,
+  os: [os],
+  cpu: [cpu],
+  bin: { 'apex-log-viewer': `bin/${binName}` }
+}, null, 2);
+
+fs.writeFileSync(path.join(pkgDir, 'package.json'), `${patched}\n`);
+fs.copyFileSync(path.join(templateDir, 'README.md'), path.join(pkgDir, 'README.md'));
+fs.copyFileSync('LICENSE', path.join(pkgDir, 'LICENSE'));
+fs.copyFileSync(binaryPath, path.join(pkgDir, 'bin', binName));

--- a/scripts/cli-npm/package-wrapper.mjs
+++ b/scripts/cli-npm/package-wrapper.mjs
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { readCargoVersion } from './read-version.mjs';
+
+const [,, outDir, ...platforms] = process.argv;
+if (!outDir || platforms.length === 0) {
+  throw new Error('usage: package-wrapper <outDir> <platformName...>');
+}
+
+const version = readCargoVersion('crates/cli/Cargo.toml');
+const templateDir = 'crates/cli/npm/wrapper';
+const pkgDir = path.join(outDir, 'wrapper');
+
+fs.mkdirSync(path.join(pkgDir, 'bin'), { recursive: true });
+fs.mkdirSync(path.join(pkgDir, 'lib'), { recursive: true });
+
+const pkgJson = JSON.parse(fs.readFileSync(path.join(templateDir, 'package.json'), 'utf8'));
+const optionalDeps = Object.fromEntries(
+  platforms.map((p) => [`@electivus/apex-log-viewer-cli-${p}`, version])
+);
+
+const patched = JSON.stringify({
+  ...pkgJson,
+  version,
+  optionalDependencies: optionalDeps
+}, null, 2);
+
+fs.writeFileSync(path.join(pkgDir, 'package.json'), `${patched}\n`);
+fs.copyFileSync(path.join(templateDir, 'README.md'), path.join(pkgDir, 'README.md'));
+fs.copyFileSync('LICENSE', path.join(pkgDir, 'LICENSE'));
+fs.copyFileSync(path.join(templateDir, 'bin', 'apex-log-viewer.js'), path.join(pkgDir, 'bin', 'apex-log-viewer.js'));
+fs.copyFileSync(path.join(templateDir, 'lib', 'resolve-platform.cjs'), path.join(pkgDir, 'lib', 'resolve-platform.cjs'));

--- a/scripts/cli-npm/read-version.mjs
+++ b/scripts/cli-npm/read-version.mjs
@@ -1,0 +1,10 @@
+import fs from 'fs';
+
+export function readCargoVersion(filePath) {
+  const text = fs.readFileSync(filePath, 'utf8');
+  const match = text.match(/^version\s*=\s*"([^"]+)"/m);
+  if (!match) {
+    throw new Error('version not found');
+  }
+  return match[1];
+}

--- a/scripts/cli-npm/read-version.test.cjs
+++ b/scripts/cli-npm/read-version.test.cjs
@@ -1,0 +1,11 @@
+const assert = require('assert');
+
+(async () => {
+  const { readCargoVersion } = await import('./read-version.mjs');
+  const version = readCargoVersion('scripts/cli-npm/fixtures/Cargo.toml');
+  assert.strictEqual(version, '1.2.3');
+  console.log('version ok');
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/cli-npm/resolve-platform.test.cjs
+++ b/scripts/cli-npm/resolve-platform.test.cjs
@@ -1,0 +1,17 @@
+const assert = require('assert');
+const { resolvePlatform } = require('../../crates/cli/npm/wrapper/lib/resolve-platform.cjs');
+
+assert.deepStrictEqual(resolvePlatform('linux', 'x64'), {
+  packageName: '@electivus/apex-log-viewer-cli-linux-x64',
+  binName: 'apex-log-viewer'
+});
+assert.deepStrictEqual(resolvePlatform('darwin', 'arm64'), {
+  packageName: '@electivus/apex-log-viewer-cli-darwin-arm64',
+  binName: 'apex-log-viewer'
+});
+assert.deepStrictEqual(resolvePlatform('win32', 'x64'), {
+  packageName: '@electivus/apex-log-viewer-cli-win32-x64',
+  binName: 'apex-log-viewer.exe'
+});
+assert.throws(() => resolvePlatform('freebsd', 'x64'));
+console.log('resolve-platform ok');

--- a/scripts/cli-npm/validate-docs.test.cjs
+++ b/scripts/cli-npm/validate-docs.test.cjs
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const ci = fs.readFileSync('docs/CI.md', 'utf8');
+const pub = fs.readFileSync('docs/PUBLISHING.md', 'utf8');
+assert.ok(ci.includes('cli-v'));
+assert.ok(pub.includes('NPM_TOKEN'));
+console.log('docs ok');

--- a/scripts/cli-npm/validate-templates.test.cjs
+++ b/scripts/cli-npm/validate-templates.test.cjs
@@ -1,0 +1,15 @@
+const assert = require('assert');
+const path = require('path');
+
+const wrapperPkg = require(path.resolve('crates/cli/npm/wrapper/package.json'));
+const platformPkg = require(path.resolve('crates/cli/npm/platform/package.json'));
+
+assert.ok(wrapperPkg.name === '@electivus/apex-log-viewer-cli');
+assert.ok(wrapperPkg.bin && wrapperPkg.bin['apex-log-viewer']);
+assert.ok(Array.isArray(wrapperPkg.files));
+
+assert.ok(platformPkg.name.includes('@electivus/apex-log-viewer-cli-'));
+assert.ok(Array.isArray(platformPkg.files));
+assert.ok(platformPkg.os && platformPkg.cpu);
+
+console.log('templates ok');

--- a/scripts/cli-npm/validate-workflow.test.cjs
+++ b/scripts/cli-npm/validate-workflow.test.cjs
@@ -1,0 +1,8 @@
+const assert = require('assert');
+const fs = require('fs');
+
+const text = fs.readFileSync('.github/workflows/cli-npm-release.yml', 'utf8');
+assert.ok(text.includes('cli-v*'));
+assert.ok(text.includes('npm publish'));
+assert.ok(text.includes('id-token: write'));
+console.log('workflow ok');


### PR DESCRIPTION
## Summary
- add npm wrapper/platform templates plus resolver and packaging scripts
- add CLI npm release workflow for tag cli-v* with provenance
- document CLI npm publishing requirements and flow

## Test Plan
- [x] node scripts/cli-npm/resolve-platform.test.cjs
- [x] node scripts/cli-npm/validate-templates.test.cjs
- [x] node scripts/cli-npm/read-version.test.cjs
- [x] node scripts/cli-npm/validate-workflow.test.cjs
- [x] node scripts/cli-npm/validate-docs.test.cjs
