### PR TITLE
[codex] add Playwright E2E (scratch org)

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,6 +1,9 @@
 name: E2E (Playwright • Real Org)
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       vscode_version:
@@ -19,7 +22,7 @@ on:
       keep_scratch_org:
         description: Keep the scratch org after the run
         required: false
-        default: false
+        default: true
         type: boolean
 
 concurrency:
@@ -59,12 +62,12 @@ jobs:
       - name: Run Playwright E2E
         run: npm run ext:test:e2e -- openLogViewer.e2e.spec.ts
         env:
-          VSCODE_TEST_VERSION: ${{ inputs.vscode_version }}
+          VSCODE_TEST_VERSION: ${{ github.event.inputs.vscode_version || 'stable' }}
           SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
           SF_DEVHUB_ALIAS: InsuranceOrgTrialCreme6DevHub
           SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}
-          SF_SCRATCH_DURATION: ${{ inputs.scratch_duration_days }}
-          SF_TEST_KEEP_ORG: ${{ inputs.keep_scratch_org && '1' || '' }}
+          SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || '1' }}
+          SF_TEST_KEEP_ORG: ${{ github.event.inputs.keep_scratch_org == 'false' && '' || '1' }}
 
       - name: Upload Playwright artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -67,7 +67,10 @@ jobs:
           SF_DEVHUB_ALIAS: InsuranceOrgTrialCreme6DevHub
           SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}
           SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || '1' }}
-          SF_TEST_KEEP_ORG: ${{ github.event.inputs.keep_scratch_org == 'false' && '' || '1' }}
+          # Default behavior:
+          # - pull_request: delete scratch org (avoid leaking scratch orgs on every PR update)
+          # - workflow_dispatch: keep unless explicitly disabled
+          SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '' }}
 
       - name: Upload Playwright artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -1,0 +1,75 @@
+name: E2E (Playwright • Real Org)
+
+on:
+  workflow_dispatch:
+    inputs:
+      vscode_version:
+        description: VS Code version (stable recommended)
+        required: false
+        default: stable
+        type: choice
+        options:
+          - stable
+          - insiders
+      scratch_duration_days:
+        description: Scratch org duration in days
+        required: false
+        default: "1"
+        type: string
+      keep_scratch_org:
+        description: Keep the scratch org after the run
+        required: false
+        default: false
+        type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  playwright_e2e:
+    name: Playwright E2E (scratch org)
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js 22.x
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22.x
+          cache: npm
+          cache-dependency-path: apps/vscode-extension/package-lock.json
+
+      - name: Install Salesforce CLI
+        run: npm install -g @salesforce/cli
+
+      - name: Install extension dependencies
+        run: npm ci --workspaces=false
+        working-directory: apps/vscode-extension
+
+      - name: Install Linux deps for Electron (best-effort)
+        run: INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh
+        working-directory: apps/vscode-extension
+
+      - name: Run Playwright E2E
+        run: npm run ext:test:e2e -- openLogViewer.e2e.spec.ts
+        env:
+          VSCODE_TEST_VERSION: ${{ inputs.vscode_version }}
+          SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
+          SF_DEVHUB_ALIAS: InsuranceOrgTrialCreme6DevHub
+          SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}
+          SF_SCRATCH_DURATION: ${{ inputs.scratch_duration_days }}
+          SF_TEST_KEEP_ORG: ${{ inputs.keep_scratch_org && '1' || '' }}
+
+      - name: Upload Playwright artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-e2e
+          path: output/playwright/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ media/webview-dev.css
 *.vsix
 *.zip
 coverage/
+output/playwright/
 
 # allow tracking webview entrypoints
 *.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Features
+
+- Testing: add Playwright E2E coverage against a real scratch org (Dev Hub + seeded Apex log). Also adds a manual GitHub Actions workflow for opt-in validation.
+
+### Bug Fixes
+
+- CLI: add an optional `electivus.apexLogs.cliPath` setting to help VS Code find the Salesforce CLI (`sf`) when PATH inheritance is limited (for example when launched from the OS GUI).
+
 ## [0.22.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.20.0...v0.22.0) (2026-02-13)
 
 ### ⚠ BREAKING CHANGES

--- a/apps/vscode-extension/docs/TESTING.md
+++ b/apps/vscode-extension/docs/TESTING.md
@@ -8,6 +8,7 @@ This project uses VS Code integration tests (Mocha running inside the Extension 
 - `npm run test:unit`: fast path; runs Jest first and then the VS Code-hosted unit scope.
 - `npm run test:integration`: installs dependency extensions if needed and runs integration tests.
 - `npm run test:all`: runs the Jest webview suites, then both unit and integration scopes.
+- `npm run test:e2e`: runs Playwright E2E tests against a real scratch org (creates a scratch org + seeds an Apex log).
 
 The test orchestrator lives in `scripts/run-tests.js` and the Mocha programmatic runner in `src/test/runner.ts`.
 
@@ -36,12 +37,41 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 
 Tests do not require an authenticated org by default. If you want the runner to authenticate a Dev Hub and create a scratch org automatically:
 
-- `SF_DEVHUB_AUTH_URL`: SFDX URL for the Dev Hub auth (or `SFDX_AUTH_URL`).
+- `SF_DEVHUB_AUTH_URL`: SFDX URL for the Dev Hub auth.
 - `SF_DEVHUB_ALIAS`: Alias for the Dev Hub (default `DevHub`).
 - `SF_SETUP_SCRATCH=1`: Enables scratch org creation when a Dev Hub is available.
 - `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_Test_Scratch`).
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Skip deleting the scratch org during cleanup.
+
+## Playwright E2E (real org)
+
+The Playwright suite validates the webview UX end-to-end by:
+
+1. Authenticating a Dev Hub (CI via `SF_DEVHUB_AUTH_URL`, local via an existing auth)
+2. Creating/reusing a scratch org
+3. Seeding an Apex log (anonymous Apex with a unique marker)
+4. Launching VS Code and verifying the Logs panel + Log Viewer show that log
+
+### Run locally
+
+From `apps/vscode-extension/`:
+
+- `SF_TEST_KEEP_ORG=1 npm run test:e2e`
+
+Useful env vars:
+
+- `SF_DEVHUB_AUTH_URL`: Optional locally; required in CI. If not set, the E2E suite assumes you already have a Dev Hub authenticated locally.
+- `SF_DEVHUB_ALIAS`: Dev Hub alias to use. If unset, local runs prefer `InsuranceOrgTrialCreme6DevHub` when available.
+- `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_E2E_Scratch`).
+- `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
+- `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).
+
+Troubleshooting:
+
+- If the Logs panel shows **“Salesforce CLI not found”**, set the VS Code setting `electivus.apexLogs.cliPath` to the absolute path of your `sf` executable.
+
+Artifacts (screenshots/traces/videos on failure) are written under `../../output/playwright/`.
 
 ## Debugging
 

--- a/apps/vscode-extension/package-lock.json
+++ b/apps/vscode-extension/package-lock.json
@@ -27,6 +27,7 @@
       "devDependencies": {
         "@commitlint/cli": "^20.2.0",
         "@commitlint/config-conventional": "^20.2.0",
+        "@playwright/test": "^1.58.2",
         "@tailwindcss/cli": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.1",
@@ -347,7 +348,6 @@
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1382,7 +1382,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1426,7 +1425,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4111,6 +4109,22 @@
         "url": "https://opencollective.com/pkgr"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -5648,7 +5662,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5814,7 +5829,6 @@
       "integrity": "sha512-1N9SBnWYOJTrNZCdh/yJE+t910Y128BoyY+zBLWhL3r0TYzlTmFdXrPwHL9DyFZmlEXNQQolTZh3KHV31QDhyA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -5838,7 +5852,6 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -5849,7 +5862,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -5933,7 +5945,6 @@
       "integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.50.1",
         "@typescript-eslint/types": "8.50.1",
@@ -6867,7 +6878,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7502,7 +7512,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -8808,7 +8817,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-serializer": {
       "version": "2.0.0",
@@ -9258,7 +9268,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -11469,7 +11478,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -12694,7 +12702,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -13676,6 +13683,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -15332,6 +15340,53 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/pluralize": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
@@ -15371,7 +15426,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -15448,6 +15502,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -15463,6 +15518,7 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -15473,6 +15529,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15689,7 +15746,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -15699,7 +15755,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -15712,7 +15767,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-remove-scroll": {
       "version": "2.7.1",
@@ -17339,8 +17395,7 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/tailwindcss-animate": {
       "version": "1.0.7",
@@ -17572,7 +17627,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -17739,8 +17793,7 @@
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "peer": true
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/tunnel": {
       "version": "0.0.6",
@@ -17895,7 +17948,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -87,6 +87,11 @@
           "default": false,
           "markdownDescription": "Enable verbose trace logging for CLI and HTTP calls (Output: Electivus Apex Log Viewer)."
         },
+        "electivus.apexLogs.cliPath": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "%configuration.electivus.apexLogs.cliPath.description%"
+        },
         "electivus.apexLogs.tailBufferSize": {
           "type": "number",
           "default": 10000,
@@ -176,29 +181,74 @@
             "visibility": {
               "type": "object",
               "properties": {
-                "user": { "type": "boolean" },
-                "application": { "type": "boolean" },
-                "operation": { "type": "boolean" },
-                "time": { "type": "boolean" },
-                "duration": { "type": "boolean" },
-                "status": { "type": "boolean" },
-                "codeUnit": { "type": "boolean" },
-                "size": { "type": "boolean" },
-                "match": { "type": "boolean" }
+                "user": {
+                  "type": "boolean"
+                },
+                "application": {
+                  "type": "boolean"
+                },
+                "operation": {
+                  "type": "boolean"
+                },
+                "time": {
+                  "type": "boolean"
+                },
+                "duration": {
+                  "type": "boolean"
+                },
+                "status": {
+                  "type": "boolean"
+                },
+                "codeUnit": {
+                  "type": "boolean"
+                },
+                "size": {
+                  "type": "boolean"
+                },
+                "match": {
+                  "type": "boolean"
+                }
               }
             },
             "widths": {
               "type": "object",
               "properties": {
-                "user": { "type": "number", "minimum": 1 },
-                "application": { "type": "number", "minimum": 1 },
-                "operation": { "type": "number", "minimum": 1 },
-                "time": { "type": "number", "minimum": 1 },
-                "duration": { "type": "number", "minimum": 1 },
-                "status": { "type": "number", "minimum": 1 },
-                "codeUnit": { "type": "number", "minimum": 1 },
-                "size": { "type": "number", "minimum": 1 },
-                "match": { "type": "number", "minimum": 1 }
+                "user": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "application": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "operation": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "time": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "duration": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "status": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "codeUnit": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "size": {
+                  "type": "number",
+                  "minimum": 1
+                },
+                "match": {
+                  "type": "number",
+                  "minimum": 1
+                }
               }
             }
           }
@@ -406,6 +456,8 @@
     "test:webview:watch": "npm run test:webview -- --watch",
     "test:ci": "npm run test:unit:ci && npm run test:integration:ci",
     "test:smoke:vsix": "node scripts/run-tests.js --scope=unit --smoke-vsix",
+    "pretest:e2e": "npm run build",
+    "test:e2e": "node scripts/run-playwright-e2e.js",
     "format": "prettier --write .",
     "prepare": "husky",
     "tailwind:build": "tailwindcss -c tailwind.config.js -i ./src/webview/styles/tailwind.css -o ./media/webview.css --minify",
@@ -417,6 +469,7 @@
   "devDependencies": {
     "@commitlint/cli": "^20.2.0",
     "@commitlint/config-conventional": "^20.2.0",
+    "@playwright/test": "^1.58.2",
     "@tailwindcss/cli": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.1",

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -13,6 +13,7 @@
   "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page (effective maximum: 200). Higher values fetch more per request but may slow the UI or increase API load.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",
   "configuration.electivus.apexLogs.saveDirName.description": "Folder under the workspace where Apex logs are saved. If empty, the extension will auto-detect an existing 'apexlog' folder or use 'apexlogs'.",
+  "configuration.electivus.apexLogs.cliPath.description": "Optional absolute path to the Salesforce CLI binary ('sf'). Set this when VS Code can't find 'sf' on PATH (common when VS Code is launched from the OS GUI instead of a terminal).",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Lines kept in the Tail view's rolling buffer. Larger buffers use more memory and CPU.",
   "configuration.electivus.apexLogs.cliCache.enabled.description": "Enable persistent caching for Salesforce CLI calls (org list, etc.).",
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL in seconds for cached results of 'sf org list'. Set 0 to disable. Large TTLs keep results longer but may be stale.",

--- a/apps/vscode-extension/package.nls.pt-br.json
+++ b/apps/vscode-extension/package.nls.pt-br.json
@@ -13,6 +13,7 @@
   "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página (máximo efetivo: 200). Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",
   "configuration.electivus.apexLogs.saveDirName.description": "Pasta dentro do workspace onde os logs Apex são salvos. Se vazio, a extensão tenta detectar uma pasta existente 'apexlog' ou usa 'apexlogs'.",
+  "configuration.electivus.apexLogs.cliPath.description": "Caminho absoluto opcional para o binário do Salesforce CLI ('sf'). Use quando o VS Code não consegue encontrar 'sf' no PATH (comum ao abrir o VS Code pela interface gráfica do sistema, em vez de um terminal).",
   "configuration.electivus.apexLogs.tailBufferSize.description": "Quantidade de linhas mantidas no buffer do Tail. Buffers maiores consomem mais memória e CPU.",
   "configuration.electivus.apexLogs.cliCache.enabled.description": "Ativa cache persistente para chamadas do Salesforce CLI (lista de orgs, etc.).",
   "configuration.electivus.apexLogs.cliCache.orgListTtlSeconds.description": "TTL em segundos para o cache do resultado de 'sf org list'. Defina 0 para desativar. TTLs grandes mantêm resultados por mais tempo, porém podem ficar desatualizados.",

--- a/apps/vscode-extension/playwright.config.ts
+++ b/apps/vscode-extension/playwright.config.ts
@@ -1,0 +1,27 @@
+import path from 'path';
+import { defineConfig } from '@playwright/test';
+
+const repoRoot = path.join(__dirname, '..', '..');
+const artifactsRoot = path.join(repoRoot, 'output', 'playwright');
+
+export default defineConfig({
+  testDir: path.join(__dirname, 'test', 'e2e', 'specs'),
+  fullyParallel: false,
+  workers: 1,
+  timeout: 15 * 60 * 1000,
+  expect: { timeout: 60 * 1000 },
+  retries: process.env.CI ? 1 : 0,
+  outputDir: artifactsRoot,
+  reporter: process.env.CI
+    ? [
+        ['list'],
+        ['html', { open: 'never', outputFolder: path.join(artifactsRoot, 'report') }]
+      ]
+    : [['list']],
+  use: {
+    trace: 'retain-on-failure',
+    video: 'retain-on-failure',
+    screenshot: 'only-on-failure'
+  }
+});
+

--- a/apps/vscode-extension/playwright.config.ts
+++ b/apps/vscode-extension/playwright.config.ts
@@ -3,6 +3,7 @@ import { defineConfig } from '@playwright/test';
 
 const repoRoot = path.join(__dirname, '..', '..');
 const artifactsRoot = path.join(repoRoot, 'output', 'playwright');
+const resultsRoot = path.join(artifactsRoot, 'test-results');
 
 export default defineConfig({
   testDir: path.join(__dirname, 'test', 'e2e', 'specs'),
@@ -11,7 +12,7 @@ export default defineConfig({
   timeout: 15 * 60 * 1000,
   expect: { timeout: 60 * 1000 },
   retries: process.env.CI ? 1 : 0,
-  outputDir: artifactsRoot,
+  outputDir: resultsRoot,
   reporter: process.env.CI
     ? [
         ['list'],
@@ -24,4 +25,3 @@ export default defineConfig({
     screenshot: 'only-on-failure'
   }
 });
-

--- a/apps/vscode-extension/scripts/run-playwright-e2e.js
+++ b/apps/vscode-extension/scripts/run-playwright-e2e.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+'use strict';
+
+const { execFile, spawn } = require('child_process');
+const { platform } = require('os');
+const path = require('path');
+
+function execFileAsync(file, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        const err = new Error(stderr || error.message || 'exec failed');
+        err.code = error.code;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+async function main() {
+  // Some environments leak ELECTRON_RUN_AS_NODE=1; VS Code won't boot properly.
+  try {
+    delete process.env.ELECTRON_RUN_AS_NODE;
+  } catch {}
+
+  // Re-exec under Xvfb when DISPLAY is missing on Linux.
+  if (platform() === 'linux' && !process.env.DISPLAY && !process.env.__ALV_XVFB_RAN) {
+    try {
+      await execFileAsync('bash', ['-lc', 'command -v xvfb-run >/dev/null 2>&1']);
+      const child = spawn(
+        'xvfb-run',
+        ['-a', '-s', '-screen 0 1280x1024x24', process.execPath, __filename, ...process.argv.slice(2)],
+        {
+          stdio: 'inherit',
+          env: { ...process.env, __ALV_XVFB_RAN: '1' }
+        }
+      );
+      child.on('exit', code => process.exit(code ?? 0));
+      return;
+    } catch {
+      // no xvfb-run; continue and let Electron try (may fail)
+    }
+  }
+
+  const repoRoot = path.join(__dirname, '..');
+  const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
+  const args = ['playwright', 'test', ...process.argv.slice(2)];
+  const child = spawn(cmd, args, { stdio: 'inherit', cwd: repoRoot, env: process.env });
+  child.on('exit', code => process.exit(code ?? 0));
+}
+
+main().catch(err => {
+  console.error('[e2e] Failed to run Playwright E2E tests:', err && err.message ? err.message : err);
+  process.exit(1);
+});
+

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -125,8 +125,14 @@ export async function activate(context: vscode.ExtensionContext) {
   );
 
   context.subscriptions.push(
-    vscode.commands.registerCommand('sfLogs.refresh', () => {
+    vscode.commands.registerCommand('sfLogs.refresh', async () => {
       safeSendEvent('command.refresh');
+      try {
+        await vscode.commands.executeCommand('workbench.view.extension.salesforceLogsPanel');
+        await vscode.commands.executeCommand('workbench.viewsService.openView', 'sfLogViewer');
+      } catch (e) {
+        logWarn('Command sfLogs.refresh: failed to open logs view ->', getErrorMessage(e));
+      }
       return provider.refresh();
     })
   );

--- a/apps/vscode-extension/src/test/listOrgs.persistent-fallback.test.ts
+++ b/apps/vscode-extension/src/test/listOrgs.persistent-fallback.test.ts
@@ -27,6 +27,7 @@ function loadCliWithStubs(params: {
   const cli = proxyquire('../salesforce/cli', {
     '../utils/cacheManager': { CacheManager, '@noCallThru': true },
     '../utils/config': {
+      getConfig: (_key: string, def: unknown) => def,
       getBooleanConfig: () => true,
       getNumberConfig: (_key: string, def: number) => def,
       '@noCallThru': true

--- a/apps/vscode-extension/test/e2e/fixtures/alvE2E.ts
+++ b/apps/vscode-extension/test/e2e/fixtures/alvE2E.ts
@@ -1,0 +1,64 @@
+import path from 'node:path';
+import { test as base, expect, type Page } from '@playwright/test';
+import type { ElectronApplication } from 'playwright';
+import { ensureScratchOrg } from '../utils/scratchOrg';
+import { seedApexLog } from '../utils/seedLog';
+import { resolveSfCliInvocation } from '../utils/sfCli';
+import { createTempWorkspace } from '../utils/tempWorkspace';
+import { launchVsCode } from '../utils/vscode';
+
+type SeededLog = {
+  marker: string;
+  logId: string;
+};
+
+type Fixtures = {
+  scratchAlias: string;
+  seededLog: SeededLog;
+  workspacePath: string;
+  vscodeApp: ElectronApplication;
+  vscodePage: Page;
+};
+
+export const test = base.extend<Fixtures>({
+  scratchAlias: async ({}, use) => {
+    const scratch = await ensureScratchOrg();
+    try {
+      await use(scratch.scratchAlias);
+    } finally {
+      await scratch.cleanup();
+    }
+  },
+
+  seededLog: async ({ scratchAlias }, use) => {
+    const seeded = await seedApexLog(scratchAlias);
+    await use(seeded);
+  },
+
+  workspacePath: async ({ scratchAlias }, use) => {
+    const sfCli = await resolveSfCliInvocation();
+    const ws = await createTempWorkspace({ targetOrg: scratchAlias, sfCli: sfCli ?? undefined });
+    try {
+      await use(ws.workspacePath);
+    } finally {
+      await ws.cleanup();
+    }
+  },
+
+  vscodeApp: async ({ workspacePath }, use) => {
+    const extensionDevelopmentPath = path.join(__dirname, '..', '..', '..');
+    const launch = await launchVsCode({ workspacePath, extensionDevelopmentPath });
+    try {
+      await use(launch.app);
+    } finally {
+      await launch.cleanup();
+    }
+  },
+
+  vscodePage: async ({ vscodeApp }, use) => {
+    const page = await vscodeApp.firstWindow();
+    await use(page);
+  }
+});
+
+export { expect };

--- a/apps/vscode-extension/test/e2e/specs/openLogViewer.e2e.spec.ts
+++ b/apps/vscode-extension/test/e2e/specs/openLogViewer.e2e.spec.ts
@@ -1,0 +1,45 @@
+import { test, expect } from '../fixtures/alvE2E';
+import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { waitForWebviewFrame } from '../utils/webviews';
+
+test('opens the seeded Apex log in the Log Viewer panel', async ({ vscodePage, seededLog }) => {
+  // Activate the extension by running a contributed command.
+  // (The command will be updated to ensure the Logs view is visible.)
+  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+
+  // VS Code webviews often load their actual content in a child frame hosted on
+  // a `.../fake.html?...` URL. Grab that frame first, then wait for log rows.
+  const logsFrame = await waitForWebviewFrame(
+    vscodePage,
+    async frame => /\/fake\.html\?id=/i.test(frame.url()),
+    { timeoutMs: 180_000 }
+  );
+
+  await expect
+    .poll(() => logsFrame.locator('[role="row"][tabindex="0"]').count(), { timeout: 180_000 })
+    .toBeGreaterThan(0);
+
+  // Select the first row and press Enter to open (LogRow binds Enter/Space to open).
+  const firstRow = logsFrame.locator('[role="row"][tabindex="0"]').first();
+  await firstRow.click();
+  await firstRow.press('Enter');
+
+  // Find the Log Viewer panel webview by its stable header text.
+  const viewerFrame = await waitForWebviewFrame(
+    vscodePage,
+    async frame => await frame.locator('text=Apex Log Viewer').first().isVisible(),
+    { timeoutMs: 180_000 }
+  );
+
+  await expect(viewerFrame.locator('text=Apex Log Viewer').first()).toBeVisible();
+
+  // The header shows the file name; it should include the seeded log id (e.g., 07L...log).
+  await expect(viewerFrame.locator(`text=${seededLog.logId}`).first()).toBeVisible({ timeout: 60_000 });
+
+  // Use the built-in search to ensure the marker is present in the parsed entries.
+  const searchInput = viewerFrame.locator('input[placeholder=\"Search entries…\"]');
+  await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+  await searchInput.fill(seededLog.marker);
+  await expect(viewerFrame.locator(`text=${seededLog.marker}`).first()).toBeVisible({ timeout: 60_000 });
+});

--- a/apps/vscode-extension/test/e2e/utils/commandPalette.ts
+++ b/apps/vscode-extension/test/e2e/utils/commandPalette.ts
@@ -1,0 +1,96 @@
+import type { Page } from '@playwright/test';
+
+function getModifierKey(): 'Control' | 'Meta' {
+  return process.platform === 'darwin' ? 'Meta' : 'Control';
+}
+
+async function openQuickOpen(page: Page): Promise<void> {
+  const modifier = getModifierKey();
+  await page.keyboard.press(`${modifier}+P`);
+
+  const input = page.locator('div.quick-input-widget input');
+  await input.waitFor({ state: 'visible', timeout: 15_000 });
+}
+
+function noMatchingResults(widget: ReturnType<Page['locator']>) {
+  return widget.getByText('No matching results', { exact: true });
+}
+
+export async function runCommand(page: Page, command: string): Promise<void> {
+  await openQuickOpen(page);
+  const widget = page.locator('div.quick-input-widget');
+  const input = widget.locator('input');
+  const query = command.trim().startsWith('>') ? command.trim() : `> ${command}`;
+  await input.fill(query);
+  await page.waitForTimeout(50);
+
+  const noMatches = noMatchingResults(widget);
+  if (await noMatches.isVisible()) {
+    await page.keyboard.press('Escape');
+    throw new Error(`Command not found in palette: "${command}"`);
+  }
+
+  await page.keyboard.press('Enter');
+}
+
+export async function waitForCommandAvailable(
+  page: Page,
+  query: string,
+  options?: { timeoutMs?: number }
+): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 60_000;
+  const deadline = Date.now() + timeoutMs;
+
+  while (Date.now() < deadline) {
+    await openQuickOpen(page);
+    const widget = page.locator('div.quick-input-widget');
+    const input = widget.locator('input');
+    const q = query.trim().startsWith('>') ? query.trim() : `> ${query}`;
+    await input.fill(q);
+    await page.waitForTimeout(50);
+    const noMatches = noMatchingResults(widget);
+    const ok = !(await noMatches.isVisible());
+    await page.keyboard.press('Escape');
+    if (ok) {
+      return;
+    }
+    await page.waitForTimeout(500);
+  }
+  throw new Error(`Timed out waiting for command to appear in palette: "${query}"`);
+}
+
+export async function executeCommandId(page: Page, commandId: string): Promise<void> {
+  await runCommand(page, 'Developer: Execute Command...');
+
+  const widget = page.locator('div.quick-input-widget');
+  const input = widget.locator('input');
+  await input.waitFor({ state: 'visible', timeout: 15_000 });
+  await input.fill(commandId);
+  await page.waitForTimeout(50);
+
+  const noMatches = noMatchingResults(widget);
+  if (await noMatches.isVisible()) {
+    await page.keyboard.press('Escape');
+    throw new Error(`Command id not found: "${commandId}"`);
+  }
+
+  await page.keyboard.press('Enter');
+}
+
+export async function openView(page: Page, viewName: string): Promise<void> {
+  await runCommand(page, 'View: Open View...');
+
+  const widget = page.locator('div.quick-input-widget');
+  const input = widget.locator('input');
+  await input.waitFor({ state: 'visible', timeout: 15_000 });
+  await input.fill(viewName);
+  await page.waitForTimeout(50);
+
+  const noMatches = noMatchingResults(widget);
+  if (await noMatches.isVisible()) {
+    await page.keyboard.press('Escape');
+    throw new Error(`View not found in picker: "${viewName}"`);
+  }
+
+  await page.keyboard.press('Enter');
+}

--- a/apps/vscode-extension/test/e2e/utils/scratchOrg.ts
+++ b/apps/vscode-extension/test/e2e/utils/scratchOrg.ts
@@ -1,0 +1,128 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { runSfJson } from './sfCli';
+
+type ScratchOrgResult = {
+  devHubAlias: string;
+  scratchAlias: string;
+  created: boolean;
+  cleanup: () => Promise<void>;
+};
+
+function envFlag(name: string): boolean {
+  return /^1|true$/i.test(String(process.env[name] || ''));
+}
+
+async function tryOrgDisplay(alias: string): Promise<boolean> {
+  try {
+    await runSfJson(['org', 'display', '-o', alias]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function resolveDefaultDevHubAlias(): Promise<string> {
+  if (process.env.SF_DEVHUB_ALIAS) {
+    return String(process.env.SF_DEVHUB_ALIAS).trim();
+  }
+  if (process.env.SF_DEVHUB_AUTH_URL) {
+    return 'DevHub';
+  }
+
+  // Local convenience: prefer the project team's DevHub alias if present.
+  const preferred = 'InsuranceOrgTrialCreme6DevHub';
+  if (await tryOrgDisplay(preferred)) {
+    return preferred;
+  }
+  return 'DevHub';
+}
+
+async function ensureDevHubAuth(devHubAlias: string): Promise<void> {
+  const authUrl = String(process.env.SF_DEVHUB_AUTH_URL || '').trim();
+  if (!authUrl) {
+    // Assume already authenticated locally; surface a helpful error if not.
+    const ok = await tryOrgDisplay(devHubAlias);
+    if (!ok) {
+      throw new Error(
+        `Dev Hub not found. Set SF_DEVHUB_ALIAS (current: '${devHubAlias}') or provide SF_DEVHUB_AUTH_URL to authenticate in CI.`
+      );
+    }
+    return;
+  }
+
+  const dir = await mkdtemp(path.join(tmpdir(), 'alv-devhub-'));
+  const filePath = path.join(dir, 'devhub.sfdxurl');
+  await writeFile(filePath, authUrl, 'utf8');
+  try {
+    await runSfJson(['org', 'login', 'sfdx-url', '--sfdx-url-file', filePath, '--alias', devHubAlias]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
+  const devHubAlias = await resolveDefaultDevHubAlias();
+  await ensureDevHubAuth(devHubAlias);
+
+  const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
+  const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
+  const keep = envFlag('SF_TEST_KEEP_ORG');
+
+  // Reuse existing scratch org when possible to make local runs faster.
+  const alreadyExists = await tryOrgDisplay(scratchAlias);
+  if (alreadyExists) {
+    return {
+      devHubAlias,
+      scratchAlias,
+      created: false,
+      cleanup: async () => {}
+    };
+  }
+
+  const tmp = await mkdtemp(path.join(tmpdir(), 'alv-scratch-'));
+  const defFile = path.join(tmp, 'project-scratch-def.json');
+  const def = {
+    orgName: 'apex-log-viewer-e2e',
+    edition: 'Developer',
+    hasSampleData: false
+  };
+  await writeFile(defFile, JSON.stringify(def), 'utf8');
+
+  await runSfJson([
+    'org',
+    'create',
+    'scratch',
+    '--target-dev-hub',
+    devHubAlias,
+    '--alias',
+    scratchAlias,
+    '--definition-file',
+    defFile,
+    '--duration-days',
+    String(durationDays),
+    '--wait',
+    '15'
+  ]);
+
+  await rm(tmp, { recursive: true, force: true });
+
+  const cleanup = async () => {
+    if (keep) {
+      return;
+    }
+    try {
+      await runSfJson(['org', 'delete', 'scratch', '-o', scratchAlias, '--no-prompt']);
+    } catch {
+      // Best-effort cleanup.
+    }
+  };
+
+  return {
+    devHubAlias,
+    scratchAlias,
+    created: true,
+    cleanup
+  };
+}

--- a/apps/vscode-extension/test/e2e/utils/scratchOrg.ts
+++ b/apps/vscode-extension/test/e2e/utils/scratchOrg.ts
@@ -11,7 +11,10 @@ type ScratchOrgResult = {
 };
 
 function envFlag(name: string): boolean {
-  return /^1|true$/i.test(String(process.env[name] || ''));
+  const value = String(process.env[name] || '')
+    .trim()
+    .toLowerCase();
+  return value === '1' || value === 'true';
 }
 
 async function tryOrgDisplay(alias: string): Promise<boolean> {

--- a/apps/vscode-extension/test/e2e/utils/seedLog.ts
+++ b/apps/vscode-extension/test/e2e/utils/seedLog.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { runSfJson } from './sfCli';
+import { ensureE2eTraceFlag, getOrgAuth } from './tooling';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+type SeedResult = {
+  marker: string;
+  logId: string;
+};
+
+function parseLogIds(listResult: any): string[] {
+  const rows = listResult?.result || listResult?.records || listResult;
+  if (!Array.isArray(rows)) {
+    return [];
+  }
+  return rows.map((r: any) => r?.Id).filter((v: any): v is string => typeof v === 'string' && v.length > 0);
+}
+
+export async function seedApexLog(targetOrg: string): Promise<SeedResult> {
+  const auth = await getOrgAuth(targetOrg);
+  await ensureE2eTraceFlag(auth);
+
+  const before = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
+  const beforeIds = new Set(parseLogIds(before));
+
+  const marker = `ALV_E2E_MARKER_${Date.now()}`;
+  const tmp = await mkdtemp(path.join(tmpdir(), 'alv-apex-'));
+  const apexFile = path.join(tmp, 'seed.apex');
+  await writeFile(apexFile, `System.debug('${marker}');\n`, 'utf8');
+
+  try {
+    await runSfJson(['apex', 'run', '-o', targetOrg, '--file', apexFile]);
+  } finally {
+    await rm(tmp, { recursive: true, force: true });
+  }
+
+  const deadline = Date.now() + 45_000;
+  while (Date.now() < deadline) {
+    const after = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
+    const afterIds = parseLogIds(after);
+    const created = afterIds.find(id => !beforeIds.has(id));
+    if (created) {
+      return { marker, logId: created };
+    }
+    await sleep(2_000);
+  }
+
+  throw new Error('Failed to detect a newly created ApexLog after seeding anonymous Apex.');
+}
+

--- a/apps/vscode-extension/test/e2e/utils/sfCli.ts
+++ b/apps/vscode-extension/test/e2e/utils/sfCli.ts
@@ -1,0 +1,101 @@
+import { execFile } from 'node:child_process';
+
+export type ExecOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  timeoutMs?: number;
+};
+
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+};
+
+function sfBin(): string {
+  return process.platform === 'win32' ? 'sf.cmd' : 'sf';
+}
+
+export function getSfBinPath(): string {
+  return sfBin();
+}
+
+export async function resolveSfBinAbsolutePath(): Promise<string | undefined> {
+  try {
+    if (process.platform === 'win32') {
+      const { stdout } = await execFileAsync('cmd.exe', ['/d', '/s', '/c', 'where sf'], { timeoutMs: 10_000 });
+      const first = String(stdout || '')
+        .split(/\r?\n/)
+        .map(l => l.trim())
+        .filter(Boolean)[0];
+      return first || undefined;
+    }
+    const { stdout } = await execFileAsync('bash', ['-lc', 'command -v sf'], { timeoutMs: 10_000 });
+    const resolved = String(stdout || '').trim();
+    return resolved || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export async function resolveSfCliInvocation(): Promise<{ sfBinPath: string; nodeBinPath: string } | undefined> {
+  const sfBinPath = await resolveSfBinAbsolutePath();
+  if (!sfBinPath) {
+    return undefined;
+  }
+  // Prefer the Node binary used to run the E2E tests. This is usually more reliable
+  // than assuming `node` is available on PATH inside the VS Code extension host.
+  const nodeBinPath = process.execPath;
+  return { sfBinPath, nodeBinPath };
+}
+
+export function execFileAsync(file: string, args: string[], options: ExecOptions = {}): Promise<ExecResult> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        cwd: options.cwd,
+        env: options.env,
+        encoding: 'utf8',
+        timeout: options.timeoutMs,
+        maxBuffer: 1024 * 1024 * 20
+      },
+      (error, stdout, stderr) => {
+        if (error) {
+          // Avoid echoing stdout/stderr to prevent leaking auth tokens.
+          const msg = `Command failed: ${file} ${args.join(' ')}`.trim();
+          const err = new Error(msg) as Error & { code?: unknown };
+          (err as any).code = (error as any).code;
+          reject(err);
+          return;
+        }
+        resolve({ stdout: String(stdout || ''), stderr: String(stderr || '') });
+      }
+    );
+  });
+}
+
+export async function runSfJson(args: string[], options: ExecOptions = {}): Promise<any> {
+  const withJson = args.includes('--json') ? args : [...args, '--json'];
+  const { stdout } = await execFileAsync(getSfBinPath(), withJson, options);
+  const raw = String(stdout || '').trim();
+  if (!raw) {
+    throw new Error(`Empty JSON output from sf ${withJson.join(' ')}`.trim());
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    // Some CLI/plugin combinations may print non-JSON noise before/after JSON.
+    const cleaned = raw.replace(/\u001b\[[0-9;]*m/g, '');
+    const start = cleaned.indexOf('{');
+    const end = cleaned.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      try {
+        return JSON.parse(cleaned.slice(start, end + 1));
+      } catch {
+        // fall through
+      }
+    }
+    throw new Error(`Invalid JSON output from sf ${withJson.join(' ')}`.trim());
+  }
+}

--- a/apps/vscode-extension/test/e2e/utils/tempWorkspace.ts
+++ b/apps/vscode-extension/test/e2e/utils/tempWorkspace.ts
@@ -1,0 +1,65 @@
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+
+export type TempWorkspace = {
+  workspacePath: string;
+  cleanup: () => Promise<void>;
+};
+
+export async function createTempWorkspace(options: {
+  targetOrg: string;
+  sfCli?: { sfBinPath: string; nodeBinPath: string };
+}): Promise<TempWorkspace> {
+  const workspacePath = await mkdtemp(path.join(tmpdir(), 'alv-e2e-ws-'));
+
+  const proj = {
+    packageDirectories: [{ path: 'force-app', default: true }],
+    name: 'apex-log-viewer-e2e',
+    namespace: '',
+    sfdcLoginUrl: 'https://login.salesforce.com',
+    sourceApiVersion: String(process.env.SF_TEST_API_VERSION || '60.0')
+  };
+  await writeFile(path.join(workspacePath, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
+  await mkdir(path.join(workspacePath, 'force-app'), { recursive: true });
+
+  const sfDir = path.join(workspacePath, '.sf');
+  await mkdir(sfDir, { recursive: true });
+  await writeFile(path.join(sfDir, 'config.json'), JSON.stringify({ 'target-org': options.targetOrg }, null, 2), 'utf8');
+
+  // Ensure the extension host can locate the Salesforce CLI even when VS Code
+  // is launched in an environment with a minimal PATH.
+  if (options.sfCli?.sfBinPath) {
+    const vscodeDir = path.join(workspacePath, '.vscode');
+    await mkdir(vscodeDir, { recursive: true });
+
+    let cliPath = options.sfCli.sfBinPath;
+    // On Unix-like systems, wrap `sf` so it can find `node` even if VS Code
+    // starts with a minimal PATH.
+    if (process.platform !== 'win32' && options.sfCli.nodeBinPath) {
+      const wrapperPath = path.join(vscodeDir, 'sf-cli.sh');
+      const nodeDir = path.dirname(options.sfCli.nodeBinPath);
+      const script = [
+        '#!/bin/bash',
+        'set -euo pipefail',
+        `export PATH="${nodeDir}:$PATH"`,
+        `exec "${options.sfCli.sfBinPath}" "$@"`,
+        ''
+      ].join('\n');
+      await writeFile(wrapperPath, script, 'utf8');
+      await chmod(wrapperPath, 0o755);
+      cliPath = wrapperPath;
+    }
+    const settings = {
+      'electivus.apexLogs.cliPath': cliPath
+    };
+    await writeFile(path.join(vscodeDir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf8');
+  }
+
+  return {
+    workspacePath,
+    cleanup: async () => {
+      await rm(workspacePath, { recursive: true, force: true });
+    }
+  };
+}

--- a/apps/vscode-extension/test/e2e/utils/tooling.ts
+++ b/apps/vscode-extension/test/e2e/utils/tooling.ts
@@ -1,0 +1,153 @@
+import { runSfJson } from './sfCli';
+
+export type OrgAuth = {
+  accessToken: string;
+  instanceUrl: string;
+  username?: string;
+  apiVersion: string;
+};
+
+function getApiVersion(): string {
+  const v = String(process.env.SF_TEST_API_VERSION || process.env.SF_API_VERSION || '60.0').trim();
+  return /^\d+\.\d+$/.test(v) ? v : '60.0';
+}
+
+function stripTrailingSlash(value: string): string {
+  return value.replace(/\/+$/, '');
+}
+
+function escapeSoqlLiteral(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
+}
+
+function toSfDateTimeUTC(d: Date): string {
+  const pad = (n: number, w: number = 2) => String(n).padStart(w, '0');
+  return (
+    `${d.getUTCFullYear()}-` +
+    `${pad(d.getUTCMonth() + 1)}-` +
+    `${pad(d.getUTCDate())}T` +
+    `${pad(d.getUTCHours())}:` +
+    `${pad(d.getUTCMinutes())}:` +
+    `${pad(d.getUTCSeconds())}.` +
+    `${pad(d.getUTCMilliseconds(), 3)}+0000`
+  );
+}
+
+async function requestJson(
+  auth: OrgAuth,
+  method: string,
+  resourcePath: string,
+  body?: unknown
+): Promise<any> {
+  const base = stripTrailingSlash(auth.instanceUrl);
+  const url = `${base}${resourcePath}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    body: body === undefined ? undefined : JSON.stringify(body)
+  });
+  const text = await res.text();
+  if (!res.ok) {
+    throw new Error(`Tooling API request failed (${res.status}) for ${resourcePath}`);
+  }
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+export async function getOrgAuth(targetOrg: string): Promise<OrgAuth> {
+  const apiVersion = getApiVersion();
+  const display = await runSfJson(['org', 'display', '-o', targetOrg]);
+  const result = display?.result || display;
+  const accessToken: string | undefined = result?.accessToken || result?.access_token;
+  const instanceUrl: string | undefined = result?.instanceUrl || result?.instance_url || result?.loginUrl;
+  const username: string | undefined = result?.username;
+  if (!accessToken || !instanceUrl) {
+    throw new Error(`Failed to resolve org auth for '${targetOrg}' (missing accessToken/instanceUrl).`);
+  }
+  return {
+    accessToken,
+    instanceUrl,
+    username,
+    apiVersion
+  };
+}
+
+export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelName?: string; ttlMinutes?: number }) {
+  const debugLevelName = String(options?.debugLevelName || process.env.SF_E2E_DEBUG_LEVEL || 'ALV_E2E').trim();
+  const ttlMinutes = Math.max(5, Number(options?.ttlMinutes || process.env.SF_E2E_TRACE_TTL_MINUTES || 60) || 60);
+  if (!auth.username) {
+    throw new Error('Cannot ensure TraceFlag without org username.');
+  }
+
+  const apiVersion = auth.apiVersion;
+  const usernameEsc = escapeSoqlLiteral(auth.username);
+  const userSoql = encodeURIComponent(`SELECT Id FROM User WHERE Username = '${usernameEsc}' LIMIT 1`);
+  const userRes = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/query?q=${userSoql}`);
+  const userId: string | undefined = Array.isArray(userRes?.records) ? userRes.records[0]?.Id : undefined;
+  if (!userId) {
+    throw new Error('Failed to resolve current user id for TraceFlag setup.');
+  }
+
+  const dlEsc = escapeSoqlLiteral(debugLevelName);
+  const dlSoql = encodeURIComponent(`SELECT Id FROM DebugLevel WHERE DeveloperName = '${dlEsc}' LIMIT 1`);
+  const dlQuery = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${dlSoql}`);
+  let debugLevelId: string | undefined = Array.isArray(dlQuery?.records) ? dlQuery.records[0]?.Id : undefined;
+
+  if (!debugLevelId) {
+    const createRes = await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/DebugLevel`, {
+      DeveloperName: debugLevelName,
+      MasterLabel: debugLevelName,
+      ApexCode: 'DEBUG',
+      ApexProfiling: 'ERROR',
+      Callout: 'ERROR',
+      Database: 'ERROR',
+      System: 'DEBUG',
+      Validation: 'ERROR',
+      Visualforce: 'ERROR',
+      Workflow: 'ERROR'
+    });
+    if (!createRes?.success || !createRes?.id) {
+      throw new Error('Failed to create DebugLevel for E2E TraceFlag.');
+    }
+    debugLevelId = String(createRes.id);
+  }
+
+  const tfSoql = encodeURIComponent(
+    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
+  );
+  const tfQuery = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${tfSoql}`);
+  const existingTfId: string | undefined = Array.isArray(tfQuery?.records) ? tfQuery.records[0]?.Id : undefined;
+
+  const now = new Date();
+  const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
+  const exp = toSfDateTimeUTC(new Date(now.getTime() + ttlMinutes * 60 * 1000));
+
+  if (existingTfId) {
+    await requestJson(auth, 'PATCH', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag/${existingTfId}`, {
+      StartDate: start,
+      ExpirationDate: exp
+    });
+    return;
+  }
+
+  const createTf = await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag`, {
+    TracedEntityId: userId,
+    LogType: 'USER_DEBUG',
+    DebugLevelId: debugLevelId,
+    StartDate: start,
+    ExpirationDate: exp
+  });
+  if (!createTf?.success) {
+    throw new Error('Failed to create TraceFlag for E2E.');
+  }
+}
+

--- a/apps/vscode-extension/test/e2e/utils/vscode.ts
+++ b/apps/vscode-extension/test/e2e/utils/vscode.ts
@@ -1,0 +1,63 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import path from 'node:path';
+import { tmpdir } from 'node:os';
+import { downloadAndUnzipVSCode } from '@vscode/test-electron';
+import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
+
+export type VscodeLaunch = {
+  app: ElectronApplication;
+  page: Page;
+  userDataDir: string;
+  extensionsDir: string;
+  cleanup: () => Promise<void>;
+};
+
+function getVsCodeVersion(): string {
+  const v = String(process.env.VSCODE_TEST_VERSION || 'stable').trim();
+  return v || 'stable';
+}
+
+export async function launchVsCode(options: { workspacePath: string; extensionDevelopmentPath: string }): Promise<VscodeLaunch> {
+  const vscodeExecutablePath = await downloadAndUnzipVSCode(getVsCodeVersion());
+
+  const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
+  const extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
+
+  const args = [
+    options.workspacePath,
+    `--extensionDevelopmentPath=${options.extensionDevelopmentPath}`,
+    `--user-data-dir=${userDataDir}`,
+    `--extensions-dir=${extensionsDir}`,
+    '--disable-workspace-trust',
+    '--skip-welcome',
+    '--skip-release-notes',
+    '--disable-updates',
+    '--no-sandbox'
+  ];
+
+  const app = await electron.launch({
+    executablePath: vscodeExecutablePath,
+    args,
+    env: {
+      ...process.env,
+      ELECTRON_DISABLE_GPU: process.env.ELECTRON_DISABLE_GPU || '1',
+      LC_ALL: process.env.LC_ALL || 'C.UTF-8',
+      DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS || '/dev/null',
+      NO_AT_BRIDGE: process.env.NO_AT_BRIDGE || '1'
+    }
+  });
+
+  const page = await app.firstWindow();
+  await page.locator('.monaco-workbench').waitFor({ timeout: 120_000 });
+
+  const cleanup = async () => {
+    try {
+      await app.close();
+    } catch {}
+    await rm(userDataDir, { recursive: true, force: true });
+    await rm(extensionsDir, { recursive: true, force: true });
+  };
+
+  return { app, page, userDataDir, extensionsDir, cleanup };
+}
+

--- a/apps/vscode-extension/test/e2e/utils/webviews.ts
+++ b/apps/vscode-extension/test/e2e/utils/webviews.ts
@@ -1,0 +1,83 @@
+import type { Frame, Page } from '@playwright/test';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+export async function waitForWebviewFrame(
+  page: Page,
+  matcher: (frame: Frame) => Promise<boolean>,
+  options?: { timeoutMs?: number }
+): Promise<Frame> {
+  const timeoutMs = options?.timeoutMs ?? 120_000;
+  const deadline = Date.now() + timeoutMs;
+  let sawWebviews = false;
+
+  const tryFind = async (): Promise<Frame | undefined> => {
+    const allFrames = page.frames();
+    const main = page.mainFrame();
+    const webviewFrames = allFrames.filter(f => /vscode-webview|vscode-webview\.net/i.test(f.url()));
+    if (webviewFrames.length > 0) {
+      sawWebviews = true;
+    }
+    // VS Code webviews often have nested iframes where the outer frame URL matches
+    // vscode-webview*, but the actual content is hosted in a child frame (sometimes
+    // with an about:blank URL). Prefer webview frames, but still scan all non-main
+    // frames so we don't miss the content iframe.
+    const nonMainFrames = allFrames.filter(f => f !== main);
+    const frames = [...webviewFrames, ...nonMainFrames.filter(f => !webviewFrames.includes(f))];
+    for (const frame of frames) {
+      try {
+        if (await matcher(frame)) {
+          return frame;
+        }
+      } catch {
+        // ignore and continue polling
+      }
+    }
+    return undefined;
+  };
+
+  while (Date.now() < deadline) {
+    const found = await tryFind();
+    if (found) {
+      return found;
+    }
+    await sleep(250);
+  }
+
+  // One last attempt right after the timeout window, to avoid flaking when the
+  // webview finishes rendering between the final poll and the deadline check.
+  const found = await tryFind();
+  if (found) {
+    return found;
+  }
+
+  // Best-effort diagnostics to make CI failures actionable.
+  try {
+    const main = page.mainFrame();
+    const frames = page.frames().filter(f => f !== main);
+    const lines: string[] = [];
+    for (const frame of frames.slice(0, 25)) {
+      const url = frame.url();
+      const shortUrl = url.length > 180 ? `${url.slice(0, 180)}…` : url;
+      const isWebview = /vscode-webview|vscode-webview\.net/i.test(url);
+      const rowCount = await frame.locator('[role="row"]').count().catch(() => -1);
+      const hasRefresh = await frame.locator('text=Refresh').count().catch(() => -1);
+      if (isWebview || rowCount > 0 || hasRefresh > 0) {
+        lines.push(`- url=${shortUrl} webview=${String(isWebview)} rows=${String(rowCount)} refreshText=${String(hasRefresh)}`);
+      }
+    }
+    if (lines.length) {
+      throw new Error(
+        `${sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.'}\n` +
+          `Frame diagnostics:\n${lines.join('\n')}`
+      );
+    }
+  } catch (e) {
+    if (e instanceof Error) {
+      throw e;
+    }
+  }
+  throw new Error(sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.');
+}

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -8,6 +8,7 @@ This project uses VS Code integration tests (Mocha running inside the Extension 
 - `npm run test:unit`: fast path; runs Jest first and then the VS Code-hosted unit scope.
 - `npm run test:integration`: installs dependency extensions if needed and runs integration tests.
 - `npm run test:all`: runs the Jest webview suites, then both unit and integration scopes.
+- `npm run ext:test:e2e`: runs Playwright E2E tests against a real scratch org (creates a scratch org + seeds an Apex log).
 
 The test orchestrator lives in `scripts/run-tests.js` and the Mocha programmatic runner in `src/test/runner.ts`.
 
@@ -36,12 +37,41 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 
 Tests do not require an authenticated org by default. If you want the runner to authenticate a Dev Hub and create a scratch org automatically:
 
-- `SF_DEVHUB_AUTH_URL`: SFDX URL for the Dev Hub auth (or `SFDX_AUTH_URL`).
+- `SF_DEVHUB_AUTH_URL`: SFDX URL for the Dev Hub auth.
 - `SF_DEVHUB_ALIAS`: Alias for the Dev Hub (default `DevHub`).
 - `SF_SETUP_SCRATCH=1`: Enables scratch org creation when a Dev Hub is available.
 - `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_Test_Scratch`).
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Skip deleting the scratch org during cleanup.
+
+## Playwright E2E (real org)
+
+The Playwright suite validates the webview UX end-to-end by:
+
+1. Authenticating a Dev Hub (CI via `SF_DEVHUB_AUTH_URL`, local via an existing auth)
+2. Creating/reusing a scratch org
+3. Seeding an Apex log (anonymous Apex with a unique marker)
+4. Launching VS Code and verifying the Logs panel + Log Viewer show that log
+
+### Run locally
+
+From the repo root:
+
+- `SF_TEST_KEEP_ORG=1 npm run ext:test:e2e`
+
+Useful env vars:
+
+- `SF_DEVHUB_AUTH_URL`: Optional locally; required in CI. If not set, the E2E suite assumes you already have a Dev Hub authenticated locally.
+- `SF_DEVHUB_ALIAS`: Dev Hub alias to use. If unset, local runs prefer `InsuranceOrgTrialCreme6DevHub` when available.
+- `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_E2E_Scratch`).
+- `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
+- `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).
+
+Troubleshooting:
+
+- If the Logs panel shows **“Salesforce CLI not found”**, set the VS Code setting `electivus.apexLogs.cliPath` to the absolute path of your `sf` executable.
+
+Artifacts (screenshots/traces/videos on failure) are written under `output/playwright/`.
 
 ## Debugging
 

--- a/docs/plans/2026-02-17-playwright-e2e-real-org-design.md
+++ b/docs/plans/2026-02-17-playwright-e2e-real-org-design.md
@@ -1,0 +1,160 @@
+# Playwright VS Code E2E (Real Scratch Org) — Design
+
+Date: 2026-02-17
+
+## Goal
+
+Add end-to-end (E2E) tests for the VS Code extension that:
+
+- Drive **real VS Code (Electron)** via **Playwright**
+- Use a **real Salesforce scratch org** for validation
+- Create the scratch org locally using the DevHub alias **`InsuranceOrgTrialCreme6DevHub`**
+- Support running the same E2E suite in CI using a GitHub Actions secret **`SF_DEVHUB_AUTH_URL`**
+
+The first must-pass scenario is:
+
+1. Provision scratch org (or reuse it)
+2. Seed a deterministic Apex log (unique marker)
+3. Launch VS Code with the extension under test
+4. Open the **Electivus Apex Logs** panel
+5. Click **Open** on the newest log row
+6. Assert the **Apex Log Viewer** webview renders and shows expected content
+
+## Non-goals (initial scope)
+
+- Testing Apex Replay Debugger integration (depends on Salesforce extensions; more brittle)
+- Testing Tail Logs (long-running, streaming; separate scenario)
+- Running E2E as part of the default `CI` workflow for every PR/push (secrets + flake risk)
+
+## Current state
+
+The repository already has:
+
+- Webview unit tests via Jest (`apps/vscode-extension/src/webview/__tests__`)
+- VS Code-hosted unit/integration tests via `@vscode/test-electron` and a custom runner (`apps/vscode-extension/scripts/run-tests.js`)
+- Optional DevHub + scratch org setup logic in test runner (env-driven)
+
+However, there is no Playwright-based E2E coverage that validates the full UX from the actual VS Code UI into our webviews.
+
+## Approach (recommended)
+
+Build a minimal, in-repo Playwright **desktop Electron** harness using `@playwright/test`:
+
+- Download VS Code with `@vscode/test-electron` (cached)
+- Launch VS Code as an Electron app using Playwright `_electron.launch(...)`
+- Create an isolated, temporary workspace directory containing:
+  - `sfdx-project.json` (with `sourceApiVersion`)
+  - `.sf/config.json` pointing `target-org` at the scratch org alias
+- Provision a scratch org (or reuse an existing alias) and seed a deterministic debug log
+- Drive VS Code UI:
+  - Use Command Palette to open the **Electivus Apex Logs** panel
+  - Interact with the Logs list webview and click the **Open** action
+  - Validate the Log Viewer webview renders expected content
+
+This intentionally avoids bringing in an external E2E harness dependency; we copy only the patterns we need.
+
+## Scratch org provisioning
+
+### Inputs
+
+The E2E runner will support these environment variables:
+
+- `SF_DEVHUB_ALIAS`
+  - Local default: `InsuranceOrgTrialCreme6DevHub`
+  - CI default: `DevHub` (after auth via `SF_DEVHUB_AUTH_URL`)
+- `SF_DEVHUB_AUTH_URL` (CI secret): SFDX auth URL for the Dev Hub
+- `SF_SCRATCH_ALIAS` (default `ALV_E2E_Scratch`; CI will use a unique alias per run)
+- `SF_SCRATCH_DURATION` (default `1`)
+- `SF_TEST_KEEP_ORG=1` (skip deletion)
+
+### Behavior
+
+- If `SF_DEVHUB_AUTH_URL` is set, authenticate the DevHub in a throwaway manner for the test run:
+  - `sf org login sfdx-url --sfdx-url-file <file> --alias <SF_DEVHUB_ALIAS> --set-default-dev-hub --json`
+- If the scratch alias already exists (`sf org display -o <alias> --json`), reuse it.
+- Otherwise create it:
+  - `sf org create scratch --target-dev-hub <SF_DEVHUB_ALIAS> --alias <SF_SCRATCH_ALIAS> --duration-days <n> --wait 15 --json`
+- Delete the scratch org at the end unless `SF_TEST_KEEP_ORG=1` is set.
+
+We avoid mutating the developer’s global default org except where the CLI requires a default dev hub during a CI run.
+
+## Seeding a deterministic Apex log
+
+We need a reliable way to guarantee at least one recent ApexLog row exists.
+
+### Steps
+
+1. List existing logs **before**:
+   - `sf apex list log -o <scratchAlias> --json`
+2. Ensure debug logging is enabled for the current user:
+   - Create/update Tooling API `TraceFlag` for `USER_DEBUG` with a known `DebugLevel`
+   - This will be implemented in Node using the same Tooling API primitives the extension already uses (`apps/vscode-extension/src/salesforce/traceflags.ts`)
+3. Run anonymous Apex containing a unique marker:
+   - `System.debug('ALV_E2E_MARKER_<timestamp>');`
+   - via `sf apex run -o <scratchAlias> --file <tmp.apex>`
+4. List logs **after** and select the newest ID not present in the “before” set.
+5. Store `seededLogId` for assertions.
+
+This avoids needing to deploy metadata and keeps E2E runs relatively quick.
+
+## VS Code UI automation details
+
+### Launching VS Code
+
+- Download VS Code with `@vscode/test-electron` into `apps/vscode-extension/.vscode-test/`
+- Launch via Playwright Electron with:
+  - `--extensionDevelopmentPath=<apps/vscode-extension>`
+  - isolated `--user-data-dir` and `--extensions-dir` under the temp workspace
+  - `--disable-workspace-trust`
+  - `--no-sandbox`
+  - open the temp workspace folder
+
+### Opening the extension UI
+
+- Use Command Palette (F1) with retry logic (focus is flaky on Windows)
+- Prefer command: `View: Show Electivus Apex Logs`
+- Provide fallbacks if needed:
+  - `View: Open View...` → select `Electivus Apex Logs`
+
+### Interacting with webviews
+
+- Locate the Logs view webview `<iframe>` (VS Code uses nested iframes for webviews)
+- Click the row **Open** action (`aria-label="Open"`)
+- Switch to the Log Viewer panel webview `<iframe>`
+- Assert:
+  - Header text includes `Apex Log Viewer`
+  - File name includes the seeded log id (or at least ends with `.log`)
+  - Content rendered (e.g., `Total Lines: N` where `N > 0`)
+  - Optionally: search for the marker string
+
+### Artifacts + debugging
+
+- Store Playwright artifacts under `output/playwright/`
+- Default: traces/videos/screenshots on failure only
+- `DEBUG_MODE=1` can pause Playwright on failures for local debugging
+
+## CI workflow
+
+Add a dedicated workflow (manual by default):
+
+- `.github/workflows/e2e-playwright.yml`
+- Trigger: `workflow_dispatch`
+- Uses `secrets.SF_DEVHUB_AUTH_URL`
+- Creates a unique scratch alias (example: `ALV_E2E_${{ github.run_id }}`)
+- Uploads `output/playwright/` as workflow artifacts
+
+This avoids breaking PR builds where secrets are unavailable.
+
+## Risks and mitigations
+
+- **VS Code DOM changes / iframe structure** → centralize locators + prefer accessible labels
+- **Webview virtualization** (log rows are virtualized) → avoid relying on row order beyond “first visible row” and click the `aria-label="Open"` action
+- **Scratch org provisioning delays** → generous timeouts + reuse org locally
+- **Flaky focus / keybindings** → command palette open/execute helpers with retries
+
+## Follow-ups (future)
+
+- Add a Tail Logs E2E scenario (requires streaming + waiting)
+- Add Replay Debugger integration checks (requires Salesforce extension pack behavior)
+- Expand assertions to verify the seeded marker is present in the parsed log content
+

--- a/docs/plans/2026-02-17-playwright-e2e-real-org-plan.md
+++ b/docs/plans/2026-02-17-playwright-e2e-real-org-plan.md
@@ -1,0 +1,393 @@
+# Playwright VS Code E2E (Real Scratch Org) Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add Playwright-driven VS Code (Electron) E2E tests that provision a scratch org from DevHub, seed a deterministic Apex log, open the Electivus Apex Logs panel, open a log in the Log Viewer, and assert the webview renders content.
+
+**Architecture:** Minimal in-repo Playwright harness under `apps/vscode-extension/test/playwright/` with:
+- Scratch org utilities (`sf` CLI + Tooling API for TraceFlag)
+- Temporary workspace generator (`sfdx-project.json` + `.sf/config.json`)
+- Electron launcher (download VS Code via `@vscode/test-electron`, launch via Playwright `_electron`)
+- Page helpers (command palette, webview iframe discovery)
+
+**Tech Stack:** TypeScript, `@playwright/test`, `@vscode/test-electron`, Salesforce CLI (`sf`)
+
+---
+
+## Conventions and environment variables
+
+### Local defaults
+
+- `SF_DEVHUB_ALIAS=InsuranceOrgTrialCreme6DevHub`
+- `SF_SCRATCH_ALIAS=ALV_E2E_Scratch`
+- `SF_SCRATCH_DURATION=1`
+
+### CI defaults
+
+- `SF_DEVHUB_AUTH_URL` (GitHub secret) must be present
+- `SF_DEVHUB_ALIAS=DevHub`
+- `SF_SCRATCH_ALIAS=ALV_E2E_${{ github.run_id }}`
+
+### Optional toggles
+
+- `SF_TEST_KEEP_ORG=1` keeps the scratch org after the run
+- `DEBUG_MODE=1` pauses Playwright on failure (`page.pause()`)
+
+---
+
+## Task 1: Add Playwright test runner plumbing
+
+**Files:**
+- Modify: `apps/vscode-extension/package.json`
+- Modify: `apps/vscode-extension/package-lock.json`
+- Create: `apps/vscode-extension/playwright.config.ts`
+- Modify: `package.json` (root scripts)
+- Modify: `.gitignore` (ignore `output/playwright/`)
+- Create: `apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts` (initial RED)
+
+**Step 1: Write the initial failing E2E spec**
+
+Create `apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts` with a trivial placeholder test:
+
+```ts
+import { test, expect } from '@playwright/test';
+
+test('placeholder', async () => {
+  expect(1).toBe(2);
+});
+```
+
+**Step 2: Run E2E to verify it fails**
+
+Run:
+- `npm --prefix apps/vscode-extension run test:e2e`
+
+Expected:
+- FAIL because `test:e2e` script doesn’t exist yet (or Playwright not installed)
+
+**Step 3: Add `@playwright/test` + scripts + config**
+
+- Add dev dependency: `@playwright/test`
+- Add scripts to `apps/vscode-extension/package.json`:
+  - `test:e2e`: `playwright test -c playwright.config.ts`
+  - `test:e2e:ui`: `playwright test -c playwright.config.ts --ui`
+- Add root script to `package.json`:
+  - `ext:test:e2e`: `npm --prefix apps/vscode-extension run test:e2e`
+- Add `apps/vscode-extension/playwright.config.ts`:
+  - `testDir: 'test/playwright/specs'`
+  - `outputDir: 'output/playwright/test-results'`
+  - `reporter: [['list'], ['html', { outputFolder: 'output/playwright/report', open: 'never' }]]`
+  - `use: { trace: 'retain-on-failure', screenshot: 'only-on-failure', video: 'retain-on-failure' }`
+  - `timeout` + `retries` (set retries to `process.env.CI ? 2 : 0`)
+
+**Step 4: Install deps + re-run to verify RED**
+
+Run:
+- `npm --prefix apps/vscode-extension install`
+- `npm --prefix apps/vscode-extension run test:e2e`
+
+Expected:
+- FAIL with the placeholder assertion (1 !== 2)
+
+**Step 5: Commit**
+
+Run:
+- `git add apps/vscode-extension/package.json apps/vscode-extension/package-lock.json apps/vscode-extension/playwright.config.ts package.json .gitignore apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+- `git commit -m "test(e2e): scaffold Playwright runner"`
+
+---
+
+## Task 2: Create the Electron + VS Code fixtures (launch VS Code)
+
+**Files:**
+- Create: `apps/vscode-extension/test/playwright/fixtures/desktopTest.ts`
+- Create: `apps/vscode-extension/test/playwright/utils/locators.ts`
+- Modify: `apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+
+**Step 1: Update spec to require VS Code workbench**
+
+Replace placeholder assertion with:
+
+```ts
+import { expect } from '@playwright/test';
+import { test } from '../fixtures/desktopTest';
+import { WORKBENCH } from '../utils/locators';
+
+test('opens VS Code workbench', async ({ page }) => {
+  await expect(page.locator(WORKBENCH)).toBeVisible();
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Run:
+- `npm --prefix apps/vscode-extension run test:e2e -- openLogViewer.e2e.spec.ts`
+
+Expected:
+- FAIL because `../fixtures/desktopTest` doesn’t exist
+
+**Step 3: Implement minimal `desktopTest` fixture**
+
+Implement:
+- Download VS Code once per worker via `@vscode/test-electron`
+- Launch Electron via `@playwright/test` `_electron`
+- Provide `page` as `electronApp.firstWindow()`
+- Wait for `.monaco-workbench`
+- Add `DEBUG_MODE=1` pause-on-failure in `afterEach`
+
+**Step 4: Run to verify it passes (GREEN)**
+
+Run:
+- `npm --prefix apps/vscode-extension run test:e2e -- openLogViewer.e2e.spec.ts`
+
+Expected:
+- PASS `opens VS Code workbench`
+
+**Step 5: Commit**
+
+Run:
+- `git add apps/vscode-extension/test/playwright/fixtures/desktopTest.ts apps/vscode-extension/test/playwright/utils/locators.ts apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+- `git commit -m "test(e2e): launch VS Code via Playwright"`
+
+---
+
+## Task 3: Add scratch org provisioning helpers (DevHub + scratch org)
+
+**Files:**
+- Create: `apps/vscode-extension/test/playwright/fixtures/sfCli.ts`
+- Create: `apps/vscode-extension/test/playwright/fixtures/scratchOrg.ts`
+- Modify: `apps/vscode-extension/test/playwright/fixtures/desktopTest.ts`
+
+**Step 1: Extend fixtures to create a scratch org**
+
+Update `desktopTest` to provide:
+- `scratchAlias` (string)
+- `devhubAlias` (string)
+
+RED change: reference `scratchAlias` in spec even before implementation:
+
+```ts
+test('has a scratch org alias', async ({ scratchAlias }) => {
+  expect(scratchAlias).toBeTruthy();
+});
+```
+
+**Step 2: Run to verify it fails**
+
+Expected:
+- FAIL because fixture doesn’t provide `scratchAlias`
+
+**Step 3: Implement `sfCli.ts`**
+
+- `execSfJson(args: string[], opts)` → runs `sf ... --json` and parses JSON
+- `sfOrgDisplay(alias)` → returns `{ username, instanceUrl, accessToken, apiVersion }`
+
+**Step 4: Implement `scratchOrg.ts`**
+
+- `ensureDevHub()`:
+  - if `SF_DEVHUB_AUTH_URL` set, login via `sf org login sfdx-url ... --alias <SF_DEVHUB_ALIAS> --set-default-dev-hub`
+- `ensureScratchOrg()`:
+  - reuse if `sf org display -o <SF_SCRATCH_ALIAS>` works
+  - else create with `sf org create scratch --target-dev-hub <SF_DEVHUB_ALIAS> --alias <SF_SCRATCH_ALIAS> --duration-days <n> --wait 15 --json`
+- `cleanupScratchOrg()`:
+  - delete unless `SF_TEST_KEEP_ORG=1`
+
+**Step 5: Run to verify GREEN**
+
+Run:
+- `SF_DEVHUB_ALIAS=InsuranceOrgTrialCreme6DevHub npm --prefix apps/vscode-extension run test:e2e -- openLogViewer.e2e.spec.ts`
+
+Expected:
+- PASS (and scratch org reused/created)
+
+**Step 6: Commit**
+
+Run:
+- `git add apps/vscode-extension/test/playwright/fixtures/sfCli.ts apps/vscode-extension/test/playwright/fixtures/scratchOrg.ts apps/vscode-extension/test/playwright/fixtures/desktopTest.ts apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+- `git commit -m "test(e2e): provision scratch org via DevHub"`
+
+---
+
+## Task 4: Create a temp workspace that targets the scratch org
+
+**Files:**
+- Create: `apps/vscode-extension/test/playwright/fixtures/workspace.ts`
+- Modify: `apps/vscode-extension/test/playwright/fixtures/desktopTest.ts`
+
+**Step 1: Add failing assertion that `.sf/config.json` exists**
+
+In spec:
+- assert the fixture returns `workspaceDir`
+- assert file `<workspaceDir>/.sf/config.json` exists
+
+Run and verify RED.
+
+**Step 2: Implement `workspace.ts`**
+
+Implement `createE2EWorkspace({ scratchAlias })`:
+- `mkdtemp` workspace
+- write `sfdx-project.json` (sourceApiVersion `64.0` unless env override)
+- create `.sf/config.json` with `{ "target-org": "<scratchAlias>" }`
+
+**Step 3: Wire into Electron launch args**
+
+Launch VS Code with `workspaceDir` as the last CLI arg.
+
+**Step 4: Run to verify GREEN**
+
+Expected:
+- VS Code opens that workspace and fixture assertions pass
+
+**Step 5: Commit**
+
+`git commit -m "test(e2e): launch VS Code with temp workspace"`
+
+---
+
+## Task 5: Seed a deterministic Apex log (TraceFlag + Execute Anonymous)
+
+**Files:**
+- Create: `apps/vscode-extension/test/playwright/fixtures/tooling.ts`
+- Create: `apps/vscode-extension/test/playwright/fixtures/seedLog.ts`
+- Modify: `apps/vscode-extension/test/playwright/fixtures/desktopTest.ts`
+- Modify: `apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+
+**Step 1: Add failing expectation for `seededLogId`**
+
+In spec:
+
+```ts
+test('seeds an apex log', async ({ seededLogId }) => {
+  expect(seededLogId).toMatch(/^[a-zA-Z0-9]{15,18}$/);
+});
+```
+
+Run and verify RED.
+
+**Step 2: Implement `tooling.ts`**
+
+Implement minimal REST helpers:
+- `getOrgAuthFromSf(alias)` using `sf org display -o <alias> --json`
+- `query(auth, soql)` via `GET /services/data/vXX.X/query?q=...`
+- `toolingQuery(auth, soql)` via `GET /services/data/vXX.X/tooling/query?q=...`
+- `toolingCreate(auth, sobject, payload)` via `POST /services/data/vXX.X/tooling/sobjects/<SObject>`
+- `toolingPatch(auth, sobject, id, payload)` via `PATCH ...`
+
+**Step 3: Implement TraceFlag ensure**
+
+In `seedLog.ts`:
+- Find current user id (`SELECT Id FROM User WHERE Username = '<username>'`)
+- Ensure a `DebugLevel` exists (create one if missing, with reasonable fields)
+- Ensure a `TraceFlag` exists for `USER_DEBUG` (create or update Start/Expiration window)
+
+**Step 4: Execute Apex and pick the new log**
+
+- `sf apex list log -o <scratch> --json` → before set
+- `sf apex run -o <scratch> --file <tmp.apex>`
+- `sf apex list log -o <scratch> --json` → after set
+- pick first log id not in before set as `seededLogId`
+- marker: `ALV_E2E_MARKER_<timestamp>`
+
+**Step 5: Run to verify GREEN**
+
+Expected:
+- Seed step succeeds and yields a log id
+
+**Step 6: Commit**
+
+`git commit -m "test(e2e): seed deterministic apex log"`
+
+---
+
+## Task 6: Drive the UI to open the Log Viewer webview
+
+**Files:**
+- Create: `apps/vscode-extension/test/playwright/pages/commandPalette.ts`
+- Create: `apps/vscode-extension/test/playwright/pages/webviews.ts`
+- Modify: `apps/vscode-extension/test/playwright/specs/openLogViewer.e2e.spec.ts`
+
+**Step 1: RED — spec executes the “Show Electivus Apex Logs” view**
+
+Add:
+- `executeCommandWithCommandPalette(page, 'View: Show Electivus Apex Logs')`
+
+Run and verify RED (helpers missing).
+
+**Step 2: Implement command palette helpers**
+
+Implement:
+- `openCommandPalette(page)` (F1, focus + retry)
+- `executeCommandWithCommandPalette(page, command)` (type, click first match)
+
+**Step 3: Find logs webview and click Open**
+
+Implement in `webviews.ts`:
+- `findWebviewFrameByText(page, 'Electivus Apex Logs')` (fallback: find frame containing `button[aria-label="Open"]`)
+- `findWebviewFrameByText(page, 'Apex Log Viewer')`
+
+In spec:
+- wait for logs webview open buttons
+- click up to N visible `aria-label="Open"` buttons until the log viewer title includes `seededLogId`
+
+**Step 4: Assert log viewer content includes marker**
+
+In log viewer frame:
+- expect `text=Apex Log Viewer` visible
+- expect marker text visible somewhere
+
+**Step 5: Run to verify GREEN**
+
+Run:
+- `SF_DEVHUB_ALIAS=InsuranceOrgTrialCreme6DevHub npm --prefix apps/vscode-extension run test:e2e -- openLogViewer.e2e.spec.ts`
+
+Expected:
+- PASS end-to-end
+
+**Step 6: Commit**
+
+`git commit -m "test(e2e): open log in viewer via UI"`
+
+---
+
+## Task 7: Add GitHub Actions workflow + docs updates
+
+**Files:**
+- Create: `.github/workflows/e2e-playwright.yml`
+- Modify: `docs/TESTING.md`
+- Modify: `apps/vscode-extension/docs/TESTING.md`
+
+**Step 1: Add workflow_dispatch workflow**
+
+- Setup Node 22.x
+- `npm ci --workspaces=false` in `apps/vscode-extension`
+- `npm run test:linux-deps`
+- Run E2E with env:
+  - `SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}`
+  - `SF_DEVHUB_ALIAS=DevHub`
+  - `SF_SCRATCH_ALIAS=ALV_E2E_${{ github.run_id }}`
+- Upload `output/playwright/` artifacts (always)
+
+**Step 2: Update docs**
+
+Add local run example:
+- `SF_DEVHUB_ALIAS=InsuranceOrgTrialCreme6DevHub npm run ext:test:e2e`
+
+**Step 3: Run lint/docs checks**
+
+- `npm --prefix apps/vscode-extension run lint`
+
+**Step 4: Commit**
+
+`git commit -m "ci(e2e): add Playwright workflow"`
+
+---
+
+## Verification checklist (before claiming completion)
+
+Run locally (from repo root or worktree root):
+
+- `npm --prefix apps/vscode-extension run test:webview`
+- `SF_DEVHUB_ALIAS=InsuranceOrgTrialCreme6DevHub npm --prefix apps/vscode-extension run test:e2e`
+
+If running headless Linux without a display, ensure E2E uses `xvfb-run` or Playwright headless mode appropriately and capture artifacts under `output/playwright/`.
+

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ext:test": "npm --prefix apps/vscode-extension test",
     "ext:test:unit": "npm --prefix apps/vscode-extension run test:unit",
     "ext:test:integration": "npm --prefix apps/vscode-extension run test:integration",
+    "ext:test:e2e": "npm --prefix apps/vscode-extension run test:e2e",
     "ext:package": "npm --prefix apps/vscode-extension run package"
   }
 }


### PR DESCRIPTION
This PR introduces Playwright-based end-to-end tests for the Electivus Apex Log Viewer VS Code extension.

The intent is to validate the full webview UX against a real Salesforce org by creating a scratch org from a Dev Hub, seeding an ApexLog with a unique marker via anonymous Apex, and then driving the Extension Development Host UI to:

1) open the Electivus Apex Logs webview,
2) verify that log rows render, and
3) open the selected log in the Apex Log Viewer panel and assert the seeded marker is present.

The main issue this addresses is that we previously had no repeatable E2E coverage for the webview-driven workflows (the project intentionally leans on webviews for better UX). That made it easy to ship regressions in view activation, org selection, or log rendering without noticing until manual validation.

During implementation we also hit a common VS Code/Electron pitfall: the extension host can be launched with a minimal PATH (especially in headless automation or when VS Code is started via the OS GUI), which caused the logs panel to show “Salesforce CLI not found” even when `sf` was installed and working in the user’s terminal. The root cause is simply that the extension invokes the CLI by program name, and in some environments that program (and/or the Node runtime that the `sf` shim relies on) is not discoverable. This PR fixes that by adding an optional `electivus.apexLogs.cliPath` setting and teaching the CLI wrapper to try that configured path before falling back to `sf`.

Changes include:

- A new Playwright E2E harness under `apps/vscode-extension/test/e2e` that:
  - authenticates a Dev Hub in CI via `SF_DEVHUB_AUTH_URL`,
  - creates or reuses a scratch org, and
  - seeds an ApexLog and validates it end-to-end in VS Code.
- A manual GitHub Actions workflow (`.github/workflows/e2e-playwright.yml`) that standardizes on `secrets.SF_DEVHUB_AUTH_URL`, uses the team DevHub alias `InsuranceOrgTrialCreme6DevHub`, and uploads Playwright artifacts from `output/playwright/`.
- A small command behavior tweak so `Electivus Apex Logs: Refresh Logs` opens the Logs view before refreshing, making the E2E flow deterministic.

Validation:

- `SF_TEST_KEEP_ORG=1 npm run ext:test:e2e -- openLogViewer.e2e.spec.ts`

Notes:

- The E2E helpers avoid printing sensitive CLI JSON output (for example outputs containing access tokens).
- Playwright artifacts are ignored via `.gitignore` and written under `output/playwright/`.
