### PR TITLE
chore(ci): group Tailwind Dependabot updates and harden CI installs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,11 @@ updates:
           - "react-dom"
           - "@types/react"
           - "@types/react-dom"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "tailwind-*"
     ignore:
       - dependency-name: "@types/vscode"
         update-types:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
   workflow_dispatch:
     inputs:
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Build (type-check + lint + bundle)
         run: npm run build
@@ -79,6 +81,8 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Install dependencies
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       - name: Build and run VSIX smoke
         run: npm run test:smoke:vsix
         env:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -53,6 +53,8 @@ jobs:
 
       - name: Install extension dependencies
         run: npm ci
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
 
       - name: Install Linux deps for Electron (best-effort)
         run: INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh


### PR DESCRIPTION
## Summary
- add a Dependabot "tailwind" group to bundle tailwindcss, @tailwindcss/*, and tailwind-* updates
- limit CI push trigger to main to avoid duplicate CI executions on PR branches
- pass GITHUB_TOKEN to npm ci in CI and E2E workflows to reduce GitHub API 403s during @vscode/ripgrep postinstall

## Why
- #528 has an open review thread flagging Tailwind version skew when tailwindcss and @tailwindcss/cli are updated separately
- one CI failure in #528 was due to a 403 during ripgrep download in npm ci; tokenized installs are more resilient

## Notes
- no application/runtime code changed
- workflow/config-only changes
