### PR TITLE
[codex] fix duplicate apexlogs .gitignore entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - CLI: add an optional `electivus.apexLogs.cliPath` setting to help VS Code find the Salesforce CLI (`sf`) when PATH inheritance is limited (for example when launched from the OS GUI).
 - Debug Flags: fix user search queries for orgs that reject SOQL `ESCAPE` in `LIKE` clauses, avoiding HTTP 400/MALFORMED_QUERY and keeping filtered results consistent.
+- Workspace: serialize `.gitignore` updates for `apexlogs/` so concurrent log-directory setup no longer appends duplicate entries. ([#503](https://github.com/Electivus/Apex-Log-Viewer/issues/503))
 
 ### Chores
 
@@ -21,6 +22,7 @@
 
 - Debug Flags: add unit/webview coverage for user trace-flag apply/remove flows and add a Playwright E2E scenario for the new editor panel.
 - Debug Flags: split filter behavior into a dedicated Playwright E2E spec and assert that search interactions do not surface backend error banners.
+- Workspace: add a concurrency regression test to verify `ensureApexLogsDir` writes at most one `apexlogs/` entry to `.gitignore`.
 
 ## [0.22.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.20.0...v0.22.0) (2026-02-13)
 

--- a/src/test/ensureApexLogsDir.test.ts
+++ b/src/test/ensureApexLogsDir.test.ts
@@ -1,0 +1,79 @@
+import assert from 'assert/strict';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru();
+
+function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+suite('ensureApexLogsDir', () => {
+  test('does not append duplicate apexlogs/ entries when called concurrently', async () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const gitignorePath = path.join(workspaceRoot, '.gitignore');
+
+    let gitignoreContent = 'node_modules/\n';
+    let appendCalls = 0;
+    let readCalls = 0;
+
+    const workspaceModule: typeof import('../utils/workspace') = proxyquireStrict('../utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async (dir: string, options: { recursive: boolean }): Promise<void> => {
+            assert.equal(dir, apexlogsDir);
+            assert.deepEqual(options, { recursive: true });
+          },
+          stat: async (filePath: string): Promise<{ isFile: () => boolean }> => {
+            assert.equal(filePath, gitignorePath);
+            return { isFile: () => true };
+          },
+          readFile: async (filePath: string, encoding: string): Promise<string> => {
+            assert.equal(filePath, gitignorePath);
+            assert.equal(encoding, 'utf8');
+            readCalls += 1;
+            const snapshot = gitignoreContent;
+            if (readCalls === 1) {
+              // Force overlap so both callers can observe the same pre-append state.
+              await delay(25);
+            }
+            return snapshot;
+          },
+          appendFile: async (filePath: string, value: string, encoding: string): Promise<void> => {
+            assert.equal(filePath, gitignorePath);
+            assert.equal(encoding, 'utf8');
+            appendCalls += 1;
+            gitignoreContent += value;
+          }
+        }
+      }
+    });
+
+    await Promise.all([workspaceModule.ensureApexLogsDir(), workspaceModule.ensureApexLogsDir()]);
+
+    const apexlogsEntries = gitignoreContent
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(line => line === 'apexlogs/');
+    assert.equal(apexlogsEntries.length, 1);
+    assert.equal(appendCalls, 1);
+  });
+});


### PR DESCRIPTION
## Summary
Fix duplicate `apexlogs/` entries being appended to `.gitignore` when `ensureApexLogsDir()` is called concurrently.

## User Impact
Before this change, users could end up with repeated `apexlogs/` lines in `.gitignore`, creating noisy diffs and repository clutter.

## Root Cause
`ensureApexLogsDir()` used a read-then-append flow on `.gitignore` without synchronization. Concurrent calls could both read the same pre-append content, both conclude the entry was missing, and both append `apexlogs/`.

## Fix
- Add an in-process async lock (`withGitignoreUpdateLock`) in `src/utils/workspace.ts`.
- Serialize `.gitignore` update attempts within `ensureApexLogsDir()` so only one caller can perform the read/check/append critical section at a time.
- Add regression test `src/test/ensureApexLogsDir.test.ts` that runs concurrent calls and asserts only one `apexlogs/` entry is appended.
- Update `CHANGELOG.md` (Unreleased) with bugfix and test coverage notes.

## Validation
- `npm run compile`
- `npm run compile-tests`
- `npx mocha --ui tdd --require out/test/mocha.setup.js out/test/ensureApexLogsDir.test.js`
- `npm run test:unit`

All commands passed locally.

Closes #503
