### PR TITLE
fix(ci): use workspace path when collecting VSIX artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,14 +315,18 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: apex-log-viewer-${{ steps.determine_channel.outputs.version }}-${{ steps.determine_channel.outputs.channel_suffix }}-vsix-*
-          path: vsix
+          path: ${{ github.workspace }}/vsix
 
       - name: Collect VSIX files
         shell: bash
         run: |
           set -euo pipefail
-          shopt -s nullglob
-          find vsix -name '*.vsix' -exec mv {} . \;
+          VSIX_DIR="${GITHUB_WORKSPACE}/vsix"
+          if [ ! -d "${VSIX_DIR}" ]; then
+            echo "VSIX artifact directory not found: ${VSIX_DIR}" >&2
+            exit 1
+          fi
+          find "${VSIX_DIR}" -name '*.vsix' -exec mv {} . \;
 
       - name: Publish from VSIX artifact
         env:


### PR DESCRIPTION
## Summary
- fix Publish to Marketplaces artifact collection path in release workflow
- download package artifacts to ${{ github.workspace }}/vsix
- collect VSIX files from ${GITHUB_WORKSPACE}/vsix before publish steps

## Context
After fixing Determine channel, release run still failed in Collect VSIX files:
- run: https://github.com/Electivus/Apex-Log-Viewer/actions/runs/21985016310
- error: ind: 'vsix': No such file or directory
- artifacts were downloaded under workspace root, while run steps execute from pps/vscode-extension

## Validation
- workflow logic update only
- no local test execution