### PR TITLE
[codex] normalize ERRORS ONLY control size in logs toolbar

### DIFF
--- a/src/webview/__tests__/Toolbar.test.tsx
+++ b/src/webview/__tests__/Toolbar.test.tsx
@@ -208,6 +208,20 @@ describe('Toolbar webview component', () => {
     expect(utils.errorsOnlyChanges).toEqual([true]);
   });
 
+  it('renders errors-only control with compact inline sizing styles', () => {
+    renderToolbar();
+    const toggle = screen.getByRole('switch', { name: 'Errors only' });
+    const control = toggle.closest('div');
+    const label = screen.getByText('Errors only');
+
+    expect(control).not.toBeNull();
+    expect(control).toHaveClass('h-[28px]');
+    expect(control).not.toHaveClass('py-2');
+
+    expect(label).toHaveClass('text-[13px]', 'font-medium');
+    expect(label).not.toHaveClass('uppercase', 'tracking-wide', 'text-xs');
+  });
+
   it('shows spinner when searchLoading is true', () => {
     renderToolbar({ searchLoading: true, searchMessage: 'Preparing…' });
     const notice = screen.getByText('Preparing…');

--- a/src/webview/components/Toolbar.tsx
+++ b/src/webview/components/Toolbar.tsx
@@ -207,7 +207,7 @@ export function Toolbar({
           allLabel={t.filters?.all ?? 'All'}
           disabled={loading}
         />
-        <div className="flex min-w-[160px] items-center gap-2 rounded-md border border-input bg-input px-3 py-2">
+        <div className="flex h-[28px] min-w-[160px] items-center gap-2 rounded-md border border-input bg-input px-3">
           <Switch
             id={errorsOnlyId}
             data-testid="logs-errors-only-switch"
@@ -217,7 +217,7 @@ export function Toolbar({
           />
           <Label
             htmlFor={errorsOnlyId}
-            className="cursor-pointer text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            className="cursor-pointer text-[13px] font-medium leading-none text-muted-foreground"
           >
             {t.filters?.errorsOnly ?? 'Errors only'}
           </Label>


### PR DESCRIPTION
## Issue
The `ERRORS ONLY` control in the logs toolbar was visually larger than neighboring controls (`Columns`, `Clear filters`, and inline selects), creating an inconsistent toolbar rhythm.

## User impact
The oversized control drew disproportionate visual attention and made the toolbar look misaligned, especially when controls wrapped into multiple rows.

## Root cause
The wrapper around the `ERRORS ONLY` switch used `py-2` and no fixed inline control height, while adjacent controls are rendered around a compact 28px baseline. The label style (`text-xs`, uppercase, tracking-wide) also differed from nearby control typography.

## Fix
I normalized the `ERRORS ONLY` control to the same inline sizing and typography conventions used by nearby controls:
- Set the wrapper to `h-[28px]` and removed extra vertical padding.
- Updated label typography to `text-[13px] font-medium leading-none` and removed uppercase/tracking styling.
- Kept all behavior intact (`Switch` state handling, disabled state, label-to-switch accessibility via `htmlFor`).

## Validation
- Added a regression test that asserts compact sizing and typography classes for the `ERRORS ONLY` control.
- Ran:
  - `npm run test:webview -- src/webview/__tests__/Toolbar.test.tsx`
- Result: 1 suite passed, 10 tests passed.
