### PR TITLE
perf(tests): speed up test runs with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,10 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Build (type-check + lint + bundle)
+      - name: Type-check and lint
+        run: npm run compile
+
+      - name: Build (bundle)
         run: npm run build
 
       - name: Run tests

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,12 +26,20 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 ## Environment variables
 
 - `VSCODE_TEST_VERSION`: VS Code build to test against. Defaults to `stable` (local e CI); sobrescreva quando precisar validar outra versão.
-- `VSCODE_TEST_INSTALL_DEPS=1`: Forces installing dependency extensions even in non‑integration scopes.
+- `VSCODE_TEST_EXTENSIONS`: Comma-separated list of VS Code extension IDs to install for integration tests (default: `salesforce.salesforcedx-vscode`).
+- `VSCODE_TEST_FORCE_INSTALL_DEPS=1`: Forces reinstalling dependency extensions even if already present in the cache (useful when debugging flaky installs).
 - `VSCODE_TEST_GREP`: Mocha grep filter (string or regexp); use with `VSCODE_TEST_INVERT=1` to invert.
 - `VSCODE_TEST_MOCHA_TIMEOUT_MS`: Per‑test timeout (default 120000ms).
 - `VSCODE_TEST_TOTAL_TIMEOUT_MS`: Global hard timeout for the whole run.
 - `VSCODE_TEST_WORKSPACE`: If set, path opened by the test host. Normally the runner creates one for you.
 - `SF_LOG_TRACE=1`: Enables verbose trace logging in the temporary workspace settings.
+
+### Test cache cleanup
+
+- `npm run test:clean`: cleans temp test dirs (user data, legacy temp extension dirs) but preserves `.vscode-test/` (VS Code download cache) by default.
+- `npm run test:clean:all`: fully removes `.vscode-test/` too (forces a re-download on the next run).
+- `CLEAN_VSCODE_TEST_CACHE=1`: removes `.vscode-test/` (same effect as `test:clean:all`).
+- `KEEP_VSCODE_TEST_CACHE=1`: preserves `.vscode-test/` (default behavior; useful to override `CLEAN_*`).
 
 ### Salesforce CLI and scratch org (optional)
 

--- a/docs/plan/2026-02-22-faster-tests.md
+++ b/docs/plan/2026-02-22-faster-tests.md
@@ -1,0 +1,86 @@
+# Faster test runs (plan)
+
+Date: 2026-02-22
+
+## Context
+
+Local development and CI runs were slowed down by repeated work, especially:
+
+- Re-downloading and re-unzipping VS Code test binaries (`.vscode-test/`)
+- Re-installing VS Code dependency extensions for integration tests
+- E2E flakiness/overhead from creating and deleting a scratch org per test
+
+The goal is to keep correctness while reducing the “setup tax” so rerunning tests is cheap.
+
+## Goals
+
+- Make `npm run test:*` faster for local iterative runs
+- Avoid deleting cached VS Code test installs by default
+- Cache integration dependency extensions between runs
+- Keep a clean “user data” directory per run to avoid state leakage
+- Make E2E runs more stable by reusing a scratch org within a run
+- Keep CI deterministic (explicit build steps and coverage where expected)
+
+## Non-goals
+
+- Redesign the extension’s runtime behavior
+- Remove existing test coverage
+- Introduce CI-only behavior that can’t be reproduced locally
+
+## Proposed changes
+
+### 1) VS Code test caching (integration/unit runner)
+
+- Keep `.vscode-test/` by default instead of deleting it every run
+- Add an explicit “clean everything” option (`--force` / `test:clean:all`)
+- Use a fixed cache path for `@vscode/test-electron` downloads
+
+Expected impact:
+
+- Big win for local runs (no repeated VS Code download)
+- CI can still start from a clean slate if desired
+
+### 2) Dependency extension caching (integration tests)
+
+- Use a shared extensions cache directory under `.vscode-test/extensions`
+- Skip re-install if the extension is already present
+- Provide an override to force reinstall (env/flag) when debugging
+
+Expected impact:
+
+- Cuts minutes off repeated `npm run test:integration` runs
+
+### 3) Reduce default “pretest” work locally
+
+- Avoid redundant “clean + compile” in `pretest` when scripts already build
+- Make CI do the explicit compile step so it remains strict
+
+Expected impact:
+
+- Faster `npm run test:unit` / `test:integration` for local iteration
+
+### 4) E2E stability + speed
+
+- Reuse the scratch org for the full Playwright worker run (worker-scoped fixture)
+- Add a readiness probe to wait until Tooling API is responsive
+- Hide/close the auxiliary (right) sidebar in VS Code to reduce UI flakiness
+
+Expected impact:
+
+- Large speedup for `npm run test:e2e` (avoid per-test scratch provisioning)
+- Reduced flake rate when scratch org is still “warming up”
+
+## Validation
+
+- `npm run compile`
+- `npm run test:unit`
+- `npm run test:integration`
+- `npm run test:e2e`
+
+## Rollback plan
+
+If any of these changes cause regressions, the rollback is straightforward:
+
+- Restore the previous cleanup behavior for `.vscode-test/`
+- Disable dependency extension caching and revert to per-run installs
+- Revert E2E fixture scope to per-test scratch org creation

--- a/jest.config.webview.cjs
+++ b/jest.config.webview.cjs
@@ -1,4 +1,9 @@
 /** @type {import('jest').Config} */
+const wantCoverage =
+  /^1|true$/i.test(String(process.env.JEST_COVERAGE || '')) ||
+  /^1|true$/i.test(String(process.env.ENABLE_COVERAGE || '')) ||
+  /^1|true$/i.test(String(process.env.CI || ''));
+
 module.exports = {
   displayName: 'webview',
   clearMocks: true,
@@ -15,7 +20,7 @@ module.exports = {
     ]
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx', 'json'],
-  collectCoverage: true,
+  collectCoverage: wantCoverage,
   coverageDirectory: '<rootDir>/coverage/webview',
   collectCoverageFrom: [
     '<rootDir>/src/webview/components/**/*.{ts,tsx}',

--- a/package.json
+++ b/package.json
@@ -414,6 +414,7 @@
   },
   "scripts": {
     "test:clean": "node scripts/clean-vscode-test.js",
+    "test:clean:all": "node scripts/clean-vscode-test.js --force",
     "clean": "node -e \"const fs=require('fs');const del=d=>{try{fs.rmSync(d,{recursive:true,force:true})}catch{}};del('dist');del('out');for(const f of ['media/main.js','media/main.js.map','media/tail.js','media/tail.js.map','media/logViewer.js','media/logViewer.js.map','media/debugFlags.js','media/debugFlags.js.map','media/webview.css']){try{fs.unlinkSync(f)}catch{}}\"",
     "prebuild": "npm run clean",
     "vscode:prepublish": "npm run build && npm run nls:write",
@@ -439,7 +440,7 @@
     "vsce:publish:pre": "vsce publish --pre-release",
     "compile-tests": "node -e \"try{require('fs').rmSync('out/test',{recursive:true,force:true})}catch(e){}\" && tsc -p tsconfig.test.json",
     "watch-tests": "tsc -p tsconfig.test.json -w",
-    "pretest": "npm run test:clean && npm run test:linux-deps && npm run compile && npm run build:extension && npm run compile-tests",
+    "pretest": "npm run test:linux-deps && npm run build:extension && npm run compile-tests",
     "test": "npm run test:webview && ENABLE_COVERAGE=1 bash scripts/run-tests.sh --scope=unit && npm run coverage:merge",
     "test:unit": "npm run test:webview && npm run test:e2e:utils && npm run pretest && bash scripts/run-tests.sh --scope=unit",
     "test:integration": "npm run pretest && bash scripts/run-tests.sh --scope=integration --install-deps --timeout=900000",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 import { defineConfig } from '@playwright/test';
 
-const repoRoot = path.join(__dirname, '..', '..');
+const repoRoot = __dirname;
 const artifactsRoot = path.join(repoRoot, 'output', 'playwright');
 const resultsRoot = path.join(artifactsRoot, 'test-results');
 

--- a/scripts/clean-vscode-test.js
+++ b/scripts/clean-vscode-test.js
@@ -2,6 +2,15 @@ const { rmSync } = require('fs');
 const { join } = require('path');
 const { tmpdir } = require('os');
 
+function parseArgs(argv = process.argv.slice(2)) {
+  const out = { quiet: false, force: false };
+  for (const a of argv) {
+    if (a === '--quiet' || a === '-q') out.quiet = true;
+    else if (a === '--force' || a === '-f') out.force = true;
+  }
+  return out;
+}
+
 function safeRm(p, { quiet } = {}) {
   try {
     rmSync(p, { recursive: true, force: true });
@@ -14,26 +23,39 @@ function safeRm(p, { quiet } = {}) {
 
 function cleanVsCodeTest({ quiet = false, force = false } = {}) {
   const cwd = process.cwd();
-  const keepCache = !force && /^1|true$/i.test(String(process.env.KEEP_VSCODE_TEST_CACHE || process.env.KEEP_VSCODE_CACHE || ''));
-  if (keepCache) {
-    if (!quiet) {
-      console.log('[test-clean] KEEP_VSCODE_TEST_CACHE is set; preserving .vscode-test cache.');
-    }
-  } else {
+  const requestedCleanCache = /^1|true$/i.test(
+    String(process.env.CLEAN_VSCODE_TEST_CACHE || process.env.CLEAN_VSCODE_CACHE || '')
+  );
+  // Backwards compatible: KEEP_* vars previously preserved cache. Cache is now
+  // preserved by default; KEEP_* still overrides CLEAN_* (but not --force).
+  const explicitlyKeepCache = /^1|true$/i.test(String(process.env.KEEP_VSCODE_TEST_CACHE || process.env.KEEP_VSCODE_CACHE || ''));
+  const cleanCache = force || (!explicitlyKeepCache && requestedCleanCache);
+
+  if (cleanCache) {
     safeRm(join(cwd, '.vscode-test'), { quiet });
     if (!quiet) {
-      console.log('[test-clean] Removed .vscode-test cache.');
+      console.log('[test-clean] Removed .vscode-test cache (forced).');
     }
+  } else if (!quiet) {
+    console.log('[test-clean] Preserving .vscode-test cache.');
   }
+
+  // Always start from a clean user-data-dir to avoid state leakage between runs.
   safeRm(join(tmpdir(), 'alv-user-data'), { quiet });
+
+  // Keep extensions cache by default (integration tests reuse it).
+  // Still remove legacy temp dirs and smoke-test dirs for isolation.
   safeRm(join(tmpdir(), 'alv-extensions'), { quiet });
+  safeRm(join(tmpdir(), 'alv-extensions-unit'), { quiet });
+
   if (!quiet) {
     console.log('[test-clean] Cleaned temp VS Code dirs.');
   }
 }
 
 if (require.main === module) {
-  cleanVsCodeTest();
+  const args = parseArgs();
+  cleanVsCodeTest(args);
 }
 
 module.exports = { cleanVsCodeTest };

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -560,9 +560,14 @@ async function run() {
           '--extensions-dir',
           extensionsDir
         ],
-        { encoding: 'utf8' }
+        {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          encoding: 'utf8',
+          input: 'y\n',
+          env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
+        }
       );
-      const out = (list.stdout || '').trim();
+      const out = [list.stdout, list.stderr].filter(Boolean).join('\n').trim();
       for (const line of out.split(/\r?\n/)) {
         const trimmed = (line || '').trim();
         if (!trimmed) continue;
@@ -614,9 +619,14 @@ async function run() {
           '--extensions-dir',
           extensionsDir
         ],
-        { encoding: 'utf8' }
+        {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          encoding: 'utf8',
+          input: 'y\n',
+          env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
+        }
       );
-      const out = (list.stdout || '').trim();
+      const out = [list.stdout, list.stderr].filter(Boolean).join('\n').trim();
       console.log('[deps] Extensions installed in test dir:\n' + out);
       if (
         /^salesforce\.salesforcedx-vscode(?:@|$)/m.test(out) ||

--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,7 +2,6 @@
 set -euo pipefail
 
 script_dir="$(cd -- "$(dirname "$0")" >/dev/null 2>&1 && pwd)"
-node "$script_dir/clean-vscode-test.js"
 cmd=(node "$script_dir/run-tests.js" "$@")
 
 if [[ -n "${ENABLE_COVERAGE:-}" && "${ENABLE_COVERAGE}" != "0" ]]; then

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -129,6 +129,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.refresh', async () => {
       safeSendEvent('command.refresh');
+      const viewAlreadyResolved = provider.hasResolvedView();
       try {
         await vscode.commands.executeCommand('workbench.view.extension.salesforceLogsPanel');
         try {
@@ -139,7 +140,11 @@ export async function activate(context: vscode.ExtensionContext) {
       } catch (e) {
         logWarn('Command sfLogs.refresh: failed to open logs view ->', getErrorMessage(e));
       }
-      return provider.refresh();
+      // The logs webview runs an initial refresh when it posts the "ready" message.
+      // Avoid triggering a second refresh (and duplicate notifications) on the first open.
+      if (viewAlreadyResolved) {
+        return provider.refresh();
+      }
     })
   );
 

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -116,6 +116,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
     );
   }
 
+  public hasResolvedView(): boolean {
+    return Boolean(this.view) && !this.disposed;
+  }
+
   public async refresh() {
     if (!this.view) {
       return;

--- a/test/e2e/fixtures/alvE2E.ts
+++ b/test/e2e/fixtures/alvE2E.ts
@@ -21,14 +21,17 @@ type Fixtures = {
 };
 
 export const test = base.extend<Fixtures>({
-  scratchAlias: async ({}, use) => {
-    const scratch = await ensureScratchOrg();
-    try {
-      await use(scratch.scratchAlias);
-    } finally {
-      await scratch.cleanup();
-    }
-  },
+  scratchAlias: [
+    async ({}, use) => {
+      const scratch = await ensureScratchOrg();
+      try {
+        await use(scratch.scratchAlias);
+      } finally {
+        await scratch.cleanup();
+      }
+    },
+    { scope: 'worker' }
+  ],
 
   seededLog: async ({ scratchAlias }, use) => {
     const seeded = await seedApexLog(scratchAlias);

--- a/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
@@ -44,7 +44,9 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
     async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
     { timeoutMs: 180_000 }
   );
-  await logsFrame.locator('[data-testid="logs-open-debug-flags"]').first().click();
+  const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
+  await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+  await openDebugFlags.click();
 
   const debugFlagsFrame = await waitForWebviewFrame(
     vscodePage,

--- a/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
@@ -62,6 +62,7 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
     async frame => await frame.locator('[data-testid="tail-open-debug-flags"]').first().isVisible(),
     { timeoutMs: 180_000 }
   );
+  await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
   await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
 
   const debugFlagsFrameFromTail = await waitForWebviewFrame(

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -18,7 +18,9 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
       async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
       { timeoutMs: 180_000 }
     );
-    await logsFrame.locator('[data-testid="logs-open-debug-flags"]').first().click();
+    const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
+    await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+    await openDebugFlags.click();
 
     const debugFlagsFrame = await waitForWebviewFrame(
       vscodePage,

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -63,6 +63,7 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
       async frame => await frame.locator('[data-testid="tail-open-debug-flags"]').first().isVisible(),
       { timeoutMs: 180_000 }
     );
+    await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
     await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
 
     const debugFlagsFrameFromTail = await waitForWebviewFrame(

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -18,7 +18,10 @@ function getVsCodeVersion(): string {
 }
 
 export async function launchVsCode(options: { workspacePath: string; extensionDevelopmentPath: string }): Promise<VscodeLaunch> {
-  const vscodeExecutablePath = await downloadAndUnzipVSCode(getVsCodeVersion());
+  const vscodeCachePath = process.env.VSCODE_TEST_CACHE_PATH
+    ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
+    : path.join(options.extensionDevelopmentPath, '.vscode-test');
+  const vscodeExecutablePath = await downloadAndUnzipVSCode({ version: getVsCodeVersion(), cachePath: vscodeCachePath });
 
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
   const extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
@@ -60,4 +63,3 @@ export async function launchVsCode(options: { workspacePath: string; extensionDe
 
   return { app, page, userDataDir, extensionsDir, cleanup };
 }
-


### PR DESCRIPTION
## Summary

- Preserve VS Code download cache in `.vscode-test/` by default; add `npm run test:clean:all` for a full reset.
- Cache integration dependency extensions under `.vscode-test/extensions` and skip reinstall when already present (WSL-safe).
- Reduce local overhead by collecting webview coverage only in CI or when explicitly enabled.
- Stabilize E2E by reusing a scratch org per Playwright worker, waiting for Tooling API readiness, and closing the auxiliary right sidebar (e.g. Copilot Chat) to reduce UI interference.
- Keep docs up to date (`docs/plan/...`, `docs/TESTING.md`).

## Validation

- `npm run compile`
- `npm run test:unit`
- `npm run test:integration`
- `npm run test:e2e`
