### PR TITLE
ci(sf-plugin): configure npm registry auth

### DIFF
--- a/.github/workflows/sf-plugin-npm-release.yml
+++ b/.github/workflows/sf-plugin-npm-release.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: 22.x
+          registry-url: https://registry.npmjs.org
+          scope: '@electivus'
           cache: npm
           cache-dependency-path: apps/sf-plugin-apex-log-viewer/package-lock.json
 


### PR DESCRIPTION
## Summary\n- configure setup-node with npm registry + scope so NODE_AUTH_TOKEN is used\n\n## Testing\n- not run (CI-only)