### PR TITLE
fix(sf-plugin): tolerate postpack cleanup failure

### DIFF
--- a/apps/sf-plugin-apex-log-viewer/package.json
+++ b/apps/sf-plugin-apex-log-viewer/package.json
@@ -78,7 +78,7 @@
     "link-check": "wireit",
     "lint": "wireit",
     "postinstall": "node -e \"if (process.env.CI || process.env.HUSKY === '0') process.exit(0); require('child_process').execSync('yarn husky install', { stdio: 'inherit' });\"",
-    "postpack": "sf-clean --ignore-signing-artifacts",
+    "postpack": "node ./scripts/postpack.js",
     "prepack": "node ./scripts/sf-prepack.js",
     "test": "wireit",
     "test:nuts": "nyc mocha \"**/*.nut.ts\" --slow 4500 --timeout 600000 --parallel",

--- a/apps/sf-plugin-apex-log-viewer/scripts/postpack.js
+++ b/apps/sf-plugin-apex-log-viewer/scripts/postpack.js
@@ -1,0 +1,8 @@
+import { execSync } from 'node:child_process';
+
+try {
+  execSync('sf-clean --ignore-signing-artifacts', { stdio: 'inherit' });
+} catch (error) {
+  // Cleanup should not fail the publish.
+  console.warn('postpack cleanup failed; continuing.');
+}


### PR DESCRIPTION
## Summary\n- wrap postpack cleanup to avoid failing publish when sf-clean hits EACCES\n\n## Testing\n- not run (config-only)