### PR TITLE
chore(release): prepare 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,23 +4,34 @@
 
 ### Features
 
-- Logs: add a `Clear logs` action (delete all org logs or only the authenticated user's logs) with confirmation + progress.
-- Debug Flags: add a `Clear logs` menu to quickly delete Apex logs without leaving the panel.
-
 ### Bug Fixes
-
-- Debug Flags: surface apply/remove failures as VS Code error notifications (not just in-panel banners), and add a storage-full hint + shortcut to clear org logs.
-- Logs: ensure initial Refresh honors the project default org from `.sf/.sfdx` config when present.
-- Replay: avoid false “Apex Replay Debugger is unavailable” toasts when the dependency extension is installed but not yet activated (and clarify remote install guidance).
 
 ### Chores
 
-- Replay: narrow VS Code `extensionDependencies` to the Apex Replay Debugger extension (instead of the full Salesforce Extension Pack).
+### Tests
+
+## [0.26.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.24.0...v0.26.0) (2026-03-02)
+
+### Features
+
+- Logs: add a `Clear logs` action (delete all org logs or only the authenticated user's logs) with confirmation + progress. ([#551](https://github.com/Electivus/Apex-Log-Viewer/pull/551))
+- Debug Flags: add a `Clear logs` menu to quickly delete Apex logs without leaving the panel. ([#551](https://github.com/Electivus/Apex-Log-Viewer/pull/551))
+
+### Bug Fixes
+
+- Debug Flags: surface apply/remove failures as VS Code error notifications (not just in-panel banners), and add a storage-full hint + shortcut to clear org logs. ([#551](https://github.com/Electivus/Apex-Log-Viewer/pull/551))
+- Logs toolbar: normalize the `Errors only` control sizing. ([#549](https://github.com/Electivus/Apex-Log-Viewer/pull/549))
+- Logs: ensure initial Refresh honors the project default org from `.sf/.sfdx` config when present. ([#551](https://github.com/Electivus/Apex-Log-Viewer/pull/551))
+- Replay: avoid false “Apex Replay Debugger is unavailable” toasts when the dependency extension is installed but not yet activated (and clarify remote install guidance). ([#566](https://github.com/Electivus/Apex-Log-Viewer/pull/566))
+
+### Chores
+
+- Replay: narrow VS Code `extensionDependencies` to the Apex Replay Debugger extension (instead of the full Salesforce Extension Pack). ([#566](https://github.com/Electivus/Apex-Log-Viewer/pull/566))
 
 ### Tests
 
-- Logs: add unit coverage for ApexLog cleanup listing + deletion workflows.
-- Replay: add unit + Playwright E2E coverage for launching replay debugger from the Logs table.
+- Logs: add unit coverage for ApexLog cleanup listing + deletion workflows. ([#551](https://github.com/Electivus/Apex-Log-Viewer/pull/551))
+- Replay: add unit + Playwright E2E coverage for launching replay debugger from the Logs table. ([#566](https://github.com/Electivus/Apex-Log-Viewer/pull/566))
 
 ## [0.24.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.22.0...v0.24.0) (2026-02-24)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.24.0",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.24.0",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.24.0",
+  "version": "0.26.0",
   "publisher": "electivus",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Prepare the **stable** release `v0.26.0` (even minor => stable channel).

Changes:
- Bump version to `0.26.0` (`package.json` + `package-lock.json`).
- Move release notes into `CHANGELOG.md` for `0.26.0` (since last stable `v0.24.0`).

Included work since `v0.24.0`:
- #551 Clear logs actions + Debug Flags storage-full hint
- #549 Normalize ERRORS ONLY control size in logs toolbar
- #566 fix(replay): avoid false missing Apex Replay Debugger toast

Verification:
- `npm run build`
- `npm run test:ci`

After merge:
- Create and push tag `v0.26.0` to trigger the Release workflow.
  - `git tag v0.26.0 && git push origin v0.26.0`
