### PR TITLE
feat(logs): add errors-only filter in log listing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Testing: add Playwright E2E coverage against a real scratch org (Dev Hub + seeded Apex log). Also adds a manual GitHub Actions workflow for opt-in validation.
 - Debug Flags: add a dedicated editor panel to configure `USER_DEBUG` TraceFlags for active users, accessible from both Logs and Tail toolbars.
 - Logs: add an explicit `Download all logs` action with confirmation, progress feedback, and completion summary; search now reports pending logs without implicit multi-log fallback. ([#541](https://github.com/Electivus/Apex-Log-Viewer/issues/541))
+- Logs: add an `Errors only` filter with progressive full-body scanning across org logs and inline row badges for detected errors. ([#542](https://github.com/Electivus/Apex-Log-Viewer/issues/542))
 
 ### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
 - Testing: add Playwright E2E coverage against a real scratch org (Dev Hub + seeded Apex log). Also adds a manual GitHub Actions workflow for opt-in validation.
 - Debug Flags: add a dedicated editor panel to configure `USER_DEBUG` TraceFlags for active users, accessible from both Logs and Tail toolbars.
 - Logs: add an explicit `Download all logs` action with confirmation, progress feedback, and completion summary; search now reports pending logs without implicit multi-log fallback. ([#541](https://github.com/Electivus/Apex-Log-Viewer/issues/541))
-- Logs: add an `Errors only` filter with progressive full-body scanning across org logs and inline row badges for detected errors. ([#542](https://github.com/Electivus/Apex-Log-Viewer/issues/542))
+- Logs: always download full Apex log bodies in the Logs view so content search and derived metadata no longer depend on partial-header requests; removes the `electivus.apexLogs.enableFullLogSearch` setting.
+- Logs: add an `Errors only` filter with progressive full-body scanning across the current log listing (including additional pages) and inline row badges for detected errors. ([#542](https://github.com/Electivus/Apex-Log-Viewer/issues/542))
 
 ### Bug Fixes
 

--- a/package.json
+++ b/package.json
@@ -127,11 +127,6 @@
           "minimum": 0,
           "markdownDescription": "%configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description%"
         },
-        "electivus.apexLogs.enableFullLogSearch": {
-          "type": "boolean",
-          "default": true,
-          "markdownDescription": "%configuration.electivus.apexLogs.enableFullLogSearch.description%"
-        },
         "electivus.apexLogs.logsColumns": {
           "type": "object",
           "default": {

--- a/package.nls.json
+++ b/package.nls.json
@@ -20,7 +20,6 @@
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "Short-lived in-memory TTL (seconds) for cached auth tokens acquired via CLI. Tokens are NOT persisted. Larger values reduce CLI calls but increase the reuse window.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "Persistent TTL in seconds for cached results of 'sf org display'. Stores the token in VS Code storage to avoid repeated CLI calls across reloads. Larger values reduce CLI calls but keep cached auth longer; set 0 to disable.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL in seconds for cached DebugLevel queries. Set 0 to disable. Large TTLs reduce API calls but may serve stale data.",
-  "configuration.electivus.apexLogs.enableFullLogSearch.description": "Download full Apex log bodies in the list view so the search box can match log content. This consumes more bandwidth and memory; disable if you only need header searches.",
   "configuration.electivus.apexLogs.logsColumns.description": "Persisted column layout for the Logs table (managed by the Logs panel UI). Stores visibility/order/widths in user settings so it survives reloads and can sync across machines.",
   "tailSaveFailed": "Tail: failed to save log to workspace (best-effort).",
   "openLogInViewer.noDocument": "Electivus Apex Logs: No Apex log is active.",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -20,7 +20,6 @@
   "configuration.electivus.apexLogs.cliCache.authTtlSeconds.description": "TTL curto em memória (segundos) para cachear credenciais obtidas via CLI. Tokens NÃO são persistidos. Valores maiores reduzem chamadas ao CLI, mas aumentam a janela de reutilização.",
   "configuration.electivus.apexLogs.cliCache.authPersistentTtlSeconds.description": "TTL persistente (segundos) para o cache de 'sf org display'. Armazena o token no VS Code para evitar chamadas repetidas entre recarregamentos. Valores maiores reduzem chamadas ao CLI, mas mantêm o auth em cache por mais tempo; defina 0 para desativar.",
   "configuration.electivus.apexLogs.cliCache.debugLevelsTtlSeconds.description": "TTL em segundos para o cache de consultas DebugLevel. Defina 0 para desativar. TTLs grandes reduzem chamadas à API, mas podem servir dados desatualizados.",
-  "configuration.electivus.apexLogs.enableFullLogSearch.description": "Baixa o conteúdo completo dos logs Apex na lista para que a busca encontre trechos do log. Isso consome mais banda e memória; desative se precisar apenas de buscas pelos cabeçalhos.",
   "configuration.electivus.apexLogs.logsColumns.description": "Layout persistido das colunas da tabela de Logs (gerenciado pela UI do painel de Logs). Armazena visibilidade/ordem/larguras nas configurações do usuário para sobreviver a recarregamentos e sincronizar entre máquinas.",
   "tailSaveFailed": "Tail: falha ao salvar log no workspace (melhor esforço).",
   "openLogInViewer.noDocument": "Electivus Apex Logs: Nenhum log Apex está ativo.",

--- a/src/shared/logErrorSignals.ts
+++ b/src/shared/logErrorSignals.ts
@@ -1,0 +1,38 @@
+const ERROR_EVENT_TOKENS = new Set([
+  'EXCEPTION',
+  'ERROR',
+  'FATAL',
+  'FAIL',
+  'FAILED',
+  'FAILURE',
+  'FAULT'
+]);
+
+export function tokenizeLogEventType(eventType: string): string[] {
+  return eventType.toUpperCase().split(/[^A-Z]+/).filter(Boolean);
+}
+
+export function isErrorEventType(eventType: string): boolean {
+  const tokens = tokenizeLogEventType(eventType);
+  return tokens.some(token => ERROR_EVENT_TOKENS.has(token));
+}
+
+export function extractLogEventType(line: string): string | undefined {
+  if (!line.includes('|')) {
+    return undefined;
+  }
+  const parts = line.split('|');
+  if (parts.length < 2) {
+    return undefined;
+  }
+  const eventType = (parts[1] ?? '').trim();
+  return eventType || undefined;
+}
+
+export function lineHasErrorSignal(line: string): boolean {
+  const eventType = extractLogEventType(line);
+  if (!eventType) {
+    return false;
+  }
+  return isErrorEventType(eventType);
+}

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -27,7 +27,8 @@ export type ExtensionToWebviewMessage =
   | { type: 'logsColumns'; value: NormalizedLogsColumnsConfig }
   | { type: 'logs'; data: ApexLogRow[]; hasMore: boolean }
   | { type: 'appendLogs'; data: ApexLogRow[]; hasMore: boolean }
-  | { type: 'logHead'; logId: string; codeUnitStarted?: string }
+  | { type: 'logHead'; logId: string; codeUnitStarted?: string; hasErrors?: boolean }
+  | { type: 'errorScanStatus'; state: 'idle' | 'running'; processed: number; total: number; errorsFound: number }
   | {
       type: 'searchMatches';
       query: string;

--- a/src/test/i18n.test.ts
+++ b/src/test/i18n.test.ts
@@ -6,6 +6,7 @@ suite('i18n messages', () => {
     const messages = getMessages(undefined);
     assert.equal(messages.refresh, 'Refresh');
     assert.equal(messages.downloadAllLogs, 'Download all logs');
+    assert.equal(messages.filters?.errorsOnly, 'Errors only');
     assert.equal(messages.tail?.debugTag, 'debug');
   });
 
@@ -15,6 +16,7 @@ suite('i18n messages', () => {
 
     assert.equal(pt.refresh, 'Atualizar');
     assert.equal(pt.tail?.debugOnly, 'Somente USER_DEBUG');
+    assert.equal(pt.filters?.errorsOnly, 'Somente erros');
     assert.equal(ptBr.tail?.waiting, 'Aguardando logs…');
   });
 });

--- a/src/test/logErrorSignals.test.ts
+++ b/src/test/logErrorSignals.test.ts
@@ -1,0 +1,26 @@
+import assert from 'assert/strict';
+import { extractLogEventType, isErrorEventType, lineHasErrorSignal, tokenizeLogEventType } from '../shared/logErrorSignals';
+
+suite('logErrorSignals', () => {
+  test('tokenizes event types using uppercase alpha groups', () => {
+    assert.deepEqual(tokenizeLogEventType('EXCEPTION_THROWN'), ['EXCEPTION', 'THROWN']);
+    assert.deepEqual(tokenizeLogEventType('fatal.error'), ['FATAL', 'ERROR']);
+  });
+
+  test('detects error event types', () => {
+    assert.equal(isErrorEventType('EXCEPTION_THROWN'), true);
+    assert.equal(isErrorEventType('FATAL_ERROR'), true);
+    assert.equal(isErrorEventType('METHOD_ENTRY'), false);
+    assert.equal(isErrorEventType('USER_DEBUG'), false);
+  });
+
+  test('extracts event type from pipe-delimited lines', () => {
+    assert.equal(extractLogEventType('12:00:00.000 | EXCEPTION_THROWN | [6] | message'), 'EXCEPTION_THROWN');
+    assert.equal(extractLogEventType('line without delimiter'), undefined);
+  });
+
+  test('detects error markers from log lines', () => {
+    assert.equal(lineHasErrorSignal('12:00:00.000 | EXCEPTION_THROWN | [6] | message'), true);
+    assert.equal(lineHasErrorSignal('12:00:00.000 | USER_DEBUG | [6] | message with error text'), false);
+  });
+});

--- a/src/utils/configManager.ts
+++ b/src/utils/configManager.ts
@@ -1,12 +1,9 @@
-import { getNumberConfig, affectsConfiguration, getBooleanConfig } from './config';
+import { getNumberConfig, affectsConfiguration } from './config';
 import type * as vscode from 'vscode';
 
 export class ConfigManager {
-  private enableFullLogSearch: boolean;
-
   constructor(private headConcurrency: number, private pageLimit: number) {
     this.headConcurrency = getNumberConfig('electivus.apexLogs.headConcurrency', this.headConcurrency, 1, Number.MAX_SAFE_INTEGER);
-    this.enableFullLogSearch = getBooleanConfig('electivus.apexLogs.enableFullLogSearch', true);
   }
 
   handleChange(e: vscode.ConfigurationChangeEvent): void {
@@ -16,12 +13,6 @@ export class ConfigManager {
         this.headConcurrency,
         1,
         Number.MAX_SAFE_INTEGER
-      );
-    }
-    if (affectsConfiguration(e, 'electivus.apexLogs.enableFullLogSearch')) {
-      this.enableFullLogSearch = getBooleanConfig(
-        'electivus.apexLogs.enableFullLogSearch',
-        this.enableFullLogSearch
       );
     }
   }
@@ -37,6 +28,6 @@ export class ConfigManager {
   }
 
   shouldLoadFullLogBodies(): boolean {
-    return this.enableFullLogSearch;
+    return true;
   }
 }

--- a/src/webview/__tests__/LogRow.test.tsx
+++ b/src/webview/__tests__/LogRow.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
+import { render, fireEvent, screen } from '@testing-library/react';
 import { LogRow } from '../components/table/LogRow';
 import type { ApexLogRow } from '../../shared/types';
 
@@ -54,5 +54,36 @@ describe('LogRow', () => {
     expect(opened).toBe('1');
     fireEvent.keyDown(rowEl, { key: 'Enter', shiftKey: true });
     expect(replayed).toBe('1');
+  });
+
+  it('shows error badge on status column when error is detected', () => {
+    const row: ApexLogRow = {
+      Id: 'err-1',
+      StartTime: new Date().toISOString(),
+      Operation: 'Op',
+      Application: 'App',
+      DurationMilliseconds: 1,
+      Status: 'Success',
+      Request: '',
+      LogLength: 2048,
+      LogUser: { Name: 'User' }
+    };
+    render(
+      <LogRow
+        r={row}
+        logHead={{ 'err-1': { hasErrors: true } }}
+        locale="en-US"
+        t={{ open: 'Open', replay: 'Replay', filters: { errorDetectedBadge: 'Error' } }}
+        columns={['status']}
+        loading={false}
+        onOpen={() => {}}
+        onReplay={() => {}}
+        gridTemplate="1fr 96px"
+        style={{}}
+        index={0}
+        setRowHeight={() => {}}
+      />
+    );
+    expect(screen.getByText('Error')).toBeInTheDocument();
   });
 });

--- a/src/webview/__tests__/Toolbar.test.tsx
+++ b/src/webview/__tests__/Toolbar.test.tsx
@@ -38,6 +38,7 @@ type ToolbarRenderOptions = {
   filterOperation?: string;
   filterStatus?: string;
   filterCodeUnit?: string;
+  errorsOnly?: boolean;
   searchLoading?: boolean;
   searchMessage?: string;
 };
@@ -51,6 +52,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
     filterOperation = '',
     filterStatus = '',
     filterCodeUnit = '',
+    errorsOnly = false,
     searchLoading = false,
     searchMessage
   } = overrides;
@@ -70,6 +72,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
   let clearCount = 0;
   const queryChanges: string[] = [];
   const userChanges: string[] = [];
+  const errorsOnlyChanges: boolean[] = [];
 
   const docRef = globalThis as unknown as { DocumentFragment: typeof DocumentFragment | undefined };
   const originalDocumentFragment = docRef.DocumentFragment;
@@ -109,6 +112,7 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
         filterOperation={filterOperation}
         filterStatus={filterStatus}
         filterCodeUnit={filterCodeUnit}
+        errorsOnly={errorsOnly}
         onFilterUserChange={value => {
           userChanges.push(`user:${value}`);
         }}
@@ -120,6 +124,9 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
         }}
         onFilterCodeUnitChange={value => {
           userChanges.push(`code:${value}`);
+        }}
+        onErrorsOnlyChange={value => {
+          errorsOnlyChanges.push(value);
         }}
         onClearFilters={() => {
           clearCount++;
@@ -140,7 +147,8 @@ function renderToolbar(overrides: ToolbarRenderOptions = {}) {
     openDebugFlagsCount: () => openDebugFlagsCount,
     clearCount: () => clearCount,
     queryChanges,
-    userChanges
+    userChanges,
+    errorsOnlyChanges
   };
 }
 
@@ -191,6 +199,13 @@ describe('Toolbar webview component', () => {
     const searchInput = screen.getByLabelText('Search logs…') as HTMLInputElement;
     fireEvent.change(searchInput, { target: { value: 'new search' } });
     expect(utils.queryChanges).toEqual(['new search']);
+  });
+
+  it('toggles errors-only filter and reports changes', () => {
+    const utils = renderToolbar();
+    const toggle = screen.getByRole('switch', { name: 'Errors only' });
+    fireEvent.click(toggle);
+    expect(utils.errorsOnlyChanges).toEqual([true]);
   });
 
   it('shows spinner when searchLoading is true', () => {

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -6,7 +6,7 @@ import { LOGS_COLUMN_DEFAULT_TRACK, LOGS_COLUMN_MIN_WIDTH_PX } from '../utils/lo
 import { LogsHeader } from './table/LogsHeader';
 import { LogRow } from './table/LogRow';
 
-export type LogHeadMap = Record<string, { codeUnitStarted?: string }>;
+export type LogHeadMap = Record<string, { codeUnitStarted?: string; hasErrors?: boolean }>;
 
 type ListRowProps = {
   rows: ApexLogRow[];

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -210,6 +210,7 @@ export function Toolbar({
         <div className="flex min-w-[160px] items-center gap-2 rounded-md border border-input bg-input px-3 py-2">
           <Switch
             id={errorsOnlyId}
+            data-testid="logs-errors-only-switch"
             checked={errorsOnly}
             onCheckedChange={onErrorsOnlyChange}
             disabled={loading}

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -4,6 +4,7 @@ import type { OrgItem } from '../../shared/types';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
+import { Switch } from './ui/switch';
 import { FilterSelect } from './FilterSelect';
 import { OrgSelect } from './OrgSelect';
 import { ColumnsPopover } from './ColumnsPopover';
@@ -37,10 +38,12 @@ type ToolbarProps = {
   filterOperation: string;
   filterStatus: string;
   filterCodeUnit: string;
+  errorsOnly: boolean;
   onFilterUserChange: (v: string) => void;
   onFilterOperationChange: (v: string) => void;
   onFilterStatusChange: (v: string) => void;
   onFilterCodeUnitChange: (v: string) => void;
+  onErrorsOnlyChange: (v: boolean) => void;
   onClearFilters: () => void;
   columnsConfig: NormalizedLogsColumnsConfig;
   fullLogSearchEnabled: boolean;
@@ -73,17 +76,20 @@ export function Toolbar({
   filterOperation,
   filterStatus,
   filterCodeUnit,
+  errorsOnly,
   onFilterUserChange,
   onFilterOperationChange,
   onFilterStatusChange,
   onFilterCodeUnitChange,
+  onErrorsOnlyChange,
   onClearFilters,
   columnsConfig,
   fullLogSearchEnabled,
   onColumnsConfigChange
 }: ToolbarProps) {
   const searchInputId = useStableId('logs-search');
-  const hasFilters = Boolean(filterUser || filterOperation || filterStatus || filterCodeUnit);
+  const errorsOnlyId = useStableId('logs-errors-only');
+  const hasFilters = Boolean(filterUser || filterOperation || filterStatus || filterCodeUnit || errorsOnly);
   const errorLabel = t?.tail?.errorLabel ?? t?.errors?.generic ?? 'Error';
   const warningLabel = t?.warningLabel ?? 'Warning';
 
@@ -201,6 +207,20 @@ export function Toolbar({
           allLabel={t.filters?.all ?? 'All'}
           disabled={loading}
         />
+        <div className="flex min-w-[160px] items-center gap-2 rounded-md border border-input bg-input px-3 py-2">
+          <Switch
+            id={errorsOnlyId}
+            checked={errorsOnly}
+            onCheckedChange={onErrorsOnlyChange}
+            disabled={loading}
+          />
+          <Label
+            htmlFor={errorsOnlyId}
+            className="cursor-pointer text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+          >
+            {t.filters?.errorsOnly ?? 'Errors only'}
+          </Label>
+        </div>
 
         <ColumnsPopover
           t={t}

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -191,6 +191,7 @@ export function LogRow({
                     <span>{r.Status}</span>
                     {hasErrors && (
                       <Badge
+                        data-testid="logs-error-badge"
                         variant="outline"
                         className="gap-1 border-destructive/50 bg-destructive/10 text-destructive"
                         title={errorBadge}

--- a/src/webview/components/table/LogRow.tsx
+++ b/src/webview/components/table/LogRow.tsx
@@ -1,10 +1,11 @@
 import React, { useLayoutEffect, useMemo, useRef } from 'react';
-import { BugPlay, FileText, Loader2 } from 'lucide-react';
+import { AlertOctagon, BugPlay, FileText, Loader2 } from 'lucide-react';
 import type { ApexLogRow } from '../../../shared/types';
 import type { LogHeadMap } from '../LogsTable';
 import type { LogsColumnKey } from '../../../shared/logsColumns';
 import { formatBytes, formatDuration } from '../../utils/format';
 import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
 import { cn } from '../../lib/utils';
 
 type Props = {
@@ -182,11 +183,25 @@ export function LogRow({
                 </div>
               );
             case 'status':
-              return (
-                <div key={key} className={cellClass}>
-                  {r.Status}
-                </div>
-              );
+              {
+                const hasErrors = logHead[r.Id]?.hasErrors === true;
+                const errorBadge = t?.filters?.errorDetectedBadge ?? 'Error';
+                return (
+                  <div key={key} className={cn(cellClass, 'flex items-center gap-2')}>
+                    <span>{r.Status}</span>
+                    {hasErrors && (
+                      <Badge
+                        variant="outline"
+                        className="gap-1 border-destructive/50 bg-destructive/10 text-destructive"
+                        title={errorBadge}
+                      >
+                        <AlertOctagon className="h-3 w-3" aria-hidden="true" />
+                        <span>{errorBadge}</span>
+                      </Badge>
+                    )}
+                  </div>
+                );
+              }
             case 'codeUnit':
               return (
                 <div key={key} className={cellClass} title={logHead[r.Id]?.codeUnitStarted ?? ''}>

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -38,6 +38,10 @@ export type Messages = {
     user: string;
     operation: string;
     status: string;
+    errorsOnly: string;
+    errorDetectedBadge: string;
+    scanningErrors: string;
+    scanningErrorsProgress: string;
     all: string;
     clear: string;
   };
@@ -132,6 +136,10 @@ const en: Messages = {
     user: 'User',
     operation: 'Operation',
     status: 'Status',
+    errorsOnly: 'Errors only',
+    errorDetectedBadge: 'Error',
+    scanningErrors: 'Scanning logs for errors…',
+    scanningErrorsProgress: 'Scanning logs for errors… ({processed}/{total}, found: {errorsFound})',
     all: 'All',
     clear: 'Clear filters'
   },
@@ -226,6 +234,10 @@ const ptBR: Messages = {
     user: 'Usuário',
     operation: 'Operação',
     status: 'Status',
+    errorsOnly: 'Somente erros',
+    errorDetectedBadge: 'Erro',
+    scanningErrors: 'Analisando logs em busca de erros…',
+    scanningErrorsProgress: 'Analisando logs em busca de erros… ({processed}/{total}, encontrados: {errorsFound})',
     all: 'Todos',
     clear: 'Limpar filtros'
   },

--- a/src/webview/utils/logViewerParser.ts
+++ b/src/webview/utils/logViewerParser.ts
@@ -1,3 +1,5 @@
+import { isErrorEventType } from '../../shared/logErrorSignals';
+
 export type LogCategory = 'debug' | 'soql' | 'dml' | 'code' | 'limit' | 'system' | 'error' | 'other';
 
 export interface ParsedLogEntry {
@@ -100,18 +102,7 @@ function parseLogLine(raw: string, index: number): ParsedLogEntry | undefined {
 
 function categorize(type: string): LogCategory {
   const upper = type.toUpperCase();
-  const tokens = upper.split(/[^A-Z]+/).filter(Boolean);
-  if (
-    tokens.some(token =>
-      token === 'EXCEPTION' ||
-      token === 'ERROR' ||
-      token === 'FATAL' ||
-      token === 'FAIL' ||
-      token === 'FAILED' ||
-      token === 'FAILURE' ||
-      token === 'FAULT'
-    )
-  ) {
+  if (isErrorEventType(type)) {
     return 'error';
   }
   if (upper === 'USER_DEBUG') {

--- a/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
+++ b/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
@@ -16,7 +16,7 @@ async function setErrorsOnlyEnabled(
   await expect(errorsOnlySwitch).toHaveAttribute('data-state', enabled ? 'checked' : 'unchecked');
 }
 
-test('filters logs using errors-only toggle with real exception logs', async ({ vscodePage, scratchAlias, seededLog }) => {
+test('filters logs using errors-only toggle', async ({ vscodePage, scratchAlias, seededLog }) => {
   const seededErrorLog = await seedApexErrorLog(scratchAlias);
 
   await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
@@ -34,6 +34,7 @@ test('filters logs using errors-only toggle with real exception logs', async ({ 
   const errorBadges = logsFrame.locator('[data-testid="logs-error-badge"]');
 
   await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+  await expect(searchInput).toBeEnabled({ timeout: 180_000 });
 
   await setErrorsOnlyEnabled(errorsOnlySwitch, false);
   await searchInput.fill(seededLog.marker);

--- a/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
+++ b/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
@@ -1,0 +1,56 @@
+import type { Locator } from '@playwright/test';
+import { expect, test } from '../fixtures/alvE2E';
+import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { seedApexErrorLog } from '../utils/seedLog';
+import { waitForWebviewFrame } from '../utils/webviews';
+
+async function setErrorsOnlyEnabled(
+  errorsOnlySwitch: Locator,
+  enabled: boolean
+): Promise<void> {
+  const currentState = await errorsOnlySwitch.getAttribute('data-state');
+  const isChecked = currentState === 'checked';
+  if (isChecked !== enabled) {
+    await errorsOnlySwitch.click();
+  }
+  await expect(errorsOnlySwitch).toHaveAttribute('data-state', enabled ? 'checked' : 'unchecked');
+}
+
+test('filters logs using errors-only toggle with real exception logs', async ({ vscodePage, scratchAlias, seededLog }) => {
+  const seededErrorLog = await seedApexErrorLog(scratchAlias);
+
+  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+
+  const logsFrame = await waitForWebviewFrame(
+    vscodePage,
+    async frame => await frame.locator('[data-testid="logs-errors-only-switch"]').first().isVisible(),
+    { timeoutMs: 180_000 }
+  );
+
+  const searchInput = logsFrame.locator('input[type="search"]');
+  const rows = logsFrame.locator('[role="row"][tabindex="0"]');
+  const errorsOnlySwitch = logsFrame.locator('[data-testid="logs-errors-only-switch"]').first();
+  const errorBadges = logsFrame.locator('[data-testid="logs-error-badge"]');
+
+  await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+
+  await setErrorsOnlyEnabled(errorsOnlySwitch, false);
+  await searchInput.fill(seededLog.marker);
+  await expect
+    .poll(async () => await rows.count(), { timeout: 180_000 })
+    .toBeGreaterThan(0);
+
+  await setErrorsOnlyEnabled(errorsOnlySwitch, true);
+  await expect
+    .poll(async () => await rows.count(), { timeout: 180_000 })
+    .toBe(0);
+
+  await searchInput.fill(seededErrorLog.marker);
+  await expect
+    .poll(async () => await rows.count(), { timeout: 180_000 })
+    .toBeGreaterThan(0);
+  await expect
+    .poll(async () => await errorBadges.count(), { timeout: 180_000 })
+    .toBeGreaterThan(0);
+});

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -36,7 +36,7 @@ async function resolveDefaultDevHubAlias(): Promise<string> {
 
   // Local convenience: prefer the current team DevHub alias when available.
   // Keep legacy aliases as fallbacks for older local setups.
-  const preferredAliases = ['DevHubElectivus', 'InsuranceOrgTrialCreme6DevHub'];
+  const preferredAliases = ['ElectivusDevHub', 'DevHubElectivus', 'InsuranceOrgTrialCreme6DevHub'];
   for (const alias of preferredAliases) {
     if (await tryOrgDisplay(alias)) {
       return alias;

--- a/test/e2e/utils/seedLog.ts
+++ b/test/e2e/utils/seedLog.ts
@@ -29,27 +29,53 @@ export async function seedApexLog(targetOrg: string): Promise<SeedResult> {
   const beforeIds = new Set(parseLogIds(before));
 
   const marker = `ALV_E2E_MARKER_${Date.now()}`;
+  await runAnonymousApex(targetOrg, `System.debug('${marker}');\n`);
+  const logId = await waitForCreatedLogId(targetOrg, beforeIds);
+  return { marker, logId };
+}
+
+export async function seedApexErrorLog(targetOrg: string): Promise<SeedResult> {
+  const auth = await getOrgAuth(targetOrg);
+  await ensureE2eTraceFlag(auth);
+
+  const before = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
+  const beforeIds = new Set(parseLogIds(before));
+
+  const marker = `ALV_E2E_ERROR_MARKER_${Date.now()}`;
+  const anonymousApex = `System.debug('${marker}');\nInteger __alvFail = 1 / 0;\nSystem.debug(__alvFail);\n`;
+  // Intentionally throw at runtime so the generated log includes exception/fatal events.
+  await runAnonymousApex(targetOrg, anonymousApex, { allowFailure: true });
+  const logId = await waitForCreatedLogId(targetOrg, beforeIds);
+  return { marker, logId };
+}
+
+async function runAnonymousApex(targetOrg: string, anonymousApex: string, options?: { allowFailure?: boolean }): Promise<void> {
   const tmp = await mkdtemp(path.join(tmpdir(), 'alv-apex-'));
   const apexFile = path.join(tmp, 'seed.apex');
-  await writeFile(apexFile, `System.debug('${marker}');\n`, 'utf8');
-
+  await writeFile(apexFile, anonymousApex, 'utf8');
   try {
-    await runSfJson(['apex', 'run', '-o', targetOrg, '--file', apexFile]);
+    try {
+      await runSfJson(['apex', 'run', '-o', targetOrg, '--file', apexFile]);
+    } catch (e) {
+      if (!options?.allowFailure) {
+        throw e;
+      }
+    }
   } finally {
     await rm(tmp, { recursive: true, force: true });
   }
+}
 
+async function waitForCreatedLogId(targetOrg: string, beforeIds: Set<string>): Promise<string> {
   const deadline = Date.now() + 45_000;
   while (Date.now() < deadline) {
     const after = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
     const afterIds = parseLogIds(after);
     const created = afterIds.find(id => !beforeIds.has(id));
     if (created) {
-      return { marker, logId: created };
+      return created;
     }
     await sleep(2_000);
   }
-
   throw new Error('Failed to detect a newly created ApexLog after seeding anonymous Apex.');
 }
-


### PR DESCRIPTION
## Summary
- add an `Errors only` filter toggle in the logs toolbar
- classify errors by scanning full log bodies using shared error marker rules
- run org-wide error classification progressively and stream scan status + row-level `hasErrors` markers to the table
- show inline error badge in log rows and keep behavior compatible with existing search/sort/pagination/refresh flows
- add changelog entry for #542

## Testing
- npm run compile
- npm run compile-tests
- npm run build
- npm run test:webview -- --runInBand

Closes #542