### PR TITLE
[codex] fix e2e special target name fallback

### DIFF
--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -171,6 +171,40 @@ describe('ensureDebugFlagsTestUser', () => {
     });
   });
 
+  test('falls back to the first candidate name when Salesforce omits the special target name', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+
+    globalThis.fetch = jest.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
+
+      if (
+        soql.includes("Name IN ('Platform Integration', 'Platform Integration User')") &&
+        soql.includes("UserType = 'CloudIntegrationUser'")
+      ) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '005000000000777AAA' }] }
+        });
+      }
+
+      throw new Error(`Unexpected request GET ${url}`);
+    });
+
+    const resolved = await resolveSpecialTraceFlagTarget(auth, 'platformIntegration');
+
+    expect(resolved).toEqual({
+      id: '005000000000777AAA',
+      label: 'Platform Integration',
+      matchedName: 'Platform Integration'
+    });
+  });
+
   test('returns undefined when a special target query is ambiguous', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -192,7 +192,7 @@ async function findUserByExactNames(
     ambiguous: false,
     user: {
       id: record.Id,
-      name: typeof record?.Name === 'string' ? record.Name : name
+      name: typeof record?.Name === 'string' ? record.Name : normalizedNames[0]!
     }
   };
 }


### PR DESCRIPTION
## Summary
Recent debug-flags changes added E2E tooling support for resolving special trace-flag targets by exact system-user names. When Salesforce returns a matching User Id without a `Name` field, the helper falls back to an unintended ambient `name` identifier instead of one of the queried candidate names. That makes `matchedName` unstable in E2E tooling and can mislabel the resolved Platform Integration target in assertions or diagnostics.

## Root Cause
`findUserByExactNames` returned `record.Name` when present, but its fallback branch referenced `name`, which is not the local candidate list. The missing-name response shape was untested, so the bug survived the original special-target refactor.

## Fix
Use the first normalized queried candidate name as the fallback when Salesforce omits `User.Name`, and add a focused regression test that stubs the missing-name response for the Platform Integration target.

## Validation
- `npm run test:e2e:utils -- --runTestsByPath test/e2e/utils/__tests__/tooling.test.ts`
- `npm run compile`
