### PR TITLE
[codex] docs(agents): refresh repo workflows

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,8 @@
 ## Project Structure
 - `src/` contains extension host, services, providers, and shared types.
 - `src/webview/` contains the webview React UI.
-- `test/` contains VS Code extension integration/unit tests.
+- `src/test/` contains VS Code extension unit/integration tests and test harness code.
+- `test/e2e/` contains Playwright scratch-org E2E specs, fixtures, and utilities.
 - `docs/` holds architecture/testing/publishing notes and plan docs.
 - `media/` stores bundled webview assets.
 - `scripts/` contains build/test helper scripts.
@@ -15,12 +16,15 @@
 - Use Node `22` via `.nvmrc`.
 - Install deps with `npm ci`.
 - Type-check only with `npm run check-types`.
+- Lint with `npm run lint`.
 - Lint + extension TypeScript validation with `npm run compile`.
 - Build with `npm run build`.
 - Prepare a publishable package with `npm run package`.
 - Watch mode: `npm run watch`.
+- Default local test command: `npm test`.
 - Unit-focused local test suite: `npm run test:unit`.
 - Integration suite: `npm run test:integration`.
+- Combined local test sweep: `npm run test:all`.
 - Full CI-equivalent suite: `npm run test:ci`.
 - Webview-only Jest suite: `npm run test:webview`.
 - Playwright scratch-org E2E: `npm run test:e2e`.
@@ -60,6 +64,9 @@ This repo follows the VS Code Marketplace pre-release convention:
 7. **Local packaging/publishing helpers**
    - Package stable/pre-release VSIX with `npm run vsce:package` / `npm run vsce:package:pre`.
    - Publish stable/pre-release locally with `npm run vsce:publish` / `npm run vsce:publish:pre`.
+   - Publish to Open VSX locally with `npx --yes ovsx publish --pat <token>` or add `--pre-release` for the odd-minor channel.
+
+Nightly pre-releases are managed by `.github/workflows/prerelease.yml`, which packages and publishes the odd-minor pre-release channel when publishing secrets are configured.
 
 See also: `docs/PUBLISHING.md` and `docs/CI.md`.
 


### PR DESCRIPTION
## Summary
`AGENTS.md` had drifted from the repository's current workflows. It still described the extension test layout as `test/`, even though VS Code-hosted tests and harness code live under `src/test/` and Playwright end-to-end coverage lives under `test/e2e/`. It also omitted a few first-line commands that are present in the current npm scripts and docs, and it did not mention the local Open VSX publish command or the nightly pre-release workflow.

For maintainers and coding agents, that drift increases the odds of using the wrong test path, missing the default local test entry point, or overlooking the release helpers that are already part of this repository.

## Root Cause
The repository workflows evolved in `package.json`, `docs/TESTING.md`, `docs/PUBLISHING.md`, and `docs/CI.md`, but `AGENTS.md` was not updated alongside those changes.

## Fix
This PR refreshes `AGENTS.md` with repo-backed guidance only:

- updates the project structure section to reflect `src/test/` and `test/e2e/`
- adds the missing top-level commands `npm run lint`, `npm test`, and `npm run test:all`
- documents the local Open VSX publish command
- calls out the nightly `.github/workflows/prerelease.yml` flow for odd-minor pre-releases

The change is intentionally narrow and does not modify any unrelated sections or generated files.

## Validation
This is a documentation-only change. Validation was done by comparing `AGENTS.md` against the current repository sources:

- `package.json`
- `docs/TESTING.md`
- `docs/PUBLISHING.md`
- `docs/CI.md`

No runtime tests were run because the change does not alter product code, packaging output, or test behavior.
