### PR TITLE
[codex] feat(activation): support hybrid salesforce workspace startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,15 @@
 
 ### Features
 
+- Activation: auto-activate when the open workspace contains `sfdx-project.json`, while keeping standalone Apex log files and explicit Apex Logs commands working on demand.
+
 ### Bug Fixes
 
 ### Chores
 
 ### Tests
+
+- Activation: add unit coverage for multi-root Salesforce project detection and for gating `sourceApiVersion`/CLI preload work behind Salesforce-project-aware activation.
 
 ## [0.30.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.28.0...v0.30.0) (2026-03-08)
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Why developers like it
 
 ## Usage
 
+The extension activates automatically when the open workspace contains `sfdx-project.json`. Outside a Salesforce workspace, opening a standalone Apex log or running one of the Apex Logs commands still activates it on demand.
+
 ### Open the Apex Logs panel
 
 1. In VS Code, choose `View` > `Appearance` > `Panel`.
@@ -111,7 +113,7 @@ Why developers like it
 
 See [docs/SETTINGS.md](docs/SETTINGS.md) for more details on configuration.
 
-API version is automatically taken from your workspace `sfdx-project.json` (`sourceApiVersion`).
+API version is automatically taken from the first workspace folder that contains `sfdx-project.json` (`sourceApiVersion`).
 
 ## Localization
 

--- a/package.json
+++ b/package.json
@@ -50,15 +50,7 @@
     "Other"
   ],
   "activationEvents": [
-    "onView:sfLogViewer",
-    "onView:sfLogTail",
-    "onCommand:sfLogs.refresh",
-    "onCommand:sfLogs.selectOrg",
-    "onCommand:sfLogs.tail",
-    "onCommand:sfLogs.showOutput",
-    "onCommand:sfLogs.resetCliCache",
-    "onCommand:sfLogs.openLogInViewer",
-    "onLanguage:apexlog"
+    "workspaceContains:sfdx-project.json"
   ],
   "extensionDependencies": ["salesforce.salesforcedx-vscode-apex-replay-debugger"],
   "main": "./dist/extension.js",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -78,10 +78,6 @@ export async function activate(context: vscode.ExtensionContext) {
   if (salesforceProject?.sourceApiVersion) {
     setApiVersion(salesforceProject.sourceApiVersion);
     logInfo('Detected sourceApiVersion from sfdx-project.json:', salesforceProject.sourceApiVersion);
-  } else if (salesforceProject?.parseErrorMessage) {
-    logWarn('Could not parse sfdx-project.json for sourceApiVersion ->', salesforceProject.parseErrorMessage);
-  } else if (salesforceProject?.readErrorMessage) {
-    logWarn('Could not read sfdx-project.json for sourceApiVersion ->', salesforceProject.readErrorMessage);
   } else if (hasSalesforceProject) {
     logInfo('Detected Salesforce project workspace at', salesforceProject.workspaceRoot);
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,6 @@ import { SfLogsViewProvider } from './provider/SfLogsViewProvider';
 import { SfLogTailViewProvider } from './provider/SfLogTailViewProvider';
 import type { OrgItem } from './shared/types';
 import * as path from 'path';
-import { promises as fs } from 'fs';
 import { setApiVersion, getApiVersion, clearListCache } from './salesforce/http';
 import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger } from './utils/logger';
 import { localize } from './utils/localize';
@@ -14,7 +13,7 @@ import { DebugFlagsPanel } from './panel/DebugFlagsPanel';
 import { getBooleanConfig, affectsConfiguration } from './utils/config';
 import { getErrorMessage } from './utils/error';
 import { listOrgs, getOrgAuth } from './salesforce/cli';
-import { isApexLogDocument, getLogIdFromLogFilePath } from './utils/workspace';
+import { findSalesforceProjectInfo, isApexLogDocument, getLogIdFromLogFilePath } from './utils/workspace';
 import { ApexLogCodeLensProvider } from './provider/ApexLogCodeLensProvider';
 
 interface OrgQuickPick extends vscode.QuickPickItem {
@@ -30,6 +29,8 @@ export async function activate(context: vscode.ExtensionContext) {
   const activationStart = Date.now();
   LogViewerPanel.initialize(context);
   DebugFlagsPanel.initialize(context);
+  const salesforceProject = await findSalesforceProjectInfo();
+  const hasSalesforceProject = !!salesforceProject;
   // Init TTL cache (best-effort; no-op if unavailable)
   try {
     await initializePersistentCache(context);
@@ -46,7 +47,8 @@ export async function activate(context: vscode.ExtensionContext) {
   safeSendEvent('extension.activate', {
     vscodeVersion: vscode.version,
     platform: process.platform,
-    hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0)
+    hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0),
+    hasSalesforceProject: String(hasSalesforceProject)
   });
   // Avoid @salesforce/core attempting to spawn Pino transports that fail when bundled
   try {
@@ -73,26 +75,15 @@ export async function activate(context: vscode.ExtensionContext) {
     const msg = getErrorMessage(e);
     logWarn('Failed to configure trace logging ->', msg);
   }
-  // Try to read sourceApiVersion from sfdx-project.json (first workspace folder)
-  const folders = vscode.workspace.workspaceFolders;
-  if (folders && folders.length > 0) {
-    const root = folders[0]!.uri.fsPath;
-    const proj = path.join(root, 'sfdx-project.json');
-    try {
-      const txt = await fs.readFile(proj, 'utf8');
-      try {
-        const json = JSON.parse(txt);
-        const v = (json && json.sourceApiVersion) as string | undefined;
-        if (v) {
-          setApiVersion(v);
-          logInfo('Detected sourceApiVersion from sfdx-project.json:', v);
-        }
-      } catch (e) {
-        logWarn('Could not parse sfdx-project.json for sourceApiVersion ->', getErrorMessage(e));
-      }
-    } catch (e) {
-      logInfo('No sfdx-project.json found in first workspace folder ->', getErrorMessage(e));
-    }
+  if (salesforceProject?.sourceApiVersion) {
+    setApiVersion(salesforceProject.sourceApiVersion);
+    logInfo('Detected sourceApiVersion from sfdx-project.json:', salesforceProject.sourceApiVersion);
+  } else if (salesforceProject?.parseErrorMessage) {
+    logWarn('Could not parse sfdx-project.json for sourceApiVersion ->', salesforceProject.parseErrorMessage);
+  } else if (salesforceProject?.readErrorMessage) {
+    logWarn('Could not read sfdx-project.json for sourceApiVersion ->', salesforceProject.readErrorMessage);
+  } else if (hasSalesforceProject) {
+    logInfo('Detected Salesforce project workspace at', salesforceProject.workspaceRoot);
   }
   const provider = new SfLogsViewProvider(context);
   context.subscriptions.push(
@@ -259,7 +250,7 @@ export async function activate(context: vscode.ExtensionContext) {
     const enabled = getBooleanConfig('sfLogs.cliCache.enabled', true);
     // Heuristic: skip when running inside VS Code test harness to avoid interfering with unit tests
     const isVsCodeTestHost = /\.vscode-test\b/i.test(String((vscode.env as any)?.appRoot || ''));
-    if (enabled && !isVsCodeTestHost) {
+    if (enabled && hasSalesforceProject && !isVsCodeTestHost) {
       setTimeout(async () => {
         try {
           logInfo('Preloading CLI caches (org list, default auth)…');
@@ -281,6 +272,8 @@ export async function activate(context: vscode.ExtensionContext) {
           logWarn('Preloading CLI caches failed ->', getErrorMessage(e));
         }
       }, 0);
+    } else if (enabled && !hasSalesforceProject) {
+      logInfo('Skipping CLI cache preload because no sfdx-project.json was found in the workspace.');
     }
   } catch (e) {
     logWarn('Failed to schedule CLI cache preload ->', getErrorMessage(e));

--- a/src/test/extension.activation.gating.test.ts
+++ b/src/test/extension.activation.gating.test.ts
@@ -1,0 +1,286 @@
+import assert from 'assert/strict';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+type RegisteredCommand = (...args: any[]) => Promise<unknown> | unknown;
+
+function createDisposable() {
+  return { dispose: () => undefined };
+}
+
+function createContext() {
+  return {
+    subscriptions: [],
+    globalState: {
+      get: () => undefined,
+      update: async () => undefined,
+      keys: () => []
+    }
+  } as any;
+}
+
+function createExtensionHarness(options: {
+  salesforceProject?: {
+    workspaceRoot: string;
+    projectFilePath: string;
+    sourceApiVersion?: string;
+    readErrorMessage?: string;
+    parseErrorMessage?: string;
+  };
+  cliCacheEnabled?: boolean;
+  appRoot?: string;
+  activeDocument?: any;
+  isApexLogDocument?: boolean;
+  logId?: string;
+  orgs?: Array<{ username: string; isDefaultUsername?: boolean }>;
+}) {
+  const commands = new Map<string, RegisteredCommand>();
+  const events: Array<{ name: string; props?: Record<string, string> }> = [];
+  const setApiVersionCalls: string[] = [];
+  const timeoutCallbacks: Array<() => Promise<void> | void> = [];
+  const listOrgsCalls: boolean[] = [];
+  const getOrgAuthCalls: Array<string | undefined> = [];
+  const logViewerShows: Array<{ logId: string; filePath: string }> = [];
+  const infoMessages: string[] = [];
+  const warningMessages: string[] = [];
+  const errorMessages: string[] = [];
+
+  const vscodeStub = {
+    version: '1.101.0',
+    env: {
+      appRoot: options.appRoot ?? '/usr/share/code'
+    },
+    workspace: {
+      workspaceFolders: options.salesforceProject ? [{ uri: { fsPath: options.salesforceProject.workspaceRoot } }] : [],
+      onDidChangeConfiguration: () => createDisposable(),
+      openTextDocument: async () => options.activeDocument
+    },
+    window: {
+      activeTextEditor: options.activeDocument ? { document: options.activeDocument } : undefined,
+      registerWebviewViewProvider: () => createDisposable(),
+      showWarningMessage: async (message: string) => {
+        warningMessages.push(message);
+        return undefined;
+      },
+      showErrorMessage: async (message: string) => {
+        errorMessages.push(message);
+        return undefined;
+      },
+      showInformationMessage: async (message: string) => {
+        infoMessages.push(message);
+        return undefined;
+      }
+    },
+    commands: {
+      registerCommand: (command: string, handler: RegisteredCommand) => {
+        commands.set(command, handler);
+        return createDisposable();
+      },
+      executeCommand: async () => undefined
+    },
+    languages: {
+      registerCodeLensProvider: () => createDisposable()
+    }
+  };
+
+  class FakeLogsViewProvider {
+    public static viewType = 'sfLogViewer';
+
+    constructor(_context: any) {}
+
+    public hasResolvedView(): boolean {
+      return false;
+    }
+
+    public async refresh(): Promise<void> {}
+
+    public async sendOrgs(): Promise<void> {}
+
+    public setSelectedOrg(_username: string): void {}
+
+    public async tailLogs(): Promise<void> {}
+  }
+
+  class FakeTailViewProvider {
+    public static viewType = 'sfLogTail';
+
+    constructor(_context: any) {}
+  }
+
+  class FakeCodeLensProvider {}
+
+  const extension = proxyquireStrict('../extension', {
+    vscode: vscodeStub,
+    './provider/SfLogsViewProvider': { SfLogsViewProvider: FakeLogsViewProvider },
+    './provider/SfLogTailViewProvider': { SfLogTailViewProvider: FakeTailViewProvider },
+    './provider/ApexLogCodeLensProvider': { ApexLogCodeLensProvider: FakeCodeLensProvider },
+    './panel/LogViewerPanel': {
+      LogViewerPanel: {
+        initialize: () => undefined,
+        show: async (args: { logId: string; filePath: string }) => {
+          logViewerShows.push(args);
+        }
+      }
+    },
+    './panel/DebugFlagsPanel': {
+      DebugFlagsPanel: {
+        initialize: () => undefined
+      }
+    },
+    './salesforce/http': {
+      setApiVersion: (value?: string) => {
+        if (value) {
+          setApiVersionCalls.push(value);
+        }
+      },
+      getApiVersion: () => '64.0',
+      clearListCache: () => undefined
+    },
+    './utils/logger': {
+      logInfo: () => undefined,
+      logWarn: () => undefined,
+      logError: () => undefined,
+      showOutput: () => undefined,
+      setTraceEnabled: () => undefined,
+      disposeLogger: () => undefined
+    },
+    './utils/localize': {
+      localize: (_key: string, defaultValue: string, ...args: Array<string | number>) =>
+        defaultValue.replace(/\{(\d+)\}/g, (_match: string, index: string) => String(args[Number(index)] ?? ''))
+    },
+    './shared/telemetry': {
+      activateTelemetry: () => undefined,
+      safeSendEvent: (name: string, props?: Record<string, string>) => {
+        events.push({ name, props });
+      },
+      safeSendException: () => undefined,
+      disposeTelemetry: () => undefined
+    },
+    './utils/cacheManager': {
+      CacheManager: {
+        init: () => undefined,
+        clearExpired: async () => undefined,
+        delete: async () => undefined
+      }
+    },
+    './utils/config': {
+      getBooleanConfig: (key: string, fallback: boolean) => {
+        if (key === 'sfLogs.cliCache.enabled') {
+          return options.cliCacheEnabled ?? fallback;
+        }
+        return fallback;
+      },
+      affectsConfiguration: () => false
+    },
+    './utils/error': {
+      getErrorMessage: (error: unknown) => (error instanceof Error ? error.message : String(error))
+    },
+    './salesforce/cli': {
+      listOrgs: async (forceRefresh = false) => {
+        listOrgsCalls.push(forceRefresh);
+        return options.orgs ?? [];
+      },
+      getOrgAuth: async (username?: string) => {
+        getOrgAuthCalls.push(username);
+        return { username };
+      }
+    },
+    './utils/workspace': {
+      findSalesforceProjectInfo: async () => options.salesforceProject,
+      isApexLogDocument: () => options.isApexLogDocument ?? true,
+      getLogIdFromLogFilePath: () => options.logId
+    }
+  });
+
+  return {
+    extension,
+    commands,
+    events,
+    setApiVersionCalls,
+    timeoutCallbacks,
+    listOrgsCalls,
+    getOrgAuthCalls,
+    logViewerShows,
+    infoMessages,
+    warningMessages,
+    errorMessages
+  };
+}
+
+suite('extension activation gating', () => {
+  let originalSetTimeout: typeof globalThis.setTimeout;
+
+  setup(() => {
+    originalSetTimeout = globalThis.setTimeout;
+  });
+
+  teardown(() => {
+    globalThis.setTimeout = originalSetTimeout;
+  });
+
+  test('keeps on-demand commands available without a Salesforce project and skips project preload', async () => {
+    const filePath = path.join(process.cwd(), 'tmp', 'standalone.log');
+    const activeDocument = {
+      isClosed: false,
+      uri: { scheme: 'file', fsPath: filePath },
+      fileName: filePath
+    };
+    const harness = createExtensionHarness({
+      activeDocument,
+      logId: '07L000000000123'
+    });
+    (globalThis as any).setTimeout = (callback: () => Promise<void> | void) => {
+      harness.timeoutCallbacks.push(callback);
+      return 1;
+    };
+
+    await harness.extension.activate(createContext());
+
+    assert.deepEqual(harness.setApiVersionCalls, []);
+    assert.equal(harness.timeoutCallbacks.length, 0, 'should not schedule CLI preload outside Salesforce projects');
+    assert.ok(harness.commands.has('sfLogs.refresh'), 'refresh command should stay registered');
+    assert.ok(harness.commands.has('sfLogs.openLogInViewer'), 'open log viewer command should stay registered');
+
+    const activationEvent = harness.events.find(event => event.name === 'extension.activate');
+    assert.equal(activationEvent?.props?.hasSalesforceProject, 'false');
+
+    await harness.commands.get('sfLogs.openLogInViewer')!();
+
+    assert.deepEqual(harness.logViewerShows, [{ logId: '07L000000000123', filePath }]);
+    assert.deepEqual(harness.warningMessages, []);
+    assert.deepEqual(harness.errorMessages, []);
+  });
+
+  test('applies sourceApiVersion and schedules CLI preload when a Salesforce project is present', async () => {
+    const harness = createExtensionHarness({
+      salesforceProject: {
+        workspaceRoot: path.join(process.cwd(), 'workspace-salesforce'),
+        projectFilePath: path.join(process.cwd(), 'workspace-salesforce', 'sfdx-project.json'),
+        sourceApiVersion: '60.0'
+      },
+      orgs: [
+        { username: 'first@example.com' },
+        { username: 'default@example.com', isDefaultUsername: true }
+      ]
+    });
+    (globalThis as any).setTimeout = (callback: () => Promise<void> | void) => {
+      harness.timeoutCallbacks.push(callback);
+      return 1;
+    };
+
+    await harness.extension.activate(createContext());
+
+    assert.deepEqual(harness.setApiVersionCalls, ['60.0']);
+    assert.equal(harness.timeoutCallbacks.length, 1, 'should schedule CLI preload for Salesforce projects');
+
+    const activationEvent = harness.events.find(event => event.name === 'extension.activate');
+    assert.equal(activationEvent?.props?.hasSalesforceProject, 'true');
+
+    await harness.timeoutCallbacks[0]!();
+
+    assert.deepEqual(harness.listOrgsCalls, [false]);
+    assert.deepEqual(harness.getOrgAuthCalls, ['default@example.com']);
+  });
+});

--- a/src/test/salesforceProjectDetection.test.ts
+++ b/src/test/salesforceProjectDetection.test.ts
@@ -19,10 +19,10 @@ function createVscodeStub(workspaceFolders: Array<{ uri: { fsPath: string } }>) 
 }
 
 suite('findSalesforceProjectInfo', () => {
-  test('finds the first Salesforce project across multi-root workspaces', async () => {
-    const plainRoot = path.join('/tmp', 'alv-plain-root');
+  test('keeps scanning later roots when an earlier project file is unreadable', async () => {
+    const blockedRoot = path.join('/tmp', 'alv-blocked-root');
     const sfRoot = path.join('/tmp', 'alv-salesforce-root');
-    const plainProject = path.join(plainRoot, 'sfdx-project.json');
+    const blockedProject = path.join(blockedRoot, 'sfdx-project.json');
     const sfProject = path.join(sfRoot, 'sfdx-project.json');
     const readCalls: string[] = [];
 
@@ -31,15 +31,15 @@ suite('findSalesforceProjectInfo', () => {
         logInfo: () => undefined,
         logWarn: () => undefined
       },
-      vscode: createVscodeStub([{ uri: { fsPath: plainRoot } }, { uri: { fsPath: sfRoot } }]),
+      vscode: createVscodeStub([{ uri: { fsPath: blockedRoot } }, { uri: { fsPath: sfRoot } }]),
       fs: {
         promises: {
           readFile: async (filePath: string, encoding: string): Promise<string> => {
             assert.equal(encoding, 'utf8');
             readCalls.push(filePath);
-            if (filePath === plainProject) {
-              const error: NodeJS.ErrnoException = new Error('missing project file');
-              error.code = 'ENOENT';
+            if (filePath === blockedProject) {
+              const error: NodeJS.ErrnoException = new Error('project file is unreadable');
+              error.code = 'EACCES';
               throw error;
             }
             if (filePath === sfProject) {
@@ -57,7 +57,7 @@ suite('findSalesforceProjectInfo', () => {
       projectFilePath: sfProject,
       sourceApiVersion: '62.0'
     });
-    assert.deepEqual(readCalls, [plainProject, sfProject]);
+    assert.deepEqual(readCalls, [blockedProject, sfProject]);
   });
 
   test('returns undefined when no workspace folder has sfdx-project.json', async () => {

--- a/src/test/salesforceProjectDetection.test.ts
+++ b/src/test/salesforceProjectDetection.test.ts
@@ -1,0 +1,87 @@
+import assert from 'assert/strict';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru();
+
+function createVscodeStub(workspaceFolders: Array<{ uri: { fsPath: string } }>) {
+  return {
+    workspace: { workspaceFolders },
+    Range: class {
+      constructor(
+        public readonly startLine: number,
+        public readonly startCharacter: number,
+        public readonly endLine: number,
+        public readonly endCharacter: number
+      ) {}
+    }
+  };
+}
+
+suite('findSalesforceProjectInfo', () => {
+  test('finds the first Salesforce project across multi-root workspaces', async () => {
+    const plainRoot = path.join('/tmp', 'alv-plain-root');
+    const sfRoot = path.join('/tmp', 'alv-salesforce-root');
+    const plainProject = path.join(plainRoot, 'sfdx-project.json');
+    const sfProject = path.join(sfRoot, 'sfdx-project.json');
+    const readCalls: string[] = [];
+
+    const workspaceModule: typeof import('../utils/workspace') = proxyquireStrict('../utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: createVscodeStub([{ uri: { fsPath: plainRoot } }, { uri: { fsPath: sfRoot } }]),
+      fs: {
+        promises: {
+          readFile: async (filePath: string, encoding: string): Promise<string> => {
+            assert.equal(encoding, 'utf8');
+            readCalls.push(filePath);
+            if (filePath === plainProject) {
+              const error: NodeJS.ErrnoException = new Error('missing project file');
+              error.code = 'ENOENT';
+              throw error;
+            }
+            if (filePath === sfProject) {
+              return JSON.stringify({ sourceApiVersion: '62.0' });
+            }
+            throw new Error(`Unexpected readFile: ${filePath}`);
+          }
+        }
+      }
+    });
+
+    const info = await workspaceModule.findSalesforceProjectInfo();
+    assert.deepEqual(info, {
+      workspaceRoot: sfRoot,
+      projectFilePath: sfProject,
+      sourceApiVersion: '62.0'
+    });
+    assert.deepEqual(readCalls, [plainProject, sfProject]);
+  });
+
+  test('returns undefined when no workspace folder has sfdx-project.json', async () => {
+    const firstRoot = path.join('/tmp', 'alv-root-a');
+    const secondRoot = path.join('/tmp', 'alv-root-b');
+
+    const workspaceModule: typeof import('../utils/workspace') = proxyquireStrict('../utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: createVscodeStub([{ uri: { fsPath: firstRoot } }, { uri: { fsPath: secondRoot } }]),
+      fs: {
+        promises: {
+          readFile: async (): Promise<string> => {
+            const error: NodeJS.ErrnoException = new Error('missing project file');
+            error.code = 'ENOENT';
+            throw error;
+          }
+        }
+      }
+    });
+
+    const info = await workspaceModule.findSalesforceProjectInfo();
+    assert.equal(info, undefined);
+  });
+});

--- a/src/test/salesforceProjectDetection.test.ts
+++ b/src/test/salesforceProjectDetection.test.ts
@@ -84,4 +84,28 @@ suite('findSalesforceProjectInfo', () => {
     const info = await workspaceModule.findSalesforceProjectInfo();
     assert.equal(info, undefined);
   });
+
+  test('returns undefined when only unreadable project files are seen', async () => {
+    const blockedRoot = path.join('/tmp', 'alv-blocked-root');
+
+    const workspaceModule: typeof import('../utils/workspace') = proxyquireStrict('../utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: createVscodeStub([{ uri: { fsPath: blockedRoot } }]),
+      fs: {
+        promises: {
+          readFile: async (): Promise<string> => {
+            const error: NodeJS.ErrnoException = new Error('project file is unreadable');
+            error.code = 'EACCES';
+            throw error;
+          }
+        }
+      }
+    });
+
+    const info = await workspaceModule.findSalesforceProjectInfo();
+    assert.equal(info, undefined);
+  });
 });

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -4,7 +4,22 @@ import * as path from 'path';
 import { promises as fs } from 'fs';
 import { logInfo, logWarn } from './logger';
 
+export interface SalesforceProjectInfo {
+  workspaceRoot: string;
+  projectFilePath: string;
+  sourceApiVersion?: string;
+  readErrorMessage?: string;
+  parseErrorMessage?: string;
+}
+
 let gitignoreUpdateQueue: Promise<void> = Promise.resolve();
+
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return String(error);
+}
 
 async function withGitignoreUpdateLock(operation: () => Promise<void>): Promise<void> {
   const current = gitignoreUpdateQueue.then(operation, operation);
@@ -18,6 +33,57 @@ export function getWorkspaceRoot(): string | undefined {
   if (folders && folders.length > 0) {
     return folders[0]!.uri.fsPath;
   }
+  return undefined;
+}
+
+/**
+ * Find the first workspace folder that contains `sfdx-project.json`.
+ *
+ * The search order follows VS Code's multi-root workspace folder order so the
+ * runtime matches the `workspaceContains:sfdx-project.json` activation behavior.
+ */
+export async function findSalesforceProjectInfo(
+  workspaceFolders: readonly Pick<vscode.WorkspaceFolder, 'uri'>[] | undefined = vscode.workspace.workspaceFolders
+): Promise<SalesforceProjectInfo | undefined> {
+  for (const folder of workspaceFolders ?? []) {
+    const workspaceRoot = folder.uri.fsPath;
+    const projectFilePath = path.join(workspaceRoot, 'sfdx-project.json');
+
+    let rawProject: string;
+    try {
+      rawProject = await fs.readFile(projectFilePath, 'utf8');
+    } catch (error: any) {
+      const code = String(error?.code || '');
+      if (code === 'ENOENT' || code === 'ENOTDIR') {
+        continue;
+      }
+      return {
+        workspaceRoot,
+        projectFilePath,
+        readErrorMessage: getErrorMessage(error)
+      };
+    }
+
+    try {
+      const parsed = JSON.parse(rawProject);
+      const sourceApiVersion =
+        typeof parsed?.sourceApiVersion === 'string' && parsed.sourceApiVersion.trim().length > 0
+          ? parsed.sourceApiVersion.trim()
+          : undefined;
+      return {
+        workspaceRoot,
+        projectFilePath,
+        sourceApiVersion
+      };
+    } catch (error) {
+      return {
+        workspaceRoot,
+        projectFilePath,
+        parseErrorMessage: getErrorMessage(error)
+      };
+    }
+  }
+
   return undefined;
 }
 

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -8,8 +8,6 @@ export interface SalesforceProjectInfo {
   workspaceRoot: string;
   projectFilePath: string;
   sourceApiVersion?: string;
-  readErrorMessage?: string;
-  parseErrorMessage?: string;
 }
 
 let gitignoreUpdateQueue: Promise<void> = Promise.resolve();
@@ -45,8 +43,6 @@ export function getWorkspaceRoot(): string | undefined {
 export async function findSalesforceProjectInfo(
   workspaceFolders: readonly Pick<vscode.WorkspaceFolder, 'uri'>[] | undefined = vscode.workspace.workspaceFolders
 ): Promise<SalesforceProjectInfo | undefined> {
-  let firstProjectIssue: SalesforceProjectInfo | undefined;
-
   for (const folder of workspaceFolders ?? []) {
     const workspaceRoot = folder.uri.fsPath;
     const projectFilePath = path.join(workspaceRoot, 'sfdx-project.json');
@@ -59,11 +55,6 @@ export async function findSalesforceProjectInfo(
       if (code === 'ENOENT' || code === 'ENOTDIR') {
         continue;
       }
-      firstProjectIssue ??= {
-        workspaceRoot,
-        projectFilePath,
-        readErrorMessage: getErrorMessage(error)
-      };
       continue;
     }
 
@@ -79,15 +70,11 @@ export async function findSalesforceProjectInfo(
         sourceApiVersion
       };
     } catch (error) {
-      firstProjectIssue ??= {
-        workspaceRoot,
-        projectFilePath,
-        parseErrorMessage: getErrorMessage(error)
-      };
+      logWarn('Could not parse sfdx-project.json while scanning workspace roots ->', getErrorMessage(error));
     }
   }
 
-  return firstProjectIssue;
+  return undefined;
 }
 
 /** Resolve the `apexlogs` directory path (workspace or temp) without creating it. */

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -45,6 +45,8 @@ export function getWorkspaceRoot(): string | undefined {
 export async function findSalesforceProjectInfo(
   workspaceFolders: readonly Pick<vscode.WorkspaceFolder, 'uri'>[] | undefined = vscode.workspace.workspaceFolders
 ): Promise<SalesforceProjectInfo | undefined> {
+  let firstProjectIssue: SalesforceProjectInfo | undefined;
+
   for (const folder of workspaceFolders ?? []) {
     const workspaceRoot = folder.uri.fsPath;
     const projectFilePath = path.join(workspaceRoot, 'sfdx-project.json');
@@ -57,11 +59,12 @@ export async function findSalesforceProjectInfo(
       if (code === 'ENOENT' || code === 'ENOTDIR') {
         continue;
       }
-      return {
+      firstProjectIssue ??= {
         workspaceRoot,
         projectFilePath,
         readErrorMessage: getErrorMessage(error)
       };
+      continue;
     }
 
     try {
@@ -76,7 +79,7 @@ export async function findSalesforceProjectInfo(
         sourceApiVersion
       };
     } catch (error) {
-      return {
+      firstProjectIssue ??= {
         workspaceRoot,
         projectFilePath,
         parseErrorMessage: getErrorMessage(error)
@@ -84,7 +87,7 @@ export async function findSalesforceProjectInfo(
     }
   }
 
-  return undefined;
+  return firstProjectIssue;
 }
 
 /** Resolve the `apexlogs` directory path (workspace or temp) without creating it. */


### PR DESCRIPTION
## Summary
This change makes the extension activate automatically when a workspace contains `sfdx-project.json`, while keeping the existing on-demand flows for standalone Apex log files and explicit Apex Logs commands.

Before this change, Salesforce workspaces only got the extension's startup work after a user opened one of the extension views, ran one of its commands, or opened an `apexlog` document. That delayed `sourceApiVersion` discovery and CLI cache warming in the workspace where those behaviors are most useful. At the same time, once activation happened, the runtime always attempted workspace-specific initialization even if the extension had only been activated to open a standalone log outside a Salesforce project.

The root cause was a mismatch between the manifest and the runtime. The manifest still listed explicit `onCommand`, `onView`, and `onLanguage` activation events that are redundant for our VS Code target, and the activation path assumed the first workspace folder was the only place worth checking for `sfdx-project.json`.

## Fix
The manifest now uses `workspaceContains:sfdx-project.json` for proactive activation in Salesforce projects. The runtime now resolves Salesforce project context through a dedicated helper that scans workspace folders in order, so multi-root workspaces align with the activation event and `sourceApiVersion` comes from the first matching Salesforce project folder instead of blindly reading only the first workspace root.

Project-specific startup work is now gated behind that Salesforce-project detection. We still register commands, views, and CodeLens providers regardless, so opening a standalone Apex log or invoking an Apex Logs command outside a Salesforce workspace continues to work. The workspace-specific parts that are now gated are the `sourceApiVersion` read and the background CLI cache preload.

This PR also updates the README and changelog to document the new hybrid activation behavior.

## Validation
I validated the change with:

- `npm ci`
- `npm run check-types`
- `npm run compile-tests`
- `npm run compile`
- `npx mocha --ui tdd out/test/extension.activation.gating.test.js out/test/salesforceProjectDetection.test.js`
