### PR TITLE
fix(ci): read extension package version from workspace path in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,8 +120,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const version = require('./package.json').version;
-            const minor = Number(version.split('.')[1] || 0);
+            const fs = require('fs');
+            const path = require('path');
+            const pkgPath = path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'apps', 'vscode-extension', 'package.json');
+            const version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+            const minor = Number((version || '').split('.')[1] || 0);
             const tagName = process.env.TAG_NAME || '';
             let preRelease = minor % 2 === 1;
             if (/-pre|-beta|-alpha|-rc/.test(tagName)) {
@@ -255,8 +258,11 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const version = require('./package.json').version;
-            const minor = Number(version.split('.')[1] || 0);
+            const fs = require('fs');
+            const path = require('path');
+            const pkgPath = path.join(process.env.GITHUB_WORKSPACE || process.cwd(), 'apps', 'vscode-extension', 'package.json');
+            const version = JSON.parse(fs.readFileSync(pkgPath, 'utf8')).version;
+            const minor = Number((version || '').split('.')[1] || 0);
             const tagName = process.env.TAG_NAME || '';
             let preRelease = minor % 2 === 1;
             if (/-pre|-beta|-alpha|-rc/.test(tagName)) {


### PR DESCRIPTION
## Summary
- fix Release (tags) failure in Determine channel (stable vs pre-release)
- read extension version from pps/vscode-extension/package.json using GITHUB_WORKSPACE
- avoid relying on equire('./package.json') from job runtime cwd

## Context
Release run failed for tag 0.22.0 with:
- TypeError: Cannot read properties of undefined (reading 'split')
- run: https://github.com/Electivus/Apex-Log-Viewer/actions/runs/21984677374

## Validation
- workflow logic update only
- no local test execution