### PR TITLE
fix(ci): resolve release id via gh release view before prerelease patch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,7 +304,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "Setting prerelease=${PRE_RELEASE} for ${TAG_NAME}"
-          RID=$(gh api -X GET repos/${{ github.repository }}/releases/tags/${TAG_NAME} -q .id)
+          RID=$(gh release view "${TAG_NAME}" --json databaseId -q .databaseId)
           if [ "${PRE_RELEASE}" = "true" ]; then
             gh api -X PATCH repos/${{ github.repository }}/releases/$RID -f prerelease=true
           else


### PR DESCRIPTION
## Summary
- fix Set GitHub Release prerelease flag automatically in release workflow
- resolve release id with gh release view <tag> --json databaseId
- avoid REST lookup by tag endpoint that is returning 404 in this repo state

## Context
Latest release retry failed in Publish to Marketplaces:
- run: https://github.com/Electivus/Apex-Log-Viewer/actions/runs/21985294353
- failing step: Set GitHub Release prerelease flag automatically
- error: gh api -X GET repos/.../releases/tags/v0.22.0 -> Not Found (HTTP 404)

gh release view v0.22.0 succeeds and returns a release id, so using that path is reliable.

## Validation
- workflow logic update only
- no local test execution