### PR TITLE
chore(release): prepare 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,17 @@
 
 ### Features
 
-- Telemetry: enable the published VSIX to send production App Insights events through the checked-in connection string while preserving VS Code opt-out and environment-variable overrides.
-
 ### Bug Fixes
 
 ### Chores
 
 ### Tests
+
+## [0.30.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.28.0...v0.30.0) (2026-03-08)
+
+### Features
+
+- Telemetry: enable the published VSIX to send production App Insights events through the checked-in connection string while preserving VS Code opt-out and environment-variable overrides. ([#572](https://github.com/Electivus/Apex-Log-Viewer/pull/572))
 
 ## [0.28.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.26.0...v0.28.0) (2026-03-08)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.28.0",
+  "version": "0.30.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.28.0",
+      "version": "0.30.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.28.0",
+  "version": "0.30.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the extension version from `0.28.0` to `0.30.0`
- promote the unreleased telemetry/App Insights change into the `0.30.0` changelog section
- keep `Unreleased` ready for the next pre-release cycle

## Release numbering
- `0.28.0` is the previous stable release
- we are intentionally preparing `0.30.0` as the next stable release to preserve the even-minor stable / odd-minor pre-release cadence

## Verification
- `npm run build`
- `npm run test:webview -- --ci --runInBand`
- `npm run test:e2e:utils`
- `npm run pretest`
- `bash scripts/run-tests.sh --scope=unit --vscode=stable`
- `bash scripts/run-tests.sh --scope=integration --vscode=stable --install-deps --timeout=900000`

## Notes
- I also re-attempted `npm run test:ci` after fixing bash visibility for `node`, but the top-level wrapper became noisy/hung in this local VS Code extension environment.
- The underlying unit and integration runners above both completed successfully with exit code `0`.