### PR TITLE
chore(release): prepare 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,26 @@
 
 ### Features
 
-- Activation: auto-activate when the open workspace contains `sfdx-project.json`, while keeping standalone Apex log files and explicit Apex Logs commands working on demand.
-
 ### Bug Fixes
 
 ### Chores
 
 ### Tests
 
-- Activation: add unit coverage for multi-root Salesforce project detection and for gating `sourceApiVersion`/CLI preload work behind Salesforce-project-aware activation.
+## [0.32.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.30.0...v0.32.0) (2026-03-09)
+
+### Features
+
+- Activation: auto-activate when the open workspace contains `sfdx-project.json`, while keeping standalone Apex log files and explicit Apex Logs commands working on demand. ([#575](https://github.com/Electivus/Apex-Log-Viewer/pull/575))
+
+### Bug Fixes
+
+- Activation: continue scanning multi-root workspaces after project read errors and ignore unusable Salesforce project roots before CLI/API preload work starts. ([#575](https://github.com/Electivus/Apex-Log-Viewer/pull/575))
+
+### Tests
+
+- Activation: add unit coverage for multi-root Salesforce project detection and for gating `sourceApiVersion`/CLI preload work behind Salesforce-project-aware activation. ([#575](https://github.com/Electivus/Apex-Log-Viewer/pull/575))
+- Telemetry: add unit coverage for production-only reporter activation, connection-string precedence, and send-failure handling. ([#574](https://github.com/Electivus/Apex-Log-Viewer/pull/574))
 
 ## [0.30.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.28.0...v0.30.0) (2026-03-08)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.30.0",
+  "version": "0.32.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.30.0",
+      "version": "0.32.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-popover": "^1.1.15",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.30.0",
+  "version": "0.32.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump the extension version to 0.32.0 in package manifests
- promote the current activation and telemetry entries into the 0.32.0 changelog section
- reset Unreleased for the next cycle

## Testing
- npm run build
- npm run test:ci