### PR TITLE
[codex] fix empty org cache auth fallback

### DIFF
--- a/apps/vscode-extension/src/test/listOrgs.persistent-fallback.test.ts
+++ b/apps/vscode-extension/src/test/listOrgs.persistent-fallback.test.ts
@@ -1,0 +1,88 @@
+import assert from 'assert/strict';
+const proxyquire: any = require('proxyquire').noCallThru().noPreserveCache();
+
+type CacheSetCall = { section: string; key: string; value: unknown; ttl: number };
+
+function loadCliWithStubs(params: {
+  persistedOrgList: unknown;
+  execCommand: (program: string, args: string[]) => Promise<{ stdout: string; stderr: string }>;
+}) {
+  const setCalls: CacheSetCall[] = [];
+  const CacheManager = {
+    get: (_section: string, key: string) => (key === 'orgList' ? params.persistedOrgList : undefined),
+    set: async (section: string, key: string, value: unknown, ttl: number) => {
+      setCalls.push({ section, key, value, ttl });
+    },
+    delete: async () => {}
+  };
+
+  const execModule = {
+    execCommand: (program: string, args: string[]) => params.execCommand(program, args),
+    CLI_TIMEOUT_MS: 120000,
+    execOverriddenForTests: false,
+    execOverrideGeneration: 0,
+    markExecOverriddenForTests: () => {}
+  };
+
+  const cli = proxyquire('../salesforce/cli', {
+    '../utils/cacheManager': { CacheManager, '@noCallThru': true },
+    '../utils/config': {
+      getBooleanConfig: () => true,
+      getNumberConfig: (_key: string, def: number) => def,
+      '@noCallThru': true
+    },
+    './exec': { ...execModule, '@noCallThru': true },
+    './path': { resolvePATHFromLoginShell: async () => undefined, '@noCallThru': true },
+    '../shared/telemetry': { safeSendException: () => {}, '@noCallThru': true },
+    '../utils/logger': { logTrace: () => {}, '@noCallThru': true },
+    '../utils/localize': {
+      localize: (_key: string, fallback: string) => fallback,
+      '@noCallThru': true
+    }
+  });
+
+  return { listOrgs: cli.listOrgs as (forceRefresh?: boolean) => Promise<any[]>, setCalls };
+}
+
+suite('listOrgs persistent cache fallback', () => {
+  test('refreshes from CLI when persisted org list cache is empty', async () => {
+    let execCalls = 0;
+    const { listOrgs, setCalls } = loadCliWithStubs({
+      persistedOrgList: [],
+      execCommand: async () => {
+        execCalls++;
+        return {
+          stdout: JSON.stringify({
+            result: {
+              nonScratchOrgs: [{ username: 'user@example.com', alias: 'user', isDefaultUsername: true }]
+            }
+          }),
+          stderr: ''
+        };
+      }
+    });
+
+    const orgs = await listOrgs(false);
+    assert.equal(execCalls, 1, 'expected CLI call instead of returning cached empty list');
+    assert.equal(orgs.length, 1);
+    assert.equal(orgs[0]?.username, 'user@example.com');
+    assert.equal(setCalls.length, 1, 'expected refreshed list to be persisted');
+  });
+
+  test('does not persist empty cache when CLI returns errors', async () => {
+    let execCalls = 0;
+    const { listOrgs, setCalls } = loadCliWithStubs({
+      persistedOrgList: [],
+      execCommand: async () => {
+        execCalls++;
+        const err: any = new Error('boom');
+        err.code = 1;
+        throw err;
+      }
+    });
+
+    await assert.rejects(listOrgs(false), /boom/);
+    assert.equal(execCalls, 2, 'expected both sf and sfdx attempts');
+    assert.equal(setCalls.length, 0, 'expected no poisoned empty cache writes on failure');
+  });
+});


### PR DESCRIPTION
## Summary
This PR fixes a failure mode where the extension could stop showing orgs and repeatedly display:

`Failed to retrieve Salesforce org authentication. Run "sf org login web" to authenticate.`

The issue was reproducible even when `sf org list --json` returned valid orgs in the terminal.

## User impact before this change
When a stale empty org list (`[]`) was persisted in the extension cache with a long TTL, the logs view could load with no orgs selected and fail auth resolution. Users saw auth errors that suggested re-login even though their CLI sessions were still valid.

## Root cause
`listOrgs` trusted persisted empty org-list cache entries the same way as non-empty results and reused them for the full configured TTL. In addition, on non-ENOENT CLI failures it could fall back to returning an empty list, which could re-poison persistence.

That combination made the extension repeatedly operate without a target org and then fail `getOrgAuth` in the default-org path.

## What changed
- Added robust CLI JSON parsing helper (`parseCliJson`) that tolerates ANSI/noise around JSON output.
- Updated auth parsing paths to use the robust parser.
- Changed org-list persistence semantics:
  - Non-empty org lists keep configured TTL.
  - Empty org lists are now persisted with a short TTL (30s) to avoid long-lived poisoned state.
- Changed org-list cache read behavior:
  - Persisted empty list is treated as stale and forces a live CLI refresh.
- Changed error behavior:
  - Non-ENOENT CLI failures now surface an error instead of silently returning/persisting empty org lists.
- Added regression tests for persistent empty-cache fallback and non-poisoning behavior.

## Validation
Ran locally:
- `npm --prefix apps/vscode-extension run compile`
- `npm --prefix apps/vscode-extension run compile-tests`

Both commands passed.
