### PR TITLE
[codex] fix(replay): avoid false missing Apex Replay Debugger toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,17 @@
 ### Bug Fixes
 
 - Debug Flags: surface apply/remove failures as VS Code error notifications (not just in-panel banners), and add a storage-full hint + shortcut to clear org logs.
+- Logs: ensure initial Refresh honors the project default org from `.sf/.sfdx` config when present.
+- Replay: avoid false “Apex Replay Debugger is unavailable” toasts when the dependency extension is installed but not yet activated (and clarify remote install guidance).
 
 ### Chores
+
+- Replay: narrow VS Code `extensionDependencies` to the Apex Replay Debugger extension (instead of the full Salesforce Extension Pack).
 
 ### Tests
 
 - Logs: add unit coverage for ApexLog cleanup listing + deletion workflows.
+- Replay: add unit + Playwright E2E coverage for launching replay debugger from the Logs table.
 
 ## [0.24.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.22.0...v0.24.0) (2026-02-24)
 

--- a/README.md
+++ b/README.md
@@ -42,8 +42,9 @@ Why developers like it
 - Salesforce CLI: Install either `sf` (recommended) or legacy `sfdx` and authenticate to an org.
   - Login example: `sf org login web` (or `sfdx force:auth:web:login`).
 - VS Code 1.101+.
-- Required for Replay: Salesforce Extension Pack (salesforce.salesforcedx-vscode), which includes Apex Replay Debugger.
+- Required for Replay: Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger).
   - Installed automatically as an extension dependency.
+  - Included in the Salesforce Extension Pack (salesforce.salesforcedx-vscode).
   - Instalado automaticamente como dependência da extensão.
 
 ## Install

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,13 +20,13 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 
 - VS Code is downloaded via `@vscode/test-electron` and launched with `--extensionDevelopmentPath` and `--extensionTestsPath` (the compiled runner).
 - A temporary workspace is created with a minimal `sfdx-project.json` (including `sourceApiVersion`) and opened during tests.
-- On integration runs, the Salesforce Extension Pack (`salesforce.salesforcedx-vscode`) is installed via the VS Code CLI.
+- On integration runs, Apex Replay Debugger (`salesforce.salesforcedx-vscode-apex-replay-debugger`) is installed via the VS Code CLI (Replay dependency).
 - On headless Linux, the script re‑executes under `xvfb-run` if available and sets Electron flags to reduce GPU/DBus issues.
 
 ## Environment variables
 
 - `VSCODE_TEST_VERSION`: VS Code build to test against. Defaults to `stable` (local e CI); sobrescreva quando precisar validar outra versão.
-- `VSCODE_TEST_EXTENSIONS`: Comma-separated list of VS Code extension IDs to install for integration tests (default: `salesforce.salesforcedx-vscode`).
+- `VSCODE_TEST_EXTENSIONS`: Comma-separated list of VS Code extension IDs to install for integration tests (default: `salesforce.salesforcedx-vscode-apex-replay-debugger`).
 - `VSCODE_TEST_FORCE_INSTALL_DEPS=1`: Forces reinstalling dependency extensions even if already present in the cache (useful when debugging flaky installs).
 - `VSCODE_TEST_GREP`: Mocha grep filter (string or regexp); use with `VSCODE_TEST_INVERT=1` to invert.
 - `VSCODE_TEST_MOCHA_TIMEOUT_MS`: Per‑test timeout (default 120000ms).

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "onCommand:sfLogs.openLogInViewer",
     "onLanguage:apexlog"
   ],
-  "extensionDependencies": ["salesforce.salesforcedx-vscode"],
+  "extensionDependencies": ["salesforce.salesforcedx-vscode-apex-replay-debugger"],
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {

--- a/scripts/gen-nls.cjs
+++ b/scripts/gen-nls.cjs
@@ -24,7 +24,7 @@ const en = {
   replayError: 'Failed to launch Apex Replay Debugger: ',
   replayStarting: 'Starting Apex Replay Debugger…',
   replayMissingExtMessage:
-    'Apex Replay Debugger is unavailable. Ensure the Salesforce Extension Pack (salesforce.salesforcedx-vscode) is installed and enabled.',
+    'Apex Replay Debugger is unavailable. Install the Apex Replay Debugger extension (salesforce.salesforcedx-vscode-apex-replay-debugger) or the Salesforce Extension Pack (salesforce.salesforcedx-vscode) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Select a debug level',
   tailHardStop: 'Tail stopped after 30 minutes.',
   tailSavedTo: 'Saved to {0}',
@@ -48,7 +48,7 @@ const ptBr = {
   replayError: 'Falha ao iniciar o Apex Replay Debugger: ',
   replayStarting: 'Iniciando o Apex Replay Debugger…',
   replayMissingExtMessage:
-    'Apex Replay Debugger não está disponível. Garanta que o Salesforce Extension Pack (salesforce.salesforcedx-vscode) esteja instalado e habilitado.',
+    'Apex Replay Debugger não está disponível. Instale a extensão Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger) ou o Salesforce Extension Pack (salesforce.salesforcedx-vscode) e garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Selecione um nível de depuração',
   tailHardStop: 'Tail parado após 30 minutos.',
   tailSavedTo: 'Salvo em {0}',

--- a/scripts/gen-nls.cjs
+++ b/scripts/gen-nls.cjs
@@ -23,6 +23,8 @@ const en = {
   openError: 'Failed to open log: ',
   replayError: 'Failed to launch Apex Replay Debugger: ',
   replayStarting: 'Starting Apex Replay Debugger…',
+  replayCommandsUnavailableMessage:
+    'Apex Replay Debugger is installed (salesforce.salesforcedx-vscode-apex-replay-debugger), but its commands are unavailable. Ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers), then reload the window and try again.',
   replayMissingExtMessage:
     'Apex Replay Debugger is unavailable. Install the Apex Replay Debugger extension (salesforce.salesforcedx-vscode-apex-replay-debugger) or the Salesforce Extension Pack (salesforce.salesforcedx-vscode) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Select a debug level',
@@ -47,6 +49,8 @@ const ptBr = {
   openError: 'Falha ao abrir o log: ',
   replayError: 'Falha ao iniciar o Apex Replay Debugger: ',
   replayStarting: 'Iniciando o Apex Replay Debugger…',
+  replayCommandsUnavailableMessage:
+    'Apex Replay Debugger está instalado (salesforce.salesforcedx-vscode-apex-replay-debugger), mas seus comandos não estão disponíveis. Garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers), recarregue a janela e tente novamente.',
   replayMissingExtMessage:
     'Apex Replay Debugger não está disponível. Instale a extensão Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger) ou o Salesforce Extension Pack (salesforce.salesforcedx-vscode) e garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Selecione um nível de depuração',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -534,7 +534,7 @@ async function run() {
   const cachedExtensionsDir = join(vscodeCachePath, 'extensions');
   let sfExtPresent = false;
   if (shouldInstall) {
-    const toInstall = (process.env.VSCODE_TEST_EXTENSIONS || 'salesforce.salesforcedx-vscode')
+    const toInstall = (process.env.VSCODE_TEST_EXTENSIONS || 'salesforce.salesforcedx-vscode-apex-replay-debugger')
       .split(',')
       .map(s => s.trim())
       .filter(Boolean);
@@ -629,6 +629,7 @@ async function run() {
       const out = [list.stdout, list.stderr].filter(Boolean).join('\n').trim();
       console.log('[deps] Extensions installed in test dir:\n' + out);
       if (
+        /^salesforce\.salesforcedx-vscode-apex-replay-debugger(?:@|$)/m.test(out) ||
         /^salesforce\.salesforcedx-vscode(?:@|$)/m.test(out) ||
         /^salesforce\.salesforcedx-vscode-core(?:@|$)/m.test(out) ||
         /^salesforce\.salesforcedx-vscode-apex(?:@|$)/m.test(out)

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -148,6 +148,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         try {
           clearListCache();
           this.pageLimit = this.configManager.getPageLimit();
+          await this.orgManager.ensureProjectDefaultSelected();
           const auth = await getOrgAuth(this.orgManager.getSelectedOrg(), undefined, controller.signal);
           if (isCurrentRefresh()) {
             const existingWarning = getApiVersionFallbackWarning(auth);

--- a/src/test/integration.dependencies.test.ts
+++ b/src/test/integration.dependencies.test.ts
@@ -2,20 +2,20 @@ import assert from 'assert/strict';
 import * as vscode from 'vscode';
 
 suite('integration: dependencies', () => {
-  test('Salesforce extension is installed', async function () {
+  test('Apex Replay Debugger extension is installed', async function () {
     // Ensure our extension is discoverable
     const self = vscode.extensions.getExtension('electivus.apex-log-viewer');
     assert.ok(self, 'apex-log-viewer extension should be found');
 
-    // Enforce dependency presence; if not installed, fail with guidance
-    // Extension pack ID (older check) or any of the core modules
+    // Enforce Replay Debugger dependency presence; if not installed, fail with guidance.
+    // The VS Code extension dependency is the Apex Replay Debugger module. Users can also
+    // satisfy this by installing the Salesforce Extension Pack (which includes it).
+    const replay = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-apex-replay-debugger');
     const pack = vscode.extensions.getExtension('salesforce.salesforcedx-vscode');
-    const core = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-core');
-    const apex = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-apex');
     const viaEnv = process.env.SF_EXT_PRESENT === '1';
     assert.ok(
-      pack || core || apex || viaEnv,
-      'Salesforce extension not detected. Ensure the Salesforce extension pack (or core/apex modules) is installed. Use `npm run test:integration` to auto-install.'
+      replay || pack || viaEnv,
+      'Apex Replay Debugger extension not detected. Ensure salesforce.salesforcedx-vscode-apex-replay-debugger (or the Salesforce extension pack) is installed. Use `npm run test:integration` to auto-install.'
     );
   });
 });

--- a/src/test/replayDebugger.test.ts
+++ b/src/test/replayDebugger.test.ts
@@ -1,0 +1,34 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+
+suite('Replay Debugger availability', () => {
+  test('treats the Apex Replay Debugger extension as available before activation', async () => {
+    const shown: string[] = [];
+    const vscodeStub = {
+      commands: {
+        getCommands: async () => []
+      },
+      extensions: {
+        getExtension: (id: string) =>
+          id === 'salesforce.salesforcedx-vscode-apex-replay-debugger' ? ({ id } as any) : undefined
+      },
+      window: {
+        showErrorMessage: (msg: string) => {
+          shown.push(msg);
+        }
+      }
+    };
+
+    const { ensureReplayDebuggerAvailable } = proxyquire('../utils/replayDebugger', {
+      vscode: vscodeStub,
+      './localize': { localize: (_key: string, message: string) => message },
+      './logger': { logWarn: () => {} },
+      './error': { getErrorMessage: () => 'err' }
+    });
+
+    const ok = await ensureReplayDebuggerAvailable();
+    assert.equal(ok, true);
+    assert.equal(shown.length, 0, 'should not surface a missing-extension toast');
+  });
+});
+

--- a/src/test/replayDebugger.test.ts
+++ b/src/test/replayDebugger.test.ts
@@ -4,13 +4,22 @@ import proxyquire from 'proxyquire';
 suite('Replay Debugger availability', () => {
   test('treats the Apex Replay Debugger extension as available before activation', async () => {
     const shown: string[] = [];
+    let activated = false;
     const vscodeStub = {
       commands: {
-        getCommands: async () => []
+        getCommands: async () =>
+          activated ? ['sf.launch.replay.debugger.logfile', 'sf.launch.replay.debugger.last.logfile'] : []
       },
       extensions: {
         getExtension: (id: string) =>
-          id === 'salesforce.salesforcedx-vscode-apex-replay-debugger' ? ({ id } as any) : undefined
+          id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'
+            ? ({
+                id,
+                activate: async () => {
+                  activated = true;
+                }
+              } as any)
+            : undefined
       },
       window: {
         showErrorMessage: (msg: string) => {
@@ -30,5 +39,39 @@ suite('Replay Debugger availability', () => {
     assert.equal(ok, true);
     assert.equal(shown.length, 0, 'should not surface a missing-extension toast');
   });
-});
 
+  test('surfaces guidance when the Replay Debugger extension is installed but commands stay unavailable', async () => {
+    const shown: string[] = [];
+    const vscodeStub = {
+      commands: {
+        getCommands: async () => []
+      },
+      extensions: {
+        getExtension: (id: string) =>
+          id === 'salesforce.salesforcedx-vscode-apex-replay-debugger'
+            ? ({
+                id,
+                activate: async () => {}
+              } as any)
+            : undefined
+      },
+      window: {
+        showErrorMessage: (msg: string) => {
+          shown.push(msg);
+        }
+      }
+    };
+
+    const { ensureReplayDebuggerAvailable } = proxyquire('../utils/replayDebugger', {
+      vscode: vscodeStub,
+      './localize': { localize: (_key: string, message: string) => message },
+      './logger': { logWarn: () => {} },
+      './error': { getErrorMessage: () => 'err' }
+    });
+
+    const ok = await ensureReplayDebuggerAvailable();
+    assert.equal(ok, false);
+    assert.equal(shown.length, 1);
+    assert.match(shown[0]!, /commands are unavailable/i);
+  });
+});

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -27,13 +27,13 @@ export class OrgManager {
 
   async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {
     const orgs = await listOrgs(forceRefresh, signal);
-    await this.ensureInitialSelection(orgs);
+    await this.ensureProjectDefaultSelected(orgs);
     const selected = pickSelectedOrg(orgs, this.selectedOrg);
     this.selectedOrg = selected;
     return { orgs, selected };
   }
 
-  private async ensureInitialSelection(orgs: OrgItem[]): Promise<void> {
+  async ensureProjectDefaultSelected(orgs?: OrgItem[]): Promise<void> {
     if (this.initialSelectionLoaded) {
       return;
     }
@@ -54,9 +54,11 @@ export class OrgManager {
         return;
       }
       this.selectedOrg = trimmed;
-      const match = orgs.find(o => o.username === trimmed || o.alias === trimmed);
-      if (match?.username) {
-        this.selectedOrg = match.username;
+      if (Array.isArray(orgs) && orgs.length > 0) {
+        const match = orgs.find(o => o.username === trimmed || o.alias === trimmed);
+        if (match?.username) {
+          this.selectedOrg = match.username;
+        }
       }
     })()
       .catch(e => {

--- a/src/utils/replayDebugger.ts
+++ b/src/utils/replayDebugger.ts
@@ -10,16 +10,31 @@ const APEX_REPLAY_DEBUGGER_EXTENSION_ID = 'salesforce.salesforcedx-vscode-apex-r
  * Returns true when available, otherwise surfaces a user-facing error and returns false.
  */
 export async function ensureReplayDebuggerAvailable(): Promise<boolean> {
-  const hasReplay = await detectReplayDebuggerAvailable();
-  if (hasReplay) {
+  if (await detectReplayDebuggerAvailable()) {
     return true;
   }
 
-  // The Replay Debugger extension only contributes "last logfile" command in package.json.
-  // The `sf.launch.replay.debugger.logfile*` commands are registered at activation time,
-  // so `getCommands(true)` can return a false negative until the extension is activated.
-  if (vscode.extensions.getExtension(APEX_REPLAY_DEBUGGER_EXTENSION_ID)) {
-    return true;
+  const replayExt = vscode.extensions.getExtension(APEX_REPLAY_DEBUGGER_EXTENSION_ID);
+  if (replayExt) {
+    // The Replay Debugger extension only contributes "last logfile" command in package.json.
+    // The `sf.launch.replay.debugger.logfile*` commands are registered at activation time,
+    // so `getCommands(true)` can return a false negative until the extension is activated.
+    try {
+      await replayExt.activate();
+    } catch (e) {
+      logWarn('Failed to activate Apex Replay Debugger extension ->', getErrorMessage(e));
+    }
+
+    if (await detectReplayDebuggerAvailable()) {
+      return true;
+    }
+
+    const msg = localize(
+      'replayCommandsUnavailableMessage',
+      `Apex Replay Debugger is installed (${APEX_REPLAY_DEBUGGER_EXTENSION_ID}), but its commands are unavailable. Ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers), then reload the window and try again.`
+    );
+    void vscode.window.showErrorMessage(msg);
+    return false;
   }
 
   // If users explicitly disabled/uninstalled the dependency extension, fail gracefully with guidance.

--- a/src/utils/replayDebugger.ts
+++ b/src/utils/replayDebugger.ts
@@ -3,6 +3,8 @@ import { logWarn } from './logger';
 import { localize } from './localize';
 import { getErrorMessage } from './error';
 
+const APEX_REPLAY_DEBUGGER_EXTENSION_ID = 'salesforce.salesforcedx-vscode-apex-replay-debugger';
+
 /**
  * Ensure Apex Replay Debugger commands are available.
  * Returns true when available, otherwise surfaces a user-facing error and returns false.
@@ -13,11 +15,17 @@ export async function ensureReplayDebuggerAvailable(): Promise<boolean> {
     return true;
   }
 
-  // This should be rare because the Salesforce Extension Pack is declared as an extensionDependency.
-  // If users explicitly disabled/uninstalled it, fail gracefully with guidance.
+  // The Replay Debugger extension only contributes "last logfile" command in package.json.
+  // The `sf.launch.replay.debugger.logfile*` commands are registered at activation time,
+  // so `getCommands(true)` can return a false negative until the extension is activated.
+  if (vscode.extensions.getExtension(APEX_REPLAY_DEBUGGER_EXTENSION_ID)) {
+    return true;
+  }
+
+  // If users explicitly disabled/uninstalled the dependency extension, fail gracefully with guidance.
   const msg = localize(
     'replayMissingExtMessage',
-    'Apex Replay Debugger is unavailable. Ensure the Salesforce Extension Pack (salesforce.salesforcedx-vscode) is installed and enabled.'
+    `Apex Replay Debugger is unavailable. Install the Apex Replay Debugger extension (${APEX_REPLAY_DEBUGGER_EXTENSION_ID}) or the Salesforce Extension Pack (salesforce.salesforcedx-vscode) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).`
   );
   void vscode.window.showErrorMessage(msg);
   return false;

--- a/test/e2e/specs/replayDebugger.e2e.spec.ts
+++ b/test/e2e/specs/replayDebugger.e2e.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '../fixtures/alvE2E';
+import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { waitForWebviewFrame } from '../utils/webviews';
+
+test('launches replay debugger from logs table without missing-extension toast', async ({ vscodePage, seededLog }) => {
+  void seededLog;
+
+  // Activate the extension by running a contributed command.
+  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+
+  const logsFrame = await waitForWebviewFrame(
+    vscodePage,
+    async frame => {
+      if (!/\/fake\.html\?id=/i.test(frame.url())) return false;
+      const hasRefresh = await frame.locator('text=Refresh').count().catch(() => 0);
+      const hasDownloadAll = await frame.locator('text=Download all logs').count().catch(() => 0);
+      return hasRefresh > 0 && hasDownloadAll > 0;
+    },
+    { timeoutMs: 180_000 }
+  );
+
+  await expect
+    .poll(() => logsFrame.locator('[role="row"][tabindex="0"]').count(), { timeout: 180_000 })
+    .toBeGreaterThan(0);
+
+  // Click the per-row "Apex Replay" icon button.
+  const replayButton = logsFrame.locator('button[aria-label="Apex Replay"]').first();
+  await replayButton.waitFor({ state: 'visible', timeout: 60_000 });
+  await replayButton.click();
+
+  // Historically we surfaced a toast claiming Replay Debugger was unavailable even when installed,
+  // because the dependent extension registers commands at activation time.
+  await vscodePage.waitForTimeout(1_000);
+  await expect(vscodePage.locator('text=Apex Replay Debugger is unavailable')).toHaveCount(0, { timeout: 5_000 });
+});


### PR DESCRIPTION
## What / Why

When clicking **Apex Replay** in the logs UI, some users (commonly in Remote contexts like WSL/SSH/Dev Containers) see a toast saying the Apex Replay Debugger is unavailable, even when the Salesforce replay debugger extension is installed.

This is a false negative that blocks the replay debugger flow and creates confusion about which Salesforce extensions are actually required.

## Root cause

The extension was checking `vscode.commands.getCommands(true)` for internal Replay Debugger commands (for example `sf.launch.replay.debugger.logfile`). Those commands are registered when the Replay Debugger extension activates, so the command-list check can fail before activation and incorrectly report the debugger as unavailable.

## Fix

- Consider the Replay Debugger available when the extension `salesforce.salesforcedx-vscode-apex-replay-debugger` is installed (via `vscode.extensions.getExtension(...)`), without relying on activation-time command registration.
- Improve the missing-extension toast copy to call out that VS Code environment matters (Local vs WSL/SSH/Dev Containers).
- Tighten `extensionDependencies` to the Apex Replay Debugger extension (instead of the full Salesforce Extension Pack) and update docs/test harness expectations.
- Small maintainability/testability refactor around org selection to ensure the project default org is picked before org listing/refresh.

## Tests

- `npm run -s compile-tests`
- `bash scripts/run-tests.sh --scope=unit`
- `bash scripts/run-tests.sh --scope=integration`

## Notes

- Adds regression coverage (unit + Playwright) for the replay debugger availability check.
