### PR TITLE
fix(sf-plugin): skip lib check for build

### DIFF
--- a/apps/sf-plugin-apex-log-viewer/tsconfig.json
+++ b/apps/sf-plugin-apex-log-viewer/tsconfig.json
@@ -2,7 +2,8 @@
   "extends": "@salesforce/dev-config/tsconfig-strict-esm",
   "compilerOptions": {
     "outDir": "lib",
-    "rootDir": "src"
+    "rootDir": "src",
+    "skipLibCheck": true
   },
   "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary\n- skip lib checking to avoid type errors from dependency typings during publish build\n\n## Testing\n- not run (config-only)