### PR TITLE
feat(logs): replace infinite scroll with Load more button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Debug Flags: add a dedicated editor panel to configure `USER_DEBUG` TraceFlags for active users, accessible from both Logs and Tail toolbars.
 - Logs: add an explicit `Download all logs` action with confirmation, progress feedback, and completion summary; search now reports pending logs without implicit multi-log fallback. ([#541](https://github.com/Electivus/Apex-Log-Viewer/issues/541))
 - Logs: always download full Apex log bodies in the Logs view so content search and derived metadata no longer depend on partial-header requests; removes the `electivus.apexLogs.enableFullLogSearch` setting.
+- Logs: replace infinite scroll with a manual `Load more` button below the listing.
 - Logs: add an `Errors only` filter with progressive full-body scanning across the current log listing (including additional pages) and inline row badges for detected errors. ([#542](https://github.com/Electivus/Apex-Log-Viewer/issues/542))
 
 ### Bug Fixes

--- a/docs/plans/2026-02-22-logs-manual-pagination-design.md
+++ b/docs/plans/2026-02-22-logs-manual-pagination-design.md
@@ -1,0 +1,63 @@
+# Logs manual pagination (remove infinite scroll) — design
+
+Date: 2026-02-22
+
+## Context
+
+The Logs webview currently supports auto-pagination ("infinite scroll") when no filters are active. When filters are active, auto-pagination is disabled and a manual **Load more** button is shown.
+
+The desired UX is to remove infinite scroll entirely and always use an explicit **Load more** button below the table.
+
+## Goals
+
+- Remove infinite scroll behavior from the Logs list.
+- Show a **Load more** button below the table whenever additional pages are available.
+- Keep existing sorting, filtering, column sizing, and virtualized rendering behavior.
+- Keep i18n strings (English + Portuguese) consistent with existing copy.
+
+## Non-goals
+
+- Change how paging works in the extension host (message protocol stays `{ type: 'loadMore' }`).
+- Redesign the table UI or add new settings/toggles.
+- Modify Tail view behavior.
+
+## Proposed UX
+
+- When `hasMore === true`, render a **Load more** button below the Logs table.
+  - If filters/search are active, use the existing “Load more results” copy (`t.loadMoreFiltered`).
+  - Otherwise use the existing “Load more logs” copy (`t.loadMore`).
+- The button is always visible (not gated by scroll position) and is disabled while `loading === true`.
+- The table never triggers paging automatically based on scroll position or rendered row range.
+
+## Implementation outline
+
+### Webview app (`LogsApp`)
+
+- Always render the manual pagination button when `hasMore` is true.
+- Remove any reliance on `autoLoadEnabled` in the table.
+
+### Table component (`LogsTable`)
+
+- Remove the auto-pagination logic:
+  - Eliminate `handleRowsRendered` load triggers.
+  - Remove the “bottom proximity” scroll fallback trigger that calls `onLoadMore`.
+  - Remove the `autoLoadEnabled` prop and related refs.
+- Keep the scroll listener only for:
+  - Adaptive overscan adjustments.
+  - Header horizontal scroll synchronization.
+
+### Tests
+
+- Update `LogsTable` unit tests to no longer expect automatic calls to `onLoadMore`.
+- Add/adjust `LogsApp` tests to assert that:
+  - Without filters and with `hasMore: true`, the “Load more logs” button is shown and posts `{ type: 'loadMore' }` on click.
+  - With filters and `hasMore: true`, the “Load more results” button behavior remains.
+
+## Changelog
+
+Add an Unreleased entry noting that Logs pagination is now manual via a Load more button (no infinite scroll).
+
+## Rollback plan
+
+If manual pagination causes regressions, revert by reintroducing the removed `LogsTable` auto-pagination logic and restoring the conditional button rendering behavior in `LogsApp`.
+

--- a/docs/plans/2026-02-22-logs-manual-pagination.md
+++ b/docs/plans/2026-02-22-logs-manual-pagination.md
@@ -1,0 +1,148 @@
+# Logs manual pagination Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove Logs infinite scroll (auto-pagination) and always use a manual **Load more** button below the table.
+
+**Architecture:** Keep the virtualized `LogsTable` focused on rendering + scroll/overscan behavior only. Move pagination to `LogsApp` by always rendering a `Load more` button when `hasMore` is true. Remove all auto-load triggers (`onRowsRendered` and bottom-proximity scroll fallback).
+
+**Tech Stack:** React 19, `react-window` (List v2 wrapper), Jest + Testing Library, Tailwind, VS Code webview message passing.
+
+---
+
+## Prereqs
+
+- Worktree location (recommended): `.worktrees/logs-manual-pagination`
+- Install deps: `npm ci`
+- Baseline webview tests: `npm run test:webview`
+
+## Task 1: Update `LogsTable` tests to assert no auto-pagination (RED)
+
+**Files:**
+- Modify: `src/webview/__tests__/LogsTable.test.tsx`
+
+**Step 1: Write a failing test that ensures scrolling near the bottom does NOT call `onLoadMore`**
+
+- Replace the current pagination-trigger tests with a new behavior test:
+  - Render `LogsTable` with `hasMore: true` and `loading: false`
+  - Simulate a scroll position near the bottom (`scrollTop` set so remaining <= ~2 rows)
+  - Expect `onLoadMore` NOT to be called
+
+**Step 2: Run the test to verify it fails**
+
+Run: `npm run test:webview -- src/webview/__tests__/LogsTable.test.tsx`
+
+Expected: FAIL because the current component triggers `onLoadMore` via the “bottom proximity” scroll fallback.
+
+**Step 3: Commit the failing test**
+
+```bash
+git add src/webview/__tests__/LogsTable.test.tsx
+git commit -m "test(logs): assert no auto-pagination in LogsTable"
+```
+
+## Task 2: Remove auto-pagination logic from `LogsTable` (GREEN)
+
+**Files:**
+- Modify: `src/webview/components/LogsTable.tsx`
+- Modify: `src/webview/main.tsx`
+- Modify: `src/webview/__tests__/LogsTable.test.tsx`
+
+**Step 1: Remove `LogsTable` props and refs used for auto-pagination**
+
+- In `LogsTable` props:
+  - Remove: `hasMore`, `onLoadMore`, `autoLoadEnabled`
+- Remove related refs/effects:
+  - `hasMoreRef`, `loadingRef`, `autoLoadRef`, `onLoadMoreRef`, `lastLoadTsRef`
+  - `handleRowsRendered`
+- Remove the `onRowsRendered` prop passed down to the virtual list component.
+
+**Step 2: Keep scroll listener for overscan + header sync only**
+
+- The `useEffect` scroll handler should:
+  - Update overscan based on scroll velocity
+  - Synchronize `headerRef.scrollLeft` with the list element
+- It must not call `onLoadMore` anymore.
+
+**Step 3: Update call site**
+
+- Update `LogsApp` usage in `src/webview/main.tsx`:
+  - Stop passing removed props to `LogsTable`
+
+**Step 4: Run the test to verify it now passes**
+
+Run: `npm run test:webview -- src/webview/__tests__/LogsTable.test.tsx`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/webview/components/LogsTable.tsx src/webview/main.tsx src/webview/__tests__/LogsTable.test.tsx
+git commit -m "refactor(logs): remove infinite scroll from LogsTable"
+```
+
+## Task 3: Always show the manual Load more button in `LogsApp`
+
+**Files:**
+- Modify: `src/webview/main.tsx`
+- Modify: `src/webview/__tests__/logsApp.test.tsx`
+
+**Step 1: Change button rendering**
+
+- Replace the conditional `{hasFilters && hasMore && (...)}` with `{hasMore && (...)}`.
+- Button label:
+  - When `hasFilters` is true: `t.loadMoreFiltered ?? t.loadMore ?? 'Load more results'`
+  - When `hasFilters` is false: `t.loadMore ?? 'Load more logs'`
+- Keep `disabled={loading}`.
+
+**Step 2: Add a failing test for “no filters still shows button”**
+
+- In `logsApp.test.tsx`, add a new test:
+  - Render app
+  - Send `{ type: 'logs', hasMore: true }` and `{ type: 'loading', value: false }`
+  - Assert a button exists with name `Load more logs`
+  - Click it and assert `{ type: 'loadMore' }` was posted
+
+Run: `npm run test:webview -- src/webview/__tests__/logsApp.test.tsx`
+
+Expected: FAIL before the UI change, PASS after.
+
+**Step 3: Commit**
+
+```bash
+git add src/webview/main.tsx src/webview/__tests__/logsApp.test.tsx
+git commit -m "feat(logs): always show manual load more button"
+```
+
+## Task 4: Update changelog
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Step 1: Add an Unreleased note**
+
+- Under `## Unreleased` → `### Features`, add:
+  - `- Logs: replace infinite scroll with a manual Load more button below the listing.`
+
+**Step 2: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): note manual logs pagination"
+```
+
+## Task 5: Verification
+
+**Step 1: Run webview tests**
+
+Run: `npm run test:webview`
+
+Expected: PASS (all webview suites).
+
+**Step 2: Run full test suite (optional but recommended)**
+
+Run: `npm test`
+
+Expected: PASS (unit + coverage merge).
+

--- a/src/webview/__tests__/LogsTable.test.tsx
+++ b/src/webview/__tests__/LogsTable.test.tsx
@@ -105,12 +105,14 @@ describe('LogsTable', () => {
     rows = createRows(10),
     loading = false,
     captured,
-    fullLogSearchEnabled = true
+    fullLogSearchEnabled = true,
+    viewportBottomInsetPx
   }: {
     rows?: ApexLogRow[];
     loading?: boolean;
     captured: CapturedList;
     fullLogSearchEnabled?: boolean;
+    viewportBottomInsetPx?: number;
   }) {
     const virtualList = createVirtualList(captured);
     const baseProps = {
@@ -133,6 +135,7 @@ describe('LogsTable', () => {
         {...baseProps}
         virtualListComponent={virtualList}
         fullLogSearchEnabled={fullLogSearchEnabled}
+        {...(typeof viewportBottomInsetPx === 'number' ? ({ viewportBottomInsetPx } as any) : {})}
       />
     );
     return {
@@ -143,6 +146,7 @@ describe('LogsTable', () => {
             {...next}
             virtualListComponent={virtualList}
             fullLogSearchEnabled={next.fullLogSearchEnabled ?? fullLogSearchEnabled}
+            {...(typeof viewportBottomInsetPx === 'number' ? ({ viewportBottomInsetPx } as any) : {})}
           />
         )
     };
@@ -152,6 +156,21 @@ describe('LogsTable', () => {
     const captured: CapturedList = {};
     renderTable({ rows: createRows(30), captured });
     expect(captured.onRowsRendered).toBeUndefined();
+  });
+
+  it('reduces the measured list height when a viewport bottom inset is provided', () => {
+    const originalInnerHeight = window.innerHeight;
+    Object.defineProperty(window, 'innerHeight', { value: 500, configurable: true });
+
+    const capturedBaseline: CapturedList = {};
+    renderTable({ captured: capturedBaseline });
+    expect(capturedBaseline.outer?.style.height).toBe('488px');
+
+    const capturedInset: CapturedList = {};
+    renderTable({ captured: capturedInset, viewportBottomInsetPx: 40 });
+    expect(capturedInset.outer?.style.height).toBe('448px');
+
+    Object.defineProperty(window, 'innerHeight', { value: originalInnerHeight, configurable: true });
   });
 
   it('adjusts overscan while scrolling quickly', async () => {

--- a/src/webview/__tests__/logsApp.test.tsx
+++ b/src/webview/__tests__/logsApp.test.tsx
@@ -222,6 +222,38 @@ describe('Logs webview App', () => {
     });
   });
 
+  it('surfaces manual pagination even when no filters are active', async () => {
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+    render(<LogsApp vscode={vscode} messageBus={bus} />);
+
+    const sampleLogs = [
+      {
+        Id: '07L00000000000AAW',
+        StartTime: '2025-09-21T22:10:00.000Z',
+        Operation: 'ExecuteAnonymous',
+        Application: 'Developer Console',
+        DurationMilliseconds: 90,
+        Status: 'Success',
+        Request: 'XYZ',
+        LogLength: 1024,
+        LogUser: { Name: 'Alice' }
+      }
+    ];
+    sendMessage(bus, { type: 'logs', data: sampleLogs, hasMore: true });
+    sendMessage(bus, { type: 'loading', value: false });
+
+    const loadMoreButton = await screen.findByRole('button', { name: 'Load more logs' });
+    const baselineLoads = posted.filter(msg => msg.type === 'loadMore').length;
+
+    fireEvent.click(loadMoreButton);
+
+    await waitFor(() => {
+      const loadCalls = posted.filter(msg => msg.type === 'loadMore').length;
+      expect(loadCalls).toBeGreaterThan(baselineLoads);
+    });
+  });
+
   it('applies errors-only filter with progressive scan status updates', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -41,15 +41,12 @@ export function LogsTable({
   onReplay,
   loading,
   locale,
-  hasMore,
-  onLoadMore,
   sortBy,
   sortDir,
   onSort,
   columnsConfig,
   onColumnsConfigChange,
   virtualListComponent,
-  autoLoadEnabled = true,
   fullLogSearchEnabled
 }: {
   rows: ApexLogRow[];
@@ -60,8 +57,6 @@ export function LogsTable({
   onReplay: (logId: string) => void;
   loading: boolean;
   locale: string;
-  hasMore: boolean;
-  onLoadMore: () => void;
   sortBy: Exclude<LogsColumnKey, 'match'>;
   sortDir: 'asc' | 'desc';
   onSort: (
@@ -73,7 +68,6 @@ export function LogsTable({
     options?: { persist?: boolean }
   ) => void;
   virtualListComponent?: typeof List;
-  autoLoadEnabled?: boolean;
   fullLogSearchEnabled: boolean;
 }) {
   const listRef = useRef<ListImperativeAPI | null>(null);

--- a/src/webview/components/LogsTable.tsx
+++ b/src/webview/components/LogsTable.tsx
@@ -47,6 +47,7 @@ export function LogsTable({
   columnsConfig,
   onColumnsConfigChange,
   virtualListComponent,
+  viewportBottomInsetPx = 0,
   fullLogSearchEnabled
 }: {
   rows: ApexLogRow[];
@@ -68,6 +69,7 @@ export function LogsTable({
     options?: { persist?: boolean }
   ) => void;
   virtualListComponent?: typeof List;
+  viewportBottomInsetPx?: number;
   fullLogSearchEnabled: boolean;
 }) {
   const listRef = useRef<ListImperativeAPI | null>(null);
@@ -213,11 +215,12 @@ export function LogsTable({
 
   useLayoutEffect(() => {
     const recompute = () => {
+      const bottomInset = Number.isFinite(viewportBottomInsetPx) ? Math.max(0, Math.floor(viewportBottomInsetPx)) : 0;
       const outerRect = outerRef.current?.getBoundingClientRect();
       const headerRect = headerRef.current?.getBoundingClientRect();
       const top = outerRect?.top ?? 0;
       const headerH = headerRect?.height ?? 0;
-      const available = Math.max(160, Math.floor(window.innerHeight - top - headerH - 12));
+      const available = Math.max(160, Math.floor(window.innerHeight - top - headerH - bottomInset - 12));
       setMeasuredListHeight(available);
     };
     recompute();
@@ -234,7 +237,7 @@ export function LogsTable({
       }
       window.removeEventListener('resize', recompute);
     };
-  }, []);
+  }, [viewportBottomInsetPx]);
 
   // Adaptive overscan based on scroll velocity
   useEffect(() => {

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState, useLayoutEffect } from 'react';
 import { createRoot } from 'react-dom/client';
 import { getMessages, type Messages } from './i18n';
 import type { OrgItem, ApexLogRow } from '../shared/types';
@@ -68,6 +68,9 @@ export function LogsApp({
   // Sorting
   const [sortBy, setSortBy] = useState<SortKey>('time');
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+
+  const loadMoreFooterRef = useRef<HTMLDivElement | null>(null);
+  const [loadMoreFooterHeightPx, setLoadMoreFooterHeightPx] = useState(0);
 
   const onColumnsConfigChange = useCallback(
     (updater: (prev: NormalizedLogsColumnsConfig) => NormalizedLogsColumnsConfig, options?: { persist?: boolean }) => {
@@ -354,8 +357,37 @@ export function LogsApp({
       .replace('{errorsFound}', String(errorScanStatus.errorsFound));
   }, [errorScanStatus, t]);
   const noLogsMessage = errorsOnly && errorScanStatus.state === 'running'
-    ? (errorScanMessage ?? t.noLogs)
-    : t.noLogs;
+      ? (errorScanMessage ?? t.noLogs)
+      : t.noLogs;
+
+  useLayoutEffect(() => {
+    if (!hasMore) {
+      setLoadMoreFooterHeightPx(0);
+      return;
+    }
+    const el = loadMoreFooterRef.current;
+    if (!el) {
+      setLoadMoreFooterHeightPx(0);
+      return;
+    }
+    const measure = () => {
+      const rect = el.getBoundingClientRect();
+      const next = rect && Number.isFinite(rect.height) ? Math.max(0, Math.floor(rect.height)) : 0;
+      setLoadMoreFooterHeightPx(next);
+    };
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => {
+      try {
+        ro.disconnect();
+      } catch (e) {
+        console.warn('LogsApp: failed to disconnect ResizeObserver', e);
+      }
+    };
+  }, [hasMore, hasFilters, locale]);
+
+  const viewportBottomInsetPx = hasMore ? Math.max(loadMoreFooterHeightPx, 42) : 0;
 
   return (
     <div className="relative flex min-h-[120px] flex-col gap-4 p-4 text-sm">
@@ -408,11 +440,12 @@ export function LogsApp({
           onSort={onSort}
           matchSnippets={matchSnippets}
           fullLogSearchEnabled={fullLogSearchEnabled}
+          viewportBottomInsetPx={viewportBottomInsetPx}
           columnsConfig={logsColumns}
           onColumnsConfigChange={onColumnsConfigChange}
         />
         {hasMore && (
-          <div className="mt-2 flex justify-center">
+          <div ref={loadMoreFooterRef} className="flex justify-center pt-2">
             <Button
               type="button"
               size="sm"

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -403,18 +403,15 @@ export function LogsApp({
           onReplay={onReplay}
           loading={loading}
           locale={locale}
-          hasMore={hasMore}
-          onLoadMore={onLoadMore}
           sortBy={sortBy}
           sortDir={sortDir}
           onSort={onSort}
           matchSnippets={matchSnippets}
           fullLogSearchEnabled={fullLogSearchEnabled}
-          autoLoadEnabled={!hasFilters}
           columnsConfig={logsColumns}
           onColumnsConfigChange={onColumnsConfigChange}
         />
-        {hasFilters && hasMore && (
+        {hasMore && (
           <div className="mt-2 flex justify-center">
             <Button
               type="button"
@@ -423,7 +420,9 @@ export function LogsApp({
               onClick={onLoadMore}
               disabled={loading}
             >
-              {t.loadMoreFiltered ?? t.loadMore ?? 'Load more results'}
+              {hasFilters
+                ? (t.loadMoreFiltered ?? t.loadMore ?? 'Load more results')
+                : (t.loadMore ?? 'Load more logs')}
             </Button>
           </div>
         )}


### PR DESCRIPTION
## Summary
- Remove auto-pagination (infinite scroll) from the Logs listing.
- Always show a manual **Load more** button below the table when `hasMore` is true (copy switches to “Load more results” when filters are active).
- Update unit/webview tests and changelog.

## Test Plan
- [x] npm run test:webview
- [x] npm test

## Screenshots
- Not included (UI change is straightforward; please verify in the Logs view).