### PR TITLE
[codex] Reset debug flags state on org switch

### DIFF
--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -293,6 +293,78 @@ describe('DebugFlags webview App', () => {
     });
   });
 
+  it('clears the selected target status when the extension switches orgs', async () => {
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+    render(<DebugFlagsApp vscode={vscode} messageBus={bus} />);
+
+    sendMessage(bus, { type: 'debugFlagsInit', locale: 'en', defaultTtlMinutes: 30 });
+    sendMessage(bus, {
+      type: 'debugFlagsOrgs',
+      data: [
+        { username: 'user@example.com', alias: 'Main', isDefaultUsername: true },
+        { username: 'other@example.com', alias: 'Other', isDefaultUsername: false }
+      ],
+      selected: 'user@example.com'
+    });
+    sendMessage(bus, { type: 'debugFlagsDebugLevels', data: ['ALV_E2E'], active: 'ALV_E2E' });
+    sendMessage(bus, {
+      type: 'debugFlagsUsers',
+      query: '',
+      data: [
+        {
+          id: '005000000000001AAA',
+          name: 'Ada Lovelace',
+          username: 'ada@example.com',
+          active: true
+        }
+      ]
+    });
+
+    fireEvent.click(screen.getByTestId('debug-flags-user-row-005000000000001AAA'));
+    await waitFor(() => {
+      expect(
+        posted.some(
+          msg =>
+            msg.type === 'debugFlagsSelectTarget' &&
+            msg.target.type === 'user' &&
+            msg.target.userId === '005000000000001AAA'
+        )
+      ).toBe(true);
+    });
+
+    sendMessage(bus, {
+      type: 'debugFlagsTargetStatus',
+      target: { type: 'user', userId: '005000000000001AAA' },
+      status: {
+        target: { type: 'user', userId: '005000000000001AAA' },
+        targetLabel: 'Ada Lovelace',
+        targetAvailable: true,
+        traceFlagId: '7tf000000000001AAA',
+        debugLevelName: 'ALV_E2E',
+        startDate: '2026-02-19T17:00:00.000Z',
+        expirationDate: '2026-02-19T18:00:00.000Z',
+        isActive: true
+      }
+    });
+
+    await screen.findByTestId('debug-flags-status-level');
+    expect(screen.getByTestId('debug-flags-selected-target-label')).toHaveTextContent('Ada Lovelace');
+
+    sendMessage(bus, {
+      type: 'debugFlagsOrgs',
+      data: [
+        { username: 'user@example.com', alias: 'Main', isDefaultUsername: true },
+        { username: 'other@example.com', alias: 'Other', isDefaultUsername: false }
+      ],
+      selected: 'other@example.com'
+    });
+
+    await screen.findByText('Select a special target or an active user to inspect and configure debug flags.');
+    expect(screen.queryByTestId('debug-flags-status-level')).toBeNull();
+    expect(screen.queryByTestId('debug-flags-selected-target-label')).toBeNull();
+  });
+
   it('sends debounced user search queries', async () => {
     const { vscode, posted } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -363,6 +363,7 @@ describe('DebugFlags webview App', () => {
     await screen.findByText('Select a special target or an active user to inspect and configure debug flags.');
     expect(screen.queryByTestId('debug-flags-status-level')).toBeNull();
     expect(screen.queryByTestId('debug-flags-selected-target-label')).toBeNull();
+    expect(screen.queryByTestId('debug-flags-user-row-005000000000001AAA')).toBeNull();
   });
 
   it('sends debounced user search queries', async () => {

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -144,6 +144,7 @@ export function DebugFlagsApp({
           break;
         case 'debugFlagsOrgs':
           if (selectedOrgRef.current !== msg.selected) {
+            setUsers([]);
             setSelectedTarget(undefined);
             setStatus(undefined);
             setNotice(undefined);
@@ -246,6 +247,7 @@ export function DebugFlagsApp({
 
   const handleSelectOrg = (nextOrg: string) => {
     setSelectedOrg(nextOrg);
+    setUsers([]);
     setSelectedTarget(undefined);
     setStatus(undefined);
     setNotice(undefined);

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -97,6 +97,7 @@ export function DebugFlagsApp({
   const [error, setError] = useState<string | undefined>(undefined);
   const [notice, setNotice] = useState<NoticeState | undefined>(undefined);
   const [initialized, setInitialized] = useState(false);
+  const selectedOrgRef = useRef<string | undefined>(undefined);
   const selectedTargetRef = useRef<TraceFlagTarget | undefined>(undefined);
   const selectedManagerIdRef = useRef<string>('');
   const [loading, setLoading] = useState<LoadingState>({
@@ -105,6 +106,10 @@ export function DebugFlagsApp({
     status: false,
     action: false
   });
+
+  useEffect(() => {
+    selectedOrgRef.current = selectedOrg;
+  }, [selectedOrg]);
 
   useEffect(() => {
     selectedTargetRef.current = selectedTarget;
@@ -138,6 +143,12 @@ export function DebugFlagsApp({
           }));
           break;
         case 'debugFlagsOrgs':
+          if (selectedOrgRef.current !== msg.selected) {
+            setSelectedTarget(undefined);
+            setStatus(undefined);
+            setNotice(undefined);
+            setError(undefined);
+          }
           setOrgs(msg.data || []);
           setSelectedOrg(msg.selected);
           break;


### PR DESCRIPTION
## Summary
The Debug Flags webview could keep showing the previously selected target and its last-known trace flag state after the extension switched to a different org. That left stale status visible in a context where the backend had already cleared the selected target.

The immediate user effect was misleading UI state: the status card could still show an old user or special target and leave apply/remove actions enabled even though the org selection had changed underneath the webview.

The root cause was that the extension-side org change path only cleared target state inside `DebugFlagsPanel`, while the React webview only cleared `selectedTarget` and `status` when the user changed orgs locally through the UI. Incoming `debugFlagsOrgs` messages updated the selected org but did not reset the current selection.

## Fix
The webview now tracks the last selected org via a ref and clears `selectedTarget`, `status`, `notice`, and `error` whenever a `debugFlagsOrgs` message changes the selected org programmatically. That keeps the visible state aligned with the backend-owned selection lifecycle.

A regression test was added to reproduce the exact message flow: select a user, receive active status, then receive an org-switch message from the extension and assert that the status card is cleared.

## Validation
I verified the change with:

`/c/Users/k2/.lmstudio/.internal/utils/node.exe node_modules/jest/bin/jest.js --runInBand --config jest.config.webview.cjs src/webview/__tests__/debugFlagsApp.test.tsx`

I also attempted a broader TypeScript pass via `tsconfig.webview-tests.json`, but that configuration currently fails on unrelated pre-existing issues in other webview test files, so I kept validation scoped to the changed area.
