### PR TITLE
[codex] fix esbuild watch problem matcher completion pattern

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,7 @@
           "background": {
             "activeOnStart": true,
             "beginsPattern": "^\\[watch\\] build started$",
-            "endsPattern": "^\\[watch\\] build finished$"
+            "endsPattern": "^\\[watch\\] build finished(?:, watching for changes\\.\\.\\.)?$"
           }
         }
       ]


### PR DESCRIPTION
## Summary
This change updates the VS Code task `problemMatcher` used by the workspace `watch` task so it correctly recognizes the current esbuild watch completion output.

Users were seeing stale or misleading items in the Problems panel (for example, unresolved module errors) even after dependencies were installed and builds were succeeding.

## User Impact
When launching the extension in development mode, the Problems panel could keep old esbuild errors visible, which looked like the project was still broken. This created confusion and made it harder to trust the local feedback loop.

## Root Cause
The background matcher in `.vscode/tasks.json` expected only this completion line:

- `[watch] build finished`

Recent esbuild output in watch mode emits:

- `[watch] build finished, watching for changes...`

Because the configured `endsPattern` did not match the actual output, VS Code could fail to transition matcher state cleanly for the background task, leading to stale problem reporting behavior.

## Fix
Updated `.vscode/tasks.json` `endsPattern` to accept both outputs:

- legacy format (`[watch] build finished`)
- current format (`[watch] build finished, watching for changes...`)

This is done with a backward-compatible regex:

`^\\[watch\\] build finished(?:, watching for changes\\.\\.\\.)?$`

## Validation
- Ran `npm run build` successfully.
- Ran `npm run watch` and confirmed the current output format appears and no TypeScript errors are reported (`Found 0 errors`).

## Scope
- Included in PR: `.vscode/tasks.json`
- Not included: unrelated local `.vscode/settings.json` edits
