### PR TITLE
fix: lazily activate replay debugger and stabilize e2e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,16 @@
 
 ### Bug Fixes
 
+- Replay: remove the Apex Replay Debugger as a hard startup dependency so the extension activates without waiting on Replay Debugger and still loads replay support lazily on demand.
+
 ### Chores
+
+- Testing: keep Playwright E2E support extensions minimal per scenario instead of installing the full Salesforce Extension Pack by default, which avoids intrusive Agentforce Vibes UI noise in the test host.
 
 ### Tests
 
+- Activation/replay: add manifest coverage for the lazy Replay Debugger startup contract and keep replay-specific environments installing support extensions explicitly.
+- E2E: add launcher coverage for per-scenario support extensions and dismiss visible VS Code notifications before sensitive debug-flags/replay interactions.
 - Activation: add unit coverage for multi-root Salesforce project detection and for gating `sourceApiVersion`/CLI preload work behind Salesforce-project-aware activation.
 
 ## [0.30.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.28.0...v0.30.0) (2026-03-08)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -20,7 +20,7 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 
 - VS Code is downloaded via `@vscode/test-electron` and launched with `--extensionDevelopmentPath` and `--extensionTestsPath` (the compiled runner).
 - A temporary workspace is created with a minimal `sfdx-project.json` (including `sourceApiVersion`) and opened during tests.
-- On integration runs, the Salesforce Extension Pack (`salesforce.salesforcedx-vscode`) is installed via the VS Code CLI by default so tests mirror a typical Salesforce developer environment. The runner also installs the standalone Apex Replay Debugger explicitly to satisfy this extension's narrowed runtime dependency when the pack alone is not enough in the isolated host. You can still override this with `VSCODE_TEST_EXTENSIONS` if you want a different setup.
+- Playwright E2E runs keep the isolated VS Code profile intentionally minimal. Support extensions are installed per scenario instead of pulling the full Salesforce Extension Pack by default. Replay-specific specs opt into `salesforce.salesforcedx-vscode-apex-replay-debugger`, and the harness dismisses visible VS Code notifications during startup to reduce click interception flakiness.
 - On headless Linux, the script re‑executes under `xvfb-run` if available and sets Electron flags to reduce GPU/DBus issues.
 
 ## Environment variables

--- a/docs/plans/2026-03-09-e2e-salesforce-support-minimization-design.md
+++ b/docs/plans/2026-03-09-e2e-salesforce-support-minimization-design.md
@@ -1,0 +1,49 @@
+# E2E Salesforce Support Minimization Design
+
+## Goal
+
+Stabilize the Playwright E2E suite by minimizing the Salesforce extensions installed into the isolated VS Code profile and by hardening interactions against intrusive notifications.
+
+## Context
+
+The current E2E fixture installs `salesforce.salesforcedx-vscode` plus `salesforce.salesforcedx-vscode-apex-replay-debugger` for every scenario. The Salesforce Extension Pack pulls in `salesforce.salesforcedx-einstein-gpt` (`Agentforce Vibes`), which surfaces welcome toasts and sidebar contributions that interfere with clicks in the bottom panel. The failing `debugFlagsFilter` and `debugFlagsPanel` traces show notification overlays intercepting the debug-flags toolbar button.
+
+## Architecture
+
+The E2E harness should install only the support extensions required by each scenario:
+
+- The base E2E fixture launches VS Code without the Salesforce pack.
+- Scenarios that need Replay Debugger explicitly request `salesforce.salesforcedx-vscode-apex-replay-debugger`.
+- `test/e2e/utils/vscode.ts` stops promoting Salesforce-related ids to the full extension pack.
+- A reusable helper dismisses visible VS Code notifications before sensitive UI interactions and after startup.
+
+## Approach Options
+
+### Recommended: per-scenario support extensions plus notification cleanup
+
+This removes the primary source of test interference, keeps scenario requirements explicit, and still leaves room to add narrowly scoped dependencies when a specific spec needs them.
+
+### Alternative: keep the pack and disable `salesforce.salesforcedx-einstein-gpt`
+
+This reduces one source of noise, but still keeps a much heavier and more variable test environment than necessary.
+
+### Alternative: keep the pack and only add click-force / retries
+
+This treats symptoms, not the environment problem, and makes the suite harder to maintain.
+
+## Testing Strategy
+
+- Add or update fixture/helper coverage so support extensions are optional and scenario-driven.
+- Run focused Playwright specs for replay and debug-flags flows.
+- Run the full `npm run test:e2e` suite after the focused checks pass.
+
+## Risks
+
+- Replay Debugger may require transitive support extensions that were previously hidden by the pack install.
+- Some scenarios may still be sensitive to unrelated VS Code notifications.
+
+## Mitigations
+
+- Let VS Code install Replay Debugger dependencies through the extension itself rather than the full pack.
+- Keep the fixture API explicit so new dependencies are added locally to the spec that needs them.
+- Add a best-effort notification dismissal helper to reduce residual UI flakiness.

--- a/docs/plans/2026-03-09-e2e-salesforce-support-minimization.md
+++ b/docs/plans/2026-03-09-e2e-salesforce-support-minimization.md
@@ -1,0 +1,150 @@
+# E2E Salesforce Support Minimization Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the Playwright E2E harness install only the Salesforce support extensions each scenario actually needs and remove notification-driven flakiness from the debug-flags flows.
+
+**Architecture:** The shared VS Code launcher stops auto-installing the Salesforce Extension Pack. The base E2E fixture becomes minimal, replay-specific specs opt into Replay Debugger support, and a reusable notification helper dismisses visible toasts before sensitive toolbar clicks.
+
+**Tech Stack:** TypeScript, Playwright, VS Code test-electron launcher helpers, Salesforce CLI-backed E2E utilities.
+
+---
+
+### Task 1: Lock the support-extension contract in the launcher
+
+**Files:**
+- Modify: `test/e2e/utils/vscode.ts`
+- Test: `test/e2e/utils/vscode.test.ts`
+
+**Step 1: Write the failing test**
+
+Add a unit test that proves Salesforce-related support ids are not expanded to `salesforce.salesforcedx-vscode` and that extra extension ids stay scenario-scoped.
+
+**Step 2: Run test to verify it fails**
+
+Run: `fnm exec --using=22 npm run test:e2e:utils`
+
+Expected: FAIL because the launcher still promotes Salesforce ids to the full extension pack.
+
+**Step 3: Write minimal implementation**
+
+Remove the Salesforce-pack expansion helper and keep the launcher limited to manifest references plus scenario-provided ids.
+
+**Step 4: Run test to verify it passes**
+
+Run: `fnm exec --using=22 npm run test:e2e:utils`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add test/e2e/utils/vscode.ts test/e2e/utils/vscode.test.ts
+git commit -m "test(e2e): stop installing the salesforce extension pack"
+```
+
+### Task 2: Make support extensions explicit per scenario
+
+**Files:**
+- Modify: `test/e2e/fixtures/alvE2E.ts`
+- Modify: `test/e2e/specs/replayDebugger.e2e.spec.ts`
+- Test: `test/e2e/specs/replayDebugger.e2e.spec.ts`
+
+**Step 1: Write the failing test**
+
+Adjust the replay spec to declare Replay Debugger support through fixture options or a helper API, then run it against the minimal fixture.
+
+**Step 2: Run test to verify it fails**
+
+Run: `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/replayDebugger.e2e.spec.ts --workers=1`
+
+Expected: FAIL until the fixture can request Replay Debugger explicitly.
+
+**Step 3: Write minimal implementation**
+
+Add a fixture-level mechanism for scenario-specific `extensionIds`, default it to `[]`, and opt the replay spec into `salesforce.salesforcedx-vscode-apex-replay-debugger`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/replayDebugger.e2e.spec.ts --workers=1`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add test/e2e/fixtures/alvE2E.ts test/e2e/specs/replayDebugger.e2e.spec.ts
+git commit -m "test(e2e): declare replay debugger support per scenario"
+```
+
+### Task 3: Harden the suite against VS Code notifications
+
+**Files:**
+- Create: `test/e2e/utils/notifications.ts`
+- Modify: `test/e2e/specs/debugFlagsFilter.e2e.spec.ts`
+- Modify: `test/e2e/specs/debugFlagsPanel.e2e.spec.ts`
+- Modify: `test/e2e/specs/debugLevelManager.e2e.spec.ts`
+
+**Step 1: Write the failing test**
+
+Re-run the debug-flags specs to capture the notification-intercept failure in the minimal environment.
+
+**Step 2: Run test to verify it fails**
+
+Run: `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsFilter.e2e.spec.ts --workers=1`
+
+Expected: FAIL with a click interception or equivalent readiness issue while notifications are visible.
+
+**Step 3: Write minimal implementation**
+
+Create a best-effort helper that dismisses visible notifications and call it after startup / before clicking debug-flags toolbar actions.
+
+**Step 4: Run test to verify it passes**
+
+Run:
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsFilter.e2e.spec.ts --workers=1`
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsPanel.e2e.spec.ts --workers=1`
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugLevelManager.e2e.spec.ts --workers=1`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add test/e2e/utils/notifications.ts test/e2e/specs/debugFlagsFilter.e2e.spec.ts test/e2e/specs/debugFlagsPanel.e2e.spec.ts test/e2e/specs/debugLevelManager.e2e.spec.ts
+git commit -m "test(e2e): dismiss intrusive vscode notifications"
+```
+
+### Task 4: Verify the full E2E suite
+
+**Files:**
+- Modify: none
+
+**Step 1: Run focused support-suite verification**
+
+Run:
+- `fnm exec --using=22 npm run test:e2e:utils`
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/replayDebugger.e2e.spec.ts --workers=1`
+
+Expected: PASS.
+
+**Step 2: Run focused debug-flags verification**
+
+Run:
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsFilter.e2e.spec.ts --workers=1`
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsPanel.e2e.spec.ts --workers=1`
+- `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugLevelManager.e2e.spec.ts --workers=1`
+
+Expected: PASS.
+
+**Step 3: Run the full suite**
+
+Run: `fnm exec --using=22 npm run test:e2e`
+
+Expected: PASS.
+
+**Step 4: Review working tree**
+
+Run: `git status --short`
+
+Expected: only the intended E2E harness/spec/doc files are modified.

--- a/docs/plans/2026-03-09-lazy-replay-activation-design.md
+++ b/docs/plans/2026-03-09-lazy-replay-activation-design.md
@@ -1,0 +1,50 @@
+# Lazy Replay Activation Design
+
+## Goal
+
+Remove the Apex Replay Debugger as a hard activation dependency so Apex Log Viewer can activate independently and only load Replay Debugger support when the user explicitly starts a replay action.
+
+## Context
+
+The extension currently declares `salesforce.salesforcedx-vscode-apex-replay-debugger` in `package.json#extensionDependencies`. VS Code can delay activation of this extension until that dependency is available and activated. That startup coupling is redundant because replay actions already route through `ensureReplayDebuggerAvailable()` in `src/utils/replayDebugger.ts`, which detects commands, attempts on-demand activation, and shows guidance when support is missing.
+
+## Architecture
+
+The extension activation path stays unchanged except for the manifest dependency removal. Replay Debugger remains optional runtime functionality:
+
+- `package.json` no longer declares the Replay Debugger in `extensionDependencies`.
+- Core activation continues to register views and commands without waiting for Replay Debugger.
+- Replay entry points in `src/services/logService.ts` and `src/provider/SfLogTailViewProvider.ts` keep calling `ensureReplayDebuggerAvailable()` before executing replay commands.
+- `src/utils/replayDebugger.ts` remains the single runtime gate for command detection, on-demand extension activation, and user-facing guidance.
+
+## Approach Options
+
+### Recommended: remove the hard dependency and keep replay lazy
+
+This directly fixes the startup bottleneck and reuses the runtime flow already implemented in the codebase.
+
+### Alternative: keep startup dependency and optimize internal activation
+
+This does not solve the VS Code-level wait on the dependency extension, so it was rejected.
+
+### Alternative: remove dependency and add broader install/telemetry UX work
+
+Useful, but larger in scope than the activation fix and not required to resolve the immediate issue.
+
+## Testing Strategy
+
+- Add a manifest-focused test that fails if `package.json#extensionDependencies` still includes the Apex Replay Debugger.
+- Update integration expectations so Replay Debugger support is treated as optional for base extension activation.
+- Keep replay-specific tests focused on the click path and runtime availability checks.
+- Refresh testing docs to describe Replay Debugger as an optional dependency for replay flows, not for extension activation.
+
+## Risks
+
+- Some tests or helpers may still assume Replay Debugger is always preinstalled.
+- E2E or integration flows that explicitly validate replay should continue installing the Salesforce extensions they need.
+
+## Mitigations
+
+- Limit the manifest change to the Replay Debugger dependency only.
+- Preserve the existing runtime guard in `ensureReplayDebuggerAvailable()`.
+- Update docs and tests together so the repository consistently models replay as optional-at-startup.

--- a/docs/plans/2026-03-09-lazy-replay-activation.md
+++ b/docs/plans/2026-03-09-lazy-replay-activation.md
@@ -1,0 +1,157 @@
+# Lazy Replay Activation Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Remove the Apex Replay Debugger as a hard startup dependency while preserving replay support through lazy runtime activation.
+
+**Architecture:** The manifest stops declaring Replay Debugger as an `extensionDependencies` requirement. Replay actions continue to flow through `ensureReplayDebuggerAvailable()`, which remains responsible for runtime detection, on-demand activation, and user guidance when Replay Debugger is unavailable.
+
+**Tech Stack:** VS Code extension manifest, TypeScript, Mocha integration/unit tests, repository docs.
+
+---
+
+### Task 1: Lock the startup contract with a failing manifest test
+
+**Files:**
+- Create: `src/test/packageManifest.test.ts`
+- Modify: `package.json`
+
+**Step 1: Write the failing test**
+
+```ts
+test('does not require Apex Replay Debugger as an extension dependency', async () => {
+  const raw = await fs.readFile(path.join(repoRoot, 'package.json'), 'utf8');
+  const json = JSON.parse(raw) as { extensionDependencies?: string[] };
+  assert.ok(!json.extensionDependencies?.includes('salesforce.salesforcedx-vscode-apex-replay-debugger'));
+});
+```
+
+**Step 2: Run test to verify it fails**
+
+Run: `fnm exec --using=22 npm run pretest && fnm exec --using=22 npx mocha --ui tdd out/test/packageManifest.test.js`
+
+Expected: FAIL because `package.json#extensionDependencies` still includes the Replay Debugger id.
+
+**Step 3: Write minimal implementation**
+
+Remove `salesforce.salesforcedx-vscode-apex-replay-debugger` from `package.json#extensionDependencies`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `fnm exec --using=22 npm run pretest && fnm exec --using=22 npx mocha --ui tdd out/test/packageManifest.test.js`
+
+Expected: PASS.
+
+**Step 5: Commit**
+
+```bash
+git add src/test/packageManifest.test.ts package.json
+git commit -m "fix(activation): remove replay debugger startup dependency"
+```
+
+### Task 2: Update test expectations around optional replay support
+
+**Files:**
+- Modify: `src/test/integration.dependencies.test.ts`
+- Modify: `test/e2e/utils/vscode.ts`
+
+**Step 1: Write the failing test**
+
+Adjust the integration dependency test to assert that the extension is discoverable and activatable without requiring Replay Debugger to be installed. Keep replay-specific environments free to install Salesforce extensions explicitly.
+
+**Step 2: Run test to verify it fails**
+
+Run: `fnm exec --using=22 npm run pretest && fnm exec --using=22 bash scripts/run-tests.sh --scope=integration`
+
+Expected: Existing dependency assertion fails or the old wording no longer matches the desired optional dependency contract.
+
+**Step 3: Write minimal implementation**
+
+- Replace the hard dependency assertion in `src/test/integration.dependencies.test.ts` with an activation-oriented check.
+- Update the E2E helper comment or dependency resolution wording in `test/e2e/utils/vscode.ts` so it no longer claims activation depends on manifest `extensionDependencies`.
+
+**Step 4: Run test to verify it passes**
+
+Run: `fnm exec --using=22 npm run pretest && fnm exec --using=22 bash scripts/run-tests.sh --scope=integration`
+
+Expected: PASS for the updated integration contract.
+
+**Step 5: Commit**
+
+```bash
+git add src/test/integration.dependencies.test.ts test/e2e/utils/vscode.ts
+git commit -m "test(activation): treat replay debugger as optional at startup"
+```
+
+### Task 3: Refresh repository docs
+
+**Files:**
+- Modify: `docs/TESTING.md`
+
+**Step 1: Write the failing test**
+
+There is no automated doc test. Use the approved design as the contract: documentation must describe Replay Debugger as optional for extension activation and still relevant for replay-specific test runs.
+
+**Step 2: Run test to verify it fails**
+
+Review `docs/TESTING.md` and confirm it still states the runner installs Replay Debugger to satisfy a narrowed runtime dependency for startup.
+
+Expected: Doc is outdated.
+
+**Step 3: Write minimal implementation**
+
+Update the testing guide to explain:
+
+- integration runs still install Salesforce extensions by default to mirror a typical environment,
+- replay-specific scenarios may still require Replay Debugger,
+- base extension activation no longer depends on Replay Debugger being a manifest dependency.
+
+**Step 4: Run test to verify it passes**
+
+Review the doc for consistency with `package.json` and the integration tests.
+
+Expected: Wording matches the implemented contract.
+
+**Step 5: Commit**
+
+```bash
+git add docs/TESTING.md
+git commit -m "docs(testing): clarify lazy replay debugger activation"
+```
+
+### Task 4: Verify the change end-to-end
+
+**Files:**
+- Modify: none
+
+**Step 1: Run focused verification**
+
+Run: `fnm exec --using=22 npm run pretest`
+
+Expected: build and compiled tests succeed.
+
+**Step 2: Run manifest test**
+
+Run: `fnm exec --using=22 npx mocha --ui tdd out/test/packageManifest.test.js`
+
+Expected: PASS.
+
+**Step 3: Run relevant VS Code-hosted verification**
+
+Run: `fnm exec --using=22 bash scripts/run-tests.sh --scope=integration`
+
+Expected: PASS for the updated integration suite.
+
+**Step 4: Run compile validation**
+
+Run: `fnm exec --using=22 npm run compile`
+
+Expected: exit code `0`.
+
+**Step 5: Commit**
+
+```bash
+git status --short
+```
+
+Expected: only the intended files remain modified and ready for review.

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
   "activationEvents": [
     "workspaceContains:sfdx-project.json"
   ],
-  "extensionDependencies": ["salesforce.salesforcedx-vscode-apex-replay-debugger"],
   "main": "./dist/extension.js",
   "contributes": {
     "configuration": {

--- a/src/test/integration.dependencies.test.ts
+++ b/src/test/integration.dependencies.test.ts
@@ -2,20 +2,18 @@ import assert from 'assert/strict';
 import * as vscode from 'vscode';
 
 suite('integration: dependencies', () => {
-  test('Apex Replay Debugger extension is installed', async function () {
-    // Ensure our extension is discoverable
+  test('extension manifest does not hard-require Apex Replay Debugger', async function () {
     const self = vscode.extensions.getExtension('electivus.apex-log-viewer');
     assert.ok(self, 'apex-log-viewer extension should be found');
 
-    // Enforce Replay Debugger dependency presence; if not installed, fail with guidance.
-    // The VS Code extension dependency is the Apex Replay Debugger module. Users can also
-    // satisfy this by installing the Salesforce Extension Pack (which includes it).
-    const replay = vscode.extensions.getExtension('salesforce.salesforcedx-vscode-apex-replay-debugger');
-    const pack = vscode.extensions.getExtension('salesforce.salesforcedx-vscode');
-    const viaEnv = process.env.SF_EXT_PRESENT === '1';
-    assert.ok(
-      replay || pack || viaEnv,
-      'Apex Replay Debugger support not detected. Ensure the Salesforce Extension Pack (recommended) or salesforce.salesforcedx-vscode-apex-replay-debugger is installed. Use `npm run test:integration` to auto-install.'
+    const packageJson = self.packageJSON as { extensionDependencies?: unknown };
+    const extensionDependencies = Array.isArray(packageJson.extensionDependencies) ? packageJson.extensionDependencies : [];
+    assert.equal(
+      extensionDependencies.includes('salesforce.salesforcedx-vscode-apex-replay-debugger'),
+      false,
+      'Apex Replay Debugger should remain optional until the user starts a replay action'
     );
+
+    await self.activate();
   });
 });

--- a/src/test/packageManifest.test.ts
+++ b/src/test/packageManifest.test.ts
@@ -1,0 +1,18 @@
+import assert from 'assert/strict';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+
+suite('package manifest', () => {
+  test('does not require Apex Replay Debugger as an extension dependency', async () => {
+    const repoRoot = path.resolve(__dirname, '..', '..');
+    const raw = await readFile(path.join(repoRoot, 'package.json'), 'utf8');
+    const manifest = JSON.parse(raw) as { extensionDependencies?: unknown };
+    const extensionDependencies = Array.isArray(manifest.extensionDependencies) ? manifest.extensionDependencies : [];
+
+    assert.equal(
+      extensionDependencies.includes('salesforce.salesforcedx-vscode-apex-replay-debugger'),
+      false,
+      'package.json should not hard-require the Apex Replay Debugger at activation time'
+    );
+  });
+});

--- a/test/e2e/fixtures/alvE2E.ts
+++ b/test/e2e/fixtures/alvE2E.ts
@@ -20,7 +20,13 @@ type Fixtures = {
   vscodePage: Page;
 };
 
-export const test = base.extend<Fixtures>({
+type Options = {
+  supportExtensionIds: string[];
+};
+
+export const test = base.extend<Fixtures & Options>({
+  supportExtensionIds: [[], { option: true }],
+
   scratchAlias: [
     async ({}, use) => {
       const scratch = await ensureScratchOrg();
@@ -48,9 +54,13 @@ export const test = base.extend<Fixtures>({
     }
   },
 
-  vscodeApp: async ({ workspacePath }, use) => {
+  vscodeApp: async ({ workspacePath, supportExtensionIds }, use) => {
     const extensionDevelopmentPath = path.join(__dirname, '..', '..', '..');
-    const launch = await launchVsCode({ workspacePath, extensionDevelopmentPath });
+    const launch = await launchVsCode({
+      workspacePath,
+      extensionDevelopmentPath,
+      extensionIds: supportExtensionIds
+    });
     try {
       await use(launch.app);
     } finally {

--- a/test/e2e/fixtures/alvNoSeed.ts
+++ b/test/e2e/fixtures/alvNoSeed.ts
@@ -13,7 +13,13 @@ type Fixtures = {
   vscodePage: Page;
 };
 
-export const test = base.extend<Fixtures>({
+type Options = {
+  supportExtensionIds: string[];
+};
+
+export const test = base.extend<Fixtures & Options>({
+  supportExtensionIds: [[], { option: true }],
+
   scratchAlias: [
     async ({}, use) => {
       const scratch = await ensureScratchOrg();
@@ -36,9 +42,13 @@ export const test = base.extend<Fixtures>({
     }
   },
 
-  vscodeApp: async ({ workspacePath }, use) => {
+  vscodeApp: async ({ workspacePath, supportExtensionIds }, use) => {
     const extensionDevelopmentPath = path.join(__dirname, '..', '..', '..');
-    const launch = await launchVsCode({ workspacePath, extensionDevelopmentPath });
+    const launch = await launchVsCode({
+      workspacePath,
+      extensionDevelopmentPath,
+      extensionIds: supportExtensionIds
+    });
     try {
       await use(launch.app);
     } finally {

--- a/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { dismissAllNotifications } from '../utils/notifications';
 import { ensureDebugFlagsTestUser, getOrgAuth } from '../utils/tooling';
 import { waitForWebviewFrame } from '../utils/webviews';
 
@@ -46,6 +47,7 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
   );
   const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
   await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+  await dismissAllNotifications(vscodePage);
   await openDebugFlags.click();
 
   const debugFlagsFrame = await waitForWebviewFrame(
@@ -65,6 +67,7 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
     { timeoutMs: 180_000 }
   );
   await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
+  await dismissAllNotifications(vscodePage);
   await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
 
   const debugFlagsFrameFromTail = await waitForWebviewFrame(

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { dismissAllNotifications } from '../utils/notifications';
 import { ensureDebugFlagsTestUser, getOrgAuth, getUserDebugTraceFlag, removeUserDebugTraceFlags } from '../utils/tooling';
 import { waitForWebviewFrame } from '../utils/webviews';
 
@@ -20,6 +21,7 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
     );
     const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
     await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+    await dismissAllNotifications(vscodePage);
     await openDebugFlags.click();
 
     const debugFlagsFrame = await waitForWebviewFrame(
@@ -66,6 +68,7 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
       { timeoutMs: 180_000 }
     );
     await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
+    await dismissAllNotifications(vscodePage);
     await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
 
     const debugFlagsFrameFromTail = await waitForWebviewFrame(

--- a/test/e2e/specs/debugLevelManager.e2e.spec.ts
+++ b/test/e2e/specs/debugLevelManager.e2e.spec.ts
@@ -8,6 +8,7 @@ import {
   getOrgAuth,
   removeUserDebugTraceFlags
 } from '../utils/tooling';
+import { dismissAllNotifications } from '../utils/notifications';
 import { waitForWebviewFrame } from '../utils/webviews';
 
 test('creates, updates and deletes DebugLevel records from the manager UI', async ({ vscodePage, scratchAlias }) => {
@@ -33,6 +34,7 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
     );
     const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
     await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+    await dismissAllNotifications(vscodePage);
     await openDebugFlags.click({ force: true });
 
     const debugFlagsFrame = await waitForWebviewFrame(

--- a/test/e2e/specs/replayDebugger.e2e.spec.ts
+++ b/test/e2e/specs/replayDebugger.e2e.spec.ts
@@ -1,6 +1,9 @@
 import { test, expect } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { dismissAllNotifications } from '../utils/notifications';
 import { waitForWebviewFrame } from '../utils/webviews';
+
+test.use({ supportExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'] });
 
 test('launches replay debugger from logs table without missing-extension toast', async ({ vscodePage, seededLog }) => {
   void seededLog;
@@ -27,6 +30,7 @@ test('launches replay debugger from logs table without missing-extension toast',
   // Click the per-row "Apex Replay" icon button.
   const replayButton = logsFrame.locator('button[aria-label="Apex Replay"]').first();
   await replayButton.waitFor({ state: 'visible', timeout: 60_000 });
+  await dismissAllNotifications(vscodePage);
   await replayButton.click();
 
   // Historically we surfaced a toast claiming Replay Debugger was unavailable even when installed,

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -1,0 +1,18 @@
+import { resolveSupportExtensionIds } from '../vscode';
+
+describe('resolveSupportExtensionIds', () => {
+  test('keeps replay debugger support local to the scenario', () => {
+    expect(resolveSupportExtensionIds(['salesforce.salesforcedx-vscode-apex-replay-debugger'])).toEqual([
+      'salesforce.salesforcedx-vscode-apex-replay-debugger'
+    ]);
+  });
+
+  test('dedupes and trims manifest and scenario extension ids', () => {
+    expect(
+      resolveSupportExtensionIds(
+        [' salesforce.salesforcedx-vscode-core ', '', 'salesforce.salesforcedx-vscode-core'],
+        ['salesforce.salesforcedx-vscode-apex-replay-debugger', 'salesforce.salesforcedx-vscode-core']
+      )
+    ).toEqual(['salesforce.salesforcedx-vscode-core', 'salesforce.salesforcedx-vscode-apex-replay-debugger']);
+  });
+});

--- a/test/e2e/utils/notifications.ts
+++ b/test/e2e/utils/notifications.ts
@@ -1,0 +1,89 @@
+import type { Page } from '@playwright/test';
+import { runCommand } from './commandPalette';
+
+const notificationSelectors = ['.notifications-toasts .notification-list-item', '.notifications-center .notification-list-item'];
+const notificationCloseSelectors = [
+  '.notifications-toasts .notification-list-item [aria-label*="Hide Notification"]',
+  '.notifications-toasts .notification-list-item [aria-label*="Clear Notification"]',
+  '.notifications-toasts .notification-list-item [aria-label*="Close"]',
+  '.notifications-toasts .notification-list-item .codicon-close',
+  '.notifications-center .notification-list-item [aria-label*="Hide Notification"]',
+  '.notifications-center .notification-list-item [aria-label*="Clear Notification"]',
+  '.notifications-center .notification-list-item [aria-label*="Close"]',
+  '.notifications-center .notification-list-item .codicon-close'
+];
+
+async function countVisibleNotifications(page: Page): Promise<number> {
+  return await page.evaluate(selectors => {
+    const isVisible = (node: Element): boolean => {
+      if (!(node instanceof HTMLElement)) {
+        return false;
+      }
+      const style = window.getComputedStyle(node);
+      const rect = node.getBoundingClientRect();
+      return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+    };
+
+    return selectors
+      .flatMap(selector => Array.from(document.querySelectorAll(selector)))
+      .filter(node => isVisible(node))
+      .length;
+  }, notificationSelectors);
+}
+
+async function clickVisibleNotificationCloseButton(page: Page): Promise<boolean> {
+  return await page.evaluate(selectors => {
+    const isVisible = (node: Element): boolean => {
+      if (!(node instanceof HTMLElement)) {
+        return false;
+      }
+      const style = window.getComputedStyle(node);
+      const rect = node.getBoundingClientRect();
+      return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+    };
+
+    for (const selector of selectors) {
+      for (const node of Array.from(document.querySelectorAll(selector))) {
+        if (!isVisible(node)) {
+          continue;
+        }
+        if (node instanceof HTMLElement) {
+          node.click();
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }, notificationCloseSelectors);
+}
+
+export async function dismissAllNotifications(page: Page, options?: { timeoutMs?: number }): Promise<void> {
+  const deadline = Date.now() + (options?.timeoutMs ?? 5_000);
+
+  while (Date.now() < deadline) {
+    const visibleCount = await countVisibleNotifications(page).catch(() => 0);
+    if (visibleCount === 0) {
+      return;
+    }
+
+    let acted = false;
+
+    try {
+      await runCommand(page, 'Notifications: Clear All Notifications');
+      acted = true;
+    } catch {
+      // Fall through to direct interaction.
+    }
+
+    if (!acted) {
+      acted = await clickVisibleNotificationCloseButton(page).catch(() => false);
+    }
+
+    if (!acted) {
+      await page.keyboard.press('Escape').catch(() => {});
+    }
+
+    await page.waitForTimeout(150);
+  }
+}

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
+import { dismissAllNotifications } from './notifications';
 
 export type VscodeLaunch = {
   app: ElectronApplication;
@@ -22,28 +23,27 @@ function getVsCodeVersion(): string {
   return v || 'stable';
 }
 
-async function readExtensionReferences(extensionDevelopmentPath: string): Promise<string[]> {
+export function resolveSupportExtensionIds(extensionIds: unknown[] = [], extraExtensionIds: string[] = []): string[] {
+  return Array.from(
+    new Set([...extensionIds, ...extraExtensionIds].map(String).map(value => value.trim()).filter(Boolean))
+  );
+}
+
+async function readExtensionReferences(extensionDevelopmentPath: string, extraExtensionIds: string[] = []): Promise<string[]> {
   try {
     const pkgPath = path.join(extensionDevelopmentPath, 'package.json');
     const raw = await readFile(pkgPath, 'utf8');
     const json = JSON.parse(raw) as { extensionDependencies?: unknown; extensionPack?: unknown };
-    const refs = [
-      ...(Array.isArray(json.extensionDependencies) ? json.extensionDependencies : []),
-      ...(Array.isArray(json.extensionPack) ? json.extensionPack : [])
-    ];
-    return Array.from(new Set(refs.map(String).map(s => s.trim()).filter(Boolean)));
+    return resolveSupportExtensionIds(
+      [
+        ...(Array.isArray(json.extensionDependencies) ? json.extensionDependencies : []),
+        ...(Array.isArray(json.extensionPack) ? json.extensionPack : [])
+      ],
+      extraExtensionIds
+    );
   } catch {
-    return [];
+    return resolveSupportExtensionIds([], extraExtensionIds);
   }
-}
-
-function expandPreferredSalesforceExtensions(extensionIds: string[]): string[] {
-  const normalized = extensionIds.map(id => String(id || '').trim()).filter(Boolean);
-  const touchesSalesforcePack = normalized.some(id => /^salesforce\.salesforcedx-vscode(?:-|$)/i.test(id));
-  if (!touchesSalesforcePack) {
-    return normalized;
-  }
-  return Array.from(new Set(['salesforce.salesforcedx-vscode', ...normalized]));
 }
 
 async function pathExists(targetPath: string): Promise<boolean> {
@@ -135,7 +135,7 @@ async function copyLocalExtensionWithDependencies(
 
   const destDir = path.join(extensionsDir, path.basename(sourceDir));
   await cp(sourceDir, destDir, { recursive: true, force: true });
-  console.log(`[e2e] Reused locally installed VS Code extension dependency: ${extensionId}`);
+  console.log(`[e2e] Reused locally installed VS Code support extension: ${extensionId}`);
 
   const nestedDeps = await readExtensionReferences(sourceDir);
   for (const dep of nestedDeps) {
@@ -192,7 +192,7 @@ function installExtensions(args: {
   extensionIds: string[];
 }): void {
   for (const id of args.extensionIds) {
-    console.log(`[e2e] Installing VS Code extension dependency: ${id}`);
+    console.log(`[e2e] Installing VS Code support extension: ${id}`);
     const res = spawnSync(
       args.cliPath,
       [
@@ -213,7 +213,7 @@ function installExtensions(args: {
       }
     );
     if (res.status !== 0) {
-      console.warn(`[e2e] Failed to install VS Code extension dependency: ${id}`);
+      console.warn(`[e2e] Failed to install VS Code support extension: ${id}`);
     }
   }
 }
@@ -223,8 +223,9 @@ async function ensureExtensionDependenciesInstalled(args: {
   extensionDevelopmentPath: string;
   userDataDir: string;
   extensionsDir: string;
+  extraExtensionIds?: string[];
 }): Promise<string> {
-  const deps = expandPreferredSalesforceExtensions(await readExtensionReferences(args.extensionDevelopmentPath));
+  const deps = await readExtensionReferences(args.extensionDevelopmentPath, args.extraExtensionIds ?? []);
   if (!deps.length) {
     return args.extensionsDir;
   }
@@ -307,7 +308,11 @@ async function isAuxiliaryBarOpen(page: Page): Promise<boolean> {
   }
 }
 
-export async function launchVsCode(options: { workspacePath: string; extensionDevelopmentPath: string }): Promise<VscodeLaunch> {
+export async function launchVsCode(options: {
+  workspacePath: string;
+  extensionDevelopmentPath: string;
+  extensionIds?: string[];
+}): Promise<VscodeLaunch> {
   const vscodeCachePath = process.env.VSCODE_TEST_CACHE_PATH
     ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
     : path.join(options.extensionDevelopmentPath, '.vscode-test');
@@ -317,15 +322,16 @@ export async function launchVsCode(options: { workspacePath: string; extensionDe
   let extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
   let shouldCleanupExtensionsDir = true;
 
-  // The extension is loaded via --extensionDevelopmentPath, but VS Code still enforces
-  // `extensionDependencies` at activation time. Install those dependencies into the
-  // isolated extensions dir so contributed commands can activate the extension.
+  // The extension is loaded via --extensionDevelopmentPath. Some E2E scenarios still
+  // need support extensions in the isolated profile (for example Replay Debugger),
+  // so install manifest references plus scenario-specific ids.
   try {
     const resolvedExtensionsDir = await ensureExtensionDependenciesInstalled({
       vscodeExecutablePath,
       extensionDevelopmentPath: options.extensionDevelopmentPath,
       userDataDir,
-      extensionsDir
+      extensionsDir,
+      extraExtensionIds: options.extensionIds
     });
     if (resolvedExtensionsDir !== extensionsDir) {
       await rm(extensionsDir, { recursive: true, force: true });
@@ -370,6 +376,12 @@ export async function launchVsCode(options: { workspacePath: string; extensionDe
       const modifier = getModifierKey();
       await page.keyboard.press(`${modifier}+Alt+B`);
     }
+  } catch {
+    // best-effort
+  }
+
+  try {
+    await dismissAllNotifications(page);
   } catch {
     // best-effort
   }


### PR DESCRIPTION
## Summary
- remove Apex Replay Debugger as a hard startup dependency and cover the lazy activation contract with manifest/integration tests
- keep Playwright E2E support extensions minimal per scenario so normal specs stop pulling the Salesforce Extension Pack and Agentforce Vibes UI noise
- add VS Code notification dismissal hardening for replay/debug-flags E2E flows and document the new test harness behavior

## Test Plan
- [x] `fnm exec --using=22 npm run test:e2e:utils`
- [x] `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/replayDebugger.e2e.spec.ts --workers=1`
- [x] `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsFilter.e2e.spec.ts --workers=1`
- [x] `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsPanel.e2e.spec.ts --workers=1`
- [x] `fnm exec --using=22 node scripts/run-playwright-e2e.js test/e2e/specs/debugLevelManager.e2e.spec.ts --workers=1`
- [x] `fnm exec --using=22 npm run test:e2e`
