### PR TITLE
feat(logs): add explicit download-all action and predictable search fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Testing: add Playwright E2E coverage against a real scratch org (Dev Hub + seeded Apex log). Also adds a manual GitHub Actions workflow for opt-in validation.
 - Debug Flags: add a dedicated editor panel to configure `USER_DEBUG` TraceFlags for active users, accessible from both Logs and Tail toolbars.
+- Logs: add an explicit `Download all logs` action with confirmation, progress feedback, and completion summary; search now reports pending logs without implicit multi-log fallback. ([#541](https://github.com/Electivus/Apex-Log-Viewer/issues/541))
 
 ### Bug Fixes
 

--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -4,6 +4,7 @@ import { logInfo } from '../utils/logger';
 export class LogsMessageHandler {
   constructor(
     private readonly refresh: () => Promise<void>,
+    private readonly downloadAllLogs: () => Promise<void>,
     private readonly sendOrgs: () => Promise<void>,
     private readonly setSelectedOrg: (org?: string) => void,
     private readonly openDebugFlags: () => Promise<void>,
@@ -30,6 +31,10 @@ export class LogsMessageHandler {
       case 'refresh':
         logInfo('Logs: message refresh');
         await this.refresh();
+        break;
+      case 'downloadAllLogs':
+        logInfo('Logs: downloadAllLogs');
+        await this.downloadAllLogs();
         break;
       case 'selectOrg':
         this.setSelectedOrg(typeof message.target === 'string' ? message.target.trim() : undefined);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -5,6 +5,7 @@ import type { LogsColumnsConfig, NormalizedLogsColumnsConfig } from './logsColum
 export type WebviewToExtensionMessage =
   | { type: 'ready' }
   | { type: 'refresh' }
+  | { type: 'downloadAllLogs' }
   | { type: 'selectOrg'; target: string }
   | { type: 'openDebugFlags' }
   | { type: 'openLog'; logId: string }

--- a/src/test/i18n.test.ts
+++ b/src/test/i18n.test.ts
@@ -5,6 +5,7 @@ suite('i18n messages', () => {
   test('defaults to english and exposes expected keys', () => {
     const messages = getMessages(undefined);
     assert.equal(messages.refresh, 'Refresh');
+    assert.equal(messages.downloadAllLogs, 'Download all logs');
     assert.equal(messages.tail?.debugTag, 'debug');
   });
 

--- a/src/test/provider.logs.behavior.test.ts
+++ b/src/test/provider.logs.behavior.test.ts
@@ -30,6 +30,10 @@ suite('SfLogsViewProvider behavior', () => {
   const origRipgrepSearch = ripgrep.ripgrepSearch;
   const origOpenTextDocument = vscode.workspace.openTextDocument;
   const origShowTextDocument = vscode.window.showTextDocument;
+  const origShowWarningMessage = vscode.window.showWarningMessage;
+  const origShowInformationMessage = vscode.window.showInformationMessage;
+  const origShowErrorMessage = vscode.window.showErrorMessage;
+  const origWithProgress = vscode.window.withProgress;
   const origGetCommands = vscode.commands.getCommands;
   const origExecCommand = vscode.commands.executeCommand;
   const origDebugFlagsShow = DebugFlagsPanel.show;
@@ -46,6 +50,10 @@ suite('SfLogsViewProvider behavior', () => {
     (ripgrep as any).ripgrepSearch = origRipgrepSearch;
     (vscode.workspace as any).openTextDocument = origOpenTextDocument;
     (vscode.window as any).showTextDocument = origShowTextDocument;
+    (vscode.window as any).showWarningMessage = origShowWarningMessage;
+    (vscode.window as any).showInformationMessage = origShowInformationMessage;
+    (vscode.window as any).showErrorMessage = origShowErrorMessage;
+    (vscode.window as any).withProgress = origWithProgress;
     (vscode.commands as any).getCommands = origGetCommands;
     (vscode.commands as any).executeCommand = origExecCommand;
     (DebugFlagsPanel as any).show = origDebugFlagsShow;
@@ -299,7 +307,11 @@ suite('SfLogsViewProvider behavior', () => {
         }
       }
     };
-    (ripgrep as any).ripgrepSearch = async () => [];
+    let ripgrepCalls = 0;
+    (ripgrep as any).ripgrepSearch = async () => {
+      ripgrepCalls++;
+      return [];
+    };
 
     try {
       await provider.refresh();
@@ -313,6 +325,7 @@ suite('SfLogsViewProvider behavior', () => {
       assert.ok(matches, 'should post searchMatches even when missing');
       assert.ok(Array.isArray(matches?.pendingLogIds), 'pendingLogIds should be an array');
       assert.deepEqual(matches?.pendingLogIds, ['07L000000000001AA']);
+      assert.equal(ripgrepCalls, 0, 'should not run ripgrep while logs are pending');
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });
     }
@@ -497,6 +510,91 @@ suite('SfLogsViewProvider behavior', () => {
     await provider.resolveWebviewView(view);
     await (webview as any).emit({ type: 'replay', logId: 'abc' });
     assert.equal(executed[0], 'abc');
+  });
+
+  test('downloadAllLogs message performs explicit bulk download flow', async () => {
+    (cli as any).getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+    const context = makeContext();
+    const provider = new SfLogsViewProvider(context);
+
+    (provider as any).logService.fetchLogs = async () => ([
+      { Id: '07L000000000001AA', StartTime: '2026-01-01T00:00:00.000Z', LogLength: 10 },
+      { Id: '07L000000000002AA', StartTime: '2025-12-31T23:59:59.000Z', LogLength: 20 }
+    ]);
+
+    const ensureCalls: Array<{ count: number; selectedOrg?: string }> = [];
+    (provider as any).logService.ensureLogsSaved = async (
+      logs: any[],
+      selectedOrg?: string,
+      _signal?: AbortSignal,
+      options?: { onItemComplete?: (result: { logId: string; status: string }) => void }
+    ) => {
+      ensureCalls.push({ count: logs.length, selectedOrg });
+      for (const log of logs) {
+        options?.onItemComplete?.({ logId: log.Id, status: 'downloaded' });
+      }
+      return {
+        total: logs.length,
+        success: logs.length,
+        downloaded: logs.length,
+        existing: 0,
+        missing: 0,
+        failed: 0,
+        cancelled: 0,
+        failedLogIds: []
+      };
+    };
+
+    const warningCalls: any[] = [];
+    (vscode.window as any).showWarningMessage = async (...args: any[]) => {
+      warningCalls.push(args);
+      return args[2];
+    };
+    const infoCalls: any[] = [];
+    (vscode.window as any).showInformationMessage = async (...args: any[]) => {
+      infoCalls.push(args);
+      return undefined;
+    };
+    (vscode.window as any).showErrorMessage = async () => undefined;
+    (vscode.window as any).withProgress = async (_opts: any, task: any) =>
+      task(
+        { report: () => {} },
+        {
+          onCancellationRequested: () => {},
+          isCancellationRequested: false
+        }
+      );
+
+    class MockWebview implements vscode.Webview {
+      html = '';
+      options: vscode.WebviewOptions = {};
+      cspSource = 'vscode-resource://test';
+      private handler: ((e: any) => any) | undefined;
+      asWebviewUri(uri: vscode.Uri): vscode.Uri { return uri; }
+      postMessage(_message: any): Thenable<boolean> { return Promise.resolve(true); }
+      onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+        this.handler = listener; return { dispose() {} } as any;
+      }
+      emit(message: any) { return this.handler?.(message); }
+    }
+    class MockWebviewView implements vscode.WebviewView {
+      visible = true; title = 'Test'; viewType = 'sfLogViewer';
+      description?: string | undefined; badge?: { value: number; tooltip: string } | undefined;
+      webview: vscode.Webview; constructor(webview: vscode.Webview) { this.webview = webview; }
+      show(): void { /* noop */ }
+      onDidChangeVisibility: vscode.Event<void> = () => ({ dispose() {} } as any);
+      onDidDispose: vscode.Event<void> = () => ({ dispose() {} } as any);
+    }
+    const webview = new MockWebview();
+    const view = new MockWebviewView(webview);
+    await provider.resolveWebviewView(view);
+    await (webview as any).emit({ type: 'downloadAllLogs' });
+    await new Promise(resolve => setTimeout(resolve, 20));
+
+    assert.equal(ensureCalls.length, 1, 'should perform one bulk save run');
+    assert.equal(ensureCalls[0]?.count, 2, 'should include all logs fetched for the org');
+    assert.ok(warningCalls.length >= 1, 'should request user confirmation');
+    assert.ok(infoCalls.length >= 1, 'should show completion summary');
   });
 
   test('openDebugFlags opens debug flags panel', async () => {

--- a/src/webview/__tests__/Toolbar.test.tsx
+++ b/src/webview/__tests__/Toolbar.test.tsx
@@ -65,6 +65,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   const statuses = ['Success', 'Failed'];
   const codeUnits = ['UnitA', 'UnitB'];
   let refreshCount = 0;
+  let downloadAllCount = 0;
   let openDebugFlagsCount = 0;
   let clearCount = 0;
   const queryChanges: string[] = [];
@@ -83,6 +84,9 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
         warning={warning}
         onRefresh={() => {
           refreshCount++;
+        }}
+        onDownloadAllLogs={() => {
+          downloadAllCount++;
         }}
         onOpenDebugFlags={() => {
           openDebugFlagsCount++;
@@ -132,6 +136,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   return {
     view,
     refreshCount: () => refreshCount,
+    downloadAllCount: () => downloadAllCount,
     openDebugFlagsCount: () => openDebugFlagsCount,
     clearCount: () => clearCount,
     queryChanges,
@@ -214,5 +219,12 @@ describe('Toolbar webview component', () => {
     const btn = screen.getByRole('button', { name: 'Debug Flags' });
     fireEvent.click(btn);
     expect(utils.openDebugFlagsCount()).toBe(1);
+  });
+
+  it('triggers download all logs entrypoint from toolbar button', () => {
+    const utils = renderToolbar();
+    const btn = screen.getByRole('button', { name: 'Download all logs' });
+    fireEvent.click(btn);
+    expect(utils.downloadAllCount()).toBe(1);
   });
 });

--- a/src/webview/__tests__/logsApp.test.tsx
+++ b/src/webview/__tests__/logsApp.test.tsx
@@ -141,6 +141,14 @@ describe('Logs webview App', () => {
     await waitFor(() => {
       expect(screen.queryByText('Preparando resultados da busca…')).toBeNull();
     });
+    sendMessage(bus, {
+      type: 'searchMatches',
+      query: 'error',
+      logIds: [],
+      snippets: {},
+      pendingLogIds: ['07L000000000001AA', '07L000000000002AA']
+    });
+    await screen.findByText('Aguardando o download de 2 logs…');
 
     fireEvent.paste(searchInput);
     await waitFor(() => {
@@ -169,14 +177,15 @@ describe('Logs webview App', () => {
     fireEvent.click(openButtons[0]!);
     fireEvent.click(screen.getAllByRole('button', { name: 'Apex Replay' })[0]!);
     fireEvent.click(screen.getByRole('button', { name: 'Debug Flags' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Baixar todos os logs' }));
     fireEvent.click(screen.getByRole('button', { name: 'Atualizar' }));
 
     await waitFor(() => {
       const types = posted.map(m => m.type);
       expect(types[0]).toBe('ready');
-      expect(types).toEqual(expect.arrayContaining(['openLog', 'replay', 'refresh', 'openDebugFlags']));
+      expect(types).toEqual(expect.arrayContaining(['openLog', 'replay', 'refresh', 'openDebugFlags', 'downloadAllLogs']));
     });
-  }, 10000);
+  }, 20000);
 
   it('surfaces manual pagination when filters are active', async () => {
     const { vscode, posted } = createVsCodeMock();

--- a/src/webview/__tests__/tailApp.test.tsx
+++ b/src/webview/__tests__/tailApp.test.tsx
@@ -96,5 +96,5 @@ describe('Tail webview App', () => {
         expect.arrayContaining(['tailStart', 'tailStop', 'tailClear', 'openLog', 'replay', 'openDebugFlags'])
       );
     });
-  });
+  }, 15000);
 });

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { RefreshCw, FilterX, Loader2, AlertCircle, Bug } from 'lucide-react';
+import { RefreshCw, FilterX, Loader2, AlertCircle, Bug, Download } from 'lucide-react';
 import type { OrgItem } from '../../shared/types';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -19,6 +19,7 @@ type ToolbarProps = {
   error?: string;
   warning?: string;
   onRefresh: () => void;
+  onDownloadAllLogs: () => void;
   onOpenDebugFlags: () => void;
   t: any;
   orgs: OrgItem[];
@@ -54,6 +55,7 @@ export function Toolbar({
   error,
   warning,
   onRefresh,
+  onDownloadAllLogs,
   onOpenDebugFlags,
   t,
   orgs,
@@ -101,6 +103,17 @@ export function Toolbar({
             <RefreshCw className="h-4 w-4" aria-hidden="true" />
           )}
           <span>{loading ? t.loading : t.refresh}</span>
+        </Button>
+
+        <Button
+          type="button"
+          onClick={onDownloadAllLogs}
+          disabled={loading}
+          variant="secondary"
+          className="flex items-center gap-2"
+        >
+          <Download className="h-4 w-4" aria-hidden="true" />
+          <span>{t.downloadAllLogs ?? 'Download all logs'}</span>
         </Button>
 
         <OrgSelect

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -9,6 +9,7 @@ export type Messages = {
   replay: string;
   loadMore?: string;
   loadMoreFiltered?: string;
+  downloadAllLogs?: string;
   open?: string;
   orgLabel: string;
   defaultOrg: string;
@@ -102,6 +103,7 @@ const en: Messages = {
   replay: 'Apex Replay',
   loadMore: 'Load more logs',
   loadMoreFiltered: 'Load more results',
+  downloadAllLogs: 'Download all logs',
   open: 'Open',
   orgLabel: 'Org',
   defaultOrg: 'Default Org',
@@ -195,6 +197,7 @@ const ptBR: Messages = {
   replay: 'Apex Replay',
   loadMore: 'Carregar mais logs',
   loadMoreFiltered: 'Carregar mais resultados',
+  downloadAllLogs: 'Baixar todos os logs',
   open: 'Abrir',
   orgLabel: 'Org',
   defaultOrg: 'Org Padrão',


### PR DESCRIPTION
## Summary
- add an explicit `Download all logs` action in the Logs toolbar
- implement confirmation + cancellable progress + completion summary for org-wide bulk download
- stop implicit multi-log fallback during search when logs are pending locally
- extend `ensureLogsSaved` with item-level status callbacks and summary stats
- update changelog and test coverage for provider/service/webview flows

## Validation
- npm run build
- npm run test

Closes #541