### PR TITLE
feat(logs): configurable columns in Logs panel

### DIFF
--- a/apps/vscode-extension/package-lock.json
+++ b/apps/vscode-extension/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
@@ -346,6 +347,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1380,6 +1382,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1423,6 +1426,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4316,6 +4320,61 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -4355,6 +4414,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -5565,8 +5648,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5732,6 +5814,7 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5755,6 +5838,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5765,6 +5849,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5848,6 +5933,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -6781,6 +6867,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7415,6 +7502,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8720,8 +8808,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9171,6 +9258,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11381,6 +11469,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12605,6 +12694,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -13586,7 +13676,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15282,6 +15371,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15358,7 +15448,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15374,7 +15463,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15385,7 +15473,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15602,6 +15689,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15611,6 +15699,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15623,8 +15712,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -17251,7 +17339,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17483,6 +17572,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17649,7 +17739,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -17804,6 +17895,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -127,6 +127,82 @@
           "default": true,
           "markdownDescription": "%configuration.electivus.apexLogs.enableFullLogSearch.description%"
         },
+        "electivus.apexLogs.logsColumns": {
+          "type": "object",
+          "default": {
+            "order": [
+              "user",
+              "application",
+              "operation",
+              "time",
+              "duration",
+              "status",
+              "codeUnit",
+              "size",
+              "match"
+            ],
+            "visibility": {
+              "user": true,
+              "application": true,
+              "operation": true,
+              "time": true,
+              "duration": true,
+              "status": true,
+              "codeUnit": true,
+              "size": true,
+              "match": true
+            },
+            "widths": {}
+          },
+          "markdownDescription": "%configuration.electivus.apexLogs.logsColumns.description%",
+          "properties": {
+            "order": {
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "user",
+                  "application",
+                  "operation",
+                  "time",
+                  "duration",
+                  "status",
+                  "codeUnit",
+                  "size",
+                  "match"
+                ]
+              }
+            },
+            "visibility": {
+              "type": "object",
+              "properties": {
+                "user": { "type": "boolean" },
+                "application": { "type": "boolean" },
+                "operation": { "type": "boolean" },
+                "time": { "type": "boolean" },
+                "duration": { "type": "boolean" },
+                "status": { "type": "boolean" },
+                "codeUnit": { "type": "boolean" },
+                "size": { "type": "boolean" },
+                "match": { "type": "boolean" }
+              }
+            },
+            "widths": {
+              "type": "object",
+              "properties": {
+                "user": { "type": "number", "minimum": 1 },
+                "application": { "type": "number", "minimum": 1 },
+                "operation": { "type": "number", "minimum": 1 },
+                "time": { "type": "number", "minimum": 1 },
+                "duration": { "type": "number", "minimum": 1 },
+                "status": { "type": "number", "minimum": 1 },
+                "codeUnit": { "type": "number", "minimum": 1 },
+                "size": { "type": "number", "minimum": 1 },
+                "match": { "type": "number", "minimum": 1 }
+              }
+            }
+          }
+        },
         "sfLogs.pageSize": {
           "type": "number",
           "default": 100,
@@ -385,6 +461,7 @@
     "vscode-nls-dev": "^4.0.4"
   },
   "dependencies": {
+    "@radix-ui/react-popover": "^1.1.15",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-switch": "^1.2.6",

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -20,6 +20,7 @@
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "Persistent TTL in seconds for cached results of 'sf org display'. Stores the token in VS Code storage to avoid repeated CLI calls across reloads. Larger values reduce CLI calls but keep cached auth longer; set 0 to disable.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL in seconds for cached DebugLevel queries. Set 0 to disable. Large TTLs reduce API calls but may serve stale data.",
   "configuration.electivus.apexLogs.enableFullLogSearch.description": "Download full Apex log bodies in the list view so the search box can match log content. This consumes more bandwidth and memory; disable if you only need header searches.",
+  "configuration.electivus.apexLogs.logsColumns.description": "Persisted column layout for the Logs table (managed by the Logs panel UI). Stores visibility/order/widths in user settings so it survives reloads and can sync across machines.",
   "tailSaveFailed": "Tail: failed to save log to workspace (best-effort).",
   "openLogInViewer.noDocument": "Electivus Apex Logs: No Apex log is active.",
   "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Unable to open Apex logs from this location.",

--- a/apps/vscode-extension/package.nls.pt-br.json
+++ b/apps/vscode-extension/package.nls.pt-br.json
@@ -20,6 +20,7 @@
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "TTL persistente (segundos) para o cache de 'sf org display'. Armazena o token no VS Code para evitar chamadas repetidas entre recarregamentos. Valores maiores reduzem chamadas ao CLI, mas mantêm o auth em cache por mais tempo; defina 0 para desativar.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL em segundos para o cache de consultas DebugLevel. Defina 0 para desativar. TTLs grandes reduzem chamadas à API, mas podem servir dados desatualizados.",
   "configuration.electivus.apexLogs.enableFullLogSearch.description": "Baixa o conteúdo completo dos logs Apex na lista para que a busca encontre trechos do log. Isso consome mais banda e memória; desative se precisar apenas de buscas pelos cabeçalhos.",
+  "configuration.electivus.apexLogs.logsColumns.description": "Layout persistido das colunas da tabela de Logs (gerenciado pela UI do painel de Logs). Armazena visibilidade/ordem/larguras nas configurações do usuário para sobreviver a recarregamentos e sincronizar entre máquinas.",
   "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço).",
   "openLogInViewer.noDocument": "Electivus Apex Logs: Nenhum log Apex está ativo.",
   "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Não é possível abrir logs Apex a partir desta origem.",

--- a/apps/vscode-extension/src/provider/logsMessageHandler.ts
+++ b/apps/vscode-extension/src/provider/logsMessageHandler.ts
@@ -10,7 +10,8 @@ export class LogsMessageHandler {
     private readonly debugLog: (logId: string) => Promise<void>,
     private readonly loadMore: () => Promise<void>,
     private readonly setLoading: (val: boolean) => void,
-    private readonly setSearchQuery: (value: string) => Promise<void>
+    private readonly setSearchQuery: (value: string) => Promise<void>,
+    private readonly setLogsColumns: (value: unknown) => Promise<void>
   ) {}
 
   async handle(message: WebviewToExtensionMessage): Promise<void> {
@@ -52,6 +53,9 @@ export class LogsMessageHandler {
         break;
       case 'searchQuery':
         await this.setSearchQuery(typeof message.value === 'string' ? message.value : '');
+        break;
+      case 'setLogsColumns':
+        await this.setLogsColumns(message.value);
         break;
     }
   }

--- a/apps/vscode-extension/src/shared/logsColumns.ts
+++ b/apps/vscode-extension/src/shared/logsColumns.ts
@@ -1,0 +1,75 @@
+export type LogsColumnKey =
+  | 'user'
+  | 'application'
+  | 'operation'
+  | 'time'
+  | 'duration'
+  | 'status'
+  | 'codeUnit'
+  | 'size'
+  | 'match';
+
+export type LogsColumnsConfig = {
+  order?: LogsColumnKey[];
+  visibility?: Partial<Record<LogsColumnKey, boolean>>;
+  widths?: Partial<Record<LogsColumnKey, number>>;
+};
+
+export type NormalizedLogsColumnsConfig = {
+  order: LogsColumnKey[];
+  visibility: Record<LogsColumnKey, boolean>;
+  widths: Partial<Record<LogsColumnKey, number>>;
+};
+
+export const DEFAULT_LOGS_COLUMN_ORDER: LogsColumnKey[] = [
+  'user',
+  'application',
+  'operation',
+  'time',
+  'duration',
+  'status',
+  'codeUnit',
+  'size',
+  'match'
+];
+
+export const DEFAULT_LOGS_COLUMNS_CONFIG: NormalizedLogsColumnsConfig = {
+  order: DEFAULT_LOGS_COLUMN_ORDER,
+  visibility: Object.fromEntries(DEFAULT_LOGS_COLUMN_ORDER.map(key => [key, true])) as Record<LogsColumnKey, boolean>,
+  widths: {}
+};
+
+const KNOWN_KEYS = new Set<LogsColumnKey>(DEFAULT_LOGS_COLUMN_ORDER);
+
+function isLogsColumnKey(value: unknown): value is LogsColumnKey {
+  return typeof value === 'string' && KNOWN_KEYS.has(value as LogsColumnKey);
+}
+
+function dedupe<T>(values: T[]): T[] {
+  return Array.from(new Set(values));
+}
+
+export function normalizeLogsColumnsConfig(raw: unknown): NormalizedLogsColumnsConfig {
+  const input = raw && typeof raw === 'object' ? (raw as LogsColumnsConfig) : {};
+
+  const rawOrder = Array.isArray(input.order) ? input.order : [];
+  const filteredOrder = rawOrder.filter(isLogsColumnKey);
+  const order = dedupe([...filteredOrder, ...DEFAULT_LOGS_COLUMN_ORDER]);
+
+  const rawVisibility = input.visibility && typeof input.visibility === 'object' ? input.visibility : {};
+  const visibility = Object.fromEntries(
+    order.map(key => [key, (rawVisibility as any)[key] === false ? false : true])
+  ) as Record<LogsColumnKey, boolean>;
+
+  const rawWidths = input.widths && typeof input.widths === 'object' ? input.widths : {};
+  const widths: Partial<Record<LogsColumnKey, number>> = {};
+  for (const key of order) {
+    const v = (rawWidths as any)[key];
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+      widths[key] = Math.floor(v);
+    }
+  }
+
+  return { order, visibility, widths };
+}
+

--- a/apps/vscode-extension/src/shared/messages.ts
+++ b/apps/vscode-extension/src/shared/messages.ts
@@ -1,4 +1,5 @@
 import type { ApexLogRow, OrgItem } from './types';
+import type { LogsColumnsConfig, NormalizedLogsColumnsConfig } from './logsColumns';
 
 // Messages sent from Webview -> Extension
 export type WebviewToExtensionMessage =
@@ -9,6 +10,7 @@ export type WebviewToExtensionMessage =
   | { type: 'replay'; logId: string }
   | { type: 'loadMore' }
   | { type: 'searchQuery'; value: string }
+  | { type: 'setLogsColumns'; value: LogsColumnsConfig }
   // Tail view messages
   | { type: 'tailStart'; debugLevel?: string }
   | { type: 'tailStop' }
@@ -19,7 +21,8 @@ export type ExtensionToWebviewMessage =
   | { type: 'loading'; value: boolean }
   | { type: 'error'; message: string }
   | { type: 'warning'; message?: string }
-  | { type: 'init'; locale: string; fullLogSearchEnabled?: boolean }
+  | { type: 'init'; locale: string; fullLogSearchEnabled?: boolean; logsColumns?: NormalizedLogsColumnsConfig }
+  | { type: 'logsColumns'; value: NormalizedLogsColumnsConfig }
   | { type: 'logs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'appendLogs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'logHead'; logId: string; codeUnitStarted?: string }

--- a/apps/vscode-extension/src/test/logsColumnsConfig.test.ts
+++ b/apps/vscode-extension/src/test/logsColumnsConfig.test.ts
@@ -1,0 +1,31 @@
+import assert from 'assert/strict';
+import { DEFAULT_LOGS_COLUMNS_CONFIG, normalizeLogsColumnsConfig } from '../shared/logsColumns';
+
+suite('logsColumns config', () => {
+  test('normalizes invalid values to defaults', () => {
+    const cfg = normalizeLogsColumnsConfig(undefined);
+    assert.deepEqual(cfg, DEFAULT_LOGS_COLUMNS_CONFIG);
+  });
+
+  test('filters unknown keys and appends missing keys', () => {
+    const cfg = normalizeLogsColumnsConfig({ order: ['time', 'nope', 'user', 'time'] });
+    assert.equal(cfg.order[0], 'time');
+    assert.equal(cfg.order[1], 'user');
+    assert.ok(cfg.order.includes('application'));
+    assert.ok(cfg.order.includes('match'));
+  });
+
+  test('ignores invalid widths and preserves valid widths', () => {
+    const cfg = normalizeLogsColumnsConfig({
+      widths: {
+        user: -5,
+        time: 123.9,
+        match: Number.NaN
+      }
+    });
+    assert.equal(cfg.widths.time, 123);
+    assert.equal(cfg.widths.user, undefined);
+    assert.equal(cfg.widths.match, undefined);
+  });
+});
+

--- a/apps/vscode-extension/src/test/resolvePATHFromLoginShell.test.ts
+++ b/apps/vscode-extension/src/test/resolvePATHFromLoginShell.test.ts
@@ -1,26 +1,65 @@
 import assert from 'assert/strict';
-import { resolvePATHFromLoginShell, __resetLoginShellPATHForTests } from '../salesforce/path';
-import { __setExecFileImplForTests, __resetExecFileImplForTests } from '../salesforce/exec';
+const proxyquire: any = require('proxyquire').noCallThru().noPreserveCache();
+
+type ExecModule = typeof import('../salesforce/exec');
+
+function loadExecModule(): ExecModule {
+  return proxyquire('../salesforce/exec', {
+    '../utils/logger': { logTrace: () => {}, logWarn: () => {}, '@noCallThru': true },
+    '../utils/localize': { localize: (_key: string, fallback: string) => fallback, '@noCallThru': true },
+    '../shared/telemetry': { safeSendException: () => {}, '@noCallThru': true }
+  }) as ExecModule;
+}
+
+function loadPathModule(params: { platform: 'win32' | 'linux' | 'darwin'; execModule: ExecModule }) {
+  return proxyquire('../salesforce/path', {
+    os: { platform: () => params.platform, '@noCallThru': true },
+    './exec': params.execModule,
+    '../utils/logger': { logTrace: () => {}, '@noCallThru': true }
+  }) as typeof import('../salesforce/path');
+}
 
 suite('resolvePATHFromLoginShell', () => {
-  setup(() => {
+  test('returns undefined on win32 without spawning', async () => {
+    const execModule = loadExecModule();
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+    const { resolvePATHFromLoginShell, __resetLoginShellPATHForTests } = loadPathModule({
+      platform: 'win32',
+      execModule
+    });
     __resetLoginShellPATHForTests();
-  });
-  teardown(() => {
-    __resetExecFileImplForTests();
-    __resetLoginShellPATHForTests();
-  });
 
-  test('caches PATH on success', async () => {
     let calls = 0;
     __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
       calls++;
-      cb(null, '/usr/bin', '');
+      cb(null, '/custom/path', '');
+      return undefined as any;
+    }) as any);
+
+    const pathValue = await resolvePATHFromLoginShell();
+    assert.equal(pathValue, undefined);
+    assert.equal(calls, 0);
+    __resetExecFileImplForTests();
+  });
+
+  test('caches PATH on success', async () => {
+    const execModule = loadExecModule();
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+    const { resolvePATHFromLoginShell, __resetLoginShellPATHForTests } = loadPathModule({
+      platform: 'linux',
+      execModule
+    });
+    __resetLoginShellPATHForTests();
+
+    let calls = 0;
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      calls++;
+      cb(null, '/custom/path', '');
       return undefined as any;
     }) as any);
 
     const path1 = await resolvePATHFromLoginShell();
-    assert.equal(path1, '/usr/bin');
+    assert.equal(path1, '/custom/path');
 
     __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
       calls++;
@@ -29,11 +68,20 @@ suite('resolvePATHFromLoginShell', () => {
     }) as any);
 
     const path2 = await resolvePATHFromLoginShell();
-    assert.equal(path2, '/usr/bin');
+    assert.equal(path2, '/custom/path');
     assert.equal(calls, 1);
+    __resetExecFileImplForTests();
   });
 
   test('retries after failure', async () => {
+    const execModule = loadExecModule();
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+    const { resolvePATHFromLoginShell, __resetLoginShellPATHForTests } = loadPathModule({
+      platform: 'linux',
+      execModule
+    });
+    __resetLoginShellPATHForTests();
+
     let callCount = 0;
     __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
       callCount++;
@@ -51,5 +99,6 @@ suite('resolvePATHFromLoginShell', () => {
     const second = await resolvePATHFromLoginShell();
     assert.equal(second, '/custom/path');
     assert.equal(callCount, 2);
+    __resetExecFileImplForTests();
   });
 });

--- a/apps/vscode-extension/src/webview/__tests__/ColumnsPopover.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/ColumnsPopover.test.tsx
@@ -1,0 +1,85 @@
+import React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { ColumnsPopover } from '../components/ColumnsPopover';
+import { getMessages } from '../i18n';
+
+const initialColumnsConfig = {
+  order: [
+    'user',
+    'application',
+    'operation',
+    'time',
+    'duration',
+    'status',
+    'codeUnit',
+    'size',
+    'match'
+  ],
+  visibility: {
+    user: true,
+    application: true,
+    operation: true,
+    time: true,
+    duration: true,
+    status: true,
+    codeUnit: true,
+    size: true,
+    match: true
+  },
+  widths: {}
+} as const;
+
+function Harness({ fullLogSearchEnabled }: { fullLogSearchEnabled: boolean }) {
+  const t = getMessages('en');
+  const [cfg, setCfg] = React.useState<any>(initialColumnsConfig);
+  return (
+    <div>
+      <ColumnsPopover
+        t={t}
+        columnsConfig={cfg}
+        fullLogSearchEnabled={fullLogSearchEnabled}
+        onColumnsConfigChange={updater => setCfg((prev: any) => updater(prev))}
+      />
+      <div data-testid="cfg">{JSON.stringify(cfg)}</div>
+    </div>
+  );
+}
+
+describe('ColumnsPopover', () => {
+  it('toggles visibility, reorders, and resets to defaults', () => {
+    render(<Harness fullLogSearchEnabled={true} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }));
+    screen.getByText('Show/hide and reorder columns');
+
+    const userSwitch = screen.getByRole('switch', { name: 'User' });
+    fireEvent.click(userSwitch);
+
+    const afterToggle = JSON.parse(screen.getByTestId('cfg').textContent || '{}');
+    expect(afterToggle.visibility.user).toBe(false);
+
+    const moveDownButtons = screen.getAllByRole('button', { name: 'Move down' });
+    fireEvent.click(moveDownButtons[0]!);
+
+    const afterMove = JSON.parse(screen.getByTestId('cfg').textContent || '{}');
+    expect(afterMove.order[0]).toBe('application');
+    expect(afterMove.order[1]).toBe('user');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset to defaults' }));
+
+    const afterReset = JSON.parse(screen.getByTestId('cfg').textContent || '{}');
+    expect(afterReset.order[0]).toBe('user');
+    expect(afterReset.visibility.user).toBe(true);
+    expect(afterReset.widths).toEqual({});
+  });
+
+  it('disables Match when full log search is disabled', () => {
+    render(<Harness fullLogSearchEnabled={false} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Columns' }));
+
+    screen.getByText('Requires full log search');
+    const matchSwitch = screen.getByRole('switch', { name: 'Match' });
+    expect(matchSwitch).toBeDisabled();
+  });
+});
+

--- a/apps/vscode-extension/src/webview/__tests__/LogRow.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/LogRow.test.tsx
@@ -24,6 +24,7 @@ describe('LogRow', () => {
         logHead={{ '1': { codeUnitStarted: 'CU' } }}
         locale="en-US"
         t={{ open: 'Open', replay: 'Replay' }}
+        columns={['user']}
         loading={false}
         onOpen={id => {
           opened = id;
@@ -31,7 +32,7 @@ describe('LogRow', () => {
         onReplay={id => {
           replayed = id;
         }}
-        gridTemplate="1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr"
+        gridTemplate="1fr 96px"
         style={{}}
         index={0}
         setRowHeight={() => {}}

--- a/apps/vscode-extension/src/webview/__tests__/LogsHeader.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/LogsHeader.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { LogsHeader } from '../components/table/LogsHeader';
 
 describe('LogsHeader', () => {
@@ -11,12 +11,14 @@ describe('LogsHeader', () => {
         application: 'Application',
         operation: 'Operation',
         time: 'Time',
+        duration: 'Duration',
         status: 'Status',
         codeUnitStarted: 'Code Unit',
-        size: 'Size'
+        size: 'Size',
+        match: 'Match'
       }
     };
-    const { getByText } = render(
+    render(
       <LogsHeader
         t={t}
         sortBy="user"
@@ -24,10 +26,66 @@ describe('LogsHeader', () => {
         onSort={key => {
           sorted = key;
         }}
-        gridTemplate="1fr 1fr 1fr 1fr 1fr 1fr 1fr 1fr"
+        gridTemplate="1fr 1fr 96px"
+        columns={['user', 'application']}
+        onResizeColumn={() => {}}
+        onClearColumnWidth={() => {}}
       />
     );
-    fireEvent.click(getByText('Application'));
+    fireEvent.click(screen.getByRole('button', { name: 'Application' }));
     expect(sorted).toBe('application');
+  });
+
+  it('emits resize and clear events and renders non-sortable columns', () => {
+    const t = {
+      columns: {
+        user: 'User',
+        application: 'Application',
+        match: 'Match',
+        size: 'Size'
+      }
+    };
+    const onResizeColumn = jest.fn();
+    const onClearColumnWidth = jest.fn();
+
+    render(
+      <LogsHeader
+        t={t}
+        sortBy="user"
+        sortDir="asc"
+        onSort={() => {}}
+        gridTemplate="1fr 1fr 1fr 96px"
+        columns={['user', 'application', 'match']}
+        onResizeColumn={onResizeColumn}
+        onClearColumnWidth={onClearColumnWidth}
+      />
+    );
+
+    expect(screen.getByText('Match')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Match' })).toBeNull();
+
+    const applicationHeader = screen.getByRole('columnheader', { name: /Application/i }) as HTMLElement;
+    (applicationHeader as any).getBoundingClientRect = () => ({
+      width: 200,
+      height: 20,
+      top: 0,
+      left: 0,
+      right: 200,
+      bottom: 20,
+      x: 0,
+      y: 0,
+      toJSON: () => {}
+    });
+
+    const handle = screen.getByRole('separator', { name: 'Resize Application' });
+    fireEvent.pointerDown(handle, { clientX: 100, button: 0, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 150, pointerId: 1 });
+    fireEvent.pointerUp(handle, { pointerId: 1 });
+
+    expect(onResizeColumn).toHaveBeenCalledWith('application', 250, { persist: false });
+    expect(onResizeColumn).toHaveBeenCalledWith('application', 250, { persist: true });
+
+    fireEvent.doubleClick(handle);
+    expect(onClearColumnWidth).toHaveBeenCalledWith('application');
   });
 });

--- a/apps/vscode-extension/src/webview/__tests__/LogsTable.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/LogsTable.test.tsx
@@ -40,6 +40,32 @@ const t = {
   }
 };
 
+const defaultColumnsConfig = {
+  order: [
+    'user',
+    'application',
+    'operation',
+    'time',
+    'duration',
+    'status',
+    'codeUnit',
+    'size',
+    'match'
+  ],
+  visibility: {
+    user: true,
+    application: true,
+    operation: true,
+    time: true,
+    duration: true,
+    status: true,
+    codeUnit: true,
+    size: true,
+    match: true
+  },
+  widths: {}
+} as const;
+
 function createVirtualList(captured: CapturedList) {
   return function VirtualList({
     listRef,
@@ -104,7 +130,9 @@ describe('LogsTable', () => {
       hasMore,
       sortBy: 'time' as const,
       sortDir: 'asc' as const,
-      onSort: () => {}
+      onSort: () => {},
+      columnsConfig: defaultColumnsConfig as any,
+      onColumnsConfigChange: () => {}
     };
     const view = render(
       <LogsTable
@@ -257,7 +285,10 @@ describe('LogsTable', () => {
       locale: 'en-US',
       sortBy: 'time' as const,
       sortDir: 'asc' as const,
-      onSort: () => {}
+      onSort: () => {},
+      columnsConfig: defaultColumnsConfig as any,
+      onColumnsConfigChange: () => {},
+      fullLogSearchEnabled: true
     };
 
     const initialLoadMore = jest.fn();

--- a/apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx
+++ b/apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx
@@ -4,6 +4,32 @@ import { Toolbar } from '../components/Toolbar';
 import { getMessages } from '../i18n';
 import type { OrgItem } from '../../shared/types';
 
+const defaultColumnsConfig = {
+  order: [
+    'user',
+    'application',
+    'operation',
+    'time',
+    'duration',
+    'status',
+    'codeUnit',
+    'size',
+    'match'
+  ],
+  visibility: {
+    user: true,
+    application: true,
+    operation: true,
+    time: true,
+    duration: true,
+    status: true,
+    codeUnit: true,
+    size: true,
+    match: true
+  },
+  widths: {}
+} as const;
+
 type ToolbarRenderOptions = {
   loading?: boolean;
   error?: string;
@@ -90,6 +116,9 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
         onClearFilters={() => {
           clearCount++;
         }}
+        columnsConfig={defaultColumnsConfig as any}
+        fullLogSearchEnabled={true}
+        onColumnsConfigChange={() => {}}
       />
     );
   } finally {

--- a/apps/vscode-extension/src/webview/__tests__/setupTests.ts
+++ b/apps/vscode-extension/src/webview/__tests__/setupTests.ts
@@ -19,3 +19,14 @@ if (typeof globalThis.ResizeObserver !== 'function') {
   }
   (globalThis as unknown as { ResizeObserver: typeof ResizeObserver }).ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
 }
+
+if (typeof (globalThis as any).PointerEvent !== 'function') {
+  class PointerEventMock extends MouseEvent {
+    pointerId: number;
+    constructor(type: string, params: any = {}) {
+      super(type, params);
+      this.pointerId = typeof params.pointerId === 'number' ? params.pointerId : 0;
+    }
+  }
+  (globalThis as any).PointerEvent = PointerEventMock;
+}

--- a/apps/vscode-extension/src/webview/components/ColumnsPopover.tsx
+++ b/apps/vscode-extension/src/webview/components/ColumnsPopover.tsx
@@ -1,0 +1,157 @@
+import React, { useCallback, useMemo } from 'react';
+import * as Popover from '@radix-ui/react-popover';
+import { Columns3, ChevronDown, ChevronUp, RotateCcw, GripVertical } from 'lucide-react';
+import { Button } from './ui/button';
+import { Switch } from './ui/switch';
+import { cn } from '../lib/utils';
+import type { LogsColumnKey, NormalizedLogsColumnsConfig } from '../../shared/logsColumns';
+import { DEFAULT_LOGS_COLUMNS_CONFIG, normalizeLogsColumnsConfig } from '../../shared/logsColumns';
+import { getLogsColumnLabel } from '../utils/logsColumns';
+
+type Props = {
+  t: any;
+  columnsConfig: NormalizedLogsColumnsConfig;
+  fullLogSearchEnabled: boolean;
+  onColumnsConfigChange: (
+    updater: (prev: NormalizedLogsColumnsConfig) => NormalizedLogsColumnsConfig,
+    options?: { persist?: boolean }
+  ) => void;
+};
+
+export function ColumnsPopover({ t, columnsConfig, fullLogSearchEnabled, onColumnsConfigChange }: Props) {
+  const title = t?.columnsConfig?.title ?? t?.columnsConfig?.button ?? 'Columns';
+  const buttonLabel = t?.columnsConfig?.button ?? 'Columns';
+  const resetLabel = t?.columnsConfig?.reset ?? 'Reset to defaults';
+  const matchDisabledHint = t?.columnsConfig?.matchRequiresFullSearch ?? 'Requires full log search';
+
+  const orderedKeys = useMemo(() => columnsConfig.order, [columnsConfig.order]);
+
+  const moveColumn = useCallback(
+    (key: LogsColumnKey, delta: -1 | 1) => {
+      onColumnsConfigChange(prev => {
+        const index = prev.order.indexOf(key);
+        if (index < 0) return prev;
+        const targetIndex = index + delta;
+        if (targetIndex < 0 || targetIndex >= prev.order.length) return prev;
+        const nextOrder = prev.order.slice();
+        nextOrder.splice(index, 1);
+        nextOrder.splice(targetIndex, 0, key);
+        return { ...prev, order: nextOrder };
+      });
+    },
+    [onColumnsConfigChange]
+  );
+
+  const setVisible = useCallback(
+    (key: LogsColumnKey, visible: boolean) => {
+      onColumnsConfigChange(prev => ({ ...prev, visibility: { ...prev.visibility, [key]: visible } }));
+    },
+    [onColumnsConfigChange]
+  );
+
+  const resetToDefaults = useCallback(() => {
+    onColumnsConfigChange(() => normalizeLogsColumnsConfig(DEFAULT_LOGS_COLUMNS_CONFIG));
+  }, [onColumnsConfigChange]);
+
+  return (
+    <Popover.Root>
+      <Popover.Trigger asChild>
+        <Button type="button" variant="outline" className="flex items-center gap-2">
+          <Columns3 className="h-4 w-4" aria-hidden="true" />
+          <span>{buttonLabel}</span>
+        </Button>
+      </Popover.Trigger>
+
+      <Popover.Portal>
+        <Popover.Content
+          align="start"
+          sideOffset={8}
+          className={cn(
+            'z-50 w-[320px] rounded-lg border border-border bg-card p-3 shadow-lg outline-none',
+            'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0'
+          )}
+        >
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <h3 className="truncate text-sm font-semibold text-foreground">{title}</h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                {t?.columnsConfig?.subtitle ?? 'Show/hide and reorder columns'}
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-3 flex flex-col gap-1">
+            {orderedKeys.map((key, idx) => {
+              const label = getLogsColumnLabel(key, t);
+              const isMatch = key === 'match';
+              const matchDisabled = isMatch && !fullLogSearchEnabled;
+              const checked = columnsConfig.visibility[key] !== false;
+              return (
+                <div
+                  key={key}
+                  className={cn(
+                    'flex items-center gap-2 rounded-md px-2 py-1.5',
+                    'hover:bg-muted/40'
+                  )}
+                >
+                  <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground/70" aria-hidden="true" />
+
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center gap-2">
+                      <span className="truncate text-sm text-foreground">{label}</span>
+                      {matchDisabled && (
+                        <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground">
+                          {matchDisabledHint}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+
+                  <div className="flex items-center gap-1">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => moveColumn(key, -1)}
+                      disabled={idx === 0}
+                      aria-label={t?.columnsConfig?.moveUp ?? 'Move up'}
+                      title={t?.columnsConfig?.moveUp ?? 'Move up'}
+                    >
+                      <ChevronUp className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="icon"
+                      onClick={() => moveColumn(key, 1)}
+                      disabled={idx === orderedKeys.length - 1}
+                      aria-label={t?.columnsConfig?.moveDown ?? 'Move down'}
+                      title={t?.columnsConfig?.moveDown ?? 'Move down'}
+                    >
+                      <ChevronDown className="h-4 w-4" aria-hidden="true" />
+                    </Button>
+                  </div>
+
+                  <Switch
+                    checked={checked}
+                    onCheckedChange={v => setVisible(key, !!v)}
+                    disabled={matchDisabled}
+                    aria-label={label}
+                  />
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="mt-3 flex items-center justify-between">
+            <Button type="button" variant="outline" size="sm" onClick={resetToDefaults} className="gap-2">
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+              <span>{resetLabel}</span>
+            </Button>
+          </div>
+        </Popover.Content>
+      </Popover.Portal>
+    </Popover.Root>
+  );
+}
+

--- a/apps/vscode-extension/src/webview/components/Toolbar.tsx
+++ b/apps/vscode-extension/src/webview/components/Toolbar.tsx
@@ -6,6 +6,8 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { FilterSelect } from './FilterSelect';
 import { OrgSelect } from './OrgSelect';
+import { ColumnsPopover } from './ColumnsPopover';
+import type { NormalizedLogsColumnsConfig } from '../../shared/logsColumns';
 
 function useStableId(prefix: string) {
   const id = React.useId();
@@ -38,6 +40,12 @@ type ToolbarProps = {
   onFilterStatusChange: (v: string) => void;
   onFilterCodeUnitChange: (v: string) => void;
   onClearFilters: () => void;
+  columnsConfig: NormalizedLogsColumnsConfig;
+  fullLogSearchEnabled: boolean;
+  onColumnsConfigChange: (
+    updater: (prev: NormalizedLogsColumnsConfig) => NormalizedLogsColumnsConfig,
+    options?: { persist?: boolean }
+  ) => void;
 };
 
 export function Toolbar({
@@ -65,7 +73,10 @@ export function Toolbar({
   onFilterOperationChange,
   onFilterStatusChange,
   onFilterCodeUnitChange,
-  onClearFilters
+  onClearFilters,
+  columnsConfig,
+  fullLogSearchEnabled,
+  onColumnsConfigChange
 }: ToolbarProps) {
   const searchInputId = useStableId('logs-search');
   const hasFilters = Boolean(filterUser || filterOperation || filterStatus || filterCodeUnit);
@@ -161,6 +172,13 @@ export function Toolbar({
           options={codeUnits}
           allLabel={t.filters?.all ?? 'All'}
           disabled={loading}
+        />
+
+        <ColumnsPopover
+          t={t}
+          columnsConfig={columnsConfig}
+          fullLogSearchEnabled={fullLogSearchEnabled}
+          onColumnsConfigChange={onColumnsConfigChange}
         />
 
         <Button

--- a/apps/vscode-extension/src/webview/components/table/LogRow.tsx
+++ b/apps/vscode-extension/src/webview/components/table/LogRow.tsx
@@ -2,6 +2,7 @@ import React, { useLayoutEffect, useMemo, useRef } from 'react';
 import { BugPlay, FileText, Loader2 } from 'lucide-react';
 import type { ApexLogRow } from '../../../shared/types';
 import type { LogHeadMap } from '../LogsTable';
+import type { LogsColumnKey } from '../../../shared/logsColumns';
 import { formatBytes, formatDuration } from '../../utils/format';
 import { Button } from '../ui/button';
 import { cn } from '../../lib/utils';
@@ -10,8 +11,7 @@ type Props = {
   r: ApexLogRow;
   logHead: LogHeadMap;
   matchSnippet?: { text: string; ranges: [number, number][] };
-  showCodeUnitColumn: boolean;
-  showMatchColumn: boolean;
+  columns: LogsColumnKey[];
   locale: string;
   t: any;
   loading: boolean;
@@ -27,8 +27,7 @@ export function LogRow({
   r,
   logHead,
   matchSnippet,
-  showCodeUnitColumn,
-  showMatchColumn,
+  columns,
   locale,
   t,
   loading,
@@ -68,8 +67,7 @@ export function LogRow({
     logHead[r.Id]?.codeUnitStarted,
     matchSnippet?.text,
     r,
-    showCodeUnitColumn,
-    showMatchColumn
+    columns
   ]);
 
   const cellClass =
@@ -151,27 +149,66 @@ export function LogRow({
         style={{ gridTemplateColumns: gridTemplate }}
         className="grid items-stretch border-b border-border bg-background/40 text-sm transition-colors hover:bg-muted/40"
       >
-        <div className={cellClass}>{r.LogUser?.Name ?? ''}</div>
-        <div className={cellClass}>{r.Application}</div>
-        <div className={cellClass}>{r.Operation}</div>
-        <div className={cellClass}>{new Date(r.StartTime).toLocaleString(locale)}</div>
-        <div className={cellClass}>{formatDuration(r.DurationMilliseconds)}</div>
-        <div className={cellClass}>{r.Status}</div>
-        {showCodeUnitColumn && (
-          <div className={cellClass} title={logHead[r.Id]?.codeUnitStarted ?? ''}>
-            {logHead[r.Id]?.codeUnitStarted ?? ''}
-          </div>
-        )}
-        <div className={cn(cellClass, 'text-right font-medium tabular-nums text-foreground')}>
-          {formatBytes(r.LogLength)}
-        </div>
-        {showMatchColumn && (
-          <div className={cn(cellClass, 'text-muted-foreground/90')} title={matchSnippet?.text ?? ''}>
-            <span className="block max-h-[4.5rem] overflow-hidden whitespace-pre-wrap text-left text-sm leading-relaxed">
-              {renderSnippet}
-            </span>
-          </div>
-        )}
+        {columns.map(key => {
+          switch (key) {
+            case 'user':
+              return (
+                <div key={key} className={cellClass}>
+                  {r.LogUser?.Name ?? ''}
+                </div>
+              );
+            case 'application':
+              return (
+                <div key={key} className={cellClass}>
+                  {r.Application}
+                </div>
+              );
+            case 'operation':
+              return (
+                <div key={key} className={cellClass}>
+                  {r.Operation}
+                </div>
+              );
+            case 'time':
+              return (
+                <div key={key} className={cellClass}>
+                  {new Date(r.StartTime).toLocaleString(locale)}
+                </div>
+              );
+            case 'duration':
+              return (
+                <div key={key} className={cellClass}>
+                  {formatDuration(r.DurationMilliseconds)}
+                </div>
+              );
+            case 'status':
+              return (
+                <div key={key} className={cellClass}>
+                  {r.Status}
+                </div>
+              );
+            case 'codeUnit':
+              return (
+                <div key={key} className={cellClass} title={logHead[r.Id]?.codeUnitStarted ?? ''}>
+                  {logHead[r.Id]?.codeUnitStarted ?? ''}
+                </div>
+              );
+            case 'size':
+              return (
+                <div key={key} className={cn(cellClass, 'text-right font-medium tabular-nums text-foreground')}>
+                  {formatBytes(r.LogLength)}
+                </div>
+              );
+            case 'match':
+              return (
+                <div key={key} className={cn(cellClass, 'text-muted-foreground/90')} title={matchSnippet?.text ?? ''}>
+                  <span className="block max-h-[4.5rem] overflow-hidden whitespace-pre-wrap text-left text-sm leading-relaxed">
+                    {renderSnippet}
+                  </span>
+                </div>
+              );
+          }
+        })}
         <div className={cn(cellClass, 'flex items-center justify-center gap-2 text-center')}>
           <div className="flex items-center gap-2">
             {actionButton(

--- a/apps/vscode-extension/src/webview/components/table/LogsHeader.tsx
+++ b/apps/vscode-extension/src/webview/components/table/LogsHeader.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { ArrowDown, ArrowUp, ChevronsUpDown } from 'lucide-react';
 import { cn } from '../../lib/utils';
+import type { LogsColumnKey } from '../../../shared/logsColumns';
+import { getLogsColumnLabel, LOGS_COLUMN_MIN_WIDTH_PX } from '../../utils/logsColumns';
 
-type SortKey = 'user' | 'application' | 'operation' | 'time' | 'duration' | 'status' | 'size' | 'codeUnit';
+type SortKey = Exclude<LogsColumnKey, 'match'>;
 
 type Props = {
   t: any;
@@ -10,12 +12,13 @@ type Props = {
   sortDir: 'asc' | 'desc';
   onSort: (key: SortKey) => void;
   gridTemplate: string;
-  showCodeUnitColumn: boolean;
-  showMatchColumn: boolean;
+  columns: LogsColumnKey[];
+  onResizeColumn: (key: LogsColumnKey, widthPx: number, options: { persist: boolean }) => void;
+  onClearColumnWidth: (key: LogsColumnKey) => void;
 };
 
 export const LogsHeader = React.forwardRef<HTMLDivElement, Props>(
-  ({ t, sortBy, sortDir, onSort, gridTemplate, showCodeUnitColumn, showMatchColumn }, ref) => {
+  ({ t, sortBy, sortDir, onSort, gridTemplate, columns, onResizeColumn, onClearColumnWidth }, ref) => {
     const renderSortIcon = (key: SortKey) => {
       if (sortBy !== key) {
         return <ChevronsUpDown className="h-3.5 w-3.5 opacity-50" aria-hidden="true" />;
@@ -35,47 +38,114 @@ export const LogsHeader = React.forwardRef<HTMLDivElement, Props>(
     const headerClass =
       'flex items-center gap-1 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-muted-foreground';
 
-    const renderHeader = (key: SortKey, label: string, align?: 'start' | 'end') => (
-      <div
-        role="columnheader"
-        aria-sort={ariaSort(key)}
-        className={cn(headerClass, align === 'end' ? 'justify-end text-right' : 'justify-start text-left')}
-      >
-        <button
-          type="button"
-          onClick={() => onSort(key)}
-          className={cn(
-            'flex w-full items-center gap-1 text-xs font-semibold uppercase tracking-wide transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
-            align === 'end' ? 'justify-end text-right' : 'justify-start text-left'
-          )}
+    const isSortableColumn = (key: LogsColumnKey): key is SortKey => key !== 'match';
+
+    const alignForColumn = (key: LogsColumnKey): 'start' | 'end' =>
+      key === 'size' ? 'end' : 'start';
+
+    const startResize = (key: LogsColumnKey, e: React.PointerEvent<HTMLDivElement>) => {
+      if (e.button !== 0) return;
+      e.preventDefault();
+      e.stopPropagation();
+
+      const handle = e.currentTarget;
+      const cell = handle.parentElement as HTMLElement | null;
+      if (!cell) return;
+
+      const minWidth = LOGS_COLUMN_MIN_WIDTH_PX[key] ?? 80;
+      const startX = e.clientX;
+      const startWidth = cell.getBoundingClientRect().width;
+      let lastWidth = Math.max(minWidth, Math.round(startWidth));
+
+      const prevCursor = document.body.style.cursor;
+      const prevUserSelect = document.body.style.userSelect;
+      document.body.style.cursor = 'col-resize';
+      document.body.style.userSelect = 'none';
+
+      try {
+        handle.setPointerCapture(e.pointerId);
+      } catch {}
+
+      const onMove = (ev: PointerEvent) => {
+        const dx = ev.clientX - startX;
+        const next = Math.max(minWidth, Math.round(startWidth + dx));
+        lastWidth = next;
+        onResizeColumn(key, next, { persist: false });
+      };
+
+      const cleanup = () => {
+        window.removeEventListener('pointermove', onMove);
+        window.removeEventListener('pointerup', onUp);
+        window.removeEventListener('pointercancel', onUp);
+        document.body.style.cursor = prevCursor;
+        document.body.style.userSelect = prevUserSelect;
+      };
+
+      const onUp = () => {
+        onResizeColumn(key, lastWidth, { persist: true });
+        cleanup();
+      };
+
+      window.addEventListener('pointermove', onMove);
+      window.addEventListener('pointerup', onUp);
+      window.addEventListener('pointercancel', onUp);
+    };
+
+    const renderColumnHeader = (key: LogsColumnKey) => {
+      const label = getLogsColumnLabel(key, t);
+      const align = alignForColumn(key);
+      const justifyClass = align === 'end' ? 'justify-end text-right' : 'justify-start text-left';
+
+      return (
+        <div
+          key={key}
+          role="columnheader"
+          aria-sort={isSortableColumn(key) ? ariaSort(key) : undefined}
+          className={cn(headerClass, 'group relative', justifyClass)}
         >
-          <span className="truncate">{label}</span>
-          {renderSortIcon(key)}
-        </button>
-      </div>
-    );
+          {isSortableColumn(key) ? (
+            <button
+              type="button"
+              onClick={() => onSort(key)}
+              className={cn(
+                'flex w-full items-center gap-1 text-xs font-semibold uppercase tracking-wide transition-colors hover:text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
+                justifyClass
+              )}
+            >
+              <span className="truncate">{label}</span>
+              {renderSortIcon(key)}
+            </button>
+          ) : (
+            <span className="truncate">{label}</span>
+          )}
+
+          <div
+            role="separator"
+            aria-label={`Resize ${label}`}
+            aria-orientation="vertical"
+            onPointerDown={e => startResize(key, e)}
+            onDoubleClick={e => {
+              e.preventDefault();
+              e.stopPropagation();
+              onClearColumnWidth(key);
+            }}
+            className={cn(
+              'absolute right-0 top-0 flex h-full w-2 touch-none select-none items-center justify-center',
+              'cursor-col-resize'
+            )}
+          >
+            <div className="h-[60%] w-px bg-border opacity-0 transition-opacity group-hover:opacity-100" />
+          </div>
+        </div>
+      );
+    };
 
     return (
-      <div
-        ref={ref}
-        role="row"
-        style={{ gridTemplateColumns: gridTemplate }}
-        className="sticky top-0 z-10 grid items-stretch border-b border-border bg-card/80 backdrop-blur"
-      >
-        {renderHeader('user', t.columns.user)}
-        {renderHeader('application', t.columns.application)}
-        {renderHeader('operation', t.columns.operation)}
-        {renderHeader('time', t.columns.time)}
-        {renderHeader('duration', t.columns.duration)}
-        {renderHeader('status', t.columns.status)}
-        {showCodeUnitColumn && renderHeader('codeUnit', t.columns.codeUnitStarted)}
-        {renderHeader('size', t.columns.size, 'end')}
-        {showMatchColumn && (
-          <div className={cn(headerClass, 'justify-start text-left text-muted-foreground')} role="columnheader">
-            <span className="truncate">{t.columns.match ?? 'Match'}</span>
-          </div>
-        )}
-        <div aria-hidden="true" />
+      <div ref={ref} className="sticky top-0 z-10 overflow-x-hidden border-b border-border bg-card/80 backdrop-blur">
+        <div role="row" style={{ gridTemplateColumns: gridTemplate }} className="grid items-stretch">
+          {columns.map(key => renderColumnHeader(key))}
+          <div aria-hidden="true" />
+        </div>
       </div>
     );
   }

--- a/apps/vscode-extension/src/webview/i18n.ts
+++ b/apps/vscode-extension/src/webview/i18n.ts
@@ -51,6 +51,15 @@ export type Messages = {
     codeUnitStarted: string;
     match?: string;
   };
+  columnsConfig?: {
+    button: string;
+    title: string;
+    subtitle?: string;
+    reset: string;
+    matchRequiresFullSearch: string;
+    moveUp: string;
+    moveDown: string;
+  };
 };
 
 const en: Messages = {
@@ -105,6 +114,15 @@ const en: Messages = {
     size: 'Size',
     codeUnitStarted: 'Code Unit',
     match: 'Match'
+  },
+  columnsConfig: {
+    button: 'Columns',
+    title: 'Columns',
+    subtitle: 'Show/hide and reorder columns',
+    reset: 'Reset to defaults',
+    matchRequiresFullSearch: 'Requires full log search',
+    moveUp: 'Move up',
+    moveDown: 'Move down'
   }
 };
 
@@ -160,6 +178,15 @@ const ptBR: Messages = {
     size: 'Tamanho',
     codeUnitStarted: 'Code Unit',
     match: 'Trecho'
+  },
+  columnsConfig: {
+    button: 'Colunas',
+    title: 'Colunas',
+    subtitle: 'Mostrar/ocultar e reordenar colunas',
+    reset: 'Restaurar padrão',
+    matchRequiresFullSearch: 'Requer busca completa',
+    moveUp: 'Mover para cima',
+    moveDown: 'Mover para baixo'
   }
 };
 

--- a/apps/vscode-extension/src/webview/utils/logsColumns.ts
+++ b/apps/vscode-extension/src/webview/utils/logsColumns.ts
@@ -1,0 +1,49 @@
+import type { LogsColumnKey } from '../../shared/logsColumns';
+
+export const LOGS_COLUMN_MIN_WIDTH_PX: Record<LogsColumnKey, number> = {
+  user: 160,
+  application: 140,
+  operation: 200,
+  time: 200,
+  duration: 110,
+  status: 120,
+  codeUnit: 260,
+  size: 90,
+  match: 320
+};
+
+export const LOGS_COLUMN_DEFAULT_TRACK: Record<LogsColumnKey, string> = {
+  user: 'minmax(160px,1fr)',
+  application: 'minmax(140px,1fr)',
+  operation: 'minmax(200px,1.2fr)',
+  time: 'minmax(200px,1fr)',
+  duration: 'minmax(110px,0.6fr)',
+  status: 'minmax(120px,0.8fr)',
+  codeUnit: 'minmax(260px,1.4fr)',
+  size: 'minmax(90px,0.6fr)',
+  match: 'minmax(320px,1.6fr)'
+};
+
+export function getLogsColumnLabel(key: LogsColumnKey, t: any): string {
+  switch (key) {
+    case 'user':
+      return t?.columns?.user ?? 'User';
+    case 'application':
+      return t?.columns?.application ?? 'Application';
+    case 'operation':
+      return t?.columns?.operation ?? 'Operation';
+    case 'time':
+      return t?.columns?.time ?? 'Time';
+    case 'duration':
+      return t?.columns?.duration ?? 'Duration';
+    case 'status':
+      return t?.columns?.status ?? 'Status';
+    case 'codeUnit':
+      return t?.columns?.codeUnitStarted ?? 'Code Unit';
+    case 'size':
+      return t?.columns?.size ?? 'Size';
+    case 'match':
+      return t?.columns?.match ?? 'Match';
+  }
+}
+

--- a/docs/SETTINGS.md
+++ b/docs/SETTINGS.md
@@ -41,6 +41,14 @@ The Electivus Apex Log Viewer extension exposes several settings under the `Elec
 - Number of lines retained in the Tail view's rolling buffer. Higher values keep more history visible to filters and search, at the cost of additional memory and CPU.
 - Changes take effect immediately in an open Tail view; no reload required.
 
+## `electivus.apexLogs.logsColumns`
+
+- Type: object
+- Default: managed by extension defaults
+- Persisted column layout for the **Electivus Apex Logs** table (visibility, order, and optional column widths).
+- This setting is typically updated via the Logs panel UI (the **Columns** button in the toolbar), not edited by hand.
+- When changed via the UI, it applies immediately and is stored in **User** settings so it survives reloads and can sync across machines.
+
 ## Applying changes
 
 After adjusting settings, reload the VS Code window to ensure the extension picks up the new configuration (`Developer: Reload Window`).

--- a/docs/plans/2026-02-15-logs-columns-customization-design.md
+++ b/docs/plans/2026-02-15-logs-columns-customization-design.md
@@ -1,0 +1,186 @@
+# Logs Panel Column Customization (Design)
+
+Date: 2026-02-15
+
+## Summary
+
+Add user-configurable columns for the **Electivus Apex Logs** panel (the `sfLogViewer` webview):
+
+- Toggle which columns are visible
+- Reorder columns via drag-and-drop
+- Resize columns via drag handles in the sticky table header
+- Persist choices in **VS Code user settings** (global scope)
+
+This is implemented as a **webview popover** opened from the existing toolbar, with changes applied immediately.
+
+## Goals
+
+- Let users control which columns they see in the logs table.
+- Let users reorder columns without leaving the panel.
+- Let users resize columns using familiar “grab the divider” interaction.
+- Persist configuration to user settings so it survives reloads and can sync across machines.
+- Keep default behavior consistent with the current table layout when no customization is set.
+
+## Non-goals
+
+- Customizing the Tail panel (`sfLogTail`) in this iteration.
+- Adding new data columns beyond what the table already renders.
+- Per-org/per-workspace column profiles.
+- Arbitrary per-row formatting customization.
+
+## Current State
+
+The logs table columns are hard-coded in the webview:
+
+- Header rendering: `apps/vscode-extension/src/webview/components/table/LogsHeader.tsx`
+- Row rendering: `apps/vscode-extension/src/webview/components/table/LogRow.tsx`
+- Column widths/layout: computed as a fixed CSS Grid template string in `apps/vscode-extension/src/webview/components/LogsTable.tsx`
+
+The “Match” column is currently shown only when full log search is enabled.
+
+## Proposed UX
+
+### Toolbar button
+
+Add a **Columns** button to the existing logs `Toolbar` row.
+
+- Clicking opens a popover anchored to the button.
+- Popover closes on `Escape`, outside click, or re-clicking the trigger.
+
+### Columns popover
+
+Inside the popover:
+
+- A vertical list of the available data columns.
+- Each row has:
+  - Drag handle (reorder)
+  - Column label
+  - Switch to toggle visibility
+- A **Reset to defaults** action:
+  - Restores default order
+  - Restores all columns to visible
+  - Clears custom widths (returns to responsive defaults)
+
+Column rules:
+
+- **All data columns are toggleable.**
+- The **Actions** column (Open / Replay buttons) is always present and is not configurable.
+- The **Match** column is still dependent on full log search:
+  - If full log search is disabled, the Match toggle is disabled (configuration remains stored).
+  - If full log search is enabled, Match visibility is controlled by the toggle.
+
+### Resize handles in header (sticky)
+
+Each visible header cell (except Actions) gets a resize handle on its right edge.
+
+- Dragging adjusts the column width live.
+- Width is clamped to a per-column minimum (based on existing min widths).
+- Optional quality-of-life: double-click the handle resets that column width to default (clears the custom width entry).
+
+## Data Model
+
+### Column keys
+
+Log table columns are represented by stable keys:
+
+- `user`
+- `application`
+- `operation`
+- `time`
+- `duration`
+- `status`
+- `codeUnit`
+- `size`
+- `match`
+
+`actions` is not part of the configuration (always present).
+
+### Settings shape (persisted)
+
+Add a new setting under the existing extension namespace:
+
+`electivus.apexLogs.logsColumns`
+
+Stored value (object):
+
+- `order`: array of column keys (includes keys for hidden columns so order is stable)
+- `visibility`: record of `key -> boolean` (absent means default `true`)
+- `widths`: record of `key -> number` (pixels; absent means “default responsive width”)
+
+Defaults:
+
+- `order`: current UI order
+- `visibility`: all `true`
+- `widths`: empty (all columns use existing responsive `minmax()` grid tracks)
+
+Validation rules:
+
+- Unknown keys are ignored.
+- Missing/invalid objects fall back to defaults.
+- Widths are clamped to min/max.
+
+## Extension ↔ Webview Data Flow
+
+Webview cannot directly read/write VS Code settings, so the extension host is the source of truth.
+
+### Extension → Webview
+
+- On webview init, send current config to webview (alongside locale / feature flags).
+- On settings change (`onDidChangeConfiguration`), send updated config if `electivus.apexLogs.logsColumns` changes.
+
+### Webview → Extension
+
+- When user changes visibility/order/widths, send an update message with the new config.
+- For resize:
+  - Update local state continuously for live feedback.
+  - Persist to settings on pointer-up (or debounce) to avoid excessive settings writes.
+
+## Implementation Outline
+
+### Webview (React)
+
+- Add a reusable `ColumnsPopover` component used by `Toolbar`.
+  - Uses Radix Popover for accessibility + focus management.
+  - Uses `dnd-kit` sortable list for reorder.
+- Refactor table rendering to be driven by an ordered list of “active columns”:
+  - `LogsHeader` renders headers from column list + resizers
+  - `LogRow` renders cells from the same column list
+  - `LogsTable` builds `gridTemplateColumns` from order + visibility + widths
+- Keep `react-window` virtual list intact; only the row component changes.
+
+### Extension host
+
+- Add config read/write support for `electivus.apexLogs.logsColumns`.
+- Update the logs view provider to include column config in the init payload.
+- Add a new message handler case to persist updates from the webview.
+
+## Dependencies
+
+Add webview UI dependencies (extension package):
+
+- `@radix-ui/react-popover` for popovers
+- `@dnd-kit/core`, `@dnd-kit/sortable`, `@dnd-kit/utilities` for reorder
+
+No CLI changes.
+
+## Testing Plan
+
+Webview Jest tests:
+
+- Toggling a column hides it from the rendered header/rows.
+- Reordering updates render order.
+- Resizing updates the computed `gridTemplateColumns` style (unit-level).
+- “Match” column respects both:
+  - `fullLogSearchEnabled`
+  - user visibility toggle
+
+Extension tests (if present/appropriate):
+
+- Config validation + defaults applied when setting missing/invalid.
+- Settings update is called with `ConfigurationTarget.Global`.
+
+## Rollout / Compatibility
+
+- New setting is additive; existing users see no behavior change unless they use the Columns UI.
+- Default column layout remains the current layout.
+

--- a/docs/plans/2026-02-15-logs-columns-customization-plan.md
+++ b/docs/plans/2026-02-15-logs-columns-customization-plan.md
@@ -1,0 +1,505 @@
+# Logs Panel Column Customization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Let users configure which columns are visible in the Electivus Apex Logs panel, including toggle visibility, reorder, and resize, persisted to VS Code **User** settings.
+
+**Architecture:** Store a `logsColumns` config object in VS Code settings (`electivus.apexLogs.logsColumns`) and sync it to/from the Logs webview via webview messaging. The webview is responsible for rendering a dynamic CSS Grid table based on column order/visibility/widths and providing a Radix Popover UI with `dnd-kit` reorder + header drag-resizers.
+
+**Tech Stack:** VS Code extension host (TypeScript), Webview (React + Tailwind), webview messaging, Jest (webview tests), Mocha (@vscode/test-electron) extension tests, Radix UI, dnd-kit.
+
+---
+
+## Column Model (reference)
+
+**Data column keys:**
+
+- `user`
+- `application`
+- `operation`
+- `time`
+- `duration`
+- `status`
+- `codeUnit`
+- `size`
+- `match`
+
+**Non-configurable column:**
+
+- `actions` (always present, always last)
+
+**Default order:** current UI order: `user, application, operation, time, duration, status, codeUnit, size, match`
+
+**Match gating rule:** `match` can only be shown when `fullLogSearchEnabled === true`. If disabled, the toggle is disabled but the preference is preserved.
+
+---
+
+### Task 1: Add shared column config types + normalization
+
+**Files:**
+- Create: `apps/vscode-extension/src/shared/logsColumns.ts`
+- Test: `apps/vscode-extension/src/test/logsColumnsConfig.test.ts`
+
+**Step 1: Write failing test for normalization**
+
+Create `apps/vscode-extension/src/test/logsColumnsConfig.test.ts`:
+
+```ts
+import assert from 'assert/strict';
+import { normalizeLogsColumnsConfig, DEFAULT_LOGS_COLUMNS_CONFIG } from '../shared/logsColumns';
+
+suite('logsColumns config', () => {
+  test('normalizes invalid values to defaults', () => {
+    const cfg = normalizeLogsColumnsConfig(undefined);
+    assert.deepEqual(cfg.order, DEFAULT_LOGS_COLUMNS_CONFIG.order);
+  });
+
+  test('filters unknown keys and appends missing keys', () => {
+    const cfg = normalizeLogsColumnsConfig({ order: ['time', 'nope', 'user'] });
+    assert.equal(cfg.order[0], 'time');
+    assert.ok(cfg.order.includes('application'));
+  });
+
+  test('clamps widths and ignores invalid', () => {
+    const cfg = normalizeLogsColumnsConfig({ widths: { user: -5, time: 123 } });
+    assert.ok(cfg.widths.time === 123);
+    assert.ok(cfg.widths.user === undefined);
+  });
+});
+```
+
+**Step 2: Run extension unit tests to see failure**
+
+Run: `npm --prefix apps/vscode-extension run compile-tests`
+
+Run: `KEEP_VSCODE_TEST_CACHE=1 bash apps/vscode-extension/scripts/run-tests.sh --scope=unit`
+
+Expected: FAIL because `../shared/logsColumns` doesn’t exist yet.
+
+**Step 3: Implement shared model + normalization**
+
+Create `apps/vscode-extension/src/shared/logsColumns.ts` with:
+
+```ts
+export type LogsColumnKey =
+  | 'user'
+  | 'application'
+  | 'operation'
+  | 'time'
+  | 'duration'
+  | 'status'
+  | 'codeUnit'
+  | 'size'
+  | 'match';
+
+export type LogsColumnsConfig = {
+  order?: LogsColumnKey[];
+  visibility?: Partial<Record<LogsColumnKey, boolean>>;
+  widths?: Partial<Record<LogsColumnKey, number>>;
+};
+
+export type NormalizedLogsColumnsConfig = {
+  order: LogsColumnKey[];
+  visibility: Record<LogsColumnKey, boolean>;
+  widths: Partial<Record<LogsColumnKey, number>>;
+};
+
+export const DEFAULT_LOGS_COLUMN_ORDER: LogsColumnKey[] = [
+  'user',
+  'application',
+  'operation',
+  'time',
+  'duration',
+  'status',
+  'codeUnit',
+  'size',
+  'match'
+];
+
+export const DEFAULT_LOGS_COLUMNS_CONFIG: NormalizedLogsColumnsConfig = {
+  order: DEFAULT_LOGS_COLUMN_ORDER,
+  visibility: Object.fromEntries(DEFAULT_LOGS_COLUMN_ORDER.map(k => [k, true])) as Record<LogsColumnKey, boolean>,
+  widths: {}
+};
+
+const KEY_SET = new Set<LogsColumnKey>(DEFAULT_LOGS_COLUMN_ORDER);
+
+export function normalizeLogsColumnsConfig(raw: unknown): NormalizedLogsColumnsConfig {
+  const input = (raw && typeof raw === 'object' ? (raw as any) : {}) as LogsColumnsConfig;
+  const orderRaw = Array.isArray(input.order) ? input.order : [];
+  const orderFiltered = orderRaw.filter((k): k is LogsColumnKey => typeof k === 'string' && KEY_SET.has(k as LogsColumnKey));
+  const order = [...new Set([...orderFiltered, ...DEFAULT_LOGS_COLUMN_ORDER])] as LogsColumnKey[];
+
+  const visibilityIn = input.visibility && typeof input.visibility === 'object' ? (input.visibility as any) : {};
+  const visibility = Object.fromEntries(order.map(k => [k, visibilityIn[k] === false ? false : true])) as Record<
+    LogsColumnKey,
+    boolean
+  >;
+
+  const widthsIn = input.widths && typeof input.widths === 'object' ? (input.widths as any) : {};
+  const widths: Partial<Record<LogsColumnKey, number>> = {};
+  for (const k of order) {
+    const v = widthsIn[k];
+    if (typeof v === 'number' && Number.isFinite(v) && v > 0) {
+      widths[k] = Math.floor(v);
+    }
+  }
+
+  return { order, visibility, widths };
+}
+```
+
+**Step 4: Run extension unit tests**
+
+Run: `npm --prefix apps/vscode-extension run compile-tests`
+
+Run: `KEEP_VSCODE_TEST_CACHE=1 bash apps/vscode-extension/scripts/run-tests.sh --scope=unit`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add apps/vscode-extension/src/shared/logsColumns.ts apps/vscode-extension/src/test/logsColumnsConfig.test.ts
+git commit -m "feat(logs): add columns config model"
+```
+
+---
+
+### Task 2: Add the VS Code setting schema for `electivus.apexLogs.logsColumns`
+
+**Files:**
+- Modify: `apps/vscode-extension/package.json`
+- Modify: `docs/SETTINGS.md`
+
+**Step 1: Add configuration contribution**
+
+Update `apps/vscode-extension/package.json` to include:
+
+- Key: `electivus.apexLogs.logsColumns`
+- Type: `object`
+- Default: `{ order: [...], visibility: {...}, widths: {} }`
+- Description: “Persisted column layout for Logs table (managed by UI).”
+
+**Step 2: Document setting**
+
+Update `docs/SETTINGS.md` with a new section describing:
+
+- what it does
+- that it is managed by the Logs panel UI
+- where it’s stored (User settings)
+
+**Step 3: Verify JSON validity**
+
+Run: `node -c apps/vscode-extension/package.json`
+
+Expected: exit code 0 (no output).
+
+**Step 4: Commit**
+
+```bash
+git add apps/vscode-extension/package.json docs/SETTINGS.md
+git commit -m "feat(logs): add logsColumns setting"
+```
+
+---
+
+### Task 3: Wire extension ↔ webview messages for column config
+
+**Files:**
+- Modify: `apps/vscode-extension/src/shared/messages.ts`
+- Modify: `apps/vscode-extension/src/provider/logsMessageHandler.ts`
+- Modify: `apps/vscode-extension/src/provider/SfLogsViewProvider.ts`
+- Modify: `apps/vscode-extension/src/utils/configManager.ts` (optional; if used to read config)
+
+**Step 1: Extend shared messages**
+
+In `apps/vscode-extension/src/shared/messages.ts`:
+
+- Add Webview → Extension:
+
+```ts
+| { type: 'setLogsColumns'; value: import('./logsColumns').LogsColumnsConfig }
+```
+
+- Extend Extension → Webview `init` payload to include normalized config:
+
+```ts
+| { type: 'init'; locale: string; fullLogSearchEnabled?: boolean; logsColumns?: import('./logsColumns').NormalizedLogsColumnsConfig }
+```
+
+- Add a live update message (so changes apply without refresh):
+
+```ts
+| { type: 'logsColumns'; value: import('./logsColumns').NormalizedLogsColumnsConfig }
+```
+
+**Step 2: Provider sends config on init + settings changes**
+
+In `apps/vscode-extension/src/provider/SfLogsViewProvider.ts`:
+
+- When posting `init`, include `logsColumns: normalizeLogsColumnsConfig(getConfig(...))`
+- In `onDidChangeConfiguration` handler:
+  - If `affectsConfiguration(e, 'electivus.apexLogs.logsColumns')`, post `{ type: 'logsColumns', value: normalized }`
+
+**Step 3: Provider persists webview updates**
+
+Add a method on provider:
+
+```ts
+public async setLogsColumnsConfig(value: LogsColumnsConfig): Promise<void> {
+  const cfg = vscode.workspace.getConfiguration();
+  await cfg.update('electivus.apexLogs.logsColumns', value, vscode.ConfigurationTarget.Global);
+  this.post({ type: 'logsColumns', value: normalizeLogsColumnsConfig(value) });
+}
+```
+
+**Step 4: Handle new message**
+
+In `apps/vscode-extension/src/provider/logsMessageHandler.ts`:
+
+- Add a constructor callback `setLogsColumns: (value: LogsColumnsConfig) => Promise<void>`
+- Handle `message.type === 'setLogsColumns'`
+
+**Step 5: Commit**
+
+```bash
+git add apps/vscode-extension/src/shared/messages.ts apps/vscode-extension/src/provider/logsMessageHandler.ts apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+git commit -m "feat(logs): sync columns config via webview messages"
+```
+
+---
+
+### Task 4: Store columns config in Logs webview state and pass into table
+
+**Files:**
+- Modify: `apps/vscode-extension/src/webview/main.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/Toolbar.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/LogsTable.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/table/LogsHeader.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/table/LogRow.tsx`
+
+**Step 1: Add webview state + message handling**
+
+In `apps/vscode-extension/src/webview/main.tsx`:
+
+- Add `const [logsColumns, setLogsColumns] = useState<NormalizedLogsColumnsConfig>(DEFAULT_LOGS_COLUMNS_CONFIG)`
+- In message handler:
+  - On `init`, read `msg.logsColumns` into state
+  - On `logsColumns`, update state
+- Add a helper `persistLogsColumns(next: NormalizedLogsColumnsConfig)` that:
+  - updates state
+  - posts `{ type: 'setLogsColumns', value: next }` (or the minimal config object)
+
+**Step 2: Thread config into Toolbar + LogsTable**
+
+- Add a new toolbar prop for opening the Columns popover (placeholder until Task 5)
+- Add `logsColumns` and `onLogsColumnsChange` props into `LogsTable`
+
+**Step 3: Commit**
+
+```bash
+git add apps/vscode-extension/src/webview/main.tsx apps/vscode-extension/src/webview/components/Toolbar.tsx apps/vscode-extension/src/webview/components/LogsTable.tsx apps/vscode-extension/src/webview/components/table/LogsHeader.tsx apps/vscode-extension/src/webview/components/table/LogRow.tsx
+git commit -m "feat(logs): plumb columns config into webview"
+```
+
+---
+
+### Task 5: Implement Columns popover UI (visibility + reorder + reset)
+
+**Dependencies:**
+- Add: `@radix-ui/react-popover`
+- Add: `@dnd-kit/core`
+- Add: `@dnd-kit/sortable`
+- Add: `@dnd-kit/utilities`
+
+**Files:**
+- Modify: `apps/vscode-extension/package.json`
+- Modify: `package-lock.json`
+- Create: `apps/vscode-extension/src/webview/components/ColumnsPopover.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/Toolbar.tsx`
+- Modify: `apps/vscode-extension/src/webview/i18n.ts`
+
+**Step 1: Add dependencies**
+
+Run:
+
+```bash
+npm --prefix apps/vscode-extension install @radix-ui/react-popover @dnd-kit/core @dnd-kit/sortable @dnd-kit/utilities
+```
+
+Expected: package-lock updates.
+
+**Step 2: Create `ColumnsPopover`**
+
+Implement a popover with:
+
+- Trigger button text: `t.columnsMenu?.button ?? 'Columns'`
+- List items in current `logsColumns.order`
+- Per item:
+  - drag handle (lucide `GripVertical` or similar)
+  - label
+  - `Switch` for visibility
+- Reset button: restores `DEFAULT_LOGS_COLUMNS_CONFIG`
+- Disable Match toggle if `fullLogSearchEnabled === false`
+
+**Step 3: Hook into `Toolbar`**
+
+Add the Columns button next to “Clear filters”.
+
+**Step 4: Add i18n keys**
+
+In `apps/vscode-extension/src/webview/i18n.ts`, add:
+
+```ts
+columnsMenu?: {
+  button: string;
+  title: string;
+  reset: string;
+};
+```
+
+**Step 5: Webview tests (minimal)**
+
+Add/extend `apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx` to verify:
+
+- The Columns button renders
+- Clicking opens popover content
+
+**Step 6: Commit**
+
+```bash
+git add apps/vscode-extension/package.json package-lock.json apps/vscode-extension/src/webview/components/ColumnsPopover.tsx apps/vscode-extension/src/webview/components/Toolbar.tsx apps/vscode-extension/src/webview/i18n.ts apps/vscode-extension/src/webview/__tests__/Toolbar.test.tsx
+git commit -m "feat(logs): add columns popover UI"
+```
+
+---
+
+### Task 6: Refactor Logs table rendering to use dynamic ordered/visible columns
+
+**Files:**
+- Create: `apps/vscode-extension/src/webview/utils/logsColumns.ts`
+- Modify: `apps/vscode-extension/src/webview/components/LogsTable.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/table/LogsHeader.tsx`
+- Modify: `apps/vscode-extension/src/webview/components/table/LogRow.tsx`
+- Test: `apps/vscode-extension/src/webview/__tests__/LogsTable.test.tsx`
+
+**Step 1: Add column definitions**
+
+In `apps/vscode-extension/src/webview/utils/logsColumns.ts`, define:
+
+- `COLUMN_DEFS` map `LogsColumnKey -> { minPx, defaultTrack, labelKey, sortableKey? }`
+- helper `getEffectiveVisibleOrder(config, fullLogSearchEnabled)`:
+  - filter to keys where `config.visibility[key] !== false`
+  - if key is `match` and `fullLogSearchEnabled === false`, exclude
+
+**Step 2: Build `gridTemplateColumns` dynamically**
+
+In `LogsTable.tsx`, replace the hard-coded columns list with:
+
+- `visibleOrder = getEffectiveVisibleOrder(logsColumns, fullLogSearchEnabled)`
+- For each key:
+  - if `logsColumns.widths[key]` exists -> `minmax(${minPx}px, ${width}px)`
+  - else -> `defaultTrack`
+- Append actions track: `'96px'`
+
+**Step 3: Render header + row cells from the same list**
+
+- Update `LogsHeader` props to accept `visibleOrder` and render cells via mapping.
+- Update `LogRow` to accept `visibleOrder` and render the same sequence of cells.
+
+**Step 4: Update webview tests**
+
+Extend `LogsTable.test.tsx`:
+
+- “hides columns when visibility false”
+- “does not show match when full log search disabled even if enabled in config”
+- “respects order when provided”
+
+**Step 5: Commit**
+
+```bash
+git add apps/vscode-extension/src/webview/utils/logsColumns.ts apps/vscode-extension/src/webview/components/LogsTable.tsx apps/vscode-extension/src/webview/components/table/LogsHeader.tsx apps/vscode-extension/src/webview/components/table/LogRow.tsx apps/vscode-extension/src/webview/__tests__/LogsTable.test.tsx
+git commit -m "feat(logs): render logs table from configurable columns"
+```
+
+---
+
+### Task 7: Add drag-to-resize handles in the sticky header and persist widths
+
+**Files:**
+- Modify: `apps/vscode-extension/src/webview/components/table/LogsHeader.tsx`
+- Modify: `apps/vscode-extension/src/webview/main.tsx`
+- Test: `apps/vscode-extension/src/webview/__tests__/LogsHeader.test.tsx`
+
+**Step 1: Add resizer handle UI per column**
+
+In `LogsHeader.tsx`:
+
+- Render a small `div` at right edge of each header cell:
+  - class: `absolute right-0 top-0 h-full w-2 cursor-col-resize`
+  - onPointerDown starts resize for that column key
+
+**Step 2: Resize state + handlers in `LogsApp`**
+
+In `main.tsx`:
+
+- Implement `onResizeColumn(key, nextWidthPx)` to update `logsColumns.widths[key]`
+- Persist to extension on pointer-up:
+  - easiest: handler returns a “commit” callback called at pointer-up
+
+**Step 3: Add test for resize callback**
+
+In `LogsHeader.test.tsx`, simulate:
+
+- render header with one visible column
+- pointerDown on resizer
+- pointerMove
+- pointerUp
+- assert `onColumnWidthChange` called with expected key + width
+
+**Step 4: Commit**
+
+```bash
+git add apps/vscode-extension/src/webview/components/table/LogsHeader.tsx apps/vscode-extension/src/webview/main.tsx apps/vscode-extension/src/webview/__tests__/LogsHeader.test.tsx
+git commit -m "feat(logs): add column resize handles"
+```
+
+---
+
+### Task 8: Final verification and packaging sanity
+
+**Step 1: Webview tests**
+
+Run: `npm --prefix apps/vscode-extension run test:webview`
+
+Expected: PASS.
+
+**Step 2: Extension unit tests**
+
+Run: `npm --prefix apps/vscode-extension run compile-tests`
+
+Run: `KEEP_VSCODE_TEST_CACHE=1 bash apps/vscode-extension/scripts/run-tests.sh --scope=unit`
+
+Expected: PASS (exit code 0).
+
+**Step 3: Build**
+
+Run: `npm run ext:build`
+
+Expected: builds `apps/vscode-extension/dist/extension.js` and `media/*.js` without errors.
+
+**Step 4: Manual smoke (optional)**
+
+- `F5` → open Extension Development Host
+- Open “Electivus Apex Logs”
+- Use Columns popover: toggle + reorder + resize
+- Reload window; confirm settings persisted
+
+**Step 5: Commit**
+
+```bash
+git add -A
+git commit -m "feat(logs): configurable columns in logs panel"
+```
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "version": "0.22.0",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-popover": "^1.1.15",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-switch": "^1.2.6",
@@ -352,6 +353,7 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1386,6 +1388,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1429,6 +1432,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4301,6 +4305,61 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-popover": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popover/-/react-popover-1.1.15.tgz",
+      "integrity": "sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-popover/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-popper": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
@@ -4340,6 +4399,30 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-presence": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+      "integrity": "sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2",
         "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
@@ -5551,8 +5634,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5718,6 +5800,7 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5741,6 +5824,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5751,6 +5835,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5834,6 +5919,7 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -6761,6 +6847,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7399,6 +7486,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8704,8 +8792,7 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9155,6 +9242,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11366,6 +11454,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12590,6 +12679,7 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -13582,7 +13672,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15303,6 +15392,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15379,7 +15469,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15395,7 +15484,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15406,7 +15494,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15623,6 +15710,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15632,6 +15720,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15644,8 +15733,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -17272,7 +17360,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17504,6 +17593,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17670,7 +17760,8 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "peer": true
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -17825,6 +17916,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
- Adds a **Columns** popover in the Logs webview toolbar (sfLogViewer) to show/hide columns, reorder, and reset to defaults.
- Adds draggable resize handles in the sticky header; widths are persisted.
- Persists configuration in **User** settings via `electivus.apexLogs.logsColumns` (schema + docs).
- Keeps the `match` column gated by `electivus.apexLogs.enableFullLogSearch` (preference preserved).

Tests:
- `npm --prefix apps/vscode-extension run test:webview`
- `KEEP_VSCODE_TEST_CACHE=1 bash apps/vscode-extension/scripts/run-tests.sh --scope=unit`