### PR TITLE
feat(debug-flags): add editor workflow for user trace flag management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Testing: add Playwright E2E coverage against a real scratch org (Dev Hub + seeded Apex log). Also adds a manual GitHub Actions workflow for opt-in validation.
+- Debug Flags: add a dedicated editor panel to configure `USER_DEBUG` TraceFlags for active users, accessible from both Logs and Tail toolbars.
 
 ### Bug Fixes
 
@@ -14,6 +15,10 @@
 
 - Repo: revert monorepo layout back to a single-root extension structure.
 - CLI: remove the Rust CLI package, Cargo workspace files, and CLI npm release workflow.
+
+### Tests
+
+- Debug Flags: add unit/webview coverage for user trace-flag apply/remove flows and add a Playwright E2E scenario for the new editor panel.
 
 ## [0.22.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.20.0...v0.22.0) (2026-02-13)
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Fast, searchable Salesforce Apex logs — right inside VS Code. Browse, filter, 
 - Sorting and infinite scroll: Click any header to sort; more logs load automatically as you scroll.
 - Open and debug: Open a log in the editor or start Apex Replay Debugger directly from the list.
 - Real‑time tail: Start tailing logs from the toolbar using your Salesforce CLI.
+- Debug Flags editor: Configure `USER_DEBUG` TraceFlags for active users in a dedicated editor panel with more space.
 - Org selector: Quickly switch between your authenticated orgs or use the CLI default.
 - Configurable: Tune `electivus.apexLogs.pageSize`, `electivus.apexLogs.headConcurrency`, and other options to fit your workflow. (Legacy `sfLogs.*` keys still work for backward compatibility.)
 - Localization: English and Brazilian Portuguese (pt‑BR).
@@ -79,6 +80,15 @@ Why developers like it
 ### Tail logs in real time
 
 - Choose **Tail Logs** from the toolbar to start streaming new logs. Run the command again to stop.
+
+### Configure Debug Flags
+
+- Click **Debug Flags** in either the Logs or Tail toolbar.
+- The extension opens **Apex Debug Flags** in the editor area, where you can:
+- Search active users by name/username.
+- Inspect current `USER_DEBUG` status (level + expiration).
+- Apply/update a debug level with custom TTL.
+- Remove existing `USER_DEBUG` flags for the selected user.
 
 ### Select an org
 

--- a/package.json
+++ b/package.json
@@ -419,7 +419,7 @@
   },
   "scripts": {
     "test:clean": "node scripts/clean-vscode-test.js",
-    "clean": "node -e \"const fs=require('fs');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/webview.css']){try{fs.unlinkSync(f)}catch{}}\"",
+    "clean": "node -e \"const fs=require('fs');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/logViewer.js','media/logViewer.js.map','media/debugFlags.js','media/debugFlags.js.map','media/webview.css']){try{fs.unlinkSync(f)}catch{}}\"",
     "prebuild": "npm run clean",
     "vscode:prepublish": "npm run build && npm run nls:write",
     "check-types": "tsc --noEmit -p tsconfig.extension.json",
@@ -462,8 +462,8 @@
     "prepare": "husky",
     "tailwind:build": "tailwindcss -c tailwind.config.js -i ./src/webview/styles/tailwind.css -o ./media/webview.css --minify",
     "tailwind:watch": "tailwindcss -c tailwind.config.js -i ./src/webview/styles/tailwind.css -o ./media/webview.css --watch",
-    "build:webview:bundle": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/logViewer.tsx --bundle --outdir=media --platform=browser --format=iife --minify",
-    "watch:webview:bundle": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/logViewer.tsx --bundle --outdir=media --platform=browser --format=iife --sourcemap --watch",
+    "build:webview:bundle": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/logViewer.tsx src/webview/debugFlags.tsx --bundle --outdir=media --platform=browser --format=iife --minify",
+    "watch:webview:bundle": "esbuild src/webview/main.tsx src/webview/tail.tsx src/webview/logViewer.tsx src/webview/debugFlags.tsx --bundle --outdir=media --platform=browser --format=iife --sourcemap --watch",
     "coverage:merge": "node scripts/merge-coverage.cjs"
   },
   "devDependencies": {
@@ -535,6 +535,7 @@
     "media/webview.css",
     "media/tail.js",
     "media/logViewer.js",
+    "media/debugFlags.js",
     "media/icon.png",
     "node_modules/@vscode/ripgrep/**",
     "README.md",

--- a/package.nls.json
+++ b/package.nls.json
@@ -27,5 +27,17 @@
   "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Unable to open Apex logs from this location.",
   "openLogInViewer.notApex": "Electivus Apex Logs: The active document is not recognized as a Salesforce Apex log.",
   "openLogInViewer.failed": "Failed to open Apex log: {0}",
-  "openLogInViewer.codeLensTitle": "Open in Apex Log Viewer"
+  "openLogInViewer.codeLensTitle": "Open in Apex Log Viewer",
+  "debugFlags.panel.title": "Apex Debug Flags",
+  "debugFlags.unavailable": "Debug Flags panel is unavailable before extension activation.",
+  "debugFlags.loadOrgsFailed": "Failed to load org and debug level data: {0}",
+  "debugFlags.loadUsersFailed": "Failed to load users: {0}",
+  "debugFlags.loadStatusFailed": "Failed to load debug flag status: {0}",
+  "debugFlags.applyCreated": "Debug flag created successfully.",
+  "debugFlags.applyUpdated": "Debug flag updated successfully.",
+  "debugFlags.applyFailed": "Failed to apply debug flag: {0}",
+  "debugFlags.removeSuccess": "Debug flag removed successfully.",
+  "debugFlags.removeNone": "No active USER_DEBUG trace flag was found for this user.",
+  "debugFlags.removeFailed": "Failed to remove debug flag: {0}",
+  "debugFlags.noOrg": "No Salesforce org is selected."
 }

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -27,5 +27,17 @@
   "openLogInViewer.unsupportedScheme": "Electivus Apex Logs: Não é possível abrir logs Apex a partir desta origem.",
   "openLogInViewer.notApex": "Electivus Apex Logs: O documento ativo não é reconhecido como um log Apex do Salesforce.",
   "openLogInViewer.failed": "Falha ao abrir log Apex: {0}",
-  "openLogInViewer.codeLensTitle": "Abrir no Apex Log Viewer"
+  "openLogInViewer.codeLensTitle": "Abrir no Apex Log Viewer",
+  "debugFlags.panel.title": "Apex Debug Flags",
+  "debugFlags.unavailable": "O painel Debug Flags não está disponível antes da ativação da extensão.",
+  "debugFlags.loadOrgsFailed": "Falha ao carregar dados de org e níveis de depuração: {0}",
+  "debugFlags.loadUsersFailed": "Falha ao carregar usuários: {0}",
+  "debugFlags.loadStatusFailed": "Falha ao carregar status da debug flag: {0}",
+  "debugFlags.applyCreated": "Debug flag criada com sucesso.",
+  "debugFlags.applyUpdated": "Debug flag atualizada com sucesso.",
+  "debugFlags.applyFailed": "Falha ao aplicar debug flag: {0}",
+  "debugFlags.removeSuccess": "Debug flag removida com sucesso.",
+  "debugFlags.removeNone": "Nenhuma trace flag USER_DEBUG ativa foi encontrada para este usuário.",
+  "debugFlags.removeFailed": "Falha ao remover debug flag: {0}",
+  "debugFlags.noOrg": "Nenhuma org Salesforce foi selecionada."
 }

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -1,0 +1,380 @@
+import * as vscode from 'vscode';
+import { getOrgAuth, listOrgs } from '../salesforce/cli';
+import {
+  getActiveUserDebugLevel,
+  getUserTraceFlagStatus,
+  listActiveUsers,
+  listDebugLevels,
+  removeUserTraceFlags,
+  upsertUserTraceFlag
+} from '../salesforce/traceflags';
+import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
+import { safeSendEvent } from '../shared/telemetry';
+import { pickSelectedOrg } from '../utils/orgs';
+import { localize } from '../utils/localize';
+import { getErrorMessage } from '../utils/error';
+import { logInfo, logWarn } from '../utils/logger';
+import { buildWebviewHtml } from '../utils/webviewHtml';
+
+interface ShowOptions {
+  selectedOrg?: string;
+  sourceView?: 'logs' | 'tail';
+}
+
+export class DebugFlagsPanel {
+  private static context: vscode.ExtensionContext | undefined;
+  private static instance: DebugFlagsPanel | undefined;
+  private static readonly viewType = 'sfLogViewer.debugFlagsPanel';
+
+  static initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
+  }
+
+  static async show(options?: ShowOptions): Promise<void> {
+    const extensionUri = this.context?.extensionUri;
+    if (!extensionUri) {
+      void vscode.window.showWarningMessage(
+        localize('debugFlags.unavailable', 'Debug Flags panel is unavailable before extension activation.')
+      );
+      return;
+    }
+
+    if (this.instance) {
+      this.instance.reveal();
+      if (options?.sourceView) {
+        this.instance.lastSourceView = options.sourceView;
+      }
+      if (typeof options?.selectedOrg === 'string') {
+        await this.instance.setSelectedOrg(options.selectedOrg);
+      }
+      return;
+    }
+
+    this.instance = new DebugFlagsPanel(extensionUri, options);
+  }
+
+  private readonly panel: vscode.WebviewPanel;
+  private selectedOrg: string | undefined;
+  private selectedUserId: string | undefined;
+  private usersQuery = '';
+  private disposed = false;
+  private usersToken = 0;
+  private statusToken = 0;
+  private orgBootstrapToken = 0;
+  private lastSourceView: 'logs' | 'tail' | 'unknown' = 'unknown';
+
+  private constructor(extensionUri: vscode.Uri, options?: ShowOptions) {
+    this.selectedOrg = typeof options?.selectedOrg === 'string' ? options.selectedOrg.trim() || undefined : undefined;
+    this.lastSourceView = options?.sourceView ?? 'unknown';
+
+    this.panel = vscode.window.createWebviewPanel(
+      DebugFlagsPanel.viewType,
+      localize('debugFlags.panel.title', 'Apex Debug Flags'),
+      { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')]
+      }
+    );
+    this.panel.webview.html = buildWebviewHtml(
+      this.panel.webview,
+      extensionUri,
+      'debugFlags.js',
+      localize('debugFlags.panel.title', 'Apex Debug Flags')
+    );
+
+    this.panel.onDidDispose(() => this.dispose());
+    this.panel.webview.onDidReceiveMessage(message => this.onMessage(message as DebugFlagsFromWebviewMessage));
+    DebugFlagsPanel.context?.subscriptions.push(this.panel);
+  }
+
+  private reveal(): void {
+    this.panel.reveal(undefined, true);
+  }
+
+  private async setSelectedOrg(nextOrg: string): Promise<void> {
+    const normalized = nextOrg.trim() || undefined;
+    if (this.selectedOrg === normalized) {
+      return;
+    }
+    this.selectedOrg = normalized;
+    this.selectedUserId = undefined;
+    await this.bootstrapData();
+  }
+
+  private post(message: DebugFlagsToWebviewMessage): void {
+    if (this.disposed) {
+      return;
+    }
+    void this.panel.webview.postMessage(message);
+  }
+
+  private async onMessage(message: DebugFlagsFromWebviewMessage): Promise<void> {
+    if (!message?.type || this.disposed) {
+      return;
+    }
+
+    switch (message.type) {
+      case 'debugFlagsReady':
+        this.post({ type: 'debugFlagsInit', locale: vscode.env.language, defaultTtlMinutes: 30 });
+        await this.bootstrapData();
+        break;
+      case 'debugFlagsSelectOrg':
+        await this.setSelectedOrg(typeof message.target === 'string' ? message.target : '');
+        break;
+      case 'debugFlagsSearchUsers':
+        this.usersQuery = typeof message.query === 'string' ? message.query : '';
+        await this.searchUsers();
+        break;
+      case 'debugFlagsSelectUser':
+        if (!message.userId) {
+          return;
+        }
+        this.selectedUserId = message.userId;
+        await this.loadSelectedUserStatus(message.userId);
+        break;
+      case 'debugFlagsApply':
+        await this.applyUserTraceFlag(message.userId, message.debugLevelName, message.ttlMinutes);
+        break;
+      case 'debugFlagsRemove':
+        await this.removeUserTraceFlag(message.userId);
+        break;
+    }
+  }
+
+  private async bootstrapData(): Promise<void> {
+    const token = ++this.orgBootstrapToken;
+    this.post({ type: 'debugFlagsLoading', scope: 'orgs', value: true });
+    try {
+      const orgs = await listOrgs();
+      if (token !== this.orgBootstrapToken || this.disposed) {
+        return;
+      }
+
+      this.selectedOrg = pickSelectedOrg(orgs, this.selectedOrg);
+      this.post({
+        type: 'debugFlagsOrgs',
+        data: orgs,
+        selected: this.selectedOrg
+      });
+
+      const auth = await this.getSelectedAuth();
+      if (token !== this.orgBootstrapToken || this.disposed) {
+        return;
+      }
+
+      const [levels, active] = await Promise.all([
+        listDebugLevels(auth).catch(err => {
+          logWarn('DebugFlagsPanel: failed to load debug levels ->', getErrorMessage(err));
+          return [] as string[];
+        }),
+        getActiveUserDebugLevel(auth).catch(() => undefined as string | undefined)
+      ]);
+      if (token !== this.orgBootstrapToken || this.disposed) {
+        return;
+      }
+      const output = [...levels];
+      if (active && !output.includes(active)) {
+        output.unshift(active);
+      }
+      this.post({
+        type: 'debugFlagsDebugLevels',
+        data: output,
+        active
+      });
+      await this.searchUsers();
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: bootstrap failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.loadOrgsFailed', 'Failed to load org and debug level data: {0}', msg)
+      });
+    } finally {
+      if (token === this.orgBootstrapToken) {
+        this.post({ type: 'debugFlagsLoading', scope: 'orgs', value: false });
+      }
+    }
+  }
+
+  private async searchUsers(): Promise<void> {
+    const token = ++this.usersToken;
+    this.post({ type: 'debugFlagsLoading', scope: 'users', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      const users = await listActiveUsers(auth, this.usersQuery, 50);
+      if (token !== this.usersToken || this.disposed) {
+        return;
+      }
+      this.post({ type: 'debugFlagsUsers', query: this.usersQuery, data: users });
+      if (this.selectedUserId && !users.some(user => user.id === this.selectedUserId)) {
+        const previous = this.selectedUserId;
+        this.selectedUserId = undefined;
+        this.post({ type: 'debugFlagsUserStatus', userId: previous, status: undefined });
+      }
+    } catch (e) {
+      if (token !== this.usersToken || this.disposed) {
+        return;
+      }
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: user search failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.loadUsersFailed', 'Failed to load users: {0}', msg)
+      });
+    } finally {
+      if (token === this.usersToken && !this.disposed) {
+        this.post({ type: 'debugFlagsLoading', scope: 'users', value: false });
+      }
+    }
+  }
+
+  private async loadSelectedUserStatus(userId: string): Promise<void> {
+    if (!userId) {
+      return;
+    }
+    const token = ++this.statusToken;
+    this.post({ type: 'debugFlagsLoading', scope: 'status', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      const status = await getUserTraceFlagStatus(auth, userId);
+      if (token !== this.statusToken || this.disposed) {
+        return;
+      }
+      this.post({
+        type: 'debugFlagsUserStatus',
+        userId,
+        status
+      });
+    } catch (e) {
+      if (token !== this.statusToken || this.disposed) {
+        return;
+      }
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: failed loading user status ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.loadStatusFailed', 'Failed to load debug flag status: {0}', msg)
+      });
+    } finally {
+      if (token === this.statusToken && !this.disposed) {
+        this.post({ type: 'debugFlagsLoading', scope: 'status', value: false });
+      }
+    }
+  }
+
+  private async applyUserTraceFlag(userId: string, debugLevelName: string, ttlMinutes: number): Promise<void> {
+    if (!userId) {
+      return;
+    }
+    const t0 = Date.now();
+    this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      const result = await upsertUserTraceFlag(auth, {
+        userId,
+        debugLevelName,
+        ttlMinutes
+      });
+      await this.loadSelectedUserStatus(userId);
+      this.post({
+        type: 'debugFlagsNotice',
+        tone: 'success',
+        message: result.created
+          ? localize('debugFlags.applyCreated', 'Debug flag created successfully.')
+          : localize('debugFlags.applyUpdated', 'Debug flag updated successfully.')
+      });
+      safeSendEvent(
+        'debugFlags.apply',
+        {
+          outcome: 'ok',
+          sourceView: this.lastSourceView
+        },
+        { durationMs: Date.now() - t0 }
+      );
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: apply failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.applyFailed', 'Failed to apply debug flag: {0}', msg)
+      });
+      safeSendEvent(
+        'debugFlags.apply',
+        {
+          outcome: 'error',
+          sourceView: this.lastSourceView
+        },
+        { durationMs: Date.now() - t0 }
+      );
+    } finally {
+      this.post({ type: 'debugFlagsLoading', scope: 'action', value: false });
+    }
+  }
+
+  private async removeUserTraceFlag(userId: string): Promise<void> {
+    if (!userId) {
+      return;
+    }
+    const t0 = Date.now();
+    this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      const removed = await removeUserTraceFlags(auth, userId);
+      await this.loadSelectedUserStatus(userId);
+      this.post({
+        type: 'debugFlagsNotice',
+        tone: removed > 0 ? 'success' : 'info',
+        message:
+          removed > 0
+            ? localize('debugFlags.removeSuccess', 'Debug flag removed successfully.')
+            : localize('debugFlags.removeNone', 'No active USER_DEBUG trace flag was found for this user.')
+      });
+      safeSendEvent(
+        'debugFlags.remove',
+        {
+          outcome: 'ok',
+          sourceView: this.lastSourceView
+        },
+        { durationMs: Date.now() - t0, removedCount: removed }
+      );
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: remove failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.removeFailed', 'Failed to remove debug flag: {0}', msg)
+      });
+      safeSendEvent(
+        'debugFlags.remove',
+        {
+          outcome: 'error',
+          sourceView: this.lastSourceView
+        },
+        { durationMs: Date.now() - t0 }
+      );
+    } finally {
+      this.post({ type: 'debugFlagsLoading', scope: 'action', value: false });
+    }
+  }
+
+  private async getSelectedAuth() {
+    const selected = (this.selectedOrg || '').trim();
+    if (!selected) {
+      throw new Error(localize('debugFlags.noOrg', 'No Salesforce org is selected.'));
+    }
+    return getOrgAuth(selected);
+  }
+
+  private dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    logInfo('DebugFlagsPanel: disposed.');
+    if (DebugFlagsPanel.instance === this) {
+      DebugFlagsPanel.instance = undefined;
+    }
+  }
+}

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -13,6 +13,7 @@ import { pickSelectedOrg } from '../utils/orgs';
 import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
 import { LogViewerPanel } from '../panel/LogViewerPanel';
+import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'sfLogTail';
@@ -119,6 +120,14 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         const id = (message as any).logId;
         logInfo('Tail: openLog requested for', id);
         await this.openLog(id);
+        return;
+      }
+      if (message?.type === 'openDebugFlags') {
+        logInfo('Tail: openDebugFlags requested');
+        await DebugFlagsPanel.show({
+          selectedOrg: this.selectedOrg,
+          sourceView: 'tail'
+        });
         return;
       }
       if (message?.type === 'replay' && (message as any).logId) {

--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -6,6 +6,7 @@ export class LogsMessageHandler {
     private readonly refresh: () => Promise<void>,
     private readonly sendOrgs: () => Promise<void>,
     private readonly setSelectedOrg: (org?: string) => void,
+    private readonly openDebugFlags: () => Promise<void>,
     private readonly openLog: (logId: string) => Promise<void>,
     private readonly debugLog: (logId: string) => Promise<void>,
     private readonly loadMore: () => Promise<void>,
@@ -34,6 +35,10 @@ export class LogsMessageHandler {
         this.setSelectedOrg(typeof message.target === 'string' ? message.target.trim() : undefined);
         logInfo('Logs: selected org set');
         await this.refresh();
+        break;
+      case 'openDebugFlags':
+        logInfo('Logs: openDebugFlags');
+        await this.openDebugFlags();
         break;
       case 'openLog':
         if (message.logId) {

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -1,10 +1,16 @@
-import { logTrace } from '../utils/logger';
+import type { ApplyUserTraceFlagInput, DebugFlagUser, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
 import { CacheManager } from '../utils/cacheManager';
 import { getBooleanConfig, getNumberConfig } from '../utils/config';
-import { httpsRequestWith401Retry, getEffectiveApiVersion } from './http';
+import { logTrace } from '../utils/logger';
+import { getEffectiveApiVersion, httpsRequestWith401Retry } from './http';
 import type { OrgAuth } from './types';
 
 const userIdCache = new Map<string, string>();
+const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
+
+type QueryResponse<TRecord = any> = {
+  records?: TRecord[];
+};
 
 function getDebugLevelsCacheConfig() {
   try {
@@ -15,6 +21,48 @@ function getDebugLevelsCacheConfig() {
   } catch {
     return { enabled: true, ttl: 300000 };
   }
+}
+
+function escapeSoqlLiteral(value: string): string {
+  return String(value || '')
+    .replace(/\\/g, '\\\\')
+    .replace(/'/g, "\\'");
+}
+
+function escapeSoqlLikeLiteral(value: string): string {
+  return escapeSoqlLiteral(value)
+    .replace(/%/g, '\\%')
+    .replace(/_/g, '\\_');
+}
+
+function isSalesforceId(value: string | undefined): value is string {
+  return typeof value === 'string' && SALESFORCE_ID_REGEX.test(value);
+}
+
+function clampTtlMinutes(value: number | undefined): number {
+  const raw = Number(value);
+  if (!Number.isFinite(raw)) {
+    return 30;
+  }
+  return Math.max(1, Math.min(1440, Math.floor(raw)));
+}
+
+function queryTooling<TRecord>(auth: OrgAuth, soql: string): Promise<QueryResponse<TRecord>> {
+  const encoded = encodeURIComponent(soql);
+  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${encoded}`;
+  return httpsRequestWith401Retry(auth, 'GET', url, {
+    Authorization: `Bearer ${auth.accessToken}`,
+    'Content-Type': 'application/json'
+  }).then(body => JSON.parse(body) as QueryResponse<TRecord>);
+}
+
+function queryStandard<TRecord>(auth: OrgAuth, soql: string): Promise<QueryResponse<TRecord>> {
+  const encoded = encodeURIComponent(soql);
+  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/query?q=${encoded}`;
+  return httpsRequestWith401Retry(auth, 'GET', url, {
+    Authorization: `Bearer ${auth.accessToken}`,
+    'Content-Type': 'application/json'
+  }).then(body => JSON.parse(body) as QueryResponse<TRecord>);
 }
 
 export async function listDebugLevels(auth: OrgAuth): Promise<string[]> {
@@ -30,20 +78,39 @@ export async function listDebugLevels(auth: OrgAuth): Promise<string[]> {
       return cached;
     }
   }
-  const soql = encodeURIComponent('SELECT DeveloperName FROM DebugLevel ORDER BY DeveloperName');
-  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${soql}`;
-  const body = await httpsRequestWith401Retry(auth, 'GET', url, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
-  const json = JSON.parse(body);
+
+  const soql = 'SELECT DeveloperName FROM DebugLevel ORDER BY DeveloperName';
+  const json = await queryTooling<{ DeveloperName?: string }>(auth, soql);
   const names = (json.records || [])
-    .map((r: any) => r?.DeveloperName)
-    .filter((n: any): n is string => typeof n === 'string');
+    .map(r => r?.DeveloperName)
+    .filter((n): n is string => typeof n === 'string');
+
   if (enabled && ttl > 0) {
     await CacheManager.set('cli', cacheKey, names, ttl);
   }
   return names;
+}
+
+export async function listActiveUsers(auth: OrgAuth, query = '', limit = 50): Promise<DebugFlagUser[]> {
+  const safeLimit = Math.max(1, Math.min(200, Math.floor(Number(limit) || 50)));
+  const trimmed = String(query || '').trim();
+  const clauses = ['IsActive = true'];
+  if (trimmed) {
+    const escaped = escapeSoqlLikeLiteral(trimmed);
+    clauses.push(`(Name LIKE '%${escaped}%' ESCAPE '\\\\' OR Username LIKE '%${escaped}%' ESCAPE '\\\\')`);
+  }
+  const soql =
+    `SELECT Id, Name, Username, IsActive FROM User ` +
+    `WHERE ${clauses.join(' AND ')} ORDER BY Name NULLS LAST LIMIT ${safeLimit}`;
+  const json = await queryStandard<{ Id?: string; Name?: string; Username?: string; IsActive?: boolean }>(auth, soql);
+  return (json.records || [])
+    .filter(record => isSalesforceId(record?.Id))
+    .map(record => ({
+      id: record.Id!,
+      name: typeof record.Name === 'string' && record.Name.trim() ? record.Name.trim() : record.Username || record.Id!,
+      username: typeof record.Username === 'string' ? record.Username : '',
+      active: Boolean(record.IsActive)
+    }));
 }
 
 export async function getActiveUserDebugLevel(auth: OrgAuth): Promise<string | undefined> {
@@ -51,17 +118,8 @@ export async function getActiveUserDebugLevel(auth: OrgAuth): Promise<string | u
   if (!userId) {
     return undefined;
   }
-  const tfSoql = encodeURIComponent(
-    `SELECT DebugLevel.DeveloperName FROM TraceFlag WHERE TracedEntityId = '${userId}' ORDER BY CreatedDate DESC LIMIT 1`
-  );
-  const tfUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${tfSoql}`;
-  const tfBody = await httpsRequestWith401Retry(auth, 'GET', tfUrl, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
-  const tfJson = JSON.parse(tfBody);
-  const rec = (tfJson.records || [])[0];
-  return rec?.DebugLevel?.DeveloperName as string | undefined;
+  const status = await getUserTraceFlagStatus(auth, userId);
+  return status?.debugLevelName;
 }
 
 // Format date as Salesforce datetime: YYYY-MM-DDTHH:mm:ss.SSS+0000 (UTC)
@@ -78,6 +136,16 @@ function toSfDateTimeUTC(d: Date): string {
   );
 }
 
+function isTraceFlagActive(startDate: string | undefined, expirationDate: string | undefined): boolean {
+  const now = Date.now();
+  const startMs = startDate ? Date.parse(startDate) : Number.NEGATIVE_INFINITY;
+  const expMs = expirationDate ? Date.parse(expirationDate) : Number.NEGATIVE_INFINITY;
+  if (!Number.isFinite(expMs)) {
+    return false;
+  }
+  return startMs <= now && now <= expMs;
+}
+
 export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefined> {
   const username = (auth.username || '').trim();
   if (!username) {
@@ -88,14 +156,10 @@ export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefine
   if (cached) {
     return cached;
   }
-  const esc = username.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-  const userSoql = encodeURIComponent(`SELECT Id FROM User WHERE Username = '${esc}' LIMIT 1`);
-  const userUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/query?q=${userSoql}`;
-  const userBody = await httpsRequestWith401Retry(auth, 'GET', userUrl, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
-  const userJson = JSON.parse(userBody);
+
+  const esc = escapeSoqlLiteral(username);
+  const soql = `SELECT Id FROM User WHERE Username = '${esc}' LIMIT 1`;
+  const userJson = await queryStandard<{ Id?: string }>(auth, soql);
   const userId: string | undefined = Array.isArray(userJson.records) ? userJson.records[0]?.Id : undefined;
   if (userId) {
     userIdCache.set(key, userId);
@@ -112,34 +176,141 @@ async function getDebugLevelIdByName(auth: OrgAuth, developerName: string): Prom
   if (!name) {
     return undefined;
   }
-  const esc = name.replace(/\\/g, '\\\\').replace(/'/g, "\\'");
-  const soql = encodeURIComponent(`SELECT Id FROM DebugLevel WHERE DeveloperName = '${esc}' LIMIT 1`);
-  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${soql}`;
-  const body = await httpsRequestWith401Retry(auth, 'GET', url, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
-  const json = JSON.parse(body);
+  const esc = escapeSoqlLiteral(name);
+  const soql = `SELECT Id FROM DebugLevel WHERE DeveloperName = '${esc}' LIMIT 1`;
+  const json = await queryTooling<{ Id?: string }>(auth, soql);
   const rec = (json.records || [])[0];
-  return rec?.Id as string | undefined;
+  return rec?.Id;
 }
 
-async function findExistingUserDebugTraceFlagId(
+async function getLatestUserDebugTraceFlagRecord(auth: OrgAuth, userId: string): Promise<any | undefined> {
+  if (!isSalesforceId(userId)) {
+    return undefined;
+  }
+  const soql =
+    `SELECT Id, DebugLevel.DeveloperName, StartDate, ExpirationDate ` +
+    `FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' ` +
+    `ORDER BY CreatedDate DESC LIMIT 1`;
+  const json = await queryTooling<any>(auth, soql);
+  return (json.records || [])[0];
+}
+
+async function getLatestUserDebugTraceFlagId(auth: OrgAuth, userId: string): Promise<string | undefined> {
+  if (!isSalesforceId(userId)) {
+    return undefined;
+  }
+  const soql =
+    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' ` +
+    `ORDER BY CreatedDate DESC LIMIT 1`;
+  const json = await queryTooling<{ Id?: string }>(auth, soql);
+  return (json.records || [])[0]?.Id;
+}
+
+export async function getUserTraceFlagStatus(auth: OrgAuth, userId: string): Promise<UserTraceFlagStatus | undefined> {
+  const record = await getLatestUserDebugTraceFlagRecord(auth, userId);
+  if (!record?.Id) {
+    return undefined;
+  }
+  const startDate = typeof record.StartDate === 'string' ? record.StartDate : undefined;
+  const expirationDate = typeof record.ExpirationDate === 'string' ? record.ExpirationDate : undefined;
+  return {
+    traceFlagId: String(record.Id),
+    debugLevelName:
+      typeof record.DebugLevel?.DeveloperName === 'string' ? record.DebugLevel.DeveloperName : '(unknown)',
+    startDate,
+    expirationDate,
+    isActive: isTraceFlagActive(startDate, expirationDate)
+  };
+}
+
+export async function upsertUserTraceFlag(
   auth: OrgAuth,
-  userId: string,
-  debugLevelId: string
-): Promise<string | undefined> {
-  const soql = encodeURIComponent(
-    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
+  input: ApplyUserTraceFlagInput
+): Promise<{ created: boolean; traceFlagId?: string }> {
+  if (!isSalesforceId(input?.userId)) {
+    throw new Error('Invalid Salesforce user id.');
+  }
+  const debugLevelName = String(input.debugLevelName || '').trim();
+  if (!debugLevelName) {
+    throw new Error('Debug level is required.');
+  }
+
+  const debugLevelId = await getDebugLevelIdByName(auth, debugLevelName);
+  if (!debugLevelId) {
+    throw new Error(`Debug level '${debugLevelName}' was not found.`);
+  }
+
+  const ttlMinutes = clampTtlMinutes(input.ttlMinutes);
+  const now = new Date();
+  const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
+  const exp = toSfDateTimeUTC(new Date(now.getTime() + ttlMinutes * 60 * 1000));
+
+  const existingId = await getLatestUserDebugTraceFlagId(auth, input.userId);
+  if (existingId) {
+    const patchUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${existingId}`;
+    await httpsRequestWith401Retry(
+      auth,
+      'PATCH',
+      patchUrl,
+      {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      JSON.stringify({
+        DebugLevelId: debugLevelId,
+        StartDate: start,
+        ExpirationDate: exp
+      })
+    );
+    return { created: false, traceFlagId: existingId };
+  }
+
+  const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag`;
+  const payload = {
+    TracedEntityId: input.userId,
+    LogType: 'USER_DEBUG',
+    DebugLevelId: debugLevelId,
+    StartDate: start,
+    ExpirationDate: exp
+  };
+  const resBody = await httpsRequestWith401Retry(
+    auth,
+    'POST',
+    createUrl,
+    {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify(payload)
   );
-  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${soql}`;
-  const body = await httpsRequestWith401Retry(auth, 'GET', url, {
-    Authorization: `Bearer ${auth.accessToken}`,
-    'Content-Type': 'application/json'
-  });
-  const json = JSON.parse(body);
-  const rec = (json.records || [])[0];
-  return rec?.Id as string | undefined;
+  const res = JSON.parse(resBody);
+  if (res && res.success) {
+    return { created: true, traceFlagId: res.id };
+  }
+  throw new Error('Failed to create USER_DEBUG TraceFlag.');
+}
+
+export async function removeUserTraceFlags(auth: OrgAuth, userId: string): Promise<number> {
+  if (!isSalesforceId(userId)) {
+    throw new Error('Invalid Salesforce user id.');
+  }
+  const soql =
+    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' ` +
+    `ORDER BY CreatedDate DESC LIMIT 200`;
+  const json = await queryTooling<{ Id?: string }>(auth, soql);
+  const ids = (json.records || [])
+    .map(record => record?.Id)
+    .filter((id): id is string => typeof id === 'string' && id.length > 0);
+
+  for (const id of ids) {
+    const deleteUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${id}`;
+    await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    });
+  }
+
+  return ids.length;
 }
 
 export async function ensureUserTraceFlag(
@@ -147,7 +318,7 @@ export async function ensureUserTraceFlag(
   developerName: string,
   ttlMinutes: number = 30
 ): Promise<boolean> {
-  // Returns true if created a new TraceFlag, false if updated or not possible
+  // Returns true if created a new TraceFlag, false if updated or not possible.
   try {
     const userId = await getCurrentUserId(auth);
     if (!userId) {
@@ -156,68 +327,14 @@ export async function ensureUserTraceFlag(
       } catch {}
       return false;
     }
-    // Resolve DebugLevelId
-    const debugLevelId = await getDebugLevelIdByName(auth, developerName);
-    if (!debugLevelId) {
-      try {
-        logTrace('ensureUserTraceFlag: debug level not found for', developerName);
-      } catch {}
-      return false;
-    }
-    const now = new Date();
-    const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
-    const exp = toSfDateTimeUTC(new Date(now.getTime() + Math.max(1, ttlMinutes) * 60 * 1000));
-
-    // Try to find existing USER_DEBUG TraceFlag for this user and debug level
-    const existingId = await findExistingUserDebugTraceFlagId(auth, userId, debugLevelId);
-    if (existingId) {
-      // Update existing TraceFlag window (PATCH returns 204 No Content on success)
-      const patchUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${existingId}`;
-      await httpsRequestWith401Retry(
-        auth,
-        'PATCH',
-        patchUrl,
-        {
-          Authorization: `Bearer ${auth.accessToken}`,
-          'Content-Type': 'application/json'
-        },
-        JSON.stringify({ StartDate: start, ExpirationDate: exp })
-      );
-      try {
-        logTrace('ensureUserTraceFlag: updated existing USER_DEBUG TraceFlag', existingId);
-      } catch {}
-      return false;
-    }
-
-    // Create a new USER_DEBUG TraceFlag
-    const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag`;
-    const payload = {
-      TracedEntityId: userId,
-      LogType: 'USER_DEBUG',
-      DebugLevelId: debugLevelId,
-      StartDate: start,
-      ExpirationDate: exp
-    } as any;
-    const resBody = await httpsRequestWith401Retry(
-      auth,
-      'POST',
-      createUrl,
-      {
-        Authorization: `Bearer ${auth.accessToken}`,
-        'Content-Type': 'application/json'
-      },
-      JSON.stringify(payload)
-    );
-    const res = JSON.parse(resBody);
-    if (res && res.success) {
-      try {
-        logTrace('ensureUserTraceFlag: created USER_DEBUG TraceFlag', res.id || '(unknown id)');
-      } catch {}
-      return true;
-    }
-    return false;
+    const result = await upsertUserTraceFlag(auth, {
+      userId,
+      debugLevelName: developerName,
+      ttlMinutes
+    });
+    return result.created;
   } catch (_e) {
-    // Swallow errors to avoid breaking tail; caller can log a warning
+    // Swallow errors to avoid breaking tail; caller can log a warning.
     return false;
   }
 }

--- a/src/shared/debugFlagsMessages.ts
+++ b/src/shared/debugFlagsMessages.ts
@@ -1,0 +1,20 @@
+import type { OrgItem } from './types';
+import type { DebugFlagUser, UserTraceFlagStatus } from './debugFlagsTypes';
+
+export type DebugFlagsFromWebviewMessage =
+  | { type: 'debugFlagsReady' }
+  | { type: 'debugFlagsSelectOrg'; target: string }
+  | { type: 'debugFlagsSearchUsers'; query: string }
+  | { type: 'debugFlagsSelectUser'; userId: string }
+  | { type: 'debugFlagsApply'; userId: string; debugLevelName: string; ttlMinutes: number }
+  | { type: 'debugFlagsRemove'; userId: string };
+
+export type DebugFlagsToWebviewMessage =
+  | { type: 'debugFlagsInit'; locale: string; defaultTtlMinutes: number }
+  | { type: 'debugFlagsLoading'; scope: 'orgs' | 'users' | 'status' | 'action'; value: boolean }
+  | { type: 'debugFlagsOrgs'; data: OrgItem[]; selected: string | undefined }
+  | { type: 'debugFlagsUsers'; query: string; data: DebugFlagUser[] }
+  | { type: 'debugFlagsDebugLevels'; data: string[]; active?: string }
+  | { type: 'debugFlagsUserStatus'; userId: string; status?: UserTraceFlagStatus }
+  | { type: 'debugFlagsNotice'; message: string; tone: 'success' | 'info' | 'warning' }
+  | { type: 'debugFlagsError'; message: string };

--- a/src/shared/debugFlagsTypes.ts
+++ b/src/shared/debugFlagsTypes.ts
@@ -1,0 +1,20 @@
+export interface DebugFlagUser {
+  id: string;
+  name: string;
+  username: string;
+  active: boolean;
+}
+
+export interface UserTraceFlagStatus {
+  traceFlagId: string;
+  debugLevelName: string;
+  startDate?: string;
+  expirationDate?: string;
+  isActive: boolean;
+}
+
+export interface ApplyUserTraceFlagInput {
+  userId: string;
+  debugLevelName: string;
+  ttlMinutes: number;
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -6,6 +6,7 @@ export type WebviewToExtensionMessage =
   | { type: 'ready' }
   | { type: 'refresh' }
   | { type: 'selectOrg'; target: string }
+  | { type: 'openDebugFlags' }
   | { type: 'openLog'; logId: string }
   | { type: 'replay'; logId: string }
   | { type: 'loadMore' }

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -1,0 +1,226 @@
+import assert from 'assert/strict';
+import { EventEmitter } from 'events';
+import type { OrgAuth } from '../salesforce/types';
+import { __resetHttpsRequestImplForTests, __setHttpsRequestImplForTests } from '../salesforce/http';
+import {
+  getUserTraceFlagStatus,
+  listActiveUsers,
+  removeUserTraceFlags,
+  upsertUserTraceFlag
+} from '../salesforce/traceflags';
+
+type StubRequest = {
+  method: string;
+  path: string;
+  body: string;
+};
+
+function installHttpsStub(
+  responder: (req: StubRequest) => { statusCode: number; body?: unknown }
+): StubRequest[] {
+  const calls: StubRequest[] = [];
+  __setHttpsRequestImplForTests((options: any, cb: any) => {
+    const req = new EventEmitter() as any;
+    let body = '';
+    req.on = function (event: string, listener: any) {
+      EventEmitter.prototype.on.call(this, event, listener);
+      return this;
+    };
+    req.setHeader = () => {};
+    req.write = (chunk: any) => {
+      body += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk || '');
+    };
+    req.setTimeout = () => req;
+    req.destroy = () => {};
+    req.end = () => {
+      const snapshot: StubRequest = {
+        method: String(options?.method || 'GET'),
+        path: String(options?.path || ''),
+        body
+      };
+      calls.push(snapshot);
+      let output: { statusCode: number; body?: unknown };
+      try {
+        output = responder(snapshot);
+      } catch (e) {
+        process.nextTick(() => req.emit('error', e));
+        return;
+      }
+      const res = new EventEmitter() as any;
+      res.statusCode = output.statusCode;
+      res.headers = {};
+      res.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      res.setEncoding = () => {};
+      res.req = req;
+      cb(res);
+      process.nextTick(() => {
+        const text =
+          output.body === undefined ? '' : typeof output.body === 'string' ? output.body : JSON.stringify(output.body);
+        if (text) {
+          res.emit('data', Buffer.from(text));
+        }
+        res.emit('end');
+      });
+    };
+    return req;
+  });
+  return calls;
+}
+
+function decodeSoql(path: string): string {
+  const qMarker = '?q=';
+  const idx = path.indexOf(qMarker);
+  if (idx < 0) {
+    return '';
+  }
+  return decodeURIComponent(path.slice(idx + qMarker.length));
+}
+
+suite('traceflags user management', () => {
+  const auth: OrgAuth = {
+    accessToken: 'token',
+    instanceUrl: 'https://example.my.salesforce.com',
+    username: 'user@example.com'
+  };
+
+  teardown(() => {
+    __resetHttpsRequestImplForTests();
+  });
+
+  test('listActiveUsers returns active users filtered by query', async () => {
+    const calls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        return {
+          statusCode: 200,
+          body: {
+            records: [
+              { Id: '005000000000001AAA', Name: 'Ada Lovelace', Username: 'ada@example.com', IsActive: true },
+              { Id: '005000000000002AAA', Name: 'Grace Hopper', Username: 'grace@example.com', IsActive: true }
+            ]
+          }
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const users = await listActiveUsers(auth, 'ada', 25);
+    assert.equal(users.length, 2);
+    assert.equal(users[0]?.id, '005000000000001AAA');
+    assert.equal(users[0]?.username, 'ada@example.com');
+    assert.equal(users[0]?.active, true);
+
+    const soql = decodeSoql(calls[0]?.path || '');
+    assert.match(soql, /FROM User/);
+    assert.match(soql, /IsActive = true/);
+    assert.match(soql, /Name LIKE '%ada%'/i);
+  });
+
+  test('getUserTraceFlagStatus parses active status and metadata', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        return {
+          statusCode: 200,
+          body: {
+            records: [
+              {
+                Id: '7tf000000000001AAA',
+                StartDate: '2026-02-19T16:00:00.000Z',
+                ExpirationDate: '2099-02-19T18:00:00.000Z',
+                DebugLevel: { DeveloperName: 'ALV_E2E' }
+              }
+            ]
+          }
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const status = await getUserTraceFlagStatus(auth, '005000000000001AAA');
+    assert.ok(status);
+    assert.equal(status?.traceFlagId, '7tf000000000001AAA');
+    assert.equal(status?.debugLevelName, 'ALV_E2E');
+    assert.equal(status?.isActive, true);
+  });
+
+  test('upsertUserTraceFlag updates existing USER_DEBUG flag', async () => {
+    const calls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes('FROM DebugLevel')) {
+          return { statusCode: 200, body: { records: [{ Id: '7dl000000000001AAA' }] } };
+        }
+        if (soql.includes('FROM TraceFlag')) {
+          return { statusCode: 200, body: { records: [{ Id: '7tf000000000001AAA' }] } };
+        }
+      }
+      if (req.method === 'PATCH' && req.path.includes('/tooling/sobjects/TraceFlag/7tf000000000001AAA')) {
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.DebugLevelId, '7dl000000000001AAA');
+        assert.ok(typeof parsed.StartDate === 'string');
+        assert.ok(typeof parsed.ExpirationDate === 'string');
+        return { statusCode: 204 };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const result = await upsertUserTraceFlag(auth, {
+      userId: '005000000000001AAA',
+      debugLevelName: 'ALV_E2E',
+      ttlMinutes: 45
+    });
+    assert.equal(result.created, false);
+    assert.equal(result.traceFlagId, '7tf000000000001AAA');
+    assert.equal(calls.filter(call => call.method === 'PATCH').length, 1);
+  });
+
+  test('upsertUserTraceFlag creates USER_DEBUG flag when none exists', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes('FROM DebugLevel')) {
+          return { statusCode: 200, body: { records: [{ Id: '7dl000000000001AAA' }] } };
+        }
+        if (soql.includes('FROM TraceFlag')) {
+          return { statusCode: 200, body: { records: [] } };
+        }
+      }
+      if (req.method === 'POST' && req.path.endsWith('/tooling/sobjects/TraceFlag')) {
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.TracedEntityId, '005000000000001AAA');
+        assert.equal(parsed.LogType, 'USER_DEBUG');
+        return { statusCode: 201, body: { success: true, id: '7tf000000000999AAA' } };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const result = await upsertUserTraceFlag(auth, {
+      userId: '005000000000001AAA',
+      debugLevelName: 'ALV_E2E',
+      ttlMinutes: 30
+    });
+    assert.equal(result.created, true);
+    assert.equal(result.traceFlagId, '7tf000000000999AAA');
+  });
+
+  test('removeUserTraceFlags deletes all USER_DEBUG flags for user', async () => {
+    const calls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        return {
+          statusCode: 200,
+          body: { records: [{ Id: '7tf000000000001AAA' }, { Id: '7tf000000000002AAA' }] }
+        };
+      }
+      if (req.method === 'DELETE' && req.path.includes('/tooling/sobjects/TraceFlag/')) {
+        return { statusCode: 204 };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const removed = await removeUserTraceFlags(auth, '005000000000001AAA');
+    assert.equal(removed, 2);
+    assert.equal(calls.filter(call => call.method === 'DELETE').length, 2);
+  });
+});

--- a/src/webview/__tests__/TailToolbar.test.tsx
+++ b/src/webview/__tests__/TailToolbar.test.tsx
@@ -45,6 +45,7 @@ describe('TailToolbar webview component', () => {
         onClear={() => {}}
         onOpenSelected={() => {}}
         onReplaySelected={() => {}}
+        onOpenDebugFlags={() => {}}
         actionsEnabled={false}
         disabled={false}
         orgs={orgs}
@@ -81,6 +82,7 @@ describe('TailToolbar webview component', () => {
         onClear={() => {}}
         onOpenSelected={() => {}}
         onReplaySelected={() => {}}
+        onOpenDebugFlags={() => {}}
         actionsEnabled
         disabled={false}
         orgs={orgs}
@@ -117,6 +119,7 @@ describe('TailToolbar webview component', () => {
         onClear={() => {}}
         onOpenSelected={() => openCalls.push('open')}
         onReplaySelected={() => openCalls.push('replay')}
+        onOpenDebugFlags={() => openCalls.push('debugFlags')}
         actionsEnabled
         disabled
         orgs={orgs}
@@ -162,6 +165,7 @@ describe('TailToolbar webview component', () => {
         onClear={() => {}}
         onOpenSelected={() => {}}
         onReplaySelected={() => {}}
+        onOpenDebugFlags={() => {}}
         actionsEnabled={true}
         disabled={false}
         orgs={orgs}
@@ -209,5 +213,40 @@ describe('TailToolbar webview component', () => {
       { type: 'color', value: true },
       { type: 'auto', value: true }
     ]);
+  });
+
+  it('opens debug flags from tail toolbar', () => {
+    const calls: string[] = [];
+    renderWithNativeSelect(
+      <TailToolbar
+        running={false}
+        onStart={() => {}}
+        onStop={() => {}}
+        onClear={() => {}}
+        onOpenSelected={() => {}}
+        onReplaySelected={() => {}}
+        onOpenDebugFlags={() => calls.push('open')}
+        actionsEnabled={false}
+        disabled={false}
+        orgs={orgs}
+        selectedOrg="user@example.com"
+        onSelectOrg={() => {}}
+        query=""
+        onQueryChange={() => {}}
+        onlyUserDebug={false}
+        onToggleOnlyUserDebug={() => {}}
+        colorize={false}
+        onToggleColorize={() => {}}
+        debugLevels={['LevelA']}
+        debugLevel="LevelA"
+        onDebugLevelChange={() => {}}
+        autoScroll={false}
+        onToggleAutoScroll={() => {}}
+        t={t}
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Debug Flags' }));
+    expect(calls).toEqual(['open']);
   });
 });

--- a/src/webview/__tests__/Toolbar.test.tsx
+++ b/src/webview/__tests__/Toolbar.test.tsx
@@ -65,6 +65,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   const statuses = ['Success', 'Failed'];
   const codeUnits = ['UnitA', 'UnitB'];
   let refreshCount = 0;
+  let openDebugFlagsCount = 0;
   let clearCount = 0;
   const queryChanges: string[] = [];
   const userChanges: string[] = [];
@@ -82,6 +83,9 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
         warning={warning}
         onRefresh={() => {
           refreshCount++;
+        }}
+        onOpenDebugFlags={() => {
+          openDebugFlagsCount++;
         }}
         t={t}
         orgs={orgs}
@@ -128,6 +132,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   return {
     view,
     refreshCount: () => refreshCount,
+    openDebugFlagsCount: () => openDebugFlagsCount,
     clearCount: () => clearCount,
     queryChanges,
     userChanges
@@ -202,5 +207,12 @@ describe('Toolbar webview component', () => {
     renderToolbar({ warning: 'sourceApiVersion 66.0 > org max 64.0; falling back to 64.0' });
     screen.getByText('Warning:');
     screen.getByText('sourceApiVersion 66.0 > org max 64.0; falling back to 64.0');
+  });
+
+  it('triggers debug flags entrypoint from toolbar button', () => {
+    const utils = renderToolbar();
+    const btn = screen.getByRole('button', { name: 'Debug Flags' });
+    fireEvent.click(btn);
+    expect(utils.openDebugFlagsCount()).toBe(1);
   });
 });

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -105,6 +105,16 @@ describe('DebugFlags webview App', () => {
     render(<DebugFlagsApp vscode={vscode} messageBus={bus} />);
 
     sendMessage(bus, { type: 'debugFlagsInit', locale: 'en', defaultTtlMinutes: 30 });
+    await act(async () => {
+      await new Promise(resolve => setTimeout(resolve, 350));
+    });
+    expect(posted.some(msg => msg.type === 'debugFlagsSearchUsers')).toBe(false);
+
+    sendMessage(bus, {
+      type: 'debugFlagsOrgs',
+      data: [{ username: 'user@example.com', alias: 'Main', isDefaultUsername: true }],
+      selected: 'user@example.com'
+    });
     const search = screen.getByTestId('debug-flags-user-search');
     fireEvent.change(search, { target: { value: 'ada' } });
     await waitFor(

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../../shared/debugFlagsMessages';
+import type { VsCodeWebviewApi } from '../vscodeApi';
+import { DebugFlagsApp } from '../debugFlags';
+
+describe('DebugFlags webview App', () => {
+  function createVsCodeMock() {
+    const posted: DebugFlagsFromWebviewMessage[] = [];
+    const vscode: VsCodeWebviewApi<DebugFlagsFromWebviewMessage> = {
+      postMessage: msg => {
+        posted.push(msg);
+      },
+      getState: () => undefined,
+      setState: () => {}
+    };
+    return { vscode, posted };
+  }
+
+  function sendMessage(bus: EventTarget, message: DebugFlagsToWebviewMessage) {
+    act(() => {
+      bus.dispatchEvent(new MessageEvent('message', { data: message }));
+    });
+  }
+
+  it('loads data, configures flags and removes flags', async () => {
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+    render(<DebugFlagsApp vscode={vscode} messageBus={bus} />);
+
+    expect(posted[0]).toEqual({ type: 'debugFlagsReady' });
+
+    sendMessage(bus, { type: 'debugFlagsInit', locale: 'pt-BR', defaultTtlMinutes: 30 });
+    await screen.findByText('Apex Debug Flags');
+
+    sendMessage(bus, {
+      type: 'debugFlagsOrgs',
+      data: [{ username: 'user@example.com', alias: 'Main', isDefaultUsername: true }],
+      selected: 'user@example.com'
+    });
+    sendMessage(bus, { type: 'debugFlagsDebugLevels', data: ['ALV_E2E', 'DEVELOPER_LOG'], active: 'ALV_E2E' });
+    sendMessage(bus, {
+      type: 'debugFlagsUsers',
+      query: '',
+      data: [
+        {
+          id: '005000000000001AAA',
+          name: 'Ada Lovelace',
+          username: 'ada@example.com',
+          active: true
+        }
+      ]
+    });
+
+    fireEvent.click(screen.getByTestId('debug-flags-user-row-005000000000001AAA'));
+    await waitFor(() => {
+      expect(posted.some(msg => msg.type === 'debugFlagsSelectUser' && msg.userId === '005000000000001AAA')).toBe(true);
+    });
+
+    sendMessage(bus, {
+      type: 'debugFlagsUserStatus',
+      userId: '005000000000001AAA',
+      status: {
+        traceFlagId: '7tf000000000001AAA',
+        debugLevelName: 'ALV_E2E',
+        startDate: '2026-02-19T17:00:00.000Z',
+        expirationDate: '2026-02-19T18:00:00.000Z',
+        isActive: true
+      }
+    });
+    await screen.findByTestId('debug-flags-status-level');
+
+    const ttl = screen.getByTestId('debug-flags-ttl') as HTMLInputElement;
+    fireEvent.change(ttl, { target: { value: '45' } });
+
+    fireEvent.click(screen.getByTestId('debug-flags-apply'));
+    await waitFor(() => {
+      expect(
+        posted.some(
+          msg =>
+            msg.type === 'debugFlagsApply' &&
+            msg.userId === '005000000000001AAA' &&
+            msg.debugLevelName === 'ALV_E2E' &&
+            msg.ttlMinutes === 45
+        )
+      ).toBe(true);
+    });
+
+    sendMessage(bus, {
+      type: 'debugFlagsNotice',
+      tone: 'success',
+      message: 'Debug flag updated successfully.'
+    });
+    await screen.findByTestId('debug-flags-notice');
+
+    fireEvent.click(screen.getByTestId('debug-flags-remove'));
+    await waitFor(() => {
+      expect(posted.some(msg => msg.type === 'debugFlagsRemove' && msg.userId === '005000000000001AAA')).toBe(true);
+    });
+  });
+
+  it('sends debounced user search queries', async () => {
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+    render(<DebugFlagsApp vscode={vscode} messageBus={bus} />);
+
+    sendMessage(bus, { type: 'debugFlagsInit', locale: 'en', defaultTtlMinutes: 30 });
+    const search = screen.getByTestId('debug-flags-user-search');
+    fireEvent.change(search, { target: { value: 'ada' } });
+    await waitFor(
+      () => {
+        expect(posted.some(msg => msg.type === 'debugFlagsSearchUsers' && msg.query === 'ada')).toBe(true);
+      },
+      { timeout: 1000 }
+    );
+  });
+});

--- a/src/webview/__tests__/logsApp.test.tsx
+++ b/src/webview/__tests__/logsApp.test.tsx
@@ -168,12 +168,13 @@ describe('Logs webview App', () => {
     const openButtons = await screen.findAllByRole('button', { name: 'Abrir' });
     fireEvent.click(openButtons[0]!);
     fireEvent.click(screen.getAllByRole('button', { name: 'Apex Replay' })[0]!);
+    fireEvent.click(screen.getByRole('button', { name: 'Debug Flags' }));
     fireEvent.click(screen.getByRole('button', { name: 'Atualizar' }));
 
     await waitFor(() => {
       const types = posted.map(m => m.type);
       expect(types[0]).toBe('ready');
-      expect(types).toEqual(expect.arrayContaining(['openLog', 'replay', 'refresh']));
+      expect(types).toEqual(expect.arrayContaining(['openLog', 'replay', 'refresh', 'openDebugFlags']));
     });
   }, 10000);
 

--- a/src/webview/__tests__/tailApp.test.tsx
+++ b/src/webview/__tests__/tailApp.test.tsx
@@ -73,6 +73,7 @@ describe('Tail webview App', () => {
     await waitFor(() => expect(openBtn.hasAttribute('disabled')).toBe(false));
     fireEvent.click(openBtn);
     fireEvent.click(screen.getByRole('button', { name: 'Replay Debugger' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Debug Flags' }));
 
     fireEvent.click(screen.getByLabelText('Somente USER_DEBUG'));
     await waitFor(() => {
@@ -91,7 +92,9 @@ describe('Tail webview App', () => {
 
     await waitFor(() => {
       const types = posted.map(m => m.type);
-      expect(types).toEqual(expect.arrayContaining(['tailStart', 'tailStop', 'tailClear', 'openLog', 'replay']));
+      expect(types).toEqual(
+        expect.arrayContaining(['tailStart', 'tailStop', 'tailClear', 'openLog', 'replay', 'openDebugFlags'])
+      );
     });
   });
 });

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RefreshCw, FilterX, Loader2, AlertCircle } from 'lucide-react';
+import { RefreshCw, FilterX, Loader2, AlertCircle, Bug } from 'lucide-react';
 import type { OrgItem } from '../../shared/types';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -19,6 +19,7 @@ type ToolbarProps = {
   error?: string;
   warning?: string;
   onRefresh: () => void;
+  onOpenDebugFlags: () => void;
   t: any;
   orgs: OrgItem[];
   selectedOrg?: string;
@@ -53,6 +54,7 @@ export function Toolbar({
   error,
   warning,
   onRefresh,
+  onOpenDebugFlags,
   t,
   orgs,
   selectedOrg,
@@ -109,6 +111,19 @@ export function Toolbar({
           disabled={loading}
           emptyText={t.noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}
         />
+
+        <Button
+          type="button"
+          onClick={onOpenDebugFlags}
+          disabled={loading}
+          variant="ghost"
+          className="flex items-center gap-2"
+          title={t.debugFlags?.openTitle ?? 'Open debug flags editor'}
+          data-testid="logs-open-debug-flags"
+        >
+          <Bug className="h-4 w-4" aria-hidden="true" />
+          <span>{t.debugFlags?.open ?? 'Debug Flags'}</span>
+        </Button>
 
         <div className="flex min-w-[220px] flex-1 flex-col gap-1">
           <Label htmlFor={searchInputId}>{t.searchPlaceholder ?? 'Search logs…'}</Label>

--- a/src/webview/components/tail/TailToolbar.tsx
+++ b/src/webview/components/tail/TailToolbar.tsx
@@ -5,7 +5,8 @@ import {
   Eraser,
   ExternalLink,
   RotateCcw,
-  Loader2
+  Loader2,
+  Bug
 } from 'lucide-react';
 import type { OrgItem } from '../../../shared/types';
 import { Button } from '../ui/button';
@@ -27,6 +28,7 @@ type TailToolbarProps = {
   onClear: () => void;
   onOpenSelected: () => void;
   onReplaySelected: () => void;
+  onOpenDebugFlags: () => void;
   actionsEnabled: boolean;
   disabled?: boolean;
   orgs: OrgItem[];
@@ -54,6 +56,7 @@ export function TailToolbar({
   onClear,
   onOpenSelected,
   onReplaySelected,
+  onOpenDebugFlags,
   actionsEnabled,
   disabled = false,
   orgs,
@@ -134,6 +137,19 @@ export function TailToolbar({
         >
           <RotateCcw className="h-4 w-4" aria-hidden="true" />
           <span>{t.tail?.replayDebugger ?? 'Replay Debugger'}</span>
+        </Button>
+
+        <Button
+          type="button"
+          onClick={onOpenDebugFlags}
+          disabled={disabled}
+          variant="ghost"
+          className="flex items-center gap-2"
+          title={t.debugFlags?.openTitle ?? 'Open debug flags editor'}
+          data-testid="tail-open-debug-flags"
+        >
+          <Bug className="h-4 w-4" aria-hidden="true" />
+          <span>{t.debugFlags?.open ?? 'Debug Flags'}</span>
         </Button>
 
         <OrgSelect

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -1,0 +1,448 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { createRoot } from 'react-dom/client';
+import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
+import type { DebugFlagUser, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
+import type { OrgItem } from '../shared/types';
+import type { MessageBus, VsCodeWebviewApi } from './vscodeApi';
+import { getDefaultMessageBus, getDefaultVsCodeApi } from './vscodeApi';
+import { getMessages, type Messages } from './i18n';
+import { OrgSelect } from './components/OrgSelect';
+import { Input } from './components/ui/input';
+import { Label } from './components/ui/label';
+import { Button } from './components/ui/button';
+import { LabeledSelect } from './components/LabeledSelect';
+import { cn } from './lib/utils';
+import { AlertCircle, CheckCircle2, Info, Loader2, UserRound } from 'lucide-react';
+
+export interface DebugFlagsAppProps {
+  vscode?: VsCodeWebviewApi<DebugFlagsFromWebviewMessage>;
+  messageBus?: MessageBus;
+}
+
+type LoadingState = {
+  orgs: boolean;
+  users: boolean;
+  status: boolean;
+  action: boolean;
+};
+
+type NoticeState = {
+  tone: 'success' | 'info' | 'warning';
+  message: string;
+};
+
+function formatDate(value: string | undefined, locale: string): string {
+  if (!value) {
+    return '-';
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return new Intl.DateTimeFormat(locale || 'en', {
+    dateStyle: 'medium',
+    timeStyle: 'short'
+  }).format(date);
+}
+
+export function DebugFlagsApp({
+  vscode = getDefaultVsCodeApi<DebugFlagsFromWebviewMessage>(),
+  messageBus = getDefaultMessageBus()
+}: DebugFlagsAppProps = {}) {
+  const [locale, setLocale] = useState('en');
+  const [t, setT] = useState<Messages>(() => getMessages('en'));
+  const [orgs, setOrgs] = useState<OrgItem[]>([]);
+  const [selectedOrg, setSelectedOrg] = useState<string | undefined>(undefined);
+  const [query, setQuery] = useState('');
+  const [users, setUsers] = useState<DebugFlagUser[]>([]);
+  const [selectedUserId, setSelectedUserId] = useState<string | undefined>(undefined);
+  const [status, setStatus] = useState<UserTraceFlagStatus | undefined>(undefined);
+  const [debugLevels, setDebugLevels] = useState<string[]>([]);
+  const [debugLevel, setDebugLevel] = useState('');
+  const [ttlMinutes, setTtlMinutes] = useState('30');
+  const [error, setError] = useState<string | undefined>(undefined);
+  const [notice, setNotice] = useState<NoticeState | undefined>(undefined);
+  const [initialized, setInitialized] = useState(false);
+  const [loading, setLoading] = useState<LoadingState>({
+    orgs: false,
+    users: false,
+    status: false,
+    action: false
+  });
+
+  useEffect(() => {
+    if (!messageBus) {
+      vscode.postMessage({ type: 'debugFlagsReady' });
+      return;
+    }
+    const handler = (event: MessageEvent) => {
+      const msg = event.data as DebugFlagsToWebviewMessage;
+      if (!msg || typeof msg !== 'object') {
+        return;
+      }
+      switch (msg.type) {
+        case 'debugFlagsInit':
+          setLocale(msg.locale);
+          setT(getMessages(msg.locale));
+          setTtlMinutes(String(msg.defaultTtlMinutes || 30));
+          setInitialized(true);
+          break;
+        case 'debugFlagsLoading':
+          setLoading(prev => ({
+            ...prev,
+            [msg.scope]: msg.value
+          }));
+          break;
+        case 'debugFlagsOrgs':
+          setOrgs(msg.data || []);
+          setSelectedOrg(msg.selected);
+          break;
+        case 'debugFlagsUsers':
+          setUsers(msg.data || []);
+          break;
+        case 'debugFlagsDebugLevels': {
+          const values = msg.data || [];
+          setDebugLevels(values);
+          if (typeof msg.active === 'string' && msg.active) {
+            setDebugLevel(msg.active);
+          } else if (values.length > 0) {
+            setDebugLevel(prev => prev || values[0]!);
+          }
+          break;
+        }
+        case 'debugFlagsUserStatus':
+          if (msg.userId === selectedUserId) {
+            setStatus(msg.status);
+          }
+          break;
+        case 'debugFlagsNotice':
+          setError(undefined);
+          setNotice({
+            tone: msg.tone,
+            message: msg.message
+          });
+          break;
+        case 'debugFlagsError':
+          setNotice(undefined);
+          setError(msg.message);
+          break;
+      }
+    };
+    messageBus.addEventListener('message', handler as EventListener);
+    vscode.postMessage({ type: 'debugFlagsReady' });
+    return () => messageBus.removeEventListener('message', handler as EventListener);
+  }, [messageBus, selectedUserId, vscode]);
+
+  useEffect(() => {
+    if (!initialized) {
+      return;
+    }
+    const handle = setTimeout(() => {
+      vscode.postMessage({ type: 'debugFlagsSearchUsers', query });
+    }, 300);
+    return () => clearTimeout(handle);
+  }, [initialized, query, vscode]);
+
+  const selectedUser = useMemo(
+    () => users.find(user => user.id === selectedUserId),
+    [users, selectedUserId]
+  );
+
+  const canApply = Boolean(selectedUserId && debugLevel && !loading.action && !loading.orgs);
+  const canRemove = Boolean(selectedUserId && !loading.action && !loading.orgs);
+
+  const handleSelectOrg = (nextOrg: string) => {
+    setSelectedOrg(nextOrg);
+    setSelectedUserId(undefined);
+    setStatus(undefined);
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({ type: 'debugFlagsSelectOrg', target: nextOrg });
+  };
+
+  const handleSelectUser = (userId: string) => {
+    setSelectedUserId(userId);
+    setStatus(undefined);
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({ type: 'debugFlagsSelectUser', userId });
+  };
+
+  const handleApply = () => {
+    if (!selectedUserId || !debugLevel) {
+      return;
+    }
+    const ttl = Number(ttlMinutes);
+    if (!Number.isFinite(ttl) || ttl < 1 || ttl > 1440) {
+      setError(t.debugFlags?.ttlHelper ?? 'Default is 30 minutes. Allowed range: 1-1440.');
+      return;
+    }
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({
+      type: 'debugFlagsApply',
+      userId: selectedUserId,
+      debugLevelName: debugLevel,
+      ttlMinutes: Math.floor(ttl)
+    });
+  };
+
+  const handleRemove = () => {
+    if (!selectedUserId) {
+      return;
+    }
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({
+      type: 'debugFlagsRemove',
+      userId: selectedUserId
+    });
+  };
+
+  const noticeIcon = notice?.tone === 'success' ? CheckCircle2 : notice?.tone === 'warning' ? AlertCircle : Info;
+  const NoticeIcon = noticeIcon;
+
+  return (
+    <div className="flex min-h-screen flex-col gap-4 p-4 text-sm">
+      <header className="rounded-lg border border-border bg-card/70 p-4 shadow-sm">
+        <h1 className="text-lg font-semibold text-foreground">
+          {t.debugFlags?.panelTitle ?? 'Apex Debug Flags'}
+        </h1>
+        <p className="mt-1 text-sm text-muted-foreground">
+          {t.debugFlags?.panelSubtitle ?? 'Configure USER_DEBUG trace flags with room to focus.'}
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-border bg-card/70 p-4 shadow-sm">
+        <div className="flex flex-wrap items-end gap-3">
+          <OrgSelect
+            label={t.debugFlags?.org ?? t.orgLabel}
+            orgs={orgs}
+            selected={selectedOrg}
+            onChange={handleSelectOrg}
+            disabled={loading.orgs || loading.action}
+            emptyText={t.noOrgsDetected ?? 'No orgs detected. Run "sf org list".'}
+          />
+
+          <div className="flex min-w-[260px] flex-1 flex-col gap-1">
+            <Label htmlFor="debug-flags-user-search">
+              {t.debugFlags?.userSearchLabel ?? 'Find user'}
+            </Label>
+            <Input
+              id="debug-flags-user-search"
+              type="search"
+              value={query}
+              onChange={event => setQuery(event.target.value)}
+              placeholder={t.debugFlags?.userSearchPlaceholder ?? 'Type name or username…'}
+              disabled={loading.orgs || loading.action}
+              data-testid="debug-flags-user-search"
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="grid min-h-[420px] grid-cols-1 gap-4 lg:grid-cols-[1fr_1.4fr]">
+        <article className="rounded-lg border border-border bg-card/70 p-3 shadow-sm">
+          <h2 className="mb-2 text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+            {t.debugFlags?.users ?? 'Active users'}
+          </h2>
+          {loading.users ? (
+            <div className="flex items-center gap-2 text-muted-foreground">
+              <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+              <span>{t.debugFlags?.loadingUsers ?? 'Loading users…'}</span>
+            </div>
+          ) : users.length === 0 ? (
+            <p className="text-muted-foreground">
+              {t.debugFlags?.noUsers ?? 'No active users found for this query.'}
+            </p>
+          ) : (
+            <ul className="max-h-[460px] space-y-2 overflow-auto pr-1" data-testid="debug-flags-users-list">
+              {users.map(user => {
+                const selected = user.id === selectedUserId;
+                return (
+                  <li key={user.id}>
+                    <button
+                      type="button"
+                      className={cn(
+                        'flex w-full items-center justify-between rounded-md border px-3 py-2 text-left transition-colors',
+                        selected
+                          ? 'border-primary bg-primary/15 text-foreground'
+                          : 'border-border bg-background/50 hover:bg-muted/60'
+                      )}
+                      onClick={() => handleSelectUser(user.id)}
+                      data-testid={`debug-flags-user-row-${user.id}`}
+                    >
+                      <span className="flex min-w-0 flex-col">
+                        <span className="truncate font-medium">{user.name}</span>
+                        <span className="truncate text-xs text-muted-foreground">{user.username}</span>
+                      </span>
+                      <UserRound className="h-4 w-4 shrink-0 opacity-70" aria-hidden="true" />
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </article>
+
+        <article className="flex flex-col gap-4 rounded-lg border border-border bg-card/70 p-4 shadow-sm">
+          <div className="rounded-md border border-border/80 bg-background/40 p-3">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+              {t.debugFlags?.currentStatus ?? 'Current status'}
+            </h2>
+
+            {!selectedUser ? (
+              <p className="mt-2 text-muted-foreground">
+                {t.debugFlags?.selectUserHint ?? 'Select an active user to inspect and configure debug flags.'}
+              </p>
+            ) : loading.status ? (
+              <div className="mt-2 flex items-center gap-2 text-muted-foreground">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                <span>{t.loading}</span>
+              </div>
+            ) : status ? (
+              <div className="mt-2 space-y-2">
+                <div className="flex items-center gap-2">
+                  <span
+                    className={cn(
+                      'inline-flex rounded-full px-2 py-0.5 text-xs font-semibold',
+                      status.isActive
+                        ? 'bg-emerald-500/15 text-emerald-300'
+                        : 'bg-zinc-500/20 text-zinc-300'
+                    )}
+                    data-testid="debug-flags-status-pill"
+                  >
+                    {status.isActive
+                      ? t.debugFlags?.statusActive ?? 'Active'
+                      : t.debugFlags?.statusInactive ?? 'Inactive'}
+                  </span>
+                </div>
+                <p>
+                  <span className="font-semibold">{t.debugFlags?.statusLevel ?? 'Debug level'}:</span>{' '}
+                  <span data-testid="debug-flags-status-level">{status.debugLevelName}</span>
+                </p>
+                <p>
+                  <span className="font-semibold">{t.debugFlags?.statusStart ?? 'Starts'}:</span>{' '}
+                  {formatDate(status.startDate, locale)}
+                </p>
+                <p>
+                  <span className="font-semibold">{t.debugFlags?.statusExpiration ?? 'Expires'}:</span>{' '}
+                  <span data-testid="debug-flags-status-expiration">
+                    {formatDate(status.expirationDate, locale)}
+                  </span>
+                </p>
+              </div>
+            ) : (
+              <p className="mt-2 text-muted-foreground">
+                {t.debugFlags?.noStatus ?? 'No active USER_DEBUG trace flag for this user.'}
+              </p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_180px]">
+            <LabeledSelect
+              label={t.debugFlags?.debugLevel ?? 'Debug level'}
+              value={debugLevel}
+              onChange={setDebugLevel}
+              options={debugLevels.map(level => ({ value: level, label: level }))}
+              placeholderLabel={t.tail?.select ?? 'Select'}
+              disabled={loading.orgs || loading.action}
+            />
+            <div className="flex flex-col gap-1">
+              <Label htmlFor="debug-flags-ttl">
+                {t.debugFlags?.ttlMinutes ?? 'TTL (minutes)'}
+              </Label>
+              <Input
+                id="debug-flags-ttl"
+                type="number"
+                value={ttlMinutes}
+                onChange={event => setTtlMinutes(event.target.value)}
+                min={1}
+                max={1440}
+                disabled={loading.orgs || loading.action}
+                data-testid="debug-flags-ttl"
+              />
+            </div>
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            {t.debugFlags?.ttlHelper ?? 'Default is 30 minutes. Allowed range: 1-1440.'}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              type="button"
+              onClick={handleApply}
+              disabled={!canApply}
+              variant="secondary"
+              data-testid="debug-flags-apply"
+            >
+              {loading.action ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  <span>{t.loading}</span>
+                </>
+              ) : (
+                <span>{t.debugFlags?.apply ?? 'Apply debug flag'}</span>
+              )}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleRemove}
+              disabled={!canRemove}
+              variant="outline"
+              data-testid="debug-flags-remove"
+            >
+              {t.debugFlags?.remove ?? 'Remove debug flag'}
+            </Button>
+          </div>
+        </article>
+      </section>
+
+      {error && (
+        <div className="flex items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-destructive">
+          <AlertCircle className="h-4 w-4" aria-hidden="true" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {!error && notice && (
+        <div
+          className={cn(
+            'flex items-center gap-2 rounded-md border px-3 py-2',
+            notice.tone === 'success'
+              ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-300'
+              : notice.tone === 'warning'
+                ? 'border-amber-500/30 bg-amber-500/10 text-amber-300'
+                : 'border-sky-500/30 bg-sky-500/10 text-sky-300'
+          )}
+          data-testid="debug-flags-notice"
+        >
+          <NoticeIcon className="h-4 w-4" aria-hidden="true" />
+          <span>{notice.message}</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function mountDebugFlagsApp(
+  container: HTMLElement,
+  options: { vscode?: VsCodeWebviewApi<DebugFlagsFromWebviewMessage>; messageBus?: MessageBus } = {}
+) {
+  const root = createRoot(container);
+  root.render(
+    <DebugFlagsApp
+      vscode={options.vscode ?? getDefaultVsCodeApi<DebugFlagsFromWebviewMessage>()}
+      messageBus={options.messageBus ?? getDefaultMessageBus()}
+    />
+  );
+  return root;
+}
+
+if (typeof document !== 'undefined') {
+  const container = document.getElementById('root');
+  if (container) {
+    mountDebugFlagsApp(container);
+  }
+}

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -139,14 +139,14 @@ export function DebugFlagsApp({
   }, [messageBus, vscode]);
 
   useEffect(() => {
-    if (!initialized) {
+    if (!initialized || !selectedOrg) {
       return;
     }
     const handle = setTimeout(() => {
       vscode.postMessage({ type: 'debugFlagsSearchUsers', query });
     }, 300);
     return () => clearTimeout(handle);
-  }, [initialized, query, vscode]);
+  }, [initialized, selectedOrg, query, vscode]);
 
   const selectedUser = useMemo(
     () => users.find(user => user.id === selectedUserId),

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
 import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
 import type { DebugFlagUser, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
@@ -63,12 +63,17 @@ export function DebugFlagsApp({
   const [error, setError] = useState<string | undefined>(undefined);
   const [notice, setNotice] = useState<NoticeState | undefined>(undefined);
   const [initialized, setInitialized] = useState(false);
+  const selectedUserIdRef = useRef<string | undefined>(undefined);
   const [loading, setLoading] = useState<LoadingState>({
     orgs: false,
     users: false,
     status: false,
     action: false
   });
+
+  useEffect(() => {
+    selectedUserIdRef.current = selectedUserId;
+  }, [selectedUserId]);
 
   useEffect(() => {
     if (!messageBus) {
@@ -111,7 +116,7 @@ export function DebugFlagsApp({
           break;
         }
         case 'debugFlagsUserStatus':
-          if (msg.userId === selectedUserId) {
+          if (msg.userId === selectedUserIdRef.current) {
             setStatus(msg.status);
           }
           break;
@@ -131,7 +136,7 @@ export function DebugFlagsApp({
     messageBus.addEventListener('message', handler as EventListener);
     vscode.postMessage({ type: 'debugFlagsReady' });
     return () => messageBus.removeEventListener('message', handler as EventListener);
-  }, [messageBus, selectedUserId, vscode]);
+  }, [messageBus, vscode]);
 
   useEffect(() => {
     if (!initialized) {

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -60,6 +60,35 @@ export type Messages = {
     moveUp: string;
     moveDown: string;
   };
+  debugFlags?: {
+    open: string;
+    openTitle: string;
+    panelTitle: string;
+    panelSubtitle: string;
+    org: string;
+    userSearchLabel: string;
+    userSearchPlaceholder: string;
+    users: string;
+    noUsers: string;
+    loadingUsers: string;
+    selectUserHint: string;
+    debugLevel: string;
+    ttlMinutes: string;
+    apply: string;
+    remove: string;
+    currentStatus: string;
+    statusActive: string;
+    statusInactive: string;
+    statusLevel: string;
+    statusExpiration: string;
+    statusStart: string;
+    noStatus: string;
+    noticeCreated: string;
+    noticeUpdated: string;
+    noticeRemoved: string;
+    noticeNone: string;
+    ttlHelper: string;
+  };
 };
 
 const en: Messages = {
@@ -123,6 +152,35 @@ const en: Messages = {
     matchRequiresFullSearch: 'Requires full log search',
     moveUp: 'Move up',
     moveDown: 'Move down'
+  },
+  debugFlags: {
+    open: 'Debug Flags',
+    openTitle: 'Open debug flags editor',
+    panelTitle: 'Apex Debug Flags',
+    panelSubtitle: 'Configure USER_DEBUG trace flags with room to focus.',
+    org: 'Org',
+    userSearchLabel: 'Find user',
+    userSearchPlaceholder: 'Type name or username…',
+    users: 'Active users',
+    noUsers: 'No active users found for this query.',
+    loadingUsers: 'Loading users…',
+    selectUserHint: 'Select an active user to inspect and configure debug flags.',
+    debugLevel: 'Debug level',
+    ttlMinutes: 'TTL (minutes)',
+    apply: 'Apply debug flag',
+    remove: 'Remove debug flag',
+    currentStatus: 'Current status',
+    statusActive: 'Active',
+    statusInactive: 'Inactive',
+    statusLevel: 'Debug level',
+    statusExpiration: 'Expires',
+    statusStart: 'Starts',
+    noStatus: 'No active USER_DEBUG trace flag for this user.',
+    noticeCreated: 'Debug flag created successfully.',
+    noticeUpdated: 'Debug flag updated successfully.',
+    noticeRemoved: 'Debug flag removed successfully.',
+    noticeNone: 'No USER_DEBUG trace flag found for this user.',
+    ttlHelper: 'Default is 30 minutes. Allowed range: 1-1440.'
   }
 };
 
@@ -187,6 +245,35 @@ const ptBR: Messages = {
     matchRequiresFullSearch: 'Requer busca completa',
     moveUp: 'Mover para cima',
     moveDown: 'Mover para baixo'
+  },
+  debugFlags: {
+    open: 'Debug Flags',
+    openTitle: 'Abrir editor de debug flags',
+    panelTitle: 'Apex Debug Flags',
+    panelSubtitle: 'Configure trace flags USER_DEBUG com mais espaço e foco.',
+    org: 'Org',
+    userSearchLabel: 'Buscar usuário',
+    userSearchPlaceholder: 'Digite nome ou username…',
+    users: 'Usuários ativos',
+    noUsers: 'Nenhum usuário ativo encontrado para esta busca.',
+    loadingUsers: 'Carregando usuários…',
+    selectUserHint: 'Selecione um usuário ativo para inspecionar e configurar debug flags.',
+    debugLevel: 'Nível de depuração',
+    ttlMinutes: 'TTL (minutos)',
+    apply: 'Aplicar debug flag',
+    remove: 'Remover debug flag',
+    currentStatus: 'Status atual',
+    statusActive: 'Ativa',
+    statusInactive: 'Inativa',
+    statusLevel: 'Nível de depuração',
+    statusExpiration: 'Expira em',
+    statusStart: 'Inicia em',
+    noStatus: 'Nenhuma trace flag USER_DEBUG ativa para este usuário.',
+    noticeCreated: 'Debug flag criada com sucesso.',
+    noticeUpdated: 'Debug flag atualizada com sucesso.',
+    noticeRemoved: 'Debug flag removida com sucesso.',
+    noticeNone: 'Nenhuma trace flag USER_DEBUG encontrada para este usuário.',
+    ttlHelper: 'Padrão de 30 minutos. Faixa permitida: 1-1440.'
   }
 };
 

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -177,6 +177,7 @@ export function LogsApp({
     setSelectedOrg(v);
     vscode.postMessage({ type: 'selectOrg', target: v });
   };
+  const onOpenDebugFlags = () => vscode.postMessage({ type: 'openDebugFlags' });
   const onOpen = (logId: string) => vscode.postMessage({ type: 'openLog', logId });
   const onReplay = (logId: string) => vscode.postMessage({ type: 'replay', logId });
   const onLoadMore = () => hasMore && vscode.postMessage({ type: 'loadMore' });
@@ -298,6 +299,7 @@ export function LogsApp({
         error={error}
         warning={warning}
         onRefresh={onRefresh}
+        onOpenDebugFlags={onOpenDebugFlags}
         t={t}
         orgs={orgs}
         selectedOrg={selectedOrg}

--- a/src/webview/tail.tsx
+++ b/src/webview/tail.tsx
@@ -202,6 +202,9 @@ export function TailApp({
             vscode.postMessage({ type: 'replay', logId: selectedLogId });
           }
         }}
+        onOpenDebugFlags={() => {
+          vscode.postMessage({ type: 'openDebugFlags' });
+        }}
         actionsEnabled={!!selectedLogId}
         orgs={orgs}
         selectedOrg={selectedOrg}

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '../fixtures/alvE2E';
+import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { getCurrentUserId, getOrgAuth, getUserDebugTraceFlag, removeUserDebugTraceFlags } from '../utils/tooling';
+import { waitForWebviewFrame } from '../utils/webviews';
+
+test('configures and removes debug flags from logs and tail entrypoints', async ({ vscodePage, scratchAlias }) => {
+  const auth = await getOrgAuth(scratchAlias);
+  const userId = await getCurrentUserId(auth);
+  await removeUserDebugTraceFlags(auth, userId);
+
+  try {
+    await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+    await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+
+    const logsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    await logsFrame.locator('[data-testid="logs-open-debug-flags"]').first().click();
+
+    const debugFlagsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+
+    const searchInput = debugFlagsFrame.locator('[data-testid="debug-flags-user-search"]');
+    await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+    await searchInput.fill(auth.username || '');
+
+    const userRow = debugFlagsFrame.locator(`[data-testid="debug-flags-user-row-${userId}"]`);
+    await userRow.waitFor({ state: 'visible', timeout: 60_000 });
+    await userRow.click();
+
+    const ttlInput = debugFlagsFrame.locator('[data-testid="debug-flags-ttl"]');
+    await ttlInput.fill('45');
+
+    await debugFlagsFrame.locator('[data-testid="debug-flags-apply"]').click();
+    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
+
+    await expect
+      .poll(async () => {
+        const status = await getUserDebugTraceFlag(auth, userId);
+        return status?.id || '';
+      }, { timeout: 60_000 })
+      .not.toBe('');
+
+    await debugFlagsFrame.locator('[data-testid="debug-flags-remove"]').click();
+    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
+
+    await expect
+      .poll(async () => {
+        const status = await getUserDebugTraceFlag(auth, userId);
+        return status?.id || '';
+      }, { timeout: 60_000 })
+      .toBe('');
+
+    await runCommand(vscodePage, 'Electivus Apex Logs: Tail Logs');
+    const tailFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="tail-open-debug-flags"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
+
+    const debugFlagsFrameFromTail = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    await expect(debugFlagsFrameFromTail.locator('text=Apex Debug Flags').first()).toBeVisible();
+  } finally {
+    await removeUserDebugTraceFlags(auth, userId).catch(() => {});
+  }
+});


### PR DESCRIPTION
## Summary
- add a dedicated **Apex Debug Flags** editor webview to configure `USER_DEBUG` trace flags with more workspace and clearer UX
- add **Debug Flags** entrypoints to both toolbars (Logs + Tail)
- implement full user-focused trace flag backend flows (active user search, status read, apply/update, remove)
- add compatibility fallback for opening views when `workbench.viewsService.openView` is unavailable
- update localization strings, packaging, and docs/changelog

## UX Details
- opens in editor (same strategy as log viewer)
- supports active user search by name/username
- shows current state (active/inactive, level, start, expiration)
- defaults TTL to 30 minutes and allows user override (1-1440)
- supports both apply/update and remove actions with inline feedback

## Test Coverage
### Webview
- added `src/webview/__tests__/debugFlagsApp.test.tsx`
- updated toolbar/app tests for new `openDebugFlags` actions

### Extension/Unit
- added `src/test/traceflags.userFlags.test.ts`
- updated provider/tail tests for opening Debug Flags and view command fallback

### E2E (Playwright)
- added `test/e2e/specs/debugFlagsPanel.e2e.spec.ts`
- validates: open from Logs, apply/remove flag, open from Tail

## Validation Run
- `npm run compile` ✅
- `npm run test:webview -- --runInBand` ✅
- `npm run compile-tests` ✅
- `bash scripts/run-tests.sh --scope=unit --timeout=600000` ✅
- `npm run test:e2e -- --grep "configures and removes debug flags"` ✅

## Notes
- `CHANGELOG.md` updated
- `README.md` updated with Debug Flags usage
