### PR TITLE
[codex] fix(vscode-extension): fallback to org max API version for #481

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- API versioning: automatically fall back to each org's max supported Salesforce API version when `sourceApiVersion` is higher, preventing 404 failures in logs and trace-flag calls and surfacing a warning in Output + Logs UI.
+
 ### Build
 
 - Workflows: publish VSIX artifacts to Open VSX when `OVSX_PAT` is configured.

--- a/apps/vscode-extension/src/shared/messages.ts
+++ b/apps/vscode-extension/src/shared/messages.ts
@@ -18,6 +18,7 @@ export type WebviewToExtensionMessage =
 export type ExtensionToWebviewMessage =
   | { type: 'loading'; value: boolean }
   | { type: 'error'; message: string }
+  | { type: 'warning'; message?: string }
   | { type: 'init'; locale: string; fullLogSearchEnabled?: boolean }
   | { type: 'logs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'appendLogs'; data: ApexLogRow[]; hasMore: boolean }

--- a/apps/vscode-extension/src/test/fetchApexLogs.test.ts
+++ b/apps/vscode-extension/src/test/fetchApexLogs.test.ts
@@ -3,14 +3,21 @@ import { EventEmitter } from 'events';
 import {
   fetchApexLogs,
   clearListCache,
+  setApiVersion,
+  getApiVersion,
+  getEffectiveApiVersion,
+  getApiVersionFallbackWarning,
   __setHttpsRequestImplForTests,
-  __resetHttpsRequestImplForTests
+  __resetHttpsRequestImplForTests,
+  __resetApiVersionFallbackStateForTests
 } from '../salesforce/http';
 import type { OrgAuth } from '../salesforce/types';
 
 suite('fetchApexLogs', () => {
   teardown(() => {
     __resetHttpsRequestImplForTests();
+    __resetApiVersionFallbackStateForTests();
+    setApiVersion('64.0');
     clearListCache();
   });
 
@@ -93,5 +100,76 @@ suite('fetchApexLogs', () => {
     const decoded = decodeURIComponent(q);
     assert.ok(decoded.includes('LIMIT 3'), 'query should include limit');
     assert.ok(decoded.includes('OFFSET 7'), 'query should include offset');
+  });
+
+  test('falls back to org max API version when configured version returns NOT_FOUND', async () => {
+    setApiVersion('66.0');
+    const auth: OrgAuth = {
+      accessToken: 'tok',
+      instanceUrl: 'https://example.com',
+      username: 'user'
+    };
+
+    const hits = new Map<string, number>();
+    const inc = (path: string) => hits.set(path, (hits.get(path) || 0) + 1);
+    const countByPrefix = (prefix: string) =>
+      Array.from(hits.entries())
+        .filter(([path]) => path.startsWith(prefix))
+        .reduce((acc, [, count]) => acc + count, 0);
+
+    __setHttpsRequestImplForTests((options: any, cb: any) => {
+      const path = String(options.path || '');
+      inc(path);
+      const req = new EventEmitter() as any;
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.end = () => {
+        const res = new EventEmitter() as any;
+        res.headers = {};
+        res.setEncoding = () => {};
+        res.req = req;
+        process.nextTick(() => {
+          cb(res);
+          process.nextTick(() => {
+            if (path.startsWith('/services/data/v66.0/tooling/query')) {
+              res.statusCode = 404;
+              res.emit(
+                'data',
+                Buffer.from('[{"errorCode":"NOT_FOUND","message":"The requested resource does not exist"}]')
+              );
+            } else if (path === '/services/data') {
+              res.statusCode = 200;
+              res.emit(
+                'data',
+                Buffer.from(JSON.stringify([{ version: '63.0' }, { version: '64.0' }, { version: '62.0' }]))
+              );
+            } else if (path.startsWith('/services/data/v64.0/tooling/query')) {
+              res.statusCode = 200;
+              res.emit('data', Buffer.from(JSON.stringify({ records: [{ Id: '07L000000000001AA' }] })));
+            } else {
+              res.statusCode = 500;
+              res.emit('data', Buffer.from(JSON.stringify({ message: `Unexpected path ${path}` })));
+            }
+            res.emit('end');
+          });
+        });
+      };
+      return req;
+    });
+
+    const first = await fetchApexLogs(auth, 50, 0);
+    const second = await fetchApexLogs(auth, 50, 0);
+
+    assert.equal(first[0]?.Id, '07L000000000001AA');
+    assert.equal(second[0]?.Id, '07L000000000001AA');
+    assert.equal(getApiVersion(), '66.0', 'configured API version should remain unchanged');
+    assert.equal(getEffectiveApiVersion(auth), '64.0', 'effective API version should fallback for this org');
+    assert.equal(countByPrefix('/services/data/v66.0/tooling/query'), 1, 'high version should only be attempted once');
+    assert.equal(countByPrefix('/services/data/v64.0/tooling/query'), 2, 'fallback version should be reused');
+    assert.equal(hits.get('/services/data') || 0, 1, 'org max versions should be discovered once');
+    const warning = getApiVersionFallbackWarning(auth);
+    assert.ok(warning?.includes('sourceApiVersion 66.0 > org max 64.0'), 'should expose fallback warning');
   });
 });

--- a/apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx
@@ -7,6 +7,7 @@ import type { OrgItem } from '../../shared/types';
 type ToolbarRenderOptions = {
   loading?: boolean;
   error?: string;
+  warning?: string;
   filterUser?: string;
   filterOperation?: string;
   filterStatus?: string;
@@ -19,6 +20,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   const {
     loading = false,
     error,
+    warning,
     filterUser = '',
     filterOperation = '',
     filterStatus = '',
@@ -51,6 +53,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
       <Toolbar
         loading={loading}
         error={error}
+        warning={warning}
         onRefresh={() => {
           refreshCount++;
         }}
@@ -164,5 +167,11 @@ describe('Toolbar webview component', () => {
     expect(notice).toBeInTheDocument();
     const container = notice.closest('div');
     expect(container?.querySelector('.animate-spin')).toBeNull();
+  });
+
+  it('shows warning banner when warning message is provided', () => {
+    renderToolbar({ warning: 'sourceApiVersion 66.0 > org max 64.0; falling back to 64.0' });
+    screen.getByText('Warning:');
+    screen.getByText('sourceApiVersion 66.0 > org max 64.0; falling back to 64.0');
   });
 });

--- a/apps/vscode-extension/src/webview/__tests__/logsApp.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/logsApp.test.tsx
@@ -83,6 +83,13 @@ describe('Logs webview App', () => {
       expect(screen.queryByText('Falhou ao carregar')).toBeNull();
     });
 
+    sendMessage(bus, {
+      type: 'warning',
+      message: 'sourceApiVersion 66.0 > org max 64.0; falling back to 64.0'
+    });
+    await screen.findByText('Aviso:');
+    await screen.findByText('sourceApiVersion 66.0 > org max 64.0; falling back to 64.0');
+
     await screen.findByText('ExecuteAnonymous');
     await screen.findByText('Test.run');
 

--- a/apps/vscode-extension/src/webview/components/Toolbar.tsx
+++ b/apps/vscode-extension/src/webview/components/Toolbar.tsx
@@ -15,6 +15,7 @@ function useStableId(prefix: string) {
 type ToolbarProps = {
   loading: boolean;
   error?: string;
+  warning?: string;
   onRefresh: () => void;
   t: any;
   orgs: OrgItem[];
@@ -42,6 +43,7 @@ type ToolbarProps = {
 export function Toolbar({
   loading,
   error,
+  warning,
   onRefresh,
   t,
   orgs,
@@ -68,6 +70,7 @@ export function Toolbar({
   const searchInputId = useStableId('logs-search');
   const hasFilters = Boolean(filterUser || filterOperation || filterStatus || filterCodeUnit);
   const errorLabel = t?.tail?.errorLabel ?? t?.errors?.generic ?? 'Error';
+  const warningLabel = t?.warningLabel ?? 'Warning';
 
   return (
     <section className="flex flex-col gap-3 rounded-lg border border-border bg-card/60 p-4 shadow-sm">
@@ -180,7 +183,18 @@ export function Toolbar({
         </div>
       )}
 
-      {!error && loading && (
+      {!error && warning && (
+        <div
+          className="flex items-center gap-2 text-sm text-[color:var(--vscode-editorWarning-foreground,var(--vscode-charts-yellow))]"
+          role="status"
+        >
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          <span className="font-semibold">{warningLabel}:</span>
+          <span>{warning}</span>
+        </div>
+      )}
+
+      {!error && !warning && loading && (
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           <span>{t.loading}</span>

--- a/apps/vscode-extension/src/webview/i18n.ts
+++ b/apps/vscode-extension/src/webview/i18n.ts
@@ -1,6 +1,7 @@
 export type Messages = {
   refresh: string;
   loading: string;
+  warningLabel?: string;
   searchPreparing?: string;
   searchPending?: string;
   searchPendingPlural?: string;
@@ -55,6 +56,7 @@ export type Messages = {
 const en: Messages = {
   refresh: 'Refresh',
   loading: 'Loading…',
+  warningLabel: 'Warning',
   searchPreparing: 'Preparing search results…',
   searchPending: 'Waiting for {count} log to finish downloading…',
   searchPendingPlural: 'Waiting for {count} logs to finish downloading…',
@@ -109,6 +111,7 @@ const en: Messages = {
 const ptBR: Messages = {
   refresh: 'Atualizar',
   loading: 'Carregando…',
+  warningLabel: 'Aviso',
   searchPreparing: 'Preparando resultados da busca…',
   searchPending: 'Aguardando o download de {count} log…',
   searchPendingPlural: 'Aguardando o download de {count} logs…',

--- a/apps/vscode-extension/src/webview/main.tsx
+++ b/apps/vscode-extension/src/webview/main.tsx
@@ -25,6 +25,7 @@ export function LogsApp({
   const [t, setT] = useState<Messages>(() => getMessages('en'));
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [warning, setWarning] = useState<string | undefined>(undefined);
   const [orgs, setOrgs] = useState<OrgItem[]>([]);
   const [selectedOrg, setSelectedOrg] = useState<string | undefined>(undefined);
 
@@ -64,6 +65,9 @@ export function LogsApp({
           break;
         case 'error':
           setError(msg.message);
+          break;
+        case 'warning':
+          setWarning(msg.message);
           break;
         case 'init':
           setLocale(msg.locale);
@@ -263,6 +267,7 @@ export function LogsApp({
       <Toolbar
         loading={loading}
         error={error}
+        warning={warning}
         onRefresh={onRefresh}
         t={t}
         orgs={orgs}


### PR DESCRIPTION
## Summary
This PR fixes issue #481 by adding an org-scoped API version fallback when the workspace `sourceApiVersion` is higher than the selected org's supported API version.

When a request hits a Salesforce version-mismatch `404 NOT_FOUND` (for example `/services/data/v66.0/...` against an org that only supports up to `v64.0`), the extension now:

1. Detects the mismatch on the failing request.
2. Discovers the org max API version via `GET /services/data`.
3. Stores that max version in an in-memory org-scoped map for the session.
4. Retries once with the org max version.
5. Surfaces a warning in Output and the Logs webview banner.

## Root cause
The extension used the configured `sourceApiVersion` globally for all REST paths. If the selected org did not support that version, Tooling and Query endpoints returned `404 NOT_FOUND`, breaking logs refresh and related flows.

## What changed
- `salesforce/http.ts`
  - Added lazy 404 mismatch fallback logic with one-time retry.
  - Added org-scoped effective API version resolution.
  - Added in-memory warning state per org.
  - Kept `getApiVersion()` behavior unchanged so configured workspace version remains observable.
- `salesforce/traceflags.ts`
  - Switched traceflag/debug-level/user paths to use effective org API version.
- Logs UI warning surface
  - Added extension->webview message type: `warning`.
  - `SfLogsViewProvider` clears stale warning on refresh/load-more and posts fallback warning when active.
  - Logs webview now renders warning banner in toolbar.
  - Added `warningLabel` i18n entries (`en`, `pt-BR`).
- Tests
  - Added fallback/caching test for 404->org max retry.
  - Added provider warning-post test.
  - Added webview and toolbar warning rendering tests.
- Docs
  - Added changelog entry under Unreleased bug fixes.

## User impact
Users with newer `sourceApiVersion` than their org supports no longer get blocked by 404s while listing logs. Logs and traceflag operations automatically continue with a safe org-supported API version, with an explicit warning showing what happened.

## Validation
Executed locally:

- `npm --prefix apps/vscode-extension run lint` ✅
- `npm --prefix apps/vscode-extension run test:webview` ✅
- `npm --prefix apps/vscode-extension run compile` ✅
- `npm --prefix apps/vscode-extension run build` ✅
- `C:\Program Files\Git\bin\bash.exe apps/vscode-extension/scripts/run-tests.sh --scope=unit` ❌

Unit run failures are existing unrelated failures observed in this environment:
- `LogService loadLogHeads prefers local full bodies when available`
- `resolvePATHFromLoginShell caches PATH on success`
- `resolvePATHFromLoginShell retries after failure`

Closes #481.
