### PR TITLE
[codex] feat(debug-flags): add debug level manager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Chores
 
+- Replay/testing: default development and integration-test dependency installs to the Salesforce Extension Pack, while still installing Apex Replay Debugger explicitly for isolated hosts and keeping the published runtime dependency narrowed.
+
 ### Tests
 
 ## [0.26.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.24.0...v0.26.0) (2026-03-02)

--- a/README.md
+++ b/README.md
@@ -42,10 +42,9 @@ Why developers like it
 - Salesforce CLI: Install either `sf` (recommended) or legacy `sfdx` and authenticate to an org.
   - Login example: `sf org login web` (or `sfdx force:auth:web:login`).
 - VS Code 1.101+.
-- Required for Replay: Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger).
-  - Installed automatically as an extension dependency.
-  - Included in the Salesforce Extension Pack (salesforce.salesforcedx-vscode).
-  - Instalado automaticamente como dependência da extensão.
+- Recommended for Replay: Salesforce Extension Pack (`salesforce.salesforcedx-vscode`).
+  - It includes Apex Replay Debugger and matches the setup most Salesforce developers already use.
+  - If you prefer a narrower install, the standalone Apex Replay Debugger (`salesforce.salesforcedx-vscode-apex-replay-debugger`) also works and is installed automatically as this extension's dependency.
 
 ## Install
 
@@ -121,7 +120,7 @@ The extension uses localized strings for the extension UI and the in‑panel int
 ## Troubleshooting
 
 - “Salesforce CLI not found”: Ensure `sf` (or `sfdx`) is installed and available on PATH. On macOS/Linux, ensure your login shell PATH includes the CLI (e.g., launch VS Code from the shell or configure the shell integration).
-- “Failed to launch Apex Replay Debugger”: Ensure the Salesforce Extension Pack is installed and enabled.
+- “Failed to launch Apex Replay Debugger”: Ensure the Salesforce Extension Pack (recommended) or the standalone Apex Replay Debugger extension is installed and enabled.
 - “No orgs detected”: Ensure you’re authenticated (`sf org login web`) and try `sf org list`.
 
 ## Architecture

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,13 +20,13 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 
 - VS Code is downloaded via `@vscode/test-electron` and launched with `--extensionDevelopmentPath` and `--extensionTestsPath` (the compiled runner).
 - A temporary workspace is created with a minimal `sfdx-project.json` (including `sourceApiVersion`) and opened during tests.
-- On integration runs, Apex Replay Debugger (`salesforce.salesforcedx-vscode-apex-replay-debugger`) is installed via the VS Code CLI (Replay dependency).
+- On integration runs, the Salesforce Extension Pack (`salesforce.salesforcedx-vscode`) is installed via the VS Code CLI by default so tests mirror a typical Salesforce developer environment. The runner also installs the standalone Apex Replay Debugger explicitly to satisfy this extension's narrowed runtime dependency when the pack alone is not enough in the isolated host. You can still override this with `VSCODE_TEST_EXTENSIONS` if you want a different setup.
 - On headless Linux, the script re‑executes under `xvfb-run` if available and sets Electron flags to reduce GPU/DBus issues.
 
 ## Environment variables
 
 - `VSCODE_TEST_VERSION`: VS Code build to test against. Defaults to `stable` (local e CI); sobrescreva quando precisar validar outra versão.
-- `VSCODE_TEST_EXTENSIONS`: Comma-separated list of VS Code extension IDs to install for integration tests (default: `salesforce.salesforcedx-vscode-apex-replay-debugger`).
+- `VSCODE_TEST_EXTENSIONS`: Comma-separated list of VS Code extension IDs to install for integration tests (default: `salesforce.salesforcedx-vscode,salesforce.salesforcedx-vscode-apex-replay-debugger`).
 - `VSCODE_TEST_FORCE_INSTALL_DEPS=1`: Forces reinstalling dependency extensions even if already present in the cache (useful when debugging flaky installs).
 - `VSCODE_TEST_GREP`: Mocha grep filter (string or regexp); use with `VSCODE_TEST_INVERT=1` to invert.
 - `VSCODE_TEST_MOCHA_TIMEOUT_MS`: Per‑test timeout (default 120000ms).

--- a/docs/plans/2026-03-05-debuglevel-manager-design.md
+++ b/docs/plans/2026-03-05-debuglevel-manager-design.md
@@ -1,0 +1,183 @@
+# DebugLevel Manager Design
+
+## Goal
+
+Add real `DebugLevel` management to the existing Debug Flags panel so users can:
+
+- create a `DebugLevel` from scratch,
+- load a useful preset and customize it field by field,
+- edit any existing `DebugLevel`,
+- delete an existing `DebugLevel`,
+- keep using the refreshed `DebugLevel` list to apply `USER_DEBUG` trace flags.
+
+## Constraints
+
+- Reuse the existing Debug Flags panel instead of creating a separate view.
+- Keep the existing TraceFlag workflow intact.
+- Support all editable `DebugLevel` fields exposed by the org query provided by the user:
+  - `DeveloperName`
+  - `Language`
+  - `MasterLabel`
+  - `Workflow`
+  - `Validation`
+  - `Callout`
+  - `ApexCode`
+  - `ApexProfiling`
+  - `Visualforce`
+  - `System`
+  - `Database`
+  - `Wave`
+  - `Nba`
+  - `DataAccess`
+- Exclude read-only metadata fields from editing.
+- Use real Tooling API CRUD operations against `DebugLevel`.
+
+## UX
+
+The Debug Flags panel keeps its current upper workflow:
+
+1. select org,
+2. search/select user,
+3. choose a `DebugLevel`,
+4. apply/remove the `USER_DEBUG` trace flag.
+
+Below that workflow, add a dedicated `Debug Level Manager` section with:
+
+- a selector for existing `DebugLevel` records,
+- a `New` action that starts with an empty draft,
+- a preset selector plus `Apply preset`,
+- editable identity fields:
+  - `DeveloperName`
+  - `MasterLabel`
+  - `Language`
+- editable pickers for every log category field,
+- actions:
+  - `Save`
+  - `Delete`
+  - `Reset changes`
+
+Behavior rules:
+
+- Selecting an existing `DebugLevel` loads its current values into a draft form.
+- `Apply preset` updates the draft only; it never saves automatically.
+- `New` starts a new unsaved draft and clears the selected persisted record.
+- `Reset changes` restores the draft to the last loaded record, or to the empty draft for a new item.
+- After save/delete, the panel refreshes the full `DebugLevel` list and keeps the affected item selected when possible.
+- Delete uses confirmation and surfaces Salesforce errors verbatim enough to explain cases like “record is still referenced by TraceFlag”.
+
+## Data Model
+
+Introduce a typed `DebugLevelRecord` shared model for the panel/webview flow:
+
+- `id?: string`
+- `developerName: string`
+- `masterLabel: string`
+- `language: string`
+- `workflow: string`
+- `validation: string`
+- `callout: string`
+- `apexCode: string`
+- `apexProfiling: string`
+- `visualforce: string`
+- `system: string`
+- `database: string`
+- `wave: string`
+- `nba: string`
+- `dataAccess: string`
+
+Also introduce:
+
+- `DebugLevelPreset`
+- `DebugLevelFieldLevel` union for the allowed log-level values
+- `DebugLevelDraftState` shape on the webview side
+
+## Presets
+
+Ship curated presets as typed local constants so they can seed the draft predictably. The first delivery should include a small set of useful defaults such as:
+
+- `Developer Focus`
+- `Integration Troubleshooting`
+- `Validation and Flow`
+- `Performance and Database`
+
+Presets are only defaults. The user can change every field before saving.
+
+## Backend Changes
+
+Extend the current `src/salesforce/traceflags.ts` responsibilities to cover `DebugLevel` CRUD because the file already owns debug-level lookup and trace-flag coupling.
+
+Add:
+
+- detailed `DebugLevel` list query,
+- fetch by id/name helper,
+- create function,
+- update function,
+- delete function,
+- mapping helpers between Salesforce payloads and shared types,
+- request-payload builder for create/update.
+
+Refresh behavior:
+
+- continue serving the simple list of names for existing consumers,
+- add a richer list for the manager UI,
+- after mutations, invalidate the debug-level cache before re-querying.
+
+## Panel/Webview Changes
+
+### Panel
+
+Extend `DebugFlagsPanel` to:
+
+- bootstrap detailed debug-level data and preset definitions,
+- process new messages for:
+  - selecting a manager item,
+  - starting a new draft,
+  - applying a preset to the draft,
+  - saving a draft,
+  - deleting a `DebugLevel`,
+- refresh both the manager list and the existing trace-flag selector after mutations.
+
+### Shared message contracts
+
+Expand `src/shared/debugFlagsMessages.ts` and `src/shared/debugFlagsTypes.ts` with:
+
+- detailed debug-level records,
+- preset payloads,
+- new manager actions,
+- manager state sync messages.
+
+### Webview
+
+Extend `src/webview/debugFlags.tsx` to render:
+
+- manager selector,
+- preset selector,
+- editable form,
+- dirty/reset/save/delete interactions,
+- notices/errors specific to debug-level CRUD.
+
+The current trace-flag controls stay available and continue using the refreshed list of names.
+
+## Validation and Error Handling
+
+- `DeveloperName` and `MasterLabel` must be required before save.
+- `Language` should default sensibly, but remain editable.
+- Every log category field must be constrained to the allowed Salesforce enum values.
+- Delete should require an explicit confirmation dialog from the extension host.
+- Save should show clear success/error notices and preserve the current draft when a mutation fails.
+
+## Testing Strategy
+
+Follow TDD:
+
+1. backend tests for mapping, CRUD requests, and cache invalidation,
+2. panel behavior tests for new message handling and refresh flows,
+3. webview tests for draft/preset/edit/save/delete behavior,
+4. targeted build/lint/test verification.
+
+## Non-Goals
+
+- showing read-only audit metadata in the UI,
+- bulk edit or bulk delete of multiple `DebugLevel` records,
+- automatic deletion of dependent `TraceFlag` records,
+- a separate dedicated `DebugLevel` view.

--- a/docs/plans/2026-03-05-debuglevel-manager.md
+++ b/docs/plans/2026-03-05-debuglevel-manager.md
@@ -1,0 +1,248 @@
+# DebugLevel Manager Implementation Plan
+
+> **For Codex CLI:** REQUIRED SUB-SKILL: Use `$executing-plans` to implement this plan task-by-task.
+
+**Goal:** Add full `DebugLevel` CRUD with presets and field-by-field editing to the existing Debug Flags panel, while preserving the current TraceFlag workflow.
+
+**Architecture:** Extend the existing debug-level/trace-flag service layer in `src/salesforce/traceflags.ts`, expand the shared message/types contract, and add a second manager section to the existing webview. The webview will maintain a local draft model that can start empty or from a preset, then save/delete through the extension host and refresh the shared debug-level list.
+
+**Tech Stack:** TypeScript, VS Code extension host, React webview, Tooling API, Mocha/Jest tests
+
+---
+
+### Task 1: Add shared DebugLevel manager types
+
+**Files:**
+- Modify: `src/shared/debugFlagsTypes.ts`
+- Modify: `src/shared/debugFlagsMessages.ts`
+- Test: `src/webview/__tests__/debugFlagsApp.test.tsx`
+
+**Step 1: Write the failing test**
+
+Update the webview test expectations so the Debug Flags app can receive richer debug-level payloads and manager bootstrap data.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`
+
+Expected: FAIL because the message/types contract does not support the new manager payloads yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- typed `DebugLevelRecord`
+- typed `DebugLevelPreset`
+- allowed field-level union
+- new manager-related inbound/outbound message variants
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`
+
+Expected: PASS or advance to the next missing contract error.
+
+### Task 2: Add failing backend tests for DebugLevel CRUD
+
+**Files:**
+- Modify: `src/test/traceflags.userFlags.test.ts`
+- Modify: `src/test/listDebugLevels.test.ts`
+- Modify: `src/salesforce/traceflags.ts`
+
+**Step 1: Write the failing test**
+
+Add focused Mocha tests for:
+
+- listing detailed `DebugLevel` records,
+- creating a `DebugLevel`,
+- updating a `DebugLevel`,
+- deleting a `DebugLevel`,
+- cache invalidation after mutations.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "traceflags user management|listDebugLevels"`
+
+Expected: FAIL because the new functions do not exist or do not produce the required requests yet.
+
+**Step 3: Write minimal implementation**
+
+In `src/salesforce/traceflags.ts`, implement:
+
+- `listDebugLevelDetails(...)`
+- `createDebugLevel(...)`
+- `updateDebugLevel(...)`
+- `deleteDebugLevel(...)`
+- mapping/payload helpers
+- debug-level cache invalidation helper
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "traceflags user management|listDebugLevels"`
+
+Expected: PASS.
+
+### Task 3: Add presets and default draft helpers
+
+**Files:**
+- Modify: `src/shared/debugFlagsTypes.ts`
+- Create or modify: `src/shared/debugLevelPresets.ts`
+- Test: `src/test/traceflags.userFlags.test.ts`
+
+**Step 1: Write the failing test**
+
+Add tests that assert preset definitions and empty-draft defaults cover all supported editable fields.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "debug level preset|debug level draft"`
+
+Expected: FAIL because presets/default helpers do not exist yet.
+
+**Step 3: Write minimal implementation**
+
+Add:
+
+- typed preset definitions,
+- empty draft helper,
+- reusable field order/constants for the UI.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "debug level preset|debug level draft"`
+
+Expected: PASS.
+
+### Task 4: Add panel tests for manager message flow
+
+**Files:**
+- Modify: `src/test/provider.webview.test.ts` or add a focused panel test file if needed
+- Modify: `src/panel/DebugFlagsPanel.ts`
+
+**Step 1: Write the failing test**
+
+Add tests that prove:
+
+- bootstrap sends manager records and presets,
+- save refreshes the list,
+- delete refreshes the list,
+- applying panel actions posts the right notices/errors.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "DebugFlagsPanel"`
+
+Expected: FAIL because the panel does not handle manager messages yet.
+
+**Step 3: Write minimal implementation**
+
+Extend `DebugFlagsPanel` message handling and bootstrap logic to support the manager flow.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "DebugFlagsPanel"`
+
+Expected: PASS.
+
+### Task 5: Add failing webview tests for draft editing and presets
+
+**Files:**
+- Modify: `src/webview/__tests__/debugFlagsApp.test.tsx`
+- Modify: `src/webview/debugFlags.tsx`
+- Modify: `src/webview/i18n.ts`
+
+**Step 1: Write the failing test**
+
+Add webview tests for:
+
+- loading a detailed manager item,
+- switching to `New`,
+- applying a preset to the draft,
+- editing individual fields,
+- saving and deleting through posted messages,
+- reset behavior.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`
+
+Expected: FAIL because the current UI lacks manager controls and draft state.
+
+**Step 3: Write minimal implementation**
+
+Update the Debug Flags webview to render the manager section and wire the draft interactions.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`
+
+Expected: PASS.
+
+### Task 6: Update i18n and polish user-facing copy
+
+**Files:**
+- Modify: `src/webview/i18n.ts`
+- Modify: `src/panel/DebugFlagsPanel.ts`
+- Test: `src/test/i18n.test.ts`
+
+**Step 1: Write the failing test**
+
+Add or update tests to cover the new strings needed by the manager section.
+
+**Step 2: Run test to verify it fails**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "i18n"`
+
+Expected: FAIL because the new keys are missing.
+
+**Step 3: Write minimal implementation**
+
+Add concise `en` and `pt-BR` copy for labels, notices, confirmations, and errors.
+
+**Step 4: Run test to verify it passes**
+
+Run: `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "i18n"`
+
+Expected: PASS.
+
+### Task 7: Run focused verification
+
+**Files:**
+- Modify: any touched source/test files from previous tasks
+
+**Step 1: Run focused tests**
+
+Run:
+
+- `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`
+- `npm run pretest && bash scripts/run-tests.sh --scope=unit --grep "traceflags user management|DebugFlagsPanel|listDebugLevels|i18n"`
+
+Expected: PASS.
+
+**Step 2: Fix any regressions**
+
+Apply the smallest changes needed until the focused suite is green.
+
+**Step 3: Run broader confidence checks**
+
+Run:
+
+- `npm run lint`
+- `npm run build`
+
+Expected: PASS.
+
+### Task 8: Summarize outcomes
+
+**Files:**
+- Review touched files only
+
+**Step 1: Inspect final diff**
+
+Run: `git diff -- src/salesforce/traceflags.ts src/panel/DebugFlagsPanel.ts src/shared/debugFlagsTypes.ts src/shared/debugFlagsMessages.ts src/shared/debugLevelPresets.ts src/webview/debugFlags.tsx src/webview/i18n.ts src/test/traceflags.userFlags.test.ts src/webview/__tests__/debugFlagsApp.test.tsx`
+
+Expected: Diff matches the approved design and keeps the existing TraceFlag flow intact.
+
+**Step 2: Report verification evidence**
+
+Include the exact commands run and any remaining gaps, if any.

--- a/scripts/gen-nls.cjs
+++ b/scripts/gen-nls.cjs
@@ -26,7 +26,7 @@ const en = {
   replayCommandsUnavailableMessage:
     'Apex Replay Debugger is installed (salesforce.salesforcedx-vscode-apex-replay-debugger), but its commands are unavailable. Ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers), then reload the window and try again.',
   replayMissingExtMessage:
-    'Apex Replay Debugger is unavailable. Install the Apex Replay Debugger extension (salesforce.salesforcedx-vscode-apex-replay-debugger) or the Salesforce Extension Pack (salesforce.salesforcedx-vscode) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).',
+    'Apex Replay Debugger is unavailable. Install the Salesforce Extension Pack (salesforce.salesforcedx-vscode) or the standalone Apex Replay Debugger extension (salesforce.salesforcedx-vscode-apex-replay-debugger) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Select a debug level',
   tailHardStop: 'Tail stopped after 30 minutes.',
   tailSavedTo: 'Saved to {0}',
@@ -52,7 +52,7 @@ const ptBr = {
   replayCommandsUnavailableMessage:
     'Apex Replay Debugger está instalado (salesforce.salesforcedx-vscode-apex-replay-debugger), mas seus comandos não estão disponíveis. Garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers), recarregue a janela e tente novamente.',
   replayMissingExtMessage:
-    'Apex Replay Debugger não está disponível. Instale a extensão Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger) ou o Salesforce Extension Pack (salesforce.salesforcedx-vscode) e garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers).',
+    'Apex Replay Debugger não está disponível. Instale o Salesforce Extension Pack (salesforce.salesforcedx-vscode) ou a extensão avulsa Apex Replay Debugger (salesforce.salesforcedx-vscode-apex-replay-debugger) e garanta que esteja habilitado neste ambiente do VS Code (Local/WSL/SSH/Dev Containers).',
   tailSelectDebugLevel: 'Selecione um nível de depuração',
   tailHardStop: 'Tail parado após 30 minutos.',
   tailSavedTo: 'Salvo em {0}',

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,6 +1,6 @@
 const { spawn, execFile, spawnSync } = require('child_process');
 const { platform, tmpdir } = require('os');
-const { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } = require('fs');
+const { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } = require('fs');
 const { join, resolve } = require('path');
 const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
 const { cleanVsCodeTest } = require('./clean-vscode-test.js');
@@ -46,6 +46,52 @@ function addLocalBinToPath() {
   } catch (e) {
     console.warn('Failed to add local bin to PATH:', e && e.message ? e.message : e);
   }
+}
+
+function getExtensionSearchRoots() {
+  return Array.from(
+    new Set(
+      [join(process.env.USERPROFILE || '', '.vscode', 'extensions'), join(process.env.HOME || '', '.vscode', 'extensions')].filter(
+        Boolean
+      )
+    )
+  );
+}
+
+function findExtensionDirectoryInRoot(root, extensionId) {
+  if (!root || !existsSync(root)) {
+    return undefined;
+  }
+
+  const normalizedId = String(extensionId || '').trim().toLowerCase();
+  const prefix = `${normalizedId}-`;
+  const matches = [];
+  try {
+    const entries = readdirSync(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const entryName = entry.name.toLowerCase();
+      if (entryName === normalizedId || entryName.startsWith(prefix)) {
+        matches.push(join(root, entry.name));
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return matches.sort((a, b) => a.localeCompare(b)).at(-1);
+}
+
+function findLocalExtensionsRootForDependencies(extensionIds) {
+  for (const root of getExtensionSearchRoots()) {
+    const allPresent = extensionIds.every(extensionId => !!findExtensionDirectoryInRoot(root, extensionId));
+    if (allPresent) {
+      return root;
+    }
+  }
+  return undefined;
 }
 
 function normalizeForMatch(value) {
@@ -532,9 +578,13 @@ async function run() {
   const shouldInstall = scope === 'integration' || scope === 'all' || !!args.installDeps;
   const unitExtensionsDir = join(tmpdir(), 'alv-extensions-unit');
   const cachedExtensionsDir = join(vscodeCachePath, 'extensions');
+  let resolvedExtensionsDir = cachedExtensionsDir;
   let sfExtPresent = false;
   if (shouldInstall) {
-    const toInstall = (process.env.VSCODE_TEST_EXTENSIONS || 'salesforce.salesforcedx-vscode-apex-replay-debugger')
+    const toInstall = (
+      process.env.VSCODE_TEST_EXTENSIONS ||
+      'salesforce.salesforcedx-vscode,salesforce.salesforcedx-vscode-apex-replay-debugger'
+    )
       .split(',')
       .map(s => s.trim())
       .filter(Boolean);
@@ -639,6 +689,15 @@ async function run() {
     } catch (e) {
       console.warn('[deps] Failed to list installed extensions:', e && e.message ? e.message : e);
     }
+
+    if (!sfExtPresent) {
+      const localRoot = findLocalExtensionsRootForDependencies(toInstall);
+      if (localRoot) {
+        console.warn(`[deps] Falling back to locally installed VS Code extensions: ${localRoot}`);
+        resolvedExtensionsDir = localRoot;
+        sfExtPresent = true;
+      }
+    }
   }
 
   // Run tests via @vscode/test-electron with our programmatic Mocha runner
@@ -738,7 +797,7 @@ async function run() {
   }, totalTimeout);
 
   const defaultUserDataDir = join(tmpdir(), 'alv-user-data');
-  const defaultExtensionsDir = shouldInstall ? cachedExtensionsDir : unitExtensionsDir;
+  const defaultExtensionsDir = shouldInstall ? resolvedExtensionsDir : unitExtensionsDir;
   try {
     mkdirSync(defaultExtensionsDir, { recursive: true });
   } catch (e) {

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -1,15 +1,21 @@
 import * as vscode from 'vscode';
 import { getOrgAuth, listOrgs } from '../salesforce/cli';
 import {
+  createDebugLevel,
+  deleteDebugLevel,
   getActiveUserDebugLevel,
   getUserTraceFlagStatus,
   listActiveUsers,
+  listDebugLevelDetails,
   listDebugLevels,
   removeUserTraceFlags,
+  updateDebugLevel,
   upsertUserTraceFlag
 } from '../salesforce/traceflags';
+import { DEBUG_LEVEL_PRESETS } from '../shared/debugLevelPresets';
 import { clearApexLogs } from '../services/apexLogCleanup';
 import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
+import type { DebugLevelRecord } from '../shared/debugFlagsTypes';
 import { safeSendEvent } from '../shared/telemetry';
 import { pickSelectedOrg } from '../utils/orgs';
 import { localize } from '../utils/localize';
@@ -139,6 +145,12 @@ export class DebugFlagsPanel {
       case 'debugFlagsApply':
         await this.applyUserTraceFlag(message.userId, message.debugLevelName, message.ttlMinutes);
         break;
+      case 'debugFlagsManagerSave':
+        await this.saveDebugLevel(message.draft);
+        break;
+      case 'debugFlagsManagerDelete':
+        await this.removeDebugLevel(message.debugLevelId);
+        break;
       case 'debugFlagsRemove':
         await this.removeUserTraceFlag(message.userId);
         break;
@@ -169,25 +181,7 @@ export class DebugFlagsPanel {
         return;
       }
 
-      const [levels, active] = await Promise.all([
-        listDebugLevels(auth).catch(err => {
-          logWarn('DebugFlagsPanel: failed to load debug levels ->', getErrorMessage(err));
-          return [] as string[];
-        }),
-        getActiveUserDebugLevel(auth).catch(() => undefined as string | undefined)
-      ]);
-      if (token !== this.orgBootstrapToken || this.disposed) {
-        return;
-      }
-      const output = [...levels];
-      if (active && !output.includes(active)) {
-        output.unshift(active);
-      }
-      this.post({
-        type: 'debugFlagsDebugLevels',
-        data: output,
-        active
-      });
+      await this.sendDebugLevelData(auth);
       await this.searchUsers();
     } catch (e) {
       const msg = getErrorMessage(e);
@@ -201,6 +195,38 @@ export class DebugFlagsPanel {
         this.post({ type: 'debugFlagsLoading', scope: 'orgs', value: false });
       }
     }
+  }
+
+  private async sendDebugLevelData(auth: Awaited<ReturnType<DebugFlagsPanel['getSelectedAuth']>>, selectedId?: string): Promise<void> {
+    const [details, active] = await Promise.all([
+      listDebugLevelDetails(auth).catch(err => {
+        logWarn('DebugFlagsPanel: failed to load debug level details ->', getErrorMessage(err));
+        return [] as DebugLevelRecord[];
+      }),
+      getActiveUserDebugLevel(auth).catch(() => undefined as string | undefined)
+    ]);
+
+    const output = details.map(record => record.developerName).filter(Boolean);
+    if (active && !output.includes(active)) {
+      output.unshift(active);
+    }
+    this.post({
+      type: 'debugFlagsDebugLevels',
+      data: output,
+      active
+    });
+
+    const preferredId =
+      selectedId && details.some(record => record.id === selectedId)
+        ? selectedId
+        : details[0]?.id;
+
+    this.post({
+      type: 'debugFlagsManagerData',
+      records: details,
+      presets: DEBUG_LEVEL_PRESETS,
+      selectedId: preferredId
+    });
   }
 
   private async searchUsers(): Promise<void> {
@@ -328,6 +354,112 @@ export class DebugFlagsPanel {
         },
         { durationMs: Date.now() - t0 }
       );
+    } finally {
+      this.post({ type: 'debugFlagsLoading', scope: 'action', value: false });
+    }
+  }
+
+  private normalizeDebugLevelDraft(draft: DebugLevelRecord): DebugLevelRecord {
+    return {
+      ...draft,
+      developerName: String(draft.developerName || '').trim(),
+      masterLabel: String(draft.masterLabel || '').trim(),
+      language: String(draft.language || '').trim() || 'en_US',
+      workflow: String(draft.workflow || '').trim(),
+      validation: String(draft.validation || '').trim(),
+      callout: String(draft.callout || '').trim(),
+      apexCode: String(draft.apexCode || '').trim(),
+      apexProfiling: String(draft.apexProfiling || '').trim(),
+      visualforce: String(draft.visualforce || '').trim(),
+      system: String(draft.system || '').trim(),
+      database: String(draft.database || '').trim(),
+      wave: String(draft.wave || '').trim(),
+      nba: String(draft.nba || '').trim(),
+      dataAccess: String(draft.dataAccess || '').trim()
+    };
+  }
+
+  private async saveDebugLevel(draft: DebugLevelRecord): Promise<void> {
+    const normalized = this.normalizeDebugLevelDraft(draft);
+    if (!normalized.developerName) {
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.managerDeveloperNameRequired', 'DeveloperName is required.')
+      });
+      return;
+    }
+    if (!normalized.masterLabel) {
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.managerMasterLabelRequired', 'MasterLabel is required.')
+      });
+      return;
+    }
+
+    this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      const savedId = normalized.id
+        ? (await updateDebugLevel(auth, normalized.id, normalized), normalized.id)
+        : (await createDebugLevel(auth, normalized)).id;
+
+      await this.sendDebugLevelData(auth, savedId);
+      this.post({
+        type: 'debugFlagsNotice',
+        tone: 'success',
+        message: normalized.id
+          ? localize('debugFlags.managerUpdated', 'Debug level updated successfully.')
+          : localize('debugFlags.managerCreated', 'Debug level created successfully.')
+      });
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: save DebugLevel failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.managerSaveFailed', 'Failed to save debug level: {0}', msg)
+      });
+    } finally {
+      this.post({ type: 'debugFlagsLoading', scope: 'action', value: false });
+    }
+  }
+
+  private async removeDebugLevel(debugLevelId: string): Promise<void> {
+    if (!debugLevelId) {
+      return;
+    }
+    const confirmAction = localize('debugFlags.managerDeleteConfirmAction', 'Delete');
+    const confirmation = await vscode.window.showWarningMessage(
+      localize('debugFlags.managerDeleteConfirmTitle', 'Delete this DebugLevel?'),
+      {
+        modal: true,
+        detail: localize(
+          'debugFlags.managerDeleteConfirmDetail',
+          "This permanently removes the DebugLevel from the org. Salesforce may block deletion if it's still referenced by a TraceFlag."
+        )
+      },
+      confirmAction
+    );
+    if (confirmation !== confirmAction) {
+      return;
+    }
+
+    this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
+    try {
+      const auth = await this.getSelectedAuth();
+      await deleteDebugLevel(auth, debugLevelId);
+      await this.sendDebugLevelData(auth);
+      this.post({
+        type: 'debugFlagsNotice',
+        tone: 'success',
+        message: localize('debugFlags.managerDeleted', 'Debug level deleted successfully.')
+      });
+    } catch (e) {
+      const msg = getErrorMessage(e);
+      logWarn('DebugFlagsPanel: delete DebugLevel failed ->', msg);
+      this.post({
+        type: 'debugFlagsError',
+        message: localize('debugFlags.managerDeleteFailed', 'Failed to delete debug level: {0}', msg)
+      });
     } finally {
       this.post({ type: 'debugFlagsLoading', scope: 'action', value: false });
     }

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -427,22 +427,6 @@ export class DebugFlagsPanel {
     if (!debugLevelId) {
       return;
     }
-    const confirmAction = localize('debugFlags.managerDeleteConfirmAction', 'Delete');
-    const confirmation = await vscode.window.showWarningMessage(
-      localize('debugFlags.managerDeleteConfirmTitle', 'Delete this DebugLevel?'),
-      {
-        modal: true,
-        detail: localize(
-          'debugFlags.managerDeleteConfirmDetail',
-          "This permanently removes the DebugLevel from the org. Salesforce may block deletion if it's still referenced by a TraceFlag."
-        )
-      },
-      confirmAction
-    );
-    if (confirmation !== confirmAction) {
-      return;
-    }
-
     this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
     try {
       const auth = await this.getSelectedAuth();

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -181,7 +181,7 @@ export class DebugFlagsPanel {
         return;
       }
 
-      await this.sendDebugLevelData(auth);
+      await this.sendDebugLevelData(auth, undefined, token);
       await this.searchUsers();
     } catch (e) {
       const msg = getErrorMessage(e);
@@ -197,7 +197,11 @@ export class DebugFlagsPanel {
     }
   }
 
-  private async sendDebugLevelData(auth: Awaited<ReturnType<DebugFlagsPanel['getSelectedAuth']>>, selectedId?: string): Promise<void> {
+  private async sendDebugLevelData(
+    auth: Awaited<ReturnType<DebugFlagsPanel['getSelectedAuth']>>,
+    selectedId?: string,
+    bootstrapToken?: number
+  ): Promise<void> {
     const [details, active] = await Promise.all([
       listDebugLevelDetails(auth).catch(err => {
         logWarn('DebugFlagsPanel: failed to load debug level details ->', getErrorMessage(err));
@@ -205,6 +209,13 @@ export class DebugFlagsPanel {
       }),
       getActiveUserDebugLevel(auth).catch(() => undefined as string | undefined)
     ]);
+
+    if (
+      this.disposed ||
+      (typeof bootstrapToken === 'number' && bootstrapToken !== this.orgBootstrapToken)
+    ) {
+      return;
+    }
 
     const output = details.map(record => record.developerName).filter(Boolean);
     if (active && !output.includes(active)) {

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -36,6 +36,8 @@ type DebugLevelQueryRecord = {
 const DEBUG_LEVEL_FIELDS =
   'Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, ' +
   'Visualforce, System, Database, Wave, Nba, DataAccess';
+const DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION = '63.0';
+const debugLevelApiVersionByOrg = new Map<string, string>();
 
 function getDebugLevelsCacheConfig() {
   try {
@@ -82,11 +84,83 @@ function getDebugLevelDetailsCacheKey(auth: OrgAuth): string {
   return `debugLevelDetails:${key}`;
 }
 
+function getDebugLevelApiVersionCacheKey(auth: OrgAuth): string {
+  return `${String(auth.instanceUrl || '').trim().toLowerCase()}|${String(auth.username || '').trim().toLowerCase()}`;
+}
+
+function parseApiVersionNumber(value: string | undefined): number | undefined {
+  const raw = String(value || '').trim();
+  if (!/^\d+\.\d+$/.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+async function getDebugLevelApiVersion(auth: OrgAuth): Promise<string> {
+  const currentVersion = getEffectiveApiVersion(auth);
+  const currentNumeric = parseApiVersionNumber(currentVersion);
+  const requiredNumeric = parseApiVersionNumber(DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION);
+  if (currentNumeric === undefined || requiredNumeric === undefined || currentNumeric >= requiredNumeric) {
+    return currentVersion;
+  }
+
+  const cacheKey = getDebugLevelApiVersionCacheKey(auth);
+  const cached = debugLevelApiVersionByOrg.get(cacheKey);
+  const cachedNumeric = parseApiVersionNumber(cached);
+  if (cached && cachedNumeric !== undefined && cachedNumeric >= requiredNumeric) {
+    return cached;
+  }
+
+  try {
+    const url = `${auth.instanceUrl}/services/data`;
+    const body = await httpsRequestWith401Retry(
+      auth,
+      'GET',
+      url,
+      {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'Content-Type': 'application/json'
+      }
+    );
+    const parsed = JSON.parse(body);
+    if (!Array.isArray(parsed)) {
+      return currentVersion;
+    }
+
+    let maxVersion = currentVersion;
+    let maxNumeric = currentNumeric;
+    for (const item of parsed) {
+      const candidate = String(item?.version || '').trim();
+      const candidateNumeric = parseApiVersionNumber(candidate);
+      if (candidateNumeric !== undefined && (maxNumeric === undefined || candidateNumeric > maxNumeric)) {
+        maxVersion = candidate;
+        maxNumeric = candidateNumeric;
+      }
+    }
+
+    if (maxNumeric !== undefined && maxNumeric >= requiredNumeric) {
+      debugLevelApiVersionByOrg.set(cacheKey, maxVersion);
+      return maxVersion;
+    }
+  } catch (e) {
+    try {
+      logTrace('getDebugLevelApiVersion: failed to discover org max API version ->', String((e as Error)?.message || e));
+    } catch {}
+  }
+
+  return currentVersion;
+}
+
 async function invalidateDebugLevelsCache(auth: OrgAuth): Promise<void> {
   await Promise.all([
     CacheManager.delete('cli', getDebugLevelsCacheKey(auth)),
     CacheManager.delete('cli', getDebugLevelDetailsCacheKey(auth))
   ]);
+}
+
+export function __resetDebugLevelApiVersionCacheForTests(): void {
+  debugLevelApiVersionByOrg.clear();
 }
 
 function mapDebugLevelRecord(record: DebugLevelQueryRecord): DebugLevelRecord {
@@ -233,8 +307,16 @@ function buildSfValuesArg(payload: Record<string, string>): string {
 }
 
 function queryTooling<TRecord>(auth: OrgAuth, soql: string): Promise<QueryResponse<TRecord>> {
+  return queryToolingWithVersion(auth, soql, getEffectiveApiVersion(auth));
+}
+
+function queryToolingWithVersion<TRecord>(
+  auth: OrgAuth,
+  soql: string,
+  apiVersion: string
+): Promise<QueryResponse<TRecord>> {
   const encoded = encodeURIComponent(soql);
-  const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${encoded}`;
+  const url = `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/query?q=${encoded}`;
   return httpsRequestWith401Retry(auth, 'GET', url, {
     Authorization: `Bearer ${auth.accessToken}`,
     'Content-Type': 'application/json'
@@ -286,7 +368,8 @@ export async function listDebugLevelDetails(auth: OrgAuth): Promise<DebugLevelRe
   }
 
   const soql = `SELECT ${DEBUG_LEVEL_FIELDS} FROM DebugLevel ORDER BY DeveloperName`;
-  const json = await queryTooling<DebugLevelQueryRecord>(auth, soql);
+  const apiVersion = await getDebugLevelApiVersion(auth);
+  const json = await queryToolingWithVersion<DebugLevelQueryRecord>(auth, soql, apiVersion);
   const records = (json.records || []).map(mapDebugLevelRecord);
 
   if (enabled && ttl > 0) {
@@ -407,6 +490,7 @@ export async function createDebugLevel(
   input: DebugLevelRecord
 ): Promise<{ id: string }> {
   const payload = buildDebugLevelPayload(input);
+  const apiVersion = await getDebugLevelApiVersion(auth);
   if (auth.username) {
     try {
       const cli = await runSfJson([
@@ -417,7 +501,7 @@ export async function createDebugLevel(
         '--target-org',
         auth.username,
         '--api-version',
-        getEffectiveApiVersion(auth),
+        apiVersion,
         '--sobject',
         'DebugLevel',
         '--values',
@@ -435,7 +519,7 @@ export async function createDebugLevel(
     }
   }
 
-  const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel`;
+  const createUrl = `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel`;
   const resBody = await httpsRequestWith401Retry(
     auth,
     'POST',
@@ -463,6 +547,7 @@ export async function updateDebugLevel(
     throw new Error('Invalid DebugLevel id.');
   }
   const payload = buildDebugLevelPayload(input);
+  const apiVersion = await getDebugLevelApiVersion(auth);
   if (auth.username) {
     try {
       const cli = await runSfJson([
@@ -473,7 +558,7 @@ export async function updateDebugLevel(
         '--target-org',
         auth.username,
         '--api-version',
-        getEffectiveApiVersion(auth),
+        apiVersion,
         '--sobject',
         'DebugLevel',
         '--record-id',
@@ -494,7 +579,7 @@ export async function updateDebugLevel(
   }
 
   const updateUrl =
-    `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+    `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
   await httpsRequestWith401Retry(
     auth,
     'PATCH',
@@ -512,6 +597,7 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
   if (!isSalesforceId(debugLevelId)) {
     throw new Error('Invalid DebugLevel id.');
   }
+  const apiVersion = await getDebugLevelApiVersion(auth);
   if (auth.username) {
     try {
       const cli = await runSfJson([
@@ -522,7 +608,7 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
         '--target-org',
         auth.username,
         '--api-version',
-        getEffectiveApiVersion(auth),
+        apiVersion,
         '--sobject',
         'DebugLevel',
         '--record-id',
@@ -541,7 +627,7 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
   }
 
   const deleteUrl =
-    `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+    `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
   await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
     Authorization: `Bearer ${auth.accessToken}`,
     'Content-Type': 'application/json'

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -1,8 +1,11 @@
-import type { ApplyUserTraceFlagInput, DebugFlagUser, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
+import type { ApplyUserTraceFlagInput, DebugFlagUser, DebugLevelRecord, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
 import { CacheManager } from '../utils/cacheManager';
-import { getBooleanConfig, getNumberConfig } from '../utils/config';
+import { getBooleanConfig, getConfig, getNumberConfig } from '../utils/config';
 import { logTrace } from '../utils/logger';
+import path from 'path';
+import { CLI_TIMEOUT_MS, execCommand } from './exec';
 import { getEffectiveApiVersion, httpsRequestWith401Retry } from './http';
+import { resolvePATHFromLoginShell } from './path';
 import type { OrgAuth } from './types';
 
 const userIdCache = new Map<string, string>();
@@ -11,6 +14,28 @@ const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
 type QueryResponse<TRecord = any> = {
   records?: TRecord[];
 };
+
+type DebugLevelQueryRecord = {
+  Id?: string;
+  DeveloperName?: string;
+  MasterLabel?: string;
+  Language?: string;
+  Workflow?: string;
+  Validation?: string;
+  Callout?: string;
+  ApexCode?: string;
+  ApexProfiling?: string;
+  Visualforce?: string;
+  System?: string;
+  Database?: string;
+  Wave?: string;
+  Nba?: string;
+  DataAccess?: string;
+};
+
+const DEBUG_LEVEL_FIELDS =
+  'Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, ' +
+  'Visualforce, System, Database, Wave, Nba, DataAccess';
 
 function getDebugLevelsCacheConfig() {
   try {
@@ -47,6 +72,166 @@ function clampTtlMinutes(value: number | undefined): number {
   return Math.max(1, Math.min(1440, Math.floor(raw)));
 }
 
+function getDebugLevelsCacheKey(auth: OrgAuth): string {
+  const key = auth.instanceUrl || auth.username || '';
+  return `debugLevels:${key}`;
+}
+
+function getDebugLevelDetailsCacheKey(auth: OrgAuth): string {
+  const key = auth.instanceUrl || auth.username || '';
+  return `debugLevelDetails:${key}`;
+}
+
+async function invalidateDebugLevelsCache(auth: OrgAuth): Promise<void> {
+  await Promise.all([
+    CacheManager.delete('cli', getDebugLevelsCacheKey(auth)),
+    CacheManager.delete('cli', getDebugLevelDetailsCacheKey(auth))
+  ]);
+}
+
+function mapDebugLevelRecord(record: DebugLevelQueryRecord): DebugLevelRecord {
+  return {
+    id: typeof record.Id === 'string' ? record.Id : undefined,
+    developerName: typeof record.DeveloperName === 'string' ? record.DeveloperName : '',
+    masterLabel: typeof record.MasterLabel === 'string' ? record.MasterLabel : '',
+    language: typeof record.Language === 'string' ? record.Language : '',
+    workflow: typeof record.Workflow === 'string' ? record.Workflow : '',
+    validation: typeof record.Validation === 'string' ? record.Validation : '',
+    callout: typeof record.Callout === 'string' ? record.Callout : '',
+    apexCode: typeof record.ApexCode === 'string' ? record.ApexCode : '',
+    apexProfiling: typeof record.ApexProfiling === 'string' ? record.ApexProfiling : '',
+    visualforce: typeof record.Visualforce === 'string' ? record.Visualforce : '',
+    system: typeof record.System === 'string' ? record.System : '',
+    database: typeof record.Database === 'string' ? record.Database : '',
+    wave: typeof record.Wave === 'string' ? record.Wave : '',
+    nba: typeof record.Nba === 'string' ? record.Nba : '',
+    dataAccess: typeof record.DataAccess === 'string' ? record.DataAccess : ''
+  };
+}
+
+function buildDebugLevelPayload(input: DebugLevelRecord) {
+  return {
+    DeveloperName: String(input.developerName || '').trim(),
+    MasterLabel: String(input.masterLabel || '').trim(),
+    Language: String(input.language || '').trim(),
+    Workflow: String(input.workflow || '').trim(),
+    Validation: String(input.validation || '').trim(),
+    Callout: String(input.callout || '').trim(),
+    ApexCode: String(input.apexCode || '').trim(),
+    ApexProfiling: String(input.apexProfiling || '').trim(),
+    Visualforce: String(input.visualforce || '').trim(),
+    System: String(input.system || '').trim(),
+    Database: String(input.database || '').trim(),
+    Wave: String(input.wave || '').trim(),
+    Nba: String(input.nba || '').trim(),
+    DataAccess: String(input.dataAccess || '').trim()
+  };
+}
+
+function stripAnsi(value: string): string {
+  return value.replace(/\u001b\[[0-9;]*m/g, '');
+}
+
+function parseCliJson(stdout: string): any {
+  const raw = String(stdout || '').trim();
+  if (!raw) {
+    throw new Error('empty CLI output');
+  }
+  try {
+    return JSON.parse(raw);
+  } catch {
+    const cleaned = stripAnsi(raw);
+    const start = cleaned.indexOf('{');
+    const end = cleaned.lastIndexOf('}');
+    if (start >= 0 && end > start) {
+      return JSON.parse(cleaned.slice(start, end + 1));
+    }
+    throw new Error('invalid CLI JSON output');
+  }
+}
+
+function quoteWindowsCmdArg(value: string): string {
+  const raw = String(value ?? '');
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
+async function execSfCommand(
+  program: string,
+  args: string[],
+  envOverride?: NodeJS.ProcessEnv
+): Promise<{ stdout: string; stderr: string }> {
+  if (process.platform === 'win32' && /\.cmd$/i.test(program)) {
+    const command = [program, ...args].map(quoteWindowsCmdArg).join(' ');
+    return execCommand('cmd.exe', ['/d', '/s', '/c', command], envOverride, CLI_TIMEOUT_MS);
+  }
+  return execCommand(program, args, envOverride, CLI_TIMEOUT_MS);
+}
+
+function getSfCliProgramCandidates(): string[] {
+  const configured = String(getConfig<string | undefined>('sfLogs.cliPath', undefined) || '').trim();
+  const windowsAppDataSf =
+    process.platform === 'win32' && process.env.APPDATA
+      ? path.join(process.env.APPDATA, 'npm', 'sf.cmd')
+      : '';
+  const windowsUserProfileSf =
+    process.platform === 'win32' && process.env.USERPROFILE
+      ? path.join(process.env.USERPROFILE, 'AppData', 'Roaming', 'npm', 'sf.cmd')
+      : '';
+  return Array.from(
+    new Set([configured, windowsAppDataSf, windowsUserProfileSf, process.platform === 'win32' ? 'sf.cmd' : '', 'sf'].filter(Boolean))
+  );
+}
+
+async function runSfJson(args: string[]): Promise<any> {
+  let lastError: unknown;
+  let sawEnoent = false;
+  for (const program of getSfCliProgramCandidates()) {
+    try {
+      const { stdout } = await execSfCommand(program, [...args, '--json']);
+      return parseCliJson(stdout);
+    } catch (e) {
+      lastError = e;
+      if ((e as any)?.code === 'ENOENT') {
+        sawEnoent = true;
+      }
+    }
+  }
+
+  if (sawEnoent) {
+    const loginPath = await resolvePATHFromLoginShell();
+    if (loginPath) {
+      const envOverride: NodeJS.ProcessEnv = { ...process.env, PATH: loginPath };
+      for (const program of getSfCliProgramCandidates()) {
+        try {
+          const { stdout } = await execSfCommand(program, [...args, '--json'], envOverride);
+          return parseCliJson(stdout);
+        } catch (e) {
+          lastError = e;
+        }
+      }
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error('Failed to execute Salesforce CLI JSON command.');
+}
+
+function encodeSfValue(value: string): string {
+  const normalized = String(value ?? '');
+  if (!normalized) {
+    return "''";
+  }
+  if (/[\s'"]/.test(normalized)) {
+    return `'${normalized.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`;
+  }
+  return normalized;
+}
+
+function buildSfValuesArg(payload: Record<string, string>): string {
+  return Object.entries(payload)
+    .map(([field, value]) => `${field}=${encodeSfValue(value)}`)
+    .join(' ');
+}
+
 function queryTooling<TRecord>(auth: OrgAuth, soql: string): Promise<QueryResponse<TRecord>> {
   const encoded = encodeURIComponent(soql);
   const url = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/query?q=${encoded}`;
@@ -67,13 +252,12 @@ function queryStandard<TRecord>(auth: OrgAuth, soql: string): Promise<QueryRespo
 
 export async function listDebugLevels(auth: OrgAuth): Promise<string[]> {
   const { enabled, ttl } = getDebugLevelsCacheConfig();
-  const key = auth.instanceUrl || auth.username || '';
-  const cacheKey = `debugLevels:${key}`;
+  const cacheKey = getDebugLevelsCacheKey(auth);
   if (enabled && ttl > 0) {
     const cached = CacheManager.get<string[]>('cli', cacheKey);
     if (Array.isArray(cached)) {
       try {
-        logTrace('listDebugLevels: cache hit for', key);
+        logTrace('listDebugLevels: cache hit for', auth.instanceUrl || auth.username || '');
       } catch {}
       return cached;
     }
@@ -89,6 +273,26 @@ export async function listDebugLevels(auth: OrgAuth): Promise<string[]> {
     await CacheManager.set('cli', cacheKey, names, ttl);
   }
   return names;
+}
+
+export async function listDebugLevelDetails(auth: OrgAuth): Promise<DebugLevelRecord[]> {
+  const { enabled, ttl } = getDebugLevelsCacheConfig();
+  const cacheKey = getDebugLevelDetailsCacheKey(auth);
+  if (enabled && ttl > 0) {
+    const cached = CacheManager.get<DebugLevelRecord[]>('cli', cacheKey);
+    if (Array.isArray(cached)) {
+      return cached;
+    }
+  }
+
+  const soql = `SELECT ${DEBUG_LEVEL_FIELDS} FROM DebugLevel ORDER BY DeveloperName`;
+  const json = await queryTooling<DebugLevelQueryRecord>(auth, soql);
+  const records = (json.records || []).map(mapDebugLevelRecord);
+
+  if (enabled && ttl > 0) {
+    await CacheManager.set('cli', cacheKey, records, ttl);
+  }
+  return records;
 }
 
 export async function listActiveUsers(auth: OrgAuth, query = '', limit = 50): Promise<DebugFlagUser[]> {
@@ -196,6 +400,153 @@ async function getDebugLevelIdByName(auth: OrgAuth, developerName: string): Prom
   const json = await queryTooling<{ Id?: string }>(auth, soql);
   const rec = (json.records || [])[0];
   return rec?.Id;
+}
+
+export async function createDebugLevel(
+  auth: OrgAuth,
+  input: DebugLevelRecord
+): Promise<{ id: string }> {
+  const payload = buildDebugLevelPayload(input);
+  if (auth.username) {
+    try {
+      const cli = await runSfJson([
+        'data',
+        'create',
+        'record',
+        '--use-tooling-api',
+        '--target-org',
+        auth.username,
+        '--api-version',
+        getEffectiveApiVersion(auth),
+        '--sobject',
+        'DebugLevel',
+        '--values',
+        buildSfValuesArg(payload)
+      ]);
+      const result = cli?.result || cli;
+      if (result?.success && result?.id) {
+        await invalidateDebugLevelsCache(auth);
+        return { id: String(result.id) };
+      }
+    } catch (e) {
+      try {
+        logTrace('createDebugLevel: CLI mutation failed, falling back to HTTP ->', String((e as Error)?.message || e));
+      } catch {}
+    }
+  }
+
+  const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel`;
+  const resBody = await httpsRequestWith401Retry(
+    auth,
+    'POST',
+    createUrl,
+    {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify(payload)
+  );
+  const res = JSON.parse(resBody);
+  if (!res?.success || !res?.id) {
+    throw new Error('Failed to create DebugLevel.');
+  }
+  await invalidateDebugLevelsCache(auth);
+  return { id: String(res.id) };
+}
+
+export async function updateDebugLevel(
+  auth: OrgAuth,
+  debugLevelId: string,
+  input: DebugLevelRecord
+): Promise<void> {
+  if (!isSalesforceId(debugLevelId)) {
+    throw new Error('Invalid DebugLevel id.');
+  }
+  const payload = buildDebugLevelPayload(input);
+  if (auth.username) {
+    try {
+      const cli = await runSfJson([
+        'data',
+        'update',
+        'record',
+        '--use-tooling-api',
+        '--target-org',
+        auth.username,
+        '--api-version',
+        getEffectiveApiVersion(auth),
+        '--sobject',
+        'DebugLevel',
+        '--record-id',
+        debugLevelId,
+        '--values',
+        buildSfValuesArg(payload)
+      ]);
+      const result = cli?.result || cli;
+      if (result?.success !== false) {
+        await invalidateDebugLevelsCache(auth);
+        return;
+      }
+    } catch (e) {
+      try {
+        logTrace('updateDebugLevel: CLI mutation failed, falling back to HTTP ->', String((e as Error)?.message || e));
+      } catch {}
+    }
+  }
+
+  const updateUrl =
+    `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+  await httpsRequestWith401Retry(
+    auth,
+    'PATCH',
+    updateUrl,
+    {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    JSON.stringify(payload)
+  );
+  await invalidateDebugLevelsCache(auth);
+}
+
+export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Promise<void> {
+  if (!isSalesforceId(debugLevelId)) {
+    throw new Error('Invalid DebugLevel id.');
+  }
+  if (auth.username) {
+    try {
+      const cli = await runSfJson([
+        'data',
+        'delete',
+        'record',
+        '--use-tooling-api',
+        '--target-org',
+        auth.username,
+        '--api-version',
+        getEffectiveApiVersion(auth),
+        '--sobject',
+        'DebugLevel',
+        '--record-id',
+        debugLevelId
+      ]);
+      const result = cli?.result || cli;
+      if (result?.success !== false) {
+        await invalidateDebugLevelsCache(auth);
+        return;
+      }
+    } catch (e) {
+      try {
+        logTrace('deleteDebugLevel: CLI mutation failed, falling back to HTTP ->', String((e as Error)?.message || e));
+      } catch {}
+    }
+  }
+
+  const deleteUrl =
+    `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+  await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
+    Authorization: `Bearer ${auth.accessToken}`,
+    'Content-Type': 'application/json'
+  });
+  await invalidateDebugLevelsCache(auth);
 }
 
 async function getLatestUserDebugTraceFlagRecord(auth: OrgAuth, userId: string): Promise<any | undefined> {

--- a/src/shared/debugFlagsMessages.ts
+++ b/src/shared/debugFlagsMessages.ts
@@ -1,5 +1,5 @@
 import type { OrgItem } from './types';
-import type { DebugFlagUser, UserTraceFlagStatus } from './debugFlagsTypes';
+import type { DebugFlagUser, DebugLevelPreset, DebugLevelRecord, UserTraceFlagStatus } from './debugFlagsTypes';
 
 export type DebugFlagsFromWebviewMessage =
   | { type: 'debugFlagsReady' }
@@ -7,6 +7,8 @@ export type DebugFlagsFromWebviewMessage =
   | { type: 'debugFlagsSearchUsers'; query: string }
   | { type: 'debugFlagsSelectUser'; userId: string }
   | { type: 'debugFlagsApply'; userId: string; debugLevelName: string; ttlMinutes: number }
+  | { type: 'debugFlagsManagerSave'; draft: DebugLevelRecord }
+  | { type: 'debugFlagsManagerDelete'; debugLevelId: string }
   | { type: 'debugFlagsRemove'; userId: string }
   | { type: 'debugFlagsClearLogs'; scope: 'all' | 'mine' };
 
@@ -16,6 +18,7 @@ export type DebugFlagsToWebviewMessage =
   | { type: 'debugFlagsOrgs'; data: OrgItem[]; selected: string | undefined }
   | { type: 'debugFlagsUsers'; query: string; data: DebugFlagUser[] }
   | { type: 'debugFlagsDebugLevels'; data: string[]; active?: string }
+  | { type: 'debugFlagsManagerData'; records: DebugLevelRecord[]; presets: DebugLevelPreset[]; selectedId?: string }
   | { type: 'debugFlagsUserStatus'; userId: string; status?: UserTraceFlagStatus }
   | { type: 'debugFlagsNotice'; message: string; tone: 'success' | 'info' | 'warning' }
   | { type: 'debugFlagsError'; message: string };

--- a/src/shared/debugFlagsTypes.ts
+++ b/src/shared/debugFlagsTypes.ts
@@ -18,3 +18,28 @@ export interface ApplyUserTraceFlagInput {
   debugLevelName: string;
   ttlMinutes: number;
 }
+
+export interface DebugLevelRecord {
+  id?: string;
+  developerName: string;
+  masterLabel: string;
+  language: string;
+  workflow: string;
+  validation: string;
+  callout: string;
+  apexCode: string;
+  apexProfiling: string;
+  visualforce: string;
+  system: string;
+  database: string;
+  wave: string;
+  nba: string;
+  dataAccess: string;
+}
+
+export interface DebugLevelPreset {
+  id: string;
+  label: string;
+  description: string;
+  record: DebugLevelRecord;
+}

--- a/src/shared/debugLevelPresets.ts
+++ b/src/shared/debugLevelPresets.ts
@@ -1,0 +1,109 @@
+import type { DebugLevelPreset, DebugLevelRecord } from './debugFlagsTypes';
+
+export const DEBUG_LEVEL_LOG_LEVELS = ['NONE', 'ERROR', 'WARN', 'INFO', 'DEBUG', 'FINE', 'FINER', 'FINEST'] as const;
+
+export type DebugLevelFieldKey =
+  | 'workflow'
+  | 'validation'
+  | 'callout'
+  | 'apexCode'
+  | 'apexProfiling'
+  | 'visualforce'
+  | 'system'
+  | 'database'
+  | 'wave'
+  | 'nba'
+  | 'dataAccess';
+
+export const DEBUG_LEVEL_FIELDS: ReadonlyArray<{ key: DebugLevelFieldKey; label: string }> = [
+  { key: 'workflow', label: 'Workflow' },
+  { key: 'validation', label: 'Validation' },
+  { key: 'callout', label: 'Callout' },
+  { key: 'apexCode', label: 'Apex Code' },
+  { key: 'apexProfiling', label: 'Apex Profiling' },
+  { key: 'visualforce', label: 'Visualforce' },
+  { key: 'system', label: 'System' },
+  { key: 'database', label: 'Database' },
+  { key: 'wave', label: 'Wave' },
+  { key: 'nba', label: 'Nba' },
+  { key: 'dataAccess', label: 'Data Access' }
+];
+
+export function createEmptyDebugLevelRecord(): DebugLevelRecord {
+  return {
+    developerName: '',
+    masterLabel: '',
+    language: 'en_US',
+    workflow: 'INFO',
+    validation: 'INFO',
+    callout: 'INFO',
+    apexCode: 'INFO',
+    apexProfiling: 'INFO',
+    visualforce: 'INFO',
+    system: 'INFO',
+    database: 'INFO',
+    wave: 'INFO',
+    nba: 'INFO',
+    dataAccess: 'INFO'
+  };
+}
+
+export const DEBUG_LEVEL_PRESETS: DebugLevelPreset[] = [
+  {
+    id: 'developer-focus',
+    label: 'Developer Focus',
+    description: 'Balanced defaults for Apex execution and general debugging.',
+    record: {
+      ...createEmptyDebugLevelRecord(),
+      developerName: 'ALV_DEVELOPER_FOCUS',
+      masterLabel: 'ALV Developer Focus',
+      apexCode: 'DEBUG',
+      apexProfiling: 'INFO',
+      system: 'DEBUG',
+      database: 'WARN'
+    }
+  },
+  {
+    id: 'integration-troubleshooting',
+    label: 'Integration Troubleshooting',
+    description: 'Higher visibility for callouts, system output, and related Apex execution.',
+    record: {
+      ...createEmptyDebugLevelRecord(),
+      developerName: 'ALV_INTEGRATION',
+      masterLabel: 'ALV Integration',
+      callout: 'DEBUG',
+      apexCode: 'DEBUG',
+      system: 'DEBUG',
+      validation: 'WARN',
+      dataAccess: 'WARN'
+    }
+  },
+  {
+    id: 'validation-and-flow',
+    label: 'Validation and Flow',
+    description: 'Focused on workflow, validation rules, and related automation activity.',
+    record: {
+      ...createEmptyDebugLevelRecord(),
+      developerName: 'ALV_AUTOMATION',
+      masterLabel: 'ALV Automation',
+      workflow: 'DEBUG',
+      validation: 'DEBUG',
+      apexCode: 'INFO',
+      system: 'WARN'
+    }
+  },
+  {
+    id: 'performance-and-database',
+    label: 'Performance and Database',
+    description: 'Useful when inspecting SOQL, profiling, and database-heavy transactions.',
+    record: {
+      ...createEmptyDebugLevelRecord(),
+      developerName: 'ALV_PERFORMANCE',
+      masterLabel: 'ALV Performance',
+      database: 'DEBUG',
+      apexProfiling: 'DEBUG',
+      apexCode: 'INFO',
+      system: 'WARN'
+    }
+  }
+];

--- a/src/test/debugFlagsPanel.test.ts
+++ b/src/test/debugFlagsPanel.test.ts
@@ -1,0 +1,51 @@
+import assert from 'assert/strict';
+import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
+import * as traceflags from '../salesforce/traceflags';
+import { createEmptyDebugLevelRecord } from '../shared/debugLevelPresets';
+
+suite('DebugFlagsPanel', () => {
+  const originalListDebugLevelDetails = traceflags.listDebugLevelDetails;
+  const originalGetActiveUserDebugLevel = traceflags.getActiveUserDebugLevel;
+
+  teardown(() => {
+    (traceflags as any).listDebugLevelDetails = originalListDebugLevelDetails;
+    (traceflags as any).getActiveUserDebugLevel = originalGetActiveUserDebugLevel;
+  });
+
+  test('sendDebugLevelData ignores stale bootstrap results', async () => {
+    let resolveDetails: ((value: ReturnType<typeof createEmptyDebugLevelRecord>[]) => void) | undefined;
+    let resolveActive: ((value: string | undefined) => void) | undefined;
+
+    (traceflags as any).listDebugLevelDetails = async () =>
+      await new Promise(resolve => {
+        resolveDetails = resolve;
+      });
+    (traceflags as any).getActiveUserDebugLevel = async () =>
+      await new Promise(resolve => {
+        resolveActive = resolve;
+      });
+
+    const posted: any[] = [];
+    const panelLike = {
+      disposed: false,
+      orgBootstrapToken: 2,
+      post: (message: any) => {
+        posted.push(message);
+      }
+    };
+
+    const promise = (DebugFlagsPanel as any).prototype.sendDebugLevelData.call(panelLike, {} as any, undefined, 1);
+    resolveDetails?.([
+      {
+        ...createEmptyDebugLevelRecord(),
+        id: '7dl000000000001AAA',
+        developerName: 'ALV_STALE',
+        masterLabel: 'ALV Stale'
+      }
+    ]);
+    resolveActive?.('ALV_STALE');
+    await promise;
+
+    assert.deepEqual(posted, []);
+  });
+});

--- a/src/test/integration.dependencies.test.ts
+++ b/src/test/integration.dependencies.test.ts
@@ -15,7 +15,7 @@ suite('integration: dependencies', () => {
     const viaEnv = process.env.SF_EXT_PRESENT === '1';
     assert.ok(
       replay || pack || viaEnv,
-      'Apex Replay Debugger extension not detected. Ensure salesforce.salesforcedx-vscode-apex-replay-debugger (or the Salesforce extension pack) is installed. Use `npm run test:integration` to auto-install.'
+      'Apex Replay Debugger support not detected. Ensure the Salesforce Extension Pack (recommended) or salesforce.salesforcedx-vscode-apex-replay-debugger is installed. Use `npm run test:integration` to auto-install.'
     );
   });
 });

--- a/src/test/listDebugLevels.test.ts
+++ b/src/test/listDebugLevels.test.ts
@@ -1,7 +1,7 @@
 import assert from 'assert/strict';
 import { EventEmitter } from 'events';
 import { workspace } from 'vscode';
-import { listDebugLevels } from '../salesforce/traceflags';
+import { createDebugLevel, listDebugLevels } from '../salesforce/traceflags';
 import { __setHttpsRequestImplForTests, __resetHttpsRequestImplForTests } from '../salesforce/http';
 import { CacheManager } from '../utils/cacheManager';
 import type { OrgAuth } from '../salesforce/types';
@@ -100,5 +100,96 @@ suite('listDebugLevels', () => {
     assert.deepEqual(first, ['DL1']);
     assert.deepEqual(second, ['DL1']);
     assert.equal(called, 1, 'expected single HTTP request');
+  });
+
+  test('invalidates cached debug levels after creating a DebugLevel', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    const auth: OrgAuth = { accessToken: 't', instanceUrl: 'https://example.com' } as OrgAuth;
+    let queryCalls = 0;
+    __setHttpsRequestImplForTests((opts: any, cb: any) => {
+      const req = new EventEmitter() as any;
+      let body = '';
+      req.on = function (event: string, listener: any) {
+        EventEmitter.prototype.on.call(this, event, listener);
+        return this;
+      };
+      req.write = (chunk: any) => {
+        body += Buffer.isBuffer(chunk) ? chunk.toString('utf8') : String(chunk || '');
+      };
+      req.end = () => {
+        const res = new EventEmitter() as any;
+        res.headers = {};
+        res.on = function (event: string, listener: any) {
+          EventEmitter.prototype.on.call(this, event, listener);
+          return this;
+        };
+        res.setEncoding = () => {};
+        res.req = req;
+        cb(res);
+        process.nextTick(() => {
+          const path = String(opts?.path || '');
+          if (path.includes('/tooling/query')) {
+            queryCalls++;
+            res.statusCode = 200;
+            const records =
+              queryCalls === 1
+                ? [{ DeveloperName: 'DL1' }]
+                : [{ DeveloperName: 'DL1' }, { DeveloperName: 'DL2' }];
+            res.emit('data', Buffer.from(JSON.stringify({ records })));
+            res.emit('end');
+            return;
+          }
+          if (String(opts?.method || 'GET') === 'POST' && path.endsWith('/tooling/sobjects/DebugLevel')) {
+            res.statusCode = 201;
+            const parsed = JSON.parse(body);
+            assert.equal(parsed.DeveloperName, 'DL2');
+            res.emit('data', Buffer.from(JSON.stringify({ success: true, id: '7dl000000000002AAA' })));
+            res.emit('end');
+            return;
+          }
+          throw new Error(`Unexpected request: ${String(opts?.method || 'GET')} ${path}`);
+        });
+      };
+      return req;
+    });
+
+    const memento = {
+      _s: new Map<string, unknown>(),
+      get(key: string) {
+        return this._s.get(key);
+      },
+      update(key: string, value: unknown) {
+        if (value === undefined) {
+          this._s.delete(key);
+        } else {
+          this._s.set(key, value);
+        }
+        return Promise.resolve();
+      }
+    } as any;
+    CacheManager.init(memento);
+
+    const first = await listDebugLevels(auth);
+    await createDebugLevel(auth, {
+      developerName: 'DL2',
+      masterLabel: 'DL2',
+      language: 'en_US',
+      workflow: 'INFO',
+      validation: 'INFO',
+      callout: 'INFO',
+      apexCode: 'DEBUG',
+      apexProfiling: 'INFO',
+      visualforce: 'INFO',
+      system: 'INFO',
+      database: 'INFO',
+      wave: 'INFO',
+      nba: 'INFO',
+      dataAccess: 'INFO'
+    });
+    const second = await listDebugLevels(auth);
+
+    assert.deepEqual(first, ['DL1']);
+    assert.deepEqual(second, ['DL1', 'DL2']);
+    assert.equal(queryCalls, 2, 'expected cache invalidation to force a second query');
   });
 });

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -2,8 +2,14 @@ import assert from 'assert/strict';
 import { EventEmitter } from 'events';
 import { __resetExecFileImplForTests, __setExecFileImplForTests } from '../salesforce/exec';
 import type { OrgAuth } from '../salesforce/types';
-import { __resetHttpsRequestImplForTests, __setHttpsRequestImplForTests } from '../salesforce/http';
 import {
+  __resetApiVersionFallbackStateForTests,
+  __resetHttpsRequestImplForTests,
+  __setHttpsRequestImplForTests,
+  setApiVersion
+} from '../salesforce/http';
+import {
+  __resetDebugLevelApiVersionCacheForTests,
   createDebugLevel,
   deleteDebugLevel,
   getUserTraceFlagStatus,
@@ -126,6 +132,9 @@ suite('traceflags user management', () => {
   teardown(() => {
     __resetHttpsRequestImplForTests();
     __resetExecFileImplForTests();
+    __resetApiVersionFallbackStateForTests();
+    __resetDebugLevelApiVersionCacheForTests();
+    setApiVersion('64.0');
   });
 
   test('listActiveUsers returns active users filtered by query', async () => {
@@ -294,7 +303,70 @@ suite('traceflags user management', () => {
     });
   });
 
+  test('listDebugLevelDetails upgrades the API version when extended fields require a newer one', async () => {
+    setApiVersion('60.0');
+    const legacyAuth: OrgAuth = {
+      ...auth,
+      instanceUrl: 'https://legacy-api.example.my.salesforce.com',
+      username: 'legacy.user@example.com'
+    };
+    const calls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path === '/services/data') {
+        return {
+          statusCode: 200,
+          body: [{ version: '60.0' }, { version: '66.0' }]
+        };
+      }
+      if (req.method === 'GET' && req.path.includes('/services/data/v66.0/tooling/query')) {
+        return {
+          statusCode: 200,
+          body: {
+            records: [
+              {
+                Id: '7dl000000000001AAA',
+                DeveloperName: 'ALV_VERBOSE',
+                MasterLabel: 'ALV Verbose',
+                Language: 'en_US',
+                Workflow: 'WARN',
+                Validation: 'INFO',
+                Callout: 'ERROR',
+                ApexCode: 'DEBUG',
+                ApexProfiling: 'INFO',
+                Visualforce: 'WARN',
+                System: 'DEBUG',
+                Database: 'FINE',
+                Wave: 'ERROR',
+                Nba: 'WARN',
+                DataAccess: 'INFO'
+              }
+            ]
+          }
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const records = await listDebugLevelDetails(legacyAuth);
+
+    assert.equal(records.length, 1);
+    assert.ok(calls.some(call => call.path === '/services/data'), 'expected org API discovery request');
+    assert.ok(
+      calls.some(call => call.path.includes('/services/data/v66.0/tooling/query')),
+      'expected DebugLevel query to use upgraded API version'
+    );
+  });
+
   test('createDebugLevel uses sf CLI with the full editable DebugLevel payload', async () => {
+    setApiVersion('60.0');
+    const httpCalls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path === '/services/data') {
+        return {
+          statusCode: 200,
+          body: [{ version: '60.0' }, { version: '66.0' }]
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
     const calls = installExecStub(call => {
       if (call.program === 'sf' && call.args[0] === 'data' && call.args[1] === 'create' && call.args[2] === 'record') {
         return {
@@ -333,11 +405,13 @@ suite('traceflags user management', () => {
     assert.match(createCommandText, /--use-tooling-api/);
     assert.match(createCommandText, /--target-org/);
     assert.match(createCommandText, /user@example\.com/);
+    assert.match(createCommandText, /--api-version 66\.0/);
     assert.match(createCommandText, /--sobject/);
     assert.match(createCommandText, /DebugLevel/);
     assert.match(createCommandText, /DeveloperName=ALV_CUSTOM/);
     assert.match(createCommandText, /MasterLabel='ALV Custom'/);
     assert.match(createCommandText, /DataAccess=INFO/);
+    assert.ok(httpCalls.some(call => call.path === '/services/data'), 'expected org API discovery before CLI create');
   });
 
   test('updateDebugLevel uses sf CLI with the full editable DebugLevel payload', async () => {
@@ -383,6 +457,16 @@ suite('traceflags user management', () => {
   });
 
   test('deleteDebugLevel deletes the tooling record with sf CLI', async () => {
+    setApiVersion('60.0');
+    const httpCalls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path === '/services/data') {
+        return {
+          statusCode: 200,
+          body: [{ version: '60.0' }, { version: '66.0' }]
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
     const calls = installExecStub(call => {
       if (call.program === 'sf' && call.args[0] === 'data' && call.args[1] === 'delete' && call.args[2] === 'record') {
         return {
@@ -402,6 +486,8 @@ suite('traceflags user management', () => {
     assert.ok(deleteCall || /data delete record/.test(deleteCommandText), 'expected DebugLevel delete command');
     assert.match(deleteCommandText, /--record-id/);
     assert.match(deleteCommandText, /7dl000000000001AAA/);
+    assert.match(deleteCommandText, /--api-version 66\.0/);
+    assert.ok(httpCalls.some(call => call.path === '/services/data'), 'expected org API discovery before CLI delete');
   });
 
   test('upsertUserTraceFlag updates existing USER_DEBUG flag', async () => {

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -1,11 +1,16 @@
 import assert from 'assert/strict';
 import { EventEmitter } from 'events';
+import { __resetExecFileImplForTests, __setExecFileImplForTests } from '../salesforce/exec';
 import type { OrgAuth } from '../salesforce/types';
 import { __resetHttpsRequestImplForTests, __setHttpsRequestImplForTests } from '../salesforce/http';
 import {
+  createDebugLevel,
+  deleteDebugLevel,
   getUserTraceFlagStatus,
+  listDebugLevelDetails,
   listActiveUsers,
   removeUserTraceFlags,
+  updateDebugLevel,
   upsertUserTraceFlag
 } from '../salesforce/traceflags';
 
@@ -79,6 +84,38 @@ function decodeSoql(path: string): string {
   return decodeURIComponent(path.slice(idx + qMarker.length));
 }
 
+type ExecCall = {
+  program: string;
+  args: string[];
+};
+
+function installExecStub(
+  responder: (call: ExecCall) => { stdout?: string; stderr?: string; code?: number }
+): ExecCall[] {
+  const calls: ExecCall[] = [];
+  __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+    const call: ExecCall = {
+      program,
+      args: Array.isArray(args) ? [...args] : []
+    };
+    calls.push(call);
+    try {
+      const response = responder(call);
+      if (response.code && response.code !== 0) {
+        const err: any = new Error(response.stderr || 'command failed');
+        err.code = response.code;
+        cb(err, response.stdout || '', response.stderr || '');
+      } else {
+        cb(null, response.stdout || '', response.stderr || '');
+      }
+    } catch (e) {
+      cb(e, '', '');
+    }
+    return undefined as any;
+  }) as any);
+  return calls;
+}
+
 suite('traceflags user management', () => {
   const auth: OrgAuth = {
     accessToken: 'token',
@@ -88,6 +125,7 @@ suite('traceflags user management', () => {
 
   teardown(() => {
     __resetHttpsRequestImplForTests();
+    __resetExecFileImplForTests();
   });
 
   test('listActiveUsers returns active users filtered by query', async () => {
@@ -202,6 +240,168 @@ suite('traceflags user management', () => {
     assert.equal(status?.traceFlagId, '7tf000000000001AAA');
     assert.equal(status?.debugLevelName, 'ALV_E2E');
     assert.equal(status?.isActive, true);
+  });
+
+  test('listDebugLevelDetails parses all editable DebugLevel fields', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        return {
+          statusCode: 200,
+          body: {
+            records: [
+              {
+                Id: '7dl000000000001AAA',
+                DeveloperName: 'ALV_VERBOSE',
+                MasterLabel: 'ALV Verbose',
+                Language: 'en_US',
+                Workflow: 'WARN',
+                Validation: 'INFO',
+                Callout: 'ERROR',
+                ApexCode: 'DEBUG',
+                ApexProfiling: 'INFO',
+                Visualforce: 'WARN',
+                System: 'DEBUG',
+                Database: 'FINE',
+                Wave: 'ERROR',
+                Nba: 'WARN',
+                DataAccess: 'INFO'
+              }
+            ]
+          }
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const records = await listDebugLevelDetails(auth);
+    assert.equal(records.length, 1);
+    assert.deepEqual(records[0], {
+      id: '7dl000000000001AAA',
+      developerName: 'ALV_VERBOSE',
+      masterLabel: 'ALV Verbose',
+      language: 'en_US',
+      workflow: 'WARN',
+      validation: 'INFO',
+      callout: 'ERROR',
+      apexCode: 'DEBUG',
+      apexProfiling: 'INFO',
+      visualforce: 'WARN',
+      system: 'DEBUG',
+      database: 'FINE',
+      wave: 'ERROR',
+      nba: 'WARN',
+      dataAccess: 'INFO'
+    });
+  });
+
+  test('createDebugLevel uses sf CLI with the full editable DebugLevel payload', async () => {
+    const calls = installExecStub(call => {
+      if (call.program === 'sf' && call.args[0] === 'data' && call.args[1] === 'create' && call.args[2] === 'record') {
+        return {
+          stdout: JSON.stringify({
+            result: {
+              success: true,
+              id: '7dl000000000999AAA'
+            }
+          })
+        };
+      }
+      throw new Error(`Unexpected command: ${call.program} ${call.args.join(' ')}`);
+    });
+
+    const created = await createDebugLevel(auth, {
+      developerName: 'ALV_CUSTOM',
+      masterLabel: 'ALV Custom',
+      language: 'en_US',
+      workflow: 'WARN',
+      validation: 'INFO',
+      callout: 'ERROR',
+      apexCode: 'DEBUG',
+      apexProfiling: 'INFO',
+      visualforce: 'WARN',
+      system: 'DEBUG',
+      database: 'FINE',
+      wave: 'ERROR',
+      nba: 'WARN',
+      dataAccess: 'INFO'
+    });
+
+    assert.equal(created.id, '7dl000000000999AAA');
+    const createCall = calls.find(call => call.args[0] === 'data' && call.args[1] === 'create');
+    const createCommandText = calls.map(call => [call.program, ...call.args].join(' ')).join('\n');
+    assert.ok(createCall || /data create record/.test(createCommandText), 'expected DebugLevel create command');
+    assert.match(createCommandText, /--use-tooling-api/);
+    assert.match(createCommandText, /--target-org/);
+    assert.match(createCommandText, /user@example\.com/);
+    assert.match(createCommandText, /--sobject/);
+    assert.match(createCommandText, /DebugLevel/);
+    assert.match(createCommandText, /DeveloperName=ALV_CUSTOM/);
+    assert.match(createCommandText, /MasterLabel='ALV Custom'/);
+    assert.match(createCommandText, /DataAccess=INFO/);
+  });
+
+  test('updateDebugLevel uses sf CLI with the full editable DebugLevel payload', async () => {
+    const calls = installExecStub(call => {
+      if (call.program === 'sf' && call.args[0] === 'data' && call.args[1] === 'update' && call.args[2] === 'record') {
+        return {
+          stdout: JSON.stringify({
+            result: {
+              success: true
+            }
+          })
+        };
+      }
+      throw new Error(`Unexpected command: ${call.program} ${call.args.join(' ')}`);
+    });
+
+    await updateDebugLevel(auth, '7dl000000000001AAA', {
+      developerName: 'ALV_CUSTOM',
+      masterLabel: 'ALV Custom',
+      language: 'pt_BR',
+      workflow: 'INFO',
+      validation: 'WARN',
+      callout: 'ERROR',
+      apexCode: 'FINEST',
+      apexProfiling: 'DEBUG',
+      visualforce: 'WARN',
+      system: 'DEBUG',
+      database: 'ERROR',
+      wave: 'NONE',
+      nba: 'INFO',
+      dataAccess: 'WARN'
+    });
+
+    const updateCall = calls.find(call => call.args[0] === 'data' && call.args[1] === 'update');
+    const updateCommandText = calls.map(call => [call.program, ...call.args].join(' ')).join('\n');
+    assert.ok(updateCall || /data update record/.test(updateCommandText), 'expected DebugLevel update command');
+    assert.match(updateCommandText, /--record-id/);
+    assert.match(updateCommandText, /7dl000000000001AAA/);
+    assert.match(updateCommandText, /DeveloperName=ALV_CUSTOM/);
+    assert.match(updateCommandText, /MasterLabel='ALV Custom'/);
+    assert.match(updateCommandText, /Language=pt_BR/);
+    assert.match(updateCommandText, /DataAccess=WARN/);
+  });
+
+  test('deleteDebugLevel deletes the tooling record with sf CLI', async () => {
+    const calls = installExecStub(call => {
+      if (call.program === 'sf' && call.args[0] === 'data' && call.args[1] === 'delete' && call.args[2] === 'record') {
+        return {
+          stdout: JSON.stringify({
+            result: {
+              success: true
+            }
+          })
+        };
+      }
+      throw new Error(`Unexpected command: ${call.program} ${call.args.join(' ')}`);
+    });
+
+    await deleteDebugLevel(auth, '7dl000000000001AAA');
+    const deleteCall = calls.find(call => call.args[0] === 'data' && call.args[1] === 'delete');
+    const deleteCommandText = calls.map(call => [call.program, ...call.args].join(' ')).join('\n');
+    assert.ok(deleteCall || /data delete record/.test(deleteCommandText), 'expected DebugLevel delete command');
+    assert.match(deleteCommandText, /--record-id/);
+    assert.match(deleteCommandText, /7dl000000000001AAA/);
   });
 
   test('upsertUserTraceFlag updates existing USER_DEBUG flag', async () => {

--- a/src/utils/replayDebugger.ts
+++ b/src/utils/replayDebugger.ts
@@ -40,7 +40,7 @@ export async function ensureReplayDebuggerAvailable(): Promise<boolean> {
   // If users explicitly disabled/uninstalled the dependency extension, fail gracefully with guidance.
   const msg = localize(
     'replayMissingExtMessage',
-    `Apex Replay Debugger is unavailable. Install the Apex Replay Debugger extension (${APEX_REPLAY_DEBUGGER_EXTENSION_ID}) or the Salesforce Extension Pack (salesforce.salesforcedx-vscode) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).`
+    `Apex Replay Debugger is unavailable. Install the Salesforce Extension Pack (salesforce.salesforcedx-vscode) or the standalone Apex Replay Debugger extension (${APEX_REPLAY_DEBUGGER_EXTENSION_ID}) and ensure it is enabled in this VS Code environment (Local/WSL/SSH/Dev Containers).`
   );
   void vscode.window.showErrorMessage(msg);
   return false;

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -68,7 +68,96 @@ describe('DebugFlags webview App', () => {
         isActive: true
       }
     });
+    sendMessage(bus, {
+      type: 'debugFlagsManagerData',
+      records: [
+        {
+          id: '7dl000000000001AAA',
+          developerName: 'ALV_E2E',
+          masterLabel: 'ALV E2E',
+          language: 'en_US',
+          workflow: 'ERROR',
+          validation: 'INFO',
+          callout: 'WARN',
+          apexCode: 'DEBUG',
+          apexProfiling: 'INFO',
+          visualforce: 'WARN',
+          system: 'DEBUG',
+          database: 'FINE',
+          wave: 'INFO',
+          nba: 'WARN',
+          dataAccess: 'INFO'
+        }
+      ],
+      presets: [
+        {
+          id: 'integration',
+          label: 'Integration Troubleshooting',
+          description: 'Useful defaults for callouts and integration diagnosis.',
+          record: {
+            developerName: 'ALV_INTEGRATION',
+            masterLabel: 'ALV Integration',
+            language: 'en_US',
+            workflow: 'INFO',
+            validation: 'WARN',
+            callout: 'DEBUG',
+            apexCode: 'DEBUG',
+            apexProfiling: 'INFO',
+            visualforce: 'WARN',
+            system: 'DEBUG',
+            database: 'INFO',
+            wave: 'INFO',
+            nba: 'INFO',
+            dataAccess: 'WARN'
+          }
+        }
+      ],
+      selectedId: '7dl000000000001AAA'
+    });
     await screen.findByTestId('debug-flags-status-level');
+    await screen.findByTestId('debug-level-manager');
+
+    const managerDeveloperName = screen.getByTestId('debug-level-draft-developer-name') as HTMLInputElement;
+    expect(managerDeveloperName.value).toBe('ALV_E2E');
+
+    fireEvent.change(managerDeveloperName, { target: { value: 'ALV_CHANGED' } });
+    expect(managerDeveloperName.value).toBe('ALV_CHANGED');
+    fireEvent.click(screen.getByTestId('debug-level-reset'));
+    expect(managerDeveloperName.value).toBe('ALV_E2E');
+
+    fireEvent.click(screen.getByTestId('debug-level-delete'));
+    await waitFor(() => {
+      expect(
+        posted.some(
+          msg => msg.type === 'debugFlagsManagerDelete' && msg.debugLevelId === '7dl000000000001AAA'
+        )
+      ).toBe(true);
+    });
+
+    fireEvent.click(screen.getByTestId('debug-level-manager-new'));
+    expect(managerDeveloperName.value).toBe('');
+
+    fireEvent.change(screen.getByTestId('debug-level-preset-select'), {
+      target: { value: 'integration' }
+    });
+    fireEvent.click(screen.getByTestId('debug-level-apply-preset'));
+    expect(managerDeveloperName.value).toBe('ALV_INTEGRATION');
+
+    fireEvent.change(managerDeveloperName, { target: { value: 'ALV_INTEGRATION_CUSTOM' } });
+    fireEvent.change(screen.getByTestId('debug-level-field-wave'), {
+      target: { value: 'DEBUG' }
+    });
+    fireEvent.click(screen.getByTestId('debug-level-save'));
+    await waitFor(() => {
+      expect(
+        posted.some(
+          msg =>
+            msg.type === 'debugFlagsManagerSave' &&
+            msg.draft.developerName === 'ALV_INTEGRATION_CUSTOM' &&
+            msg.draft.wave === 'DEBUG'
+        )
+      ).toBe(true);
+    });
 
     const ttl = screen.getByTestId('debug-flags-ttl') as HTMLInputElement;
     fireEvent.change(ttl, { target: { value: '45' } });

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -126,6 +126,12 @@ describe('DebugFlags webview App', () => {
     expect(managerDeveloperName.value).toBe('ALV_E2E');
 
     fireEvent.click(screen.getByTestId('debug-level-delete'));
+    expect(screen.getByTestId('debug-level-delete-confirmation')).toBeTruthy();
+    expect(
+      posted.some(msg => msg.type === 'debugFlagsManagerDelete' && msg.debugLevelId === '7dl000000000001AAA')
+    ).toBe(false);
+
+    fireEvent.click(screen.getByTestId('debug-level-delete-confirm'));
     await waitFor(() => {
       expect(
         posted.some(

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
+import { DEBUG_LEVEL_FIELDS, DEBUG_LEVEL_LOG_LEVELS, createEmptyDebugLevelRecord } from '../shared/debugLevelPresets';
 import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
-import type { DebugFlagUser, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
+import type { DebugFlagUser, DebugLevelPreset, DebugLevelRecord, UserTraceFlagStatus } from '../shared/debugFlagsTypes';
 import type { OrgItem } from '../shared/types';
 import type { MessageBus, VsCodeWebviewApi } from './vscodeApi';
 import { getDefaultMessageBus, getDefaultVsCodeApi } from './vscodeApi';
@@ -32,6 +33,24 @@ type NoticeState = {
   message: string;
 };
 
+function cloneDebugLevelRecord(record?: DebugLevelRecord): DebugLevelRecord {
+  const base = createEmptyDebugLevelRecord();
+  if (!record) {
+    return base;
+  }
+  return {
+    ...base,
+    ...record,
+    id: record.id
+  };
+}
+
+function debugLevelDraftEquals(left: DebugLevelRecord, right: DebugLevelRecord): boolean {
+  const { id: _leftId, ...leftComparable } = left;
+  const { id: _rightId, ...rightComparable } = right;
+  return JSON.stringify(leftComparable) === JSON.stringify(rightComparable);
+}
+
 function formatDate(value: string | undefined, locale: string): string {
   if (!value) {
     return '-';
@@ -60,11 +79,18 @@ export function DebugFlagsApp({
   const [status, setStatus] = useState<UserTraceFlagStatus | undefined>(undefined);
   const [debugLevels, setDebugLevels] = useState<string[]>([]);
   const [debugLevel, setDebugLevel] = useState('');
+  const [managerRecords, setManagerRecords] = useState<DebugLevelRecord[]>([]);
+  const [managerPresets, setManagerPresets] = useState<DebugLevelPreset[]>([]);
+  const [selectedManagerId, setSelectedManagerId] = useState('');
+  const [selectedPresetId, setSelectedPresetId] = useState('');
+  const [loadedManagerDraft, setLoadedManagerDraft] = useState<DebugLevelRecord>(() => createEmptyDebugLevelRecord());
+  const [managerDraft, setManagerDraft] = useState<DebugLevelRecord>(() => createEmptyDebugLevelRecord());
   const [ttlMinutes, setTtlMinutes] = useState('30');
   const [error, setError] = useState<string | undefined>(undefined);
   const [notice, setNotice] = useState<NoticeState | undefined>(undefined);
   const [initialized, setInitialized] = useState(false);
   const selectedUserIdRef = useRef<string | undefined>(undefined);
+  const selectedManagerIdRef = useRef<string>('');
   const [loading, setLoading] = useState<LoadingState>({
     orgs: false,
     users: false,
@@ -75,6 +101,10 @@ export function DebugFlagsApp({
   useEffect(() => {
     selectedUserIdRef.current = selectedUserId;
   }, [selectedUserId]);
+
+  useEffect(() => {
+    selectedManagerIdRef.current = selectedManagerId;
+  }, [selectedManagerId]);
 
   useEffect(() => {
     if (!messageBus) {
@@ -116,6 +146,20 @@ export function DebugFlagsApp({
           }
           break;
         }
+        case 'debugFlagsManagerData': {
+          const records = msg.records || [];
+          const presets = msg.presets || [];
+          const preferredId = msg.selectedId || selectedManagerIdRef.current;
+          const selectedRecord = records.find(record => record.id === preferredId) || records[0];
+          const nextDraft = cloneDebugLevelRecord(selectedRecord);
+          setManagerRecords(records);
+          setManagerPresets(presets);
+          setSelectedManagerId(selectedRecord?.id || '');
+          setSelectedPresetId('');
+          setLoadedManagerDraft(nextDraft);
+          setManagerDraft(nextDraft);
+          break;
+        }
         case 'debugFlagsUserStatus':
           if (msg.userId === selectedUserIdRef.current) {
             setStatus(msg.status);
@@ -153,9 +197,18 @@ export function DebugFlagsApp({
     () => users.find(user => user.id === selectedUserId),
     [users, selectedUserId]
   );
+  const managerDraftDirty = !debugLevelDraftEquals(managerDraft, loadedManagerDraft);
 
   const canApply = Boolean(selectedUserId && debugLevel && !loading.action && !loading.orgs);
   const canRemove = Boolean(selectedUserId && !loading.action && !loading.orgs);
+  const canSaveManager = Boolean(
+    !loading.action &&
+      !loading.orgs &&
+      managerDraft.developerName.trim() &&
+      managerDraft.masterLabel.trim() &&
+      managerDraftDirty
+  );
+  const canDeleteManager = Boolean(selectedManagerId && !loading.action && !loading.orgs);
 
   const handleSelectOrg = (nextOrg: string) => {
     setSelectedOrg(nextOrg);
@@ -211,6 +264,82 @@ export function DebugFlagsApp({
     vscode.postMessage({
       type: 'debugFlagsClearLogs',
       scope
+    });
+  };
+
+  const handleSelectManager = (nextId: string) => {
+    setSelectedManagerId(nextId);
+    setSelectedPresetId('');
+    const selectedRecord = managerRecords.find(record => record.id === nextId);
+    const nextDraft = cloneDebugLevelRecord(selectedRecord);
+    setLoadedManagerDraft(nextDraft);
+    setManagerDraft(nextDraft);
+    setNotice(undefined);
+    setError(undefined);
+  };
+
+  const handleNewManager = () => {
+    const nextDraft = createEmptyDebugLevelRecord();
+    setSelectedManagerId('');
+    setSelectedPresetId('');
+    setLoadedManagerDraft(nextDraft);
+    setManagerDraft(nextDraft);
+    setNotice(undefined);
+    setError(undefined);
+  };
+
+  const handleApplyPreset = () => {
+    const preset = managerPresets.find(item => item.id === selectedPresetId);
+    if (!preset) {
+      return;
+    }
+    setManagerDraft(prev => ({
+      ...cloneDebugLevelRecord(preset.record),
+      id: prev.id
+    }));
+    setNotice(undefined);
+    setError(undefined);
+  };
+
+  const handleManagerFieldChange = <K extends keyof DebugLevelRecord>(field: K, value: DebugLevelRecord[K]) => {
+    setManagerDraft(prev => ({
+      ...prev,
+      [field]: value
+    }));
+  };
+
+  const handleResetManager = () => {
+    setSelectedPresetId('');
+    setManagerDraft(cloneDebugLevelRecord(loadedManagerDraft));
+    setNotice(undefined);
+    setError(undefined);
+  };
+
+  const handleSaveManager = () => {
+    if (!managerDraft.developerName.trim() || !managerDraft.masterLabel.trim()) {
+      setNotice(undefined);
+      setError(
+        t.debugFlags?.managerValidation ?? 'DeveloperName and MasterLabel are required to save a DebugLevel.'
+      );
+      return;
+    }
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({
+      type: 'debugFlagsManagerSave',
+      draft: managerDraft
+    });
+  };
+
+  const handleDeleteManager = () => {
+    if (!selectedManagerId) {
+      return;
+    }
+    setNotice(undefined);
+    setError(undefined);
+    vscode.postMessage({
+      type: 'debugFlagsManagerDelete',
+      debugLevelId: selectedManagerId
     });
   };
 
@@ -462,6 +591,182 @@ export function DebugFlagsApp({
             </Popover.Root>
           </div>
         </article>
+      </section>
+
+      <section
+        className="rounded-lg border border-border bg-card/70 p-4 shadow-sm"
+        data-testid="debug-level-manager"
+      >
+        <div className="flex flex-col gap-1">
+          <h2 className="text-base font-semibold text-foreground">
+            {t.debugFlags?.managerTitle ?? 'Debug Level Manager'}
+          </h2>
+          <p className="text-sm text-muted-foreground">
+            {t.debugFlags?.managerSubtitle ??
+              'Create from scratch, apply a preset, or edit an existing DebugLevel field by field.'}
+          </p>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_auto_1fr_auto]">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="debug-level-manager-select">
+              {t.debugFlags?.managerExisting ?? 'Existing DebugLevel'}
+            </Label>
+            <select
+              id="debug-level-manager-select"
+              data-testid="debug-level-manager-select"
+              value={selectedManagerId}
+              onChange={event => handleSelectManager(event.target.value)}
+              disabled={loading.orgs || loading.action || managerRecords.length === 0}
+              className="flex min-h-[28px] w-full rounded-md border border-input bg-input px-3 py-1 text-[13px] shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="">{t.debugFlags?.managerNewPlaceholder ?? 'New draft'}</option>
+              {managerRecords.map(record => (
+                <option key={record.id || record.developerName} value={record.id}>
+                  {record.developerName}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleNewManager}
+              disabled={loading.orgs || loading.action}
+              data-testid="debug-level-manager-new"
+            >
+              {t.debugFlags?.managerNew ?? 'New'}
+            </Button>
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="debug-level-preset-select">
+              {t.debugFlags?.managerPreset ?? 'Preset'}
+            </Label>
+            <select
+              id="debug-level-preset-select"
+              data-testid="debug-level-preset-select"
+              value={selectedPresetId}
+              onChange={event => setSelectedPresetId(event.target.value)}
+              disabled={loading.orgs || loading.action || managerPresets.length === 0}
+              className="flex min-h-[28px] w-full rounded-md border border-input bg-input px-3 py-1 text-[13px] shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              <option value="">{t.debugFlags?.managerPresetPlaceholder ?? 'Select a preset'}</option>
+              {managerPresets.map(preset => (
+                <option key={preset.id} value={preset.id}>
+                  {preset.label}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          <div className="flex items-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={handleApplyPreset}
+              disabled={!selectedPresetId || loading.orgs || loading.action}
+              data-testid="debug-level-apply-preset"
+            >
+              {t.debugFlags?.managerApplyPreset ?? 'Apply preset'}
+            </Button>
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="debug-level-draft-developer-name">
+              {t.debugFlags?.managerDeveloperName ?? 'DeveloperName'}
+            </Label>
+            <Input
+              id="debug-level-draft-developer-name"
+              data-testid="debug-level-draft-developer-name"
+              value={managerDraft.developerName}
+              onChange={event => handleManagerFieldChange('developerName', event.target.value)}
+              disabled={loading.orgs || loading.action}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="debug-level-draft-master-label">
+              {t.debugFlags?.managerMasterLabel ?? 'MasterLabel'}
+            </Label>
+            <Input
+              id="debug-level-draft-master-label"
+              data-testid="debug-level-draft-master-label"
+              value={managerDraft.masterLabel}
+              onChange={event => handleManagerFieldChange('masterLabel', event.target.value)}
+              disabled={loading.orgs || loading.action}
+            />
+          </div>
+
+          <div className="flex flex-col gap-1">
+            <Label htmlFor="debug-level-draft-language">
+              {t.debugFlags?.managerLanguage ?? 'Language'}
+            </Label>
+            <Input
+              id="debug-level-draft-language"
+              data-testid="debug-level-draft-language"
+              value={managerDraft.language}
+              onChange={event => handleManagerFieldChange('language', event.target.value)}
+              disabled={loading.orgs || loading.action}
+            />
+          </div>
+        </div>
+
+        <div className="mt-4 grid grid-cols-1 gap-3 md:grid-cols-2 xl:grid-cols-3">
+          {DEBUG_LEVEL_FIELDS.map(field => (
+            <div key={field.key} className="flex flex-col gap-1">
+              <Label htmlFor={`debug-level-field-${field.key}`}>{field.label}</Label>
+              <select
+                id={`debug-level-field-${field.key}`}
+                data-testid={`debug-level-field-${field.key}`}
+                value={managerDraft[field.key]}
+                onChange={event => handleManagerFieldChange(field.key, event.target.value)}
+                disabled={loading.orgs || loading.action}
+                className="flex min-h-[28px] w-full rounded-md border border-input bg-input px-3 py-1 text-[13px] shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {DEBUG_LEVEL_LOG_LEVELS.map(level => (
+                  <option key={level} value={level}>
+                    {level}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          <Button
+            type="button"
+            onClick={handleSaveManager}
+            disabled={!canSaveManager}
+            variant="secondary"
+            data-testid="debug-level-save"
+          >
+            {t.debugFlags?.managerSave ?? 'Save'}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleResetManager}
+            disabled={!managerDraftDirty || loading.orgs || loading.action}
+            variant="outline"
+            data-testid="debug-level-reset"
+          >
+            {t.debugFlags?.managerReset ?? 'Reset changes'}
+          </Button>
+          <Button
+            type="button"
+            onClick={handleDeleteManager}
+            disabled={!canDeleteManager}
+            variant="outline"
+            data-testid="debug-level-delete"
+          >
+            {t.debugFlags?.managerDelete ?? 'Delete'}
+          </Button>
+        </div>
       </section>
 
       {error && (

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -85,6 +85,7 @@ export function DebugFlagsApp({
   const [selectedPresetId, setSelectedPresetId] = useState('');
   const [loadedManagerDraft, setLoadedManagerDraft] = useState<DebugLevelRecord>(() => createEmptyDebugLevelRecord());
   const [managerDraft, setManagerDraft] = useState<DebugLevelRecord>(() => createEmptyDebugLevelRecord());
+  const [confirmDeleteManager, setConfirmDeleteManager] = useState(false);
   const [ttlMinutes, setTtlMinutes] = useState('30');
   const [error, setError] = useState<string | undefined>(undefined);
   const [notice, setNotice] = useState<NoticeState | undefined>(undefined);
@@ -158,6 +159,7 @@ export function DebugFlagsApp({
           setSelectedPresetId('');
           setLoadedManagerDraft(nextDraft);
           setManagerDraft(nextDraft);
+          setConfirmDeleteManager(false);
           break;
         }
         case 'debugFlagsUserStatus':
@@ -274,6 +276,7 @@ export function DebugFlagsApp({
     const nextDraft = cloneDebugLevelRecord(selectedRecord);
     setLoadedManagerDraft(nextDraft);
     setManagerDraft(nextDraft);
+    setConfirmDeleteManager(false);
     setNotice(undefined);
     setError(undefined);
   };
@@ -284,6 +287,7 @@ export function DebugFlagsApp({
     setSelectedPresetId('');
     setLoadedManagerDraft(nextDraft);
     setManagerDraft(nextDraft);
+    setConfirmDeleteManager(false);
     setNotice(undefined);
     setError(undefined);
   };
@@ -297,11 +301,13 @@ export function DebugFlagsApp({
       ...cloneDebugLevelRecord(preset.record),
       id: prev.id
     }));
+    setConfirmDeleteManager(false);
     setNotice(undefined);
     setError(undefined);
   };
 
   const handleManagerFieldChange = <K extends keyof DebugLevelRecord>(field: K, value: DebugLevelRecord[K]) => {
+    setConfirmDeleteManager(false);
     setManagerDraft(prev => ({
       ...prev,
       [field]: value
@@ -311,6 +317,7 @@ export function DebugFlagsApp({
   const handleResetManager = () => {
     setSelectedPresetId('');
     setManagerDraft(cloneDebugLevelRecord(loadedManagerDraft));
+    setConfirmDeleteManager(false);
     setNotice(undefined);
     setError(undefined);
   };
@@ -325,6 +332,7 @@ export function DebugFlagsApp({
     }
     setNotice(undefined);
     setError(undefined);
+    setConfirmDeleteManager(false);
     vscode.postMessage({
       type: 'debugFlagsManagerSave',
       draft: managerDraft
@@ -335,12 +343,23 @@ export function DebugFlagsApp({
     if (!selectedManagerId) {
       return;
     }
+    if (!confirmDeleteManager) {
+      setConfirmDeleteManager(true);
+      setNotice(undefined);
+      setError(undefined);
+      return;
+    }
+    setConfirmDeleteManager(false);
     setNotice(undefined);
     setError(undefined);
     vscode.postMessage({
       type: 'debugFlagsManagerDelete',
       debugLevelId: selectedManagerId
     });
+  };
+
+  const handleCancelDeleteManager = () => {
+    setConfirmDeleteManager(false);
   };
 
   const noticeIcon = notice?.tone === 'success' ? CheckCircle2 : notice?.tone === 'warning' ? AlertCircle : Info;
@@ -767,6 +786,34 @@ export function DebugFlagsApp({
             {t.debugFlags?.managerDelete ?? 'Delete'}
           </Button>
         </div>
+
+        {confirmDeleteManager && (
+          <div
+            className="mt-3 flex flex-wrap items-center gap-2 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive"
+            data-testid="debug-level-delete-confirmation"
+          >
+            <AlertCircle className="h-4 w-4" aria-hidden="true" />
+            <span>{t.debugFlags?.managerDeleteConfirmPrompt ?? 'Delete this DebugLevel from the org?'}</span>
+            <Button
+              type="button"
+              onClick={handleDeleteManager}
+              disabled={!canDeleteManager}
+              variant="destructive"
+              data-testid="debug-level-delete-confirm"
+            >
+              {t.debugFlags?.managerDeleteConfirmAction ?? 'Delete'}
+            </Button>
+            <Button
+              type="button"
+              onClick={handleCancelDeleteManager}
+              disabled={loading.action || loading.orgs}
+              variant="outline"
+              data-testid="debug-level-delete-cancel"
+            >
+              {t.debugFlags?.managerDeleteCancel ?? 'Cancel'}
+            </Button>
+          </div>
+        )}
       </section>
 
       {error && (

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -114,6 +114,9 @@ export type Messages = {
     managerSave?: string;
     managerReset?: string;
     managerDelete?: string;
+    managerDeleteConfirmPrompt?: string;
+    managerDeleteConfirmAction?: string;
+    managerDeleteCancel?: string;
     managerValidation?: string;
   };
 };
@@ -234,6 +237,9 @@ const en: Messages = {
     managerSave: 'Save',
     managerReset: 'Reset changes',
     managerDelete: 'Delete',
+    managerDeleteConfirmPrompt: 'Delete this DebugLevel from the org?',
+    managerDeleteConfirmAction: 'Delete',
+    managerDeleteCancel: 'Cancel',
     managerValidation: 'DeveloperName and MasterLabel are required to save a DebugLevel.'
   }
 };
@@ -354,6 +360,9 @@ const ptBR: Messages = {
     managerSave: 'Salvar',
     managerReset: 'Restaurar alterações',
     managerDelete: 'Excluir',
+    managerDeleteConfirmPrompt: 'Excluir este DebugLevel da org?',
+    managerDeleteConfirmAction: 'Excluir',
+    managerDeleteCancel: 'Cancelar',
     managerValidation: 'DeveloperName e MasterLabel são obrigatórios para salvar um DebugLevel.'
   }
 };

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -100,6 +100,21 @@ export type Messages = {
     noticeRemoved: string;
     noticeNone: string;
     ttlHelper: string;
+    managerTitle?: string;
+    managerSubtitle?: string;
+    managerExisting?: string;
+    managerNewPlaceholder?: string;
+    managerNew?: string;
+    managerPreset?: string;
+    managerPresetPlaceholder?: string;
+    managerApplyPreset?: string;
+    managerDeveloperName?: string;
+    managerMasterLabel?: string;
+    managerLanguage?: string;
+    managerSave?: string;
+    managerReset?: string;
+    managerDelete?: string;
+    managerValidation?: string;
   };
 };
 
@@ -204,7 +219,22 @@ const en: Messages = {
     noticeUpdated: 'Debug flag updated successfully.',
     noticeRemoved: 'Debug flag removed successfully.',
     noticeNone: 'No USER_DEBUG trace flag found for this user.',
-    ttlHelper: 'Default is 30 minutes. Allowed range: 1-1440.'
+    ttlHelper: 'Default is 30 minutes. Allowed range: 1-1440.',
+    managerTitle: 'Debug Level Manager',
+    managerSubtitle: 'Create from scratch, apply a preset, or edit an existing DebugLevel field by field.',
+    managerExisting: 'Existing DebugLevel',
+    managerNewPlaceholder: 'New draft',
+    managerNew: 'New',
+    managerPreset: 'Preset',
+    managerPresetPlaceholder: 'Select a preset',
+    managerApplyPreset: 'Apply preset',
+    managerDeveloperName: 'DeveloperName',
+    managerMasterLabel: 'MasterLabel',
+    managerLanguage: 'Language',
+    managerSave: 'Save',
+    managerReset: 'Reset changes',
+    managerDelete: 'Delete',
+    managerValidation: 'DeveloperName and MasterLabel are required to save a DebugLevel.'
   }
 };
 
@@ -309,7 +339,22 @@ const ptBR: Messages = {
     noticeUpdated: 'Debug flag atualizada com sucesso.',
     noticeRemoved: 'Debug flag removida com sucesso.',
     noticeNone: 'Nenhuma trace flag USER_DEBUG encontrada para este usuário.',
-    ttlHelper: 'Padrão de 30 minutos. Faixa permitida: 1-1440.'
+    ttlHelper: 'Padrão de 30 minutos. Faixa permitida: 1-1440.',
+    managerTitle: 'Gerenciador de DebugLevel',
+    managerSubtitle: 'Crie do zero, aplique um preset ou edite um DebugLevel existente campo por campo.',
+    managerExisting: 'DebugLevel existente',
+    managerNewPlaceholder: 'Novo rascunho',
+    managerNew: 'Novo',
+    managerPreset: 'Preset',
+    managerPresetPlaceholder: 'Selecione um preset',
+    managerApplyPreset: 'Aplicar preset',
+    managerDeveloperName: 'DeveloperName',
+    managerMasterLabel: 'MasterLabel',
+    managerLanguage: 'Language',
+    managerSave: 'Salvar',
+    managerReset: 'Restaurar alterações',
+    managerDelete: 'Excluir',
+    managerValidation: 'DeveloperName e MasterLabel são obrigatórios para salvar um DebugLevel.'
   }
 };
 

--- a/test/e2e/fixtures/alvE2E.ts
+++ b/test/e2e/fixtures/alvE2E.ts
@@ -23,11 +23,6 @@ type Fixtures = {
 export const test = base.extend<Fixtures>({
   scratchAlias: [
     async ({}, use) => {
-      const explicitScratchAlias = String(process.env.SF_SCRATCH_ALIAS || '').trim();
-      if (explicitScratchAlias) {
-        await use(explicitScratchAlias);
-        return;
-      }
       const scratch = await ensureScratchOrg();
       try {
         await use(scratch.scratchAlias);

--- a/test/e2e/fixtures/alvNoSeed.ts
+++ b/test/e2e/fixtures/alvNoSeed.ts
@@ -2,19 +2,12 @@ import path from 'node:path';
 import { test as base, expect, type Page } from '@playwright/test';
 import type { ElectronApplication } from 'playwright';
 import { ensureScratchOrg } from '../utils/scratchOrg';
-import { seedApexLog } from '../utils/seedLog';
 import { resolveSfCliInvocation } from '../utils/sfCli';
 import { createTempWorkspace } from '../utils/tempWorkspace';
 import { launchVsCode } from '../utils/vscode';
 
-type SeededLog = {
-  marker: string;
-  logId: string;
-};
-
 type Fixtures = {
   scratchAlias: string;
-  seededLog: SeededLog;
   workspacePath: string;
   vscodeApp: ElectronApplication;
   vscodePage: Page;
@@ -37,11 +30,6 @@ export const test = base.extend<Fixtures>({
     },
     { scope: 'worker' }
   ],
-
-  seededLog: async ({ scratchAlias }, use) => {
-    const seeded = await seedApexLog(scratchAlias);
-    await use(seeded);
-  },
 
   workspacePath: async ({ scratchAlias }, use) => {
     const sfCli = await resolveSfCliInvocation();

--- a/test/e2e/fixtures/alvNoSeed.ts
+++ b/test/e2e/fixtures/alvNoSeed.ts
@@ -16,11 +16,6 @@ type Fixtures = {
 export const test = base.extend<Fixtures>({
   scratchAlias: [
     async ({}, use) => {
-      const explicitScratchAlias = String(process.env.SF_SCRATCH_ALIAS || '').trim();
-      if (explicitScratchAlias) {
-        await use(explicitScratchAlias);
-        return;
-      }
       const scratch = await ensureScratchOrg();
       try {
         await use(scratch.scratchAlias);

--- a/test/e2e/specs/debugLevelManager.e2e.spec.ts
+++ b/test/e2e/specs/debugLevelManager.e2e.spec.ts
@@ -1,0 +1,111 @@
+import { expect, test } from '../fixtures/alvE2E';
+import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import {
+  deleteDebugLevelByDeveloperName,
+  ensureDebugFlagsTestUser,
+  getDebugLevelByDeveloperName,
+  getDebugLevelById,
+  getOrgAuth,
+  removeUserDebugTraceFlags
+} from '../utils/tooling';
+import { waitForWebviewFrame } from '../utils/webviews';
+
+test('creates, updates and deletes DebugLevel records from the manager UI', async ({ vscodePage, scratchAlias }) => {
+  const auth = await getOrgAuth(scratchAlias);
+  const testUser = await ensureDebugFlagsTestUser(auth);
+  const createdDeveloperName = `ALV_E2E_DL_${Date.now()}`;
+  const updatedDeveloperName = `${createdDeveloperName}_UPD`;
+  const createdLabel = `${createdDeveloperName} Label`;
+  const updatedLabel = `${updatedDeveloperName} Label`;
+
+  await removeUserDebugTraceFlags(auth, testUser.id).catch(() => {});
+  await deleteDebugLevelByDeveloperName(auth, createdDeveloperName).catch(() => {});
+  await deleteDebugLevelByDeveloperName(auth, updatedDeveloperName).catch(() => {});
+
+  try {
+    await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+    await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+
+    const logsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
+    await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+    await openDebugFlags.click({ force: true });
+
+    const debugFlagsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="debug-level-manager"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+
+    await debugFlagsFrame.locator('[data-testid="debug-level-manager"]').waitFor({ state: 'visible', timeout: 60_000 });
+    const newDebugLevelButton = debugFlagsFrame.locator('[data-testid="debug-level-manager-new"]');
+    await expect(newDebugLevelButton).toBeEnabled({ timeout: 120_000 });
+    await newDebugLevelButton.click({ force: true });
+
+    await debugFlagsFrame.locator('[data-testid="debug-level-draft-developer-name"]').fill(createdDeveloperName);
+    await debugFlagsFrame.locator('[data-testid="debug-level-draft-master-label"]').fill(createdLabel);
+    await debugFlagsFrame.locator('[data-testid="debug-level-draft-language"]').fill('en_US');
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-apexCode"]').selectOption('DEBUG');
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-callout"]').selectOption('WARN');
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-wave"]').selectOption('ERROR');
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-dataAccess"]').selectOption('FINE');
+
+    await debugFlagsFrame.locator('[data-testid="debug-level-save"]').click({ force: true });
+    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
+
+    await expect
+      .poll(async () => await getDebugLevelByDeveloperName(auth, createdDeveloperName), { timeout: 60_000 })
+      .toMatchObject({
+        developerName: createdDeveloperName,
+        masterLabel: createdLabel,
+        language: 'en_US',
+        apexCode: 'DEBUG',
+        callout: 'WARN',
+        wave: 'ERROR',
+        dataAccess: 'FINE'
+      });
+
+    const created = await getDebugLevelByDeveloperName(auth, createdDeveloperName);
+    expect(created?.id).toBeTruthy();
+
+    await debugFlagsFrame.locator('[data-testid="debug-level-manager-select"]').selectOption(created!.id);
+    await debugFlagsFrame.locator('[data-testid="debug-level-preset-select"]').selectOption('integration-troubleshooting');
+    await debugFlagsFrame.locator('[data-testid="debug-level-apply-preset"]').click({ force: true });
+    await debugFlagsFrame.locator('[data-testid="debug-level-draft-developer-name"]').fill(updatedDeveloperName);
+    await debugFlagsFrame.locator('[data-testid="debug-level-draft-master-label"]').fill(updatedLabel);
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-wave"]').selectOption('DEBUG');
+    await debugFlagsFrame.locator('[data-testid="debug-level-field-nba"]').selectOption('ERROR');
+    await debugFlagsFrame.locator('[data-testid="debug-level-save"]').click({ force: true });
+    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
+
+    await expect
+      .poll(async () => await getDebugLevelById(auth, created!.id), { timeout: 60_000 })
+      .toMatchObject({
+        id: created!.id,
+        developerName: updatedDeveloperName,
+        masterLabel: updatedLabel,
+        callout: 'DEBUG',
+        apexCode: 'DEBUG',
+        wave: 'DEBUG',
+        nba: 'ERROR'
+      });
+
+    await debugFlagsFrame.locator('[data-testid="debug-level-delete"]').click({ force: true });
+    const confirmDeleteButton = vscodePage.getByRole('button', { name: /^Delete$/ }).last();
+    await confirmDeleteButton.waitFor({ state: 'visible', timeout: 60_000 });
+    await confirmDeleteButton.click();
+    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
+
+    await expect
+      .poll(async () => await getDebugLevelById(auth, created!.id), { timeout: 60_000 })
+      .toBeUndefined();
+  } finally {
+    await removeUserDebugTraceFlags(auth, testUser.id).catch(() => {});
+    await deleteDebugLevelByDeveloperName(auth, createdDeveloperName).catch(() => {});
+    await deleteDebugLevelByDeveloperName(auth, updatedDeveloperName).catch(() => {});
+  }
+});

--- a/test/e2e/specs/debugLevelManager.e2e.spec.ts
+++ b/test/e2e/specs/debugLevelManager.e2e.spec.ts
@@ -95,9 +95,11 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
       });
 
     await debugFlagsFrame.locator('[data-testid="debug-level-delete"]').click({ force: true });
-    const confirmDeleteButton = vscodePage.getByRole('button', { name: /^Delete$/ }).last();
-    await confirmDeleteButton.waitFor({ state: 'visible', timeout: 60_000 });
-    await confirmDeleteButton.click();
+    await debugFlagsFrame.locator('[data-testid="debug-level-delete-confirmation"]').waitFor({
+      state: 'visible',
+      timeout: 60_000
+    });
+    await debugFlagsFrame.locator('[data-testid="debug-level-delete-confirm"]').click({ force: true });
     await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -1,4 +1,4 @@
-import { ensureDebugFlagsTestUser, type OrgAuth } from '../tooling';
+import { ensureDebugFlagsTestUser, getDebugLevelByDeveloperName, type OrgAuth } from '../tooling';
 
 type MockFetchResponse = {
   status: number;
@@ -85,5 +85,50 @@ describe('ensureDebugFlagsTestUser', () => {
       id: '005000000000999AAA',
       username: 'auth.user@example.com'
     });
+  });
+
+  test('queries DebugLevel records with a compatible tooling API version', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '60.0'
+    };
+    const calls: string[] = [];
+
+    globalThis.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      return responseFrom({
+        status: 200,
+        body: {
+          records: [
+            {
+              Id: '7dl000000000001AAA',
+              DeveloperName: 'ALV_POST_64',
+              MasterLabel: 'ALV POST 64',
+              Language: 'en_US',
+              Workflow: 'INFO',
+              Validation: 'WARN',
+              Callout: 'DEBUG',
+              ApexCode: 'DEBUG',
+              ApexProfiling: 'INFO',
+              Visualforce: 'WARN',
+              System: 'DEBUG',
+              Database: 'INFO',
+              Wave: 'DEBUG',
+              Nba: 'ERROR',
+              DataAccess: 'WARN'
+            }
+          ]
+        }
+      });
+    });
+
+    const record = await getDebugLevelByDeveloperName(auth, 'ALV_POST_64');
+
+    expect(record?.id).toBe('7dl000000000001AAA');
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toContain('/services/data/v63.0/tooling/query');
   });
 });

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -25,7 +25,10 @@ async function tryOrgDisplay(alias: string): Promise<boolean> {
   try {
     await runSfJson(['org', 'display', '-o', alias]);
     return true;
-  } catch {
+  } catch (error) {
+    console.warn(
+      `[e2e] sf org display failed for alias '${alias}': ${error instanceof Error ? error.message : String(error)}`
+    );
     return false;
   }
 }
@@ -107,8 +110,6 @@ async function waitForScratchOrgReady(targetOrg: string): Promise<void> {
 
 export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
   const devHubAlias = await resolveDefaultDevHubAlias();
-  await ensureDevHubAuth(devHubAlias);
-
   const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
   const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
   const keep = envFlag('SF_TEST_KEEP_ORG');
@@ -124,6 +125,8 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
       cleanup: async () => {}
     };
   }
+
+  await ensureDevHubAuth(devHubAlias);
 
   const tmp = await mkdtemp(path.join(tmpdir(), 'alv-scratch-'));
   const defFile = path.join(tmp, 'project-scratch-def.json');

--- a/test/e2e/utils/sfCli.ts
+++ b/test/e2e/utils/sfCli.ts
@@ -58,15 +58,21 @@ export function getSfBinPath(): string {
   return sfBin();
 }
 
+function quoteWindowsCmdArg(value: string): string {
+  const raw = String(value ?? '');
+  return `"${raw.replace(/"/g, '""')}"`;
+}
+
 export async function resolveSfBinAbsolutePath(): Promise<string | undefined> {
   try {
     if (process.platform === 'win32') {
       const { stdout } = await execFileAsync('cmd.exe', ['/d', '/s', '/c', 'where sf'], { timeoutMs: 10_000 });
-      const first = String(stdout || '')
+      const candidates = String(stdout || '')
         .split(/\r?\n/)
         .map(l => l.trim())
-        .filter(Boolean)[0];
-      return first || undefined;
+        .filter(Boolean);
+      const preferred = candidates.find(value => /\.cmd$/i.test(value));
+      return preferred || candidates[0] || undefined;
     }
     const { stdout } = await execFileAsync('bash', ['-lc', 'command -v sf'], { timeoutMs: 10_000 });
     const resolved = String(stdout || '').trim();
@@ -89,40 +95,46 @@ export async function resolveSfCliInvocation(): Promise<{ sfBinPath: string; nod
 
 export function execFileAsync(file: string, args: string[], options: ExecOptions = {}): Promise<ExecResult> {
   return new Promise((resolve, reject) => {
-    execFile(
-      file,
-      args,
-      {
-        cwd: options.cwd,
-        env: options.env,
-        encoding: 'utf8',
-        timeout: options.timeoutMs,
-        maxBuffer: 1024 * 1024 * 20
-      },
-      (error, stdout, stderr) => {
-        if (error) {
-          const details = formatSfErrorDetails(String(stdout || ''), String(stderr || ''));
-          // Avoid echoing stdout/stderr directly to prevent leaking auth tokens.
-          const msg = details
-            ? `Command failed: ${file} ${args.join(' ')}\n${details}`.trim()
-            : `Command failed: ${file} ${args.join(' ')}`.trim();
-          const err = new Error(msg) as Error & { code?: unknown };
-          (err as any).code = (error as any).code;
-          reject(err);
-          return;
-        }
-        resolve({ stdout: String(stdout || ''), stderr: String(stderr || '') });
+    const callback = (error: unknown, stdout: string, stderr: string) => {
+      if (error) {
+        const details = formatSfErrorDetails(String(stdout || ''), String(stderr || ''));
+        // Avoid echoing stdout/stderr directly to prevent leaking auth tokens.
+        const msg = details
+          ? `Command failed: ${file} ${args.join(' ')}\n${details}`.trim()
+          : `Command failed: ${file} ${args.join(' ')}`.trim();
+        const err = new Error(msg) as Error & { code?: unknown };
+        (err as any).code = (error as any).code;
+        reject(err);
+        return;
       }
-    );
+      resolve({ stdout: String(stdout || ''), stderr: String(stderr || '') });
+    };
+
+    const execOptions = {
+      cwd: options.cwd,
+      env: options.env,
+      encoding: 'utf8' as BufferEncoding,
+      timeout: options.timeoutMs,
+      maxBuffer: 1024 * 1024 * 20
+    };
+
+    if (process.platform === 'win32' && /\.cmd$/i.test(file)) {
+      const command = [file, ...args].map(quoteWindowsCmdArg).join(' ');
+      execFile('cmd.exe', ['/d', '/s', '/c', command], execOptions, callback);
+      return;
+    }
+
+    execFile(file, args, execOptions, callback);
   });
 }
 
 export async function runSfJson(args: string[], options: ExecOptions = {}): Promise<any> {
   const withJson = args.includes('--json') ? args : [...args, '--json'];
-  const { stdout } = await execFileAsync(getSfBinPath(), withJson, options);
+  const sfPath = (await resolveSfBinAbsolutePath()) || getSfBinPath();
+  const { stdout } = await execFileAsync(sfPath, withJson, options);
   const raw = String(stdout || '').trim();
   if (!raw) {
-    throw new Error(`Empty JSON output from sf ${withJson.join(' ')}`.trim());
+    throw new Error(`Empty JSON output from ${sfPath} ${withJson.join(' ')}`.trim());
   }
   try {
     return JSON.parse(raw);
@@ -138,6 +150,6 @@ export async function runSfJson(args: string[], options: ExecOptions = {}): Prom
         // fall through
       }
     }
-    throw new Error(`Invalid JSON output from sf ${withJson.join(' ')}`.trim());
+    throw new Error(`Invalid JSON output from ${sfPath} ${withJson.join(' ')}`.trim());
   }
 }

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -12,6 +12,24 @@ export type DebugFlagsE2eUser = {
   username: string;
 };
 
+export type DebugLevelToolingRecord = {
+  id: string;
+  developerName: string;
+  masterLabel?: string;
+  language?: string;
+  workflow?: string;
+  validation?: string;
+  callout?: string;
+  apexCode?: string;
+  apexProfiling?: string;
+  visualforce?: string;
+  system?: string;
+  database?: string;
+  wave?: string;
+  nba?: string;
+  dataAccess?: string;
+};
+
 function getApiVersion(): string {
   const v = String(process.env.SF_TEST_API_VERSION || process.env.SF_API_VERSION || '60.0').trim();
   return /^\d+\.\d+$/.test(v) ? v : '60.0';
@@ -276,7 +294,81 @@ export async function removeUserDebugTraceFlags(auth: OrgAuth, userId: string): 
   return ids.length;
 }
 
+function mapDebugLevelRecord(record: any): DebugLevelToolingRecord | undefined {
+  if (!isSfId(record?.Id)) {
+    return undefined;
+  }
+  return {
+    id: record.Id,
+    developerName: typeof record?.DeveloperName === 'string' ? record.DeveloperName : '',
+    masterLabel: typeof record?.MasterLabel === 'string' ? record.MasterLabel : undefined,
+    language: typeof record?.Language === 'string' ? record.Language : undefined,
+    workflow: typeof record?.Workflow === 'string' ? record.Workflow : undefined,
+    validation: typeof record?.Validation === 'string' ? record.Validation : undefined,
+    callout: typeof record?.Callout === 'string' ? record.Callout : undefined,
+    apexCode: typeof record?.ApexCode === 'string' ? record.ApexCode : undefined,
+    apexProfiling: typeof record?.ApexProfiling === 'string' ? record.ApexProfiling : undefined,
+    visualforce: typeof record?.Visualforce === 'string' ? record.Visualforce : undefined,
+    system: typeof record?.System === 'string' ? record.System : undefined,
+    database: typeof record?.Database === 'string' ? record.Database : undefined,
+    wave: typeof record?.Wave === 'string' ? record.Wave : undefined,
+    nba: typeof record?.Nba === 'string' ? record.Nba : undefined,
+    dataAccess: typeof record?.DataAccess === 'string' ? record.DataAccess : undefined
+  };
+}
+
+export async function getDebugLevelByDeveloperName(
+  auth: OrgAuth,
+  developerName: string
+): Promise<DebugLevelToolingRecord | undefined> {
+  const esc = escapeSoqlLiteral(developerName);
+  const soql = encodeURIComponent(
+    `SELECT Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, Visualforce, System, Database, Wave, Nba, DataAccess FROM DebugLevel WHERE DeveloperName = '${esc}' LIMIT 1`
+  );
+  const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${soql}`);
+  return mapDebugLevelRecord(Array.isArray(response?.records) ? response.records[0] : undefined);
+}
+
+export async function getDebugLevelById(
+  auth: OrgAuth,
+  debugLevelId: string
+): Promise<DebugLevelToolingRecord | undefined> {
+  const esc = escapeSoqlLiteral(debugLevelId);
+  const soql = encodeURIComponent(
+    `SELECT Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, Visualforce, System, Database, Wave, Nba, DataAccess FROM DebugLevel WHERE Id = '${esc}' LIMIT 1`
+  );
+  const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${soql}`);
+  return mapDebugLevelRecord(Array.isArray(response?.records) ? response.records[0] : undefined);
+}
+
+export async function deleteDebugLevelById(auth: OrgAuth, debugLevelId: string): Promise<void> {
+  if (!isSfId(debugLevelId)) {
+    return;
+  }
+  await requestJson(auth, 'DELETE', `/services/data/v${auth.apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`);
+}
+
+export async function deleteDebugLevelByDeveloperName(auth: OrgAuth, developerName: string): Promise<void> {
+  const record = await getDebugLevelByDeveloperName(auth, developerName);
+  if (!record?.id) {
+    return;
+  }
+  await deleteDebugLevelById(auth, record.id);
+}
+
 export async function getOrgAuth(targetOrg: string): Promise<OrgAuth> {
+  const envAlias = String(process.env.SF_E2E_TARGET_ORG_ALIAS || process.env.SF_SCRATCH_ALIAS || '').trim();
+  const envAccessToken = String(process.env.SF_E2E_ACCESS_TOKEN || '').trim();
+  const envInstanceUrl = String(process.env.SF_E2E_INSTANCE_URL || '').trim();
+  if (envAccessToken && envInstanceUrl && (!envAlias || envAlias === targetOrg)) {
+    return {
+      accessToken: envAccessToken,
+      instanceUrl: envInstanceUrl,
+      username: String(process.env.SF_E2E_USERNAME || '').trim() || undefined,
+      apiVersion: String(process.env.SF_E2E_API_VERSION || getApiVersion()).trim() || getApiVersion()
+    };
+  }
+
   const apiVersion = getApiVersion();
   const display = await runSfJson(['org', 'display', '-o', targetOrg]);
   const result = display?.result || display;

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -30,9 +30,30 @@ export type DebugLevelToolingRecord = {
   dataAccess?: string;
 };
 
+const DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION = '63.0';
+
 function getApiVersion(): string {
   const v = String(process.env.SF_TEST_API_VERSION || process.env.SF_API_VERSION || '60.0').trim();
   return /^\d+\.\d+$/.test(v) ? v : '60.0';
+}
+
+function parseApiVersionNumber(value: string | undefined): number | undefined {
+  const raw = String(value || '').trim();
+  if (!/^\d+\.\d+$/.test(raw)) {
+    return undefined;
+  }
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : undefined;
+}
+
+function getDebugLevelToolingApiVersion(auth: OrgAuth): string {
+  const current = String(auth.apiVersion || '').trim() || getApiVersion();
+  const currentNumeric = parseApiVersionNumber(current);
+  const requiredNumeric = parseApiVersionNumber(DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION);
+  if (currentNumeric === undefined || requiredNumeric === undefined || currentNumeric >= requiredNumeric) {
+    return current;
+  }
+  return DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION;
 }
 
 function stripTrailingSlash(value: string): string {
@@ -321,11 +342,12 @@ export async function getDebugLevelByDeveloperName(
   auth: OrgAuth,
   developerName: string
 ): Promise<DebugLevelToolingRecord | undefined> {
+  const apiVersion = getDebugLevelToolingApiVersion(auth);
   const esc = escapeSoqlLiteral(developerName);
   const soql = encodeURIComponent(
     `SELECT Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, Visualforce, System, Database, Wave, Nba, DataAccess FROM DebugLevel WHERE DeveloperName = '${esc}' LIMIT 1`
   );
-  const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${soql}`);
+  const response = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${soql}`);
   return mapDebugLevelRecord(Array.isArray(response?.records) ? response.records[0] : undefined);
 }
 
@@ -333,11 +355,12 @@ export async function getDebugLevelById(
   auth: OrgAuth,
   debugLevelId: string
 ): Promise<DebugLevelToolingRecord | undefined> {
+  const apiVersion = getDebugLevelToolingApiVersion(auth);
   const esc = escapeSoqlLiteral(debugLevelId);
   const soql = encodeURIComponent(
     `SELECT Id, DeveloperName, Language, MasterLabel, Workflow, Validation, Callout, ApexCode, ApexProfiling, Visualforce, System, Database, Wave, Nba, DataAccess FROM DebugLevel WHERE Id = '${esc}' LIMIT 1`
   );
-  const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${soql}`);
+  const response = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${soql}`);
   return mapDebugLevelRecord(Array.isArray(response?.records) ? response.records[0] : undefined);
 }
 

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { mkdtemp, rm, readFile, cp, access, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
@@ -22,18 +22,127 @@ function getVsCodeVersion(): string {
   return v || 'stable';
 }
 
-async function readExtensionDependencies(extensionDevelopmentPath: string): Promise<string[]> {
+async function readExtensionReferences(extensionDevelopmentPath: string): Promise<string[]> {
   try {
     const pkgPath = path.join(extensionDevelopmentPath, 'package.json');
     const raw = await readFile(pkgPath, 'utf8');
-    const json = JSON.parse(raw) as { extensionDependencies?: unknown };
-    if (!Array.isArray(json.extensionDependencies)) {
-      return [];
-    }
-    return json.extensionDependencies.map(String).map(s => s.trim()).filter(Boolean);
+    const json = JSON.parse(raw) as { extensionDependencies?: unknown; extensionPack?: unknown };
+    const refs = [
+      ...(Array.isArray(json.extensionDependencies) ? json.extensionDependencies : []),
+      ...(Array.isArray(json.extensionPack) ? json.extensionPack : [])
+    ];
+    return Array.from(new Set(refs.map(String).map(s => s.trim()).filter(Boolean)));
   } catch {
     return [];
   }
+}
+
+function expandPreferredSalesforceExtensions(extensionIds: string[]): string[] {
+  const normalized = extensionIds.map(id => String(id || '').trim()).filter(Boolean);
+  const touchesSalesforcePack = normalized.some(id => /^salesforce\.salesforcedx-vscode(?:-|$)/i.test(id));
+  if (!touchesSalesforcePack) {
+    return normalized;
+  }
+  return Array.from(new Set(['salesforce.salesforcedx-vscode', ...normalized]));
+}
+
+async function pathExists(targetPath: string): Promise<boolean> {
+  try {
+    await access(targetPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function getExtensionSearchRoots(): string[] {
+  const roots = [
+    path.join(process.env.USERPROFILE || '', '.vscode', 'extensions'),
+    path.join(process.env.HOME || '', '.vscode', 'extensions')
+  ];
+  return Array.from(new Set(roots.filter(Boolean)));
+}
+
+async function findExtensionDirectoryInRoot(root: string, extensionId: string): Promise<string | undefined> {
+  const normalizedId = extensionId.toLowerCase();
+  const prefix = `${normalizedId}-`;
+  const matches: string[] = [];
+
+  if (!(await pathExists(root))) {
+    return undefined;
+  }
+
+  try {
+    const entries = await readdir(root, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const entryName = entry.name.toLowerCase();
+      if (entryName === normalizedId || entryName.startsWith(prefix)) {
+        matches.push(path.join(root, entry.name));
+      }
+    }
+  } catch {
+    // best-effort
+  }
+
+  return matches.sort((a, b) => a.localeCompare(b)).at(-1);
+}
+
+async function findLocalExtensionDirectory(extensionId: string): Promise<string | undefined> {
+  for (const root of getExtensionSearchRoots()) {
+    const match = await findExtensionDirectoryInRoot(root, extensionId);
+    if (match) {
+      return match;
+    }
+  }
+  return undefined;
+}
+
+async function findLocalExtensionsRootForDependencies(extensionIds: string[]): Promise<string | undefined> {
+  for (const root of getExtensionSearchRoots()) {
+    let allPresent = true;
+    for (const extensionId of extensionIds) {
+      const match = await findExtensionDirectoryInRoot(root, extensionId);
+      if (!match) {
+        allPresent = false;
+        break;
+      }
+    }
+    if (allPresent) {
+      return root;
+    }
+  }
+  return undefined;
+}
+
+async function copyLocalExtensionWithDependencies(
+  extensionId: string,
+  extensionsDir: string,
+  seen = new Set<string>()
+): Promise<boolean> {
+  const normalizedId = extensionId.toLowerCase();
+  if (seen.has(normalizedId)) {
+    return false;
+  }
+  seen.add(normalizedId);
+
+  const sourceDir = await findLocalExtensionDirectory(extensionId);
+  if (!sourceDir) {
+    return false;
+  }
+
+  const destDir = path.join(extensionsDir, path.basename(sourceDir));
+  await cp(sourceDir, destDir, { recursive: true, force: true });
+  console.log(`[e2e] Reused locally installed VS Code extension dependency: ${extensionId}`);
+
+  const nestedDeps = await readExtensionReferences(sourceDir);
+  for (const dep of nestedDeps) {
+    await copyLocalExtensionWithDependencies(dep, extensionsDir, seen);
+  }
+
+  return true;
 }
 
 function listInstalledExtensions(args: {
@@ -114,10 +223,10 @@ async function ensureExtensionDependenciesInstalled(args: {
   extensionDevelopmentPath: string;
   userDataDir: string;
   extensionsDir: string;
-}): Promise<void> {
-  const deps = await readExtensionDependencies(args.extensionDevelopmentPath);
+}): Promise<string> {
+  const deps = expandPreferredSalesforceExtensions(await readExtensionReferences(args.extensionDevelopmentPath));
   if (!deps.length) {
-    return;
+    return args.extensionsDir;
   }
 
   const cli = resolveCliArgsFromVSCodeExecutablePath(args.vscodeExecutablePath, { reuseMachineInstall: true });
@@ -125,10 +234,22 @@ async function ensureExtensionDependenciesInstalled(args: {
   const cliArgs = cli.slice(1);
   if (!cliPath) {
     console.warn('[e2e] Could not resolve VS Code CLI path; skipping dependency install.');
-    return;
+    return (await findLocalExtensionsRootForDependencies(deps)) || args.extensionsDir;
   }
 
-  const installed = listInstalledExtensions({
+  let installed = listInstalledExtensions({
+    cliPath,
+    cliArgs,
+    userDataDir: args.userDataDir,
+    extensionsDir: args.extensionsDir
+  });
+
+  const missingAfterInitialCheck = deps.filter(id => !installed.has(String(id).toLowerCase()));
+  for (const dep of missingAfterInitialCheck) {
+    await copyLocalExtensionWithDependencies(dep, args.extensionsDir);
+  }
+
+  installed = listInstalledExtensions({
     cliPath,
     cliArgs,
     userDataDir: args.userDataDir,
@@ -137,7 +258,7 @@ async function ensureExtensionDependenciesInstalled(args: {
 
   const toInstall = deps.filter(id => !installed.has(String(id).toLowerCase()));
   if (!toInstall.length) {
-    return;
+    return args.extensionsDir;
   }
 
   installExtensions({
@@ -147,6 +268,26 @@ async function ensureExtensionDependenciesInstalled(args: {
     extensionsDir: args.extensionsDir,
     extensionIds: toInstall
   });
+
+  installed = listInstalledExtensions({
+    cliPath,
+    cliArgs,
+    userDataDir: args.userDataDir,
+    extensionsDir: args.extensionsDir
+  });
+
+  const stillMissing = deps.filter(id => !installed.has(String(id).toLowerCase()));
+  if (!stillMissing.length) {
+    return args.extensionsDir;
+  }
+
+  const localRoot = await findLocalExtensionsRootForDependencies(deps);
+  if (localRoot) {
+    console.warn(`[e2e] Falling back to local VS Code extensions dir: ${localRoot}`);
+    return localRoot;
+  }
+
+  return args.extensionsDir;
 }
 
 async function isAuxiliaryBarOpen(page: Page): Promise<boolean> {
@@ -173,18 +314,24 @@ export async function launchVsCode(options: { workspacePath: string; extensionDe
   const vscodeExecutablePath = await downloadAndUnzipVSCode({ version: getVsCodeVersion(), cachePath: vscodeCachePath });
 
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
-  const extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
+  let extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
+  let shouldCleanupExtensionsDir = true;
 
   // The extension is loaded via --extensionDevelopmentPath, but VS Code still enforces
   // `extensionDependencies` at activation time. Install those dependencies into the
   // isolated extensions dir so contributed commands can activate the extension.
   try {
-    await ensureExtensionDependenciesInstalled({
+    const resolvedExtensionsDir = await ensureExtensionDependenciesInstalled({
       vscodeExecutablePath,
       extensionDevelopmentPath: options.extensionDevelopmentPath,
       userDataDir,
       extensionsDir
     });
+    if (resolvedExtensionsDir !== extensionsDir) {
+      await rm(extensionsDir, { recursive: true, force: true });
+      extensionsDir = resolvedExtensionsDir;
+      shouldCleanupExtensionsDir = false;
+    }
   } catch (e) {
     console.warn('[e2e] Failed to ensure VS Code extension dependencies are installed:', e);
   }
@@ -232,7 +379,9 @@ export async function launchVsCode(options: { workspacePath: string; extensionDe
       await app.close();
     } catch {}
     await rm(userDataDir, { recursive: true, force: true });
-    await rm(extensionsDir, { recursive: true, force: true });
+    if (shouldCleanupExtensionsDir) {
+      await rm(extensionsDir, { recursive: true, force: true });
+    }
   };
 
   return { app, page, userDataDir, extensionsDir, cleanup };


### PR DESCRIPTION
This change finishes the new DebugLevel management workflow inside Apex Debug Flags and also aligns the automated VS Code test environment with the Salesforce setup that real developers normally have installed.

Before this branch, the extension could list DebugLevels and apply TraceFlags, but it could not create, update, or delete DebugLevel records in the org. That forced users to leave the extension whenever they needed a custom DebugLevel or wanted to start from a preset and then tune fields one by one. It also meant our end-to-end coverage for this workflow was missing.

The root of the product change is that DebugLevel records are now first-class entities in the extension. The panel loads full DebugLevel details, exposes every editable flag field, lets the user start from scratch or from reusable presets, and performs real create, update, and delete operations against the org. The backend work adds the Tooling/CLI mutation paths for DebugLevel records, keeps the DebugLevel cache coherent after mutations, and broadens the shared message/type contracts so the webview can keep a local draft state, apply presets, reset changes, and refresh the selected record after saves. The webview and panel code now expose a dedicated Debug Level Manager section with field-by-field editing, user feedback, and delete/reset/save flows.

The test and developer-environment updates are included because the real-world Salesforce developer setup is usually the Salesforce Extension Pack, not only the standalone Replay Debugger. The integration and Playwright harnesses now prefer the full pack while still satisfying the extension's narrowed runtime dependency on the standalone Replay Debugger. When the isolated VS Code profile cannot install Marketplace dependencies, the harness falls back to locally installed VS Code extensions so the integration environment better matches a developer machine and is less flaky.

Validation completed on this branch includes `npm run build`, `npm run lint`, `npm run test:webview -- --runTestsByPath src/webview/__tests__/debugFlagsApp.test.tsx`, `npm run test:e2e:utils`, `npm run compile-tests`, `node scripts/run-tests.js --scope=unit --vscode=stable`, and `node scripts/run-tests.js --scope=integration --install-deps --timeout=900000`.

There is still one open item, so this PR is intentionally a draft: `npx playwright test test/e2e/specs/debugLevelManager.e2e.spec.ts --timeout=360000 --reporter=line` still fails in the save flow while waiting for the Debug Flags notice after clicking Save in the new DebugLevel Manager. The branch already contains the new E2E spec and the supporting harness work, but this final Playwright stabilization still needs to be resolved before the PR should be marked ready.