### PR TITLE
chore(release): prepare 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,23 @@
 
 ### Chores
 
-- Replay/testing: default development and integration-test dependency installs to the Salesforce Extension Pack, while still installing Apex Replay Debugger explicitly for isolated hosts and keeping the published runtime dependency narrowed.
+### Tests
+
+## [0.28.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.26.0...v0.28.0) (2026-03-08)
+
+### Features
+
+- Debug Flags: add a `Debug Level Manager` to create, edit, preset, and delete `DebugLevel` records directly in the panel while keeping the existing `USER_DEBUG` trace-flag flow intact. ([#569](https://github.com/Electivus/Apex-Log-Viewer/pull/569))
+
+### Chores
+
+- Replay/testing: default development and integration-test dependency installs to the Salesforce Extension Pack, while still installing Apex Replay Debugger explicitly for isolated hosts and keeping the published runtime dependency narrowed. ([#569](https://github.com/Electivus/Apex-Log-Viewer/pull/569))
+- Dependencies/workflows: update selected runtime/dev packages and GitHub Actions artifact steps across CI and nightly pre-release packaging. ([#550](https://github.com/Electivus/Apex-Log-Viewer/pull/550)) ([#552](https://github.com/Electivus/Apex-Log-Viewer/pull/552)) ([#553](https://github.com/Electivus/Apex-Log-Viewer/pull/553)) ([#554](https://github.com/Electivus/Apex-Log-Viewer/pull/554)) ([#555](https://github.com/Electivus/Apex-Log-Viewer/pull/555)) ([#557](https://github.com/Electivus/Apex-Log-Viewer/pull/557)) ([#558](https://github.com/Electivus/Apex-Log-Viewer/pull/558)) ([#559](https://github.com/Electivus/Apex-Log-Viewer/pull/559)) ([#560](https://github.com/Electivus/Apex-Log-Viewer/pull/560)) ([#561](https://github.com/Electivus/Apex-Log-Viewer/pull/561)) ([#562](https://github.com/Electivus/Apex-Log-Viewer/pull/562)) ([#563](https://github.com/Electivus/Apex-Log-Viewer/pull/563)) ([#564](https://github.com/Electivus/Apex-Log-Viewer/pull/564)) ([#565](https://github.com/Electivus/Apex-Log-Viewer/pull/565))
+- Docs: document the stable release checklist for maintainers. ([#568](https://github.com/Electivus/Apex-Log-Viewer/pull/568))
 
 ### Tests
+
+- Debug Flags: add unit, webview, and Playwright E2E coverage for `DebugLevel` CRUD and compatible tooling queries used by the new manager flow. ([#569](https://github.com/Electivus/Apex-Log-Viewer/pull/569))
 
 ## [0.26.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.24.0...v0.26.0) (2026-03-02)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.26.0",
+  "version": "0.28.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.26.0",
+      "version": "0.28.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.26.0",
+  "version": "0.28.0",
   "publisher": "electivus",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Prepare the **stable** release `v0.28.0` (even minor => stable channel).

Changes:
- Bump version to `0.28.0` (`package.json` + `package-lock.json`).
- Move release notes into `CHANGELOG.md` for `0.28.0` (since last stable `v0.26.0`).

Included work since `v0.26.0`:
- #569 Debug Level Manager for Debug Flags
- #550, #552, #553, #554, #555, #557, #558, #559, #560, #561, #562, #563, #564, #565 dependency/workflow updates
- #568 stable release checklist documentation
- #570 repo agent-instruction refresh

Pre-tag verification:
- `CHANGELOG.md`: Confirmed. This PR adds a `0.28.0` section covering the merged work since `v0.26.0`.
- Migrations: Confirmed no dedicated migration scripts/framework were found in tracked files searched via `git grep "migrat"` outside `CHANGELOG.md` and plan docs. External/runtime migration requirements: Unknown.
- Feature flags: Confirmed no new feature-flag settings were added in `package.json` between `v0.26.0` and `main`. Existing `electivus.apexLogs.*` settings remain; no new release gates were found.
- Tests: Confirmed GitHub CI succeeded on `main` for commit `e14714e` on 2026-03-06 and commit `3160237` on 2026-03-08, and the nightly pre-release workflow succeeded on `main` on 2026-03-08.
  - CI run (2026-03-06): https://github.com/Electivus/Apex-Log-Viewer/actions/runs/22775159748
  - CI run (2026-03-08): https://github.com/Electivus/Apex-Log-Viewer/actions/runs/22810029269
  - Pre-release run (2026-03-08): https://github.com/Electivus/Apex-Log-Viewer/actions/runs/22813237465
  - Local `npm run build`: Unknown
  - Local `npm run test:ci`: Unknown

After merge:
- Create and push tag `v0.28.0` to trigger the Release workflow.
  - `git tag -a v0.28.0 -m "v0.28.0" && git push origin v0.28.0`
