### PR TITLE
[codex] Support all active special entity targets and stabilize Windows E2E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Debug Flags: add special-target facilitators for `Automated Process` and `Platform Integration` directly in the panel, including status, apply, and remove flows for their `USER_DEBUG` trace flags.
+- Debug Flags: add special-target facilitators for `Automated Process` and `Platform Integration` directly in the panel, including aggregated status plus apply/remove flows across all matching active `USER_DEBUG` trace-flag targets.
 
 ### Bug Fixes
 

--- a/scripts/run-playwright-e2e.js
+++ b/scripts/run-playwright-e2e.js
@@ -32,6 +32,23 @@ function exitWithChildResult(code, signal) {
   process.exit(1);
 }
 
+function resolvePlaywrightInvocation(extraArgs) {
+  try {
+    // Prefer the local Playwright CLI directly. On Windows under Git Bash,
+    // spawning npx.cmd can throw EINVAL before Playwright even starts.
+    const cliPath = require.resolve('@playwright/test/cli');
+    return {
+      command: process.execPath,
+      args: [cliPath, 'test', ...extraArgs]
+    };
+  } catch {}
+
+  return {
+    command: process.platform === 'win32' ? 'npx.cmd' : 'npx',
+    args: ['playwright', 'test', ...extraArgs]
+  };
+}
+
 async function main() {
   // Some environments leak ELECTRON_RUN_AS_NODE=1; VS Code won't boot properly.
   try {
@@ -58,9 +75,12 @@ async function main() {
   }
 
   const repoRoot = path.join(__dirname, '..');
-  const cmd = process.platform === 'win32' ? 'npx.cmd' : 'npx';
-  const args = ['playwright', 'test', ...process.argv.slice(2)];
-  const child = spawn(cmd, args, { stdio: 'inherit', cwd: repoRoot, env: process.env });
+  const invocation = resolvePlaywrightInvocation(process.argv.slice(2));
+  const child = spawn(invocation.command, invocation.args, {
+    stdio: 'inherit',
+    cwd: repoRoot,
+    env: process.env
+  });
   child.on('exit', exitWithChildResult);
 }
 

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -209,10 +209,7 @@ export class DebugFlagsPanel {
       getActiveUserDebugLevel(auth).catch(() => undefined as string | undefined)
     ]);
 
-    if (
-      this.disposed ||
-      (typeof bootstrapToken === 'number' && bootstrapToken !== this.orgBootstrapToken)
-    ) {
+    if (this.disposed || (typeof bootstrapToken === 'number' && bootstrapToken !== this.orgBootstrapToken)) {
       return;
     }
 
@@ -226,10 +223,7 @@ export class DebugFlagsPanel {
       active
     });
 
-    const preferredId =
-      selectedId && details.some(record => record.id === selectedId)
-        ? selectedId
-        : details[0]?.id;
+    const preferredId = selectedId && details.some(record => record.id === selectedId) ? selectedId : details[0]?.id;
 
     this.post({
       type: 'debugFlagsManagerData',
@@ -303,7 +297,11 @@ export class DebugFlagsPanel {
       logWarn('DebugFlagsPanel: failed loading target status ->', msg);
       this.post({
         type: 'debugFlagsError',
-        message: localize('debugFlags.loadStatusFailed', 'Failed to load debug flag status for the selected target: {0}', msg)
+        message: localize(
+          'debugFlags.loadStatusFailed',
+          'Failed to load debug flag status for the selected target: {0}',
+          msg
+        )
       });
     } finally {
       if (token === this.statusToken && !this.disposed) {
@@ -326,12 +324,21 @@ export class DebugFlagsPanel {
         ttlMinutes
       });
       await this.loadSelectedTargetStatus(target);
+      const isAggregatedTarget = target.type !== 'user' && result.resolvedTargetCount > 1;
       this.post({
         type: 'debugFlagsNotice',
         tone: 'success',
-        message: result.created
-          ? localize('debugFlags.applyCreated', 'Debug flag created successfully.')
-          : localize('debugFlags.applyUpdated', 'Debug flag updated successfully.')
+        message: isAggregatedTarget
+          ? localize(
+              'debugFlags.applySummary',
+              'Applied debug flags to {0} matched targets ({1} created, {2} updated).',
+              result.resolvedTargetCount,
+              result.createdCount,
+              result.updatedCount
+            )
+          : result.created
+            ? localize('debugFlags.applyCreated', 'Debug flag created successfully.')
+            : localize('debugFlags.applyUpdated', 'Debug flag updated successfully.')
       });
       safeSendEvent(
         'debugFlags.apply',
@@ -476,13 +483,26 @@ export class DebugFlagsPanel {
     this.post({ type: 'debugFlagsLoading', scope: 'action', value: true });
     try {
       const auth = await this.getSelectedAuth();
-      const removed = await removeTraceFlags(auth, target);
+      const result = await removeTraceFlags(auth, target);
       await this.loadSelectedTargetStatus(target);
+      const isAggregatedTarget = target.type !== 'user' && result.resolvedTargetCount > 1;
       this.post({
         type: 'debugFlagsNotice',
-        tone: removed > 0 ? 'success' : 'info',
-        message:
-          removed > 0
+        tone: result.removedCount > 0 ? 'success' : 'info',
+        message: isAggregatedTarget
+          ? result.removedCount > 0
+            ? localize(
+                'debugFlags.removeSummary',
+                'Removed {0} USER_DEBUG trace flag records across {1} matched targets.',
+                result.removedCount,
+                result.resolvedTargetCount
+              )
+            : localize(
+                'debugFlags.removeNoneSummary',
+                'No USER_DEBUG trace flags were found across {0} matched targets.',
+                result.resolvedTargetCount
+              )
+          : result.removedCount > 0
             ? localize('debugFlags.removeSuccess', 'Debug flag removed successfully.')
             : localize('debugFlags.removeNone', 'No active USER_DEBUG trace flag was found for this target.')
       });
@@ -493,7 +513,7 @@ export class DebugFlagsPanel {
           sourceView: this.lastSourceView,
           targetType: target.type
         },
-        { durationMs: Date.now() - t0, removedCount: removed }
+        { durationMs: Date.now() - t0, removedCount: result.removedCount }
       );
     } catch (e) {
       const msg = getErrorMessage(e);

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -1,7 +1,9 @@
 import type {
   ApplyTraceFlagTargetInput,
+  ApplyTraceFlagTargetResult,
   DebugFlagUser,
   DebugLevelRecord,
+  RemoveTraceFlagsResult,
   TraceFlagTarget,
   TraceFlagTargetStatus
 } from '../shared/debugFlagsTypes';
@@ -15,7 +17,7 @@ import { resolvePATHFromLoginShell } from './path';
 import type { OrgAuth } from './types';
 
 const userIdCache = new Map<string, string>();
-const specialTargetIdCache = new Map<string, string | null>();
+const specialTargetIdsCache = new Map<string, string[]>();
 const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
 const AUTOMATED_PROCESS_TARGET_NAME = 'Automated Process';
 const PLATFORM_INTEGRATION_TARGET_NAMES = ['Platform Integration', 'Platform Integration User'] as const;
@@ -24,6 +26,20 @@ const PLATFORM_INTEGRATION_USER_TYPE = 'CloudIntegrationUser';
 
 type QueryResponse<TRecord = any> = {
   records?: TRecord[];
+};
+
+type SpecialTargetUserQueryRecord = {
+  Id?: string;
+  Name?: string;
+};
+
+type TraceFlagQueryRecord = {
+  Id?: string;
+  StartDate?: string;
+  ExpirationDate?: string;
+  DebugLevel?: {
+    DeveloperName?: string;
+  };
 };
 
 type DebugLevelQueryRecord = {
@@ -68,9 +84,7 @@ function escapeSoqlLiteral(value: string): string {
 }
 
 function escapeSoqlLikeLiteral(value: string): string {
-  return escapeSoqlLiteral(value)
-    .replace(/%/g, '\\%')
-    .replace(/_/g, '\\_');
+  return escapeSoqlLiteral(value).replace(/%/g, '\\%').replace(/_/g, '\\_');
 }
 
 function isSalesforceId(value: string | undefined): value is string {
@@ -96,11 +110,19 @@ function getDebugLevelDetailsCacheKey(auth: OrgAuth): string {
 }
 
 function getDebugLevelApiVersionCacheKey(auth: OrgAuth): string {
-  return `${String(auth.instanceUrl || '').trim().toLowerCase()}|${String(auth.username || '').trim().toLowerCase()}`;
+  return `${String(auth.instanceUrl || '')
+    .trim()
+    .toLowerCase()}|${String(auth.username || '')
+    .trim()
+    .toLowerCase()}`;
 }
 
 function getSpecialTargetCacheKey(auth: OrgAuth, targetType: Exclude<TraceFlagTarget['type'], 'user'>): string {
-  const orgKey = `${String(auth.instanceUrl || '').trim().toLowerCase()}|${String(auth.username || '').trim().toLowerCase()}`;
+  const orgKey = `${String(auth.instanceUrl || '')
+    .trim()
+    .toLowerCase()}|${String(auth.username || '')
+    .trim()
+    .toLowerCase()}`;
   return `${targetType}:${orgKey}`;
 }
 
@@ -113,6 +135,12 @@ function getTraceFlagTargetLabel(target: TraceFlagTarget): string {
     case 'platformIntegration':
       return 'Platform Integration';
   }
+}
+
+function isSpecialTraceFlagTarget(
+  target: TraceFlagTarget
+): target is Extract<TraceFlagTarget, { type: 'automatedProcess' | 'platformIntegration' }> {
+  return target.type === 'automatedProcess' || target.type === 'platformIntegration';
 }
 
 function parseApiVersionNumber(value: string | undefined): number | undefined {
@@ -141,15 +169,10 @@ async function getDebugLevelApiVersion(auth: OrgAuth): Promise<string> {
 
   try {
     const url = `${auth.instanceUrl}/services/data`;
-    const body = await httpsRequestWith401Retry(
-      auth,
-      'GET',
-      url,
-      {
-        Authorization: `Bearer ${auth.accessToken}`,
-        'Content-Type': 'application/json'
-      }
-    );
+    const body = await httpsRequestWith401Retry(auth, 'GET', url, {
+      Authorization: `Bearer ${auth.accessToken}`,
+      'Content-Type': 'application/json'
+    });
     const parsed = JSON.parse(body);
     if (!Array.isArray(parsed)) {
       return currentVersion;
@@ -172,7 +195,10 @@ async function getDebugLevelApiVersion(auth: OrgAuth): Promise<string> {
     }
   } catch (e) {
     try {
-      logTrace('getDebugLevelApiVersion: failed to discover org max API version ->', String((e as Error)?.message || e));
+      logTrace(
+        'getDebugLevelApiVersion: failed to discover org max API version ->',
+        String((e as Error)?.message || e)
+      );
     } catch {}
   }
 
@@ -271,15 +297,17 @@ async function execSfCommand(
 function getSfCliProgramCandidates(): string[] {
   const configured = String(getConfig<string | undefined>('sfLogs.cliPath', undefined) || '').trim();
   const windowsAppDataSf =
-    process.platform === 'win32' && process.env.APPDATA
-      ? path.join(process.env.APPDATA, 'npm', 'sf.cmd')
-      : '';
+    process.platform === 'win32' && process.env.APPDATA ? path.join(process.env.APPDATA, 'npm', 'sf.cmd') : '';
   const windowsUserProfileSf =
     process.platform === 'win32' && process.env.USERPROFILE
       ? path.join(process.env.USERPROFILE, 'AppData', 'Roaming', 'npm', 'sf.cmd')
       : '';
   return Array.from(
-    new Set([configured, windowsAppDataSf, windowsUserProfileSf, process.platform === 'win32' ? 'sf.cmd' : '', 'sf'].filter(Boolean))
+    new Set(
+      [configured, windowsAppDataSf, windowsUserProfileSf, process.platform === 'win32' ? 'sf.cmd' : '', 'sf'].filter(
+        Boolean
+      )
+    )
   );
 }
 
@@ -374,9 +402,7 @@ export async function listDebugLevels(auth: OrgAuth): Promise<string[]> {
 
   const soql = 'SELECT DeveloperName FROM DebugLevel ORDER BY DeveloperName';
   const json = await queryTooling<{ DeveloperName?: string }>(auth, soql);
-  const names = (json.records || [])
-    .map(r => r?.DeveloperName)
-    .filter((n): n is string => typeof n === 'string');
+  const names = (json.records || []).map(r => r?.DeveloperName).filter((n): n is string => typeof n === 'string');
 
   if (enabled && ttl > 0) {
     await CacheManager.set('cli', cacheKey, names, ttl);
@@ -475,30 +501,44 @@ function isTraceFlagActive(startDate: string | undefined, expirationDate: string
   return startMs <= now && now <= expMs;
 }
 
-async function queryUserIdByExactNamesAndType(
+async function queryUsersByExactNamesAndType(
   auth: OrgAuth,
   names: readonly string[],
   userType: string
-): Promise<{ userId?: string; ambiguous: boolean }> {
+): Promise<Array<{ id: string; name: string }>> {
   const normalizedNames = names.map(name => String(name || '').trim()).filter(Boolean);
   const normalizedUserType = String(userType || '').trim();
   if (normalizedNames.length === 0 || !normalizedUserType) {
-    return { ambiguous: false };
+    return [];
   }
 
   const escapedNames = normalizedNames.map(name => `'${escapeSoqlLiteral(name)}'`).join(', ');
   const escapedUserType = escapeSoqlLiteral(normalizedUserType);
-  const soql = `SELECT Id FROM User WHERE Name IN (${escapedNames}) AND UserType = '${escapedUserType}' ORDER BY Id LIMIT 3`;
-  const json = await queryStandard<{ Id?: string }>(auth, soql);
-  const ids = (Array.isArray(json.records) ? json.records : [])
-    .map(record => record?.Id)
-    .filter((value): value is string => isSalesforceId(value));
+  const soql =
+    `SELECT Id, Name FROM User WHERE Name IN (${escapedNames}) AND UserType = '${escapedUserType}' ` +
+    `AND IsActive = true ORDER BY Id LIMIT 200`;
+  const json = await queryStandard<SpecialTargetUserQueryRecord>(auth, soql);
+  const users = (Array.isArray(json.records) ? json.records : [])
+    .map(record => {
+      const id = record?.Id;
+      if (!isSalesforceId(id)) {
+        return undefined;
+      }
+      return {
+        id,
+        name: typeof record?.Name === 'string' ? record.Name : ''
+      };
+    })
+    .filter((value): value is { id: string; name: string } => Boolean(value));
 
-  if (ids.length > 1) {
-    return { ambiguous: true };
-  }
-
-  return { userId: ids[0], ambiguous: false };
+  const seen = new Set<string>();
+  return users.filter(user => {
+    if (seen.has(user.id)) {
+      return false;
+    }
+    seen.add(user.id);
+    return true;
+  });
 }
 
 export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefined> {
@@ -522,56 +562,49 @@ export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefine
   return userId;
 }
 
-async function getSpecialTraceFlagTargetId(
+async function getSpecialTraceFlagTargetIds(
   auth: OrgAuth,
   targetType: Exclude<TraceFlagTarget['type'], 'user'>
-): Promise<string | undefined> {
+): Promise<string[]> {
   const cacheKey = getSpecialTargetCacheKey(auth, targetType);
-  if (specialTargetIdCache.has(cacheKey)) {
-    return specialTargetIdCache.get(cacheKey) || undefined;
+  if (specialTargetIdsCache.has(cacheKey)) {
+    return [...(specialTargetIdsCache.get(cacheKey) || [])];
   }
 
   const candidateNames =
     targetType === 'automatedProcess' ? [AUTOMATED_PROCESS_TARGET_NAME] : [...PLATFORM_INTEGRATION_TARGET_NAMES];
   const expectedUserType =
     targetType === 'automatedProcess' ? AUTOMATED_PROCESS_USER_TYPE : PLATFORM_INTEGRATION_USER_TYPE;
-  const { userId, ambiguous } = await queryUserIdByExactNamesAndType(auth, candidateNames, expectedUserType);
-  if (ambiguous) {
-    specialTargetIdCache.set(cacheKey, null);
-    return undefined;
-  }
-  if (userId) {
-    specialTargetIdCache.set(cacheKey, userId);
-    return userId;
-  }
-
-  specialTargetIdCache.set(cacheKey, null);
-  return undefined;
+  const users = await queryUsersByExactNamesAndType(auth, candidateNames, expectedUserType);
+  const userIds = users.map(user => user.id);
+  specialTargetIdsCache.set(cacheKey, userIds);
+  return [...userIds];
 }
 
 async function resolveTraceFlagTarget(
   auth: OrgAuth,
   target: TraceFlagTarget
-): Promise<{ targetLabel: string; tracedEntityId?: string; targetAvailable: boolean }> {
+): Promise<{ targetLabel: string; tracedEntityIds: string[]; targetAvailable: boolean }> {
   if (target.type === 'user') {
+    const tracedEntityId = isSalesforceId(target.userId) ? target.userId : undefined;
     return {
       targetLabel: getTraceFlagTargetLabel(target),
-      tracedEntityId: isSalesforceId(target.userId) ? target.userId : undefined,
-      targetAvailable: isSalesforceId(target.userId)
+      tracedEntityIds: tracedEntityId ? [tracedEntityId] : [],
+      targetAvailable: Boolean(tracedEntityId)
     };
   }
 
-  const tracedEntityId = await getSpecialTraceFlagTargetId(auth, target.type);
+  const tracedEntityIds = await getSpecialTraceFlagTargetIds(auth, target.type);
   return {
     targetLabel: getTraceFlagTargetLabel(target),
-    tracedEntityId,
-    targetAvailable: Boolean(tracedEntityId)
+    tracedEntityIds,
+    targetAvailable: tracedEntityIds.length > 0
   };
 }
 
 export function __resetUserIdCacheForTests(): void {
   userIdCache.clear();
-  specialTargetIdCache.clear();
+  specialTargetIdsCache.clear();
 }
 
 async function getDebugLevelIdByName(auth: OrgAuth, developerName: string): Promise<string | undefined> {
@@ -586,10 +619,7 @@ async function getDebugLevelIdByName(auth: OrgAuth, developerName: string): Prom
   return rec?.Id;
 }
 
-export async function createDebugLevel(
-  auth: OrgAuth,
-  input: DebugLevelRecord
-): Promise<{ id: string }> {
+export async function createDebugLevel(auth: OrgAuth, input: DebugLevelRecord): Promise<{ id: string }> {
   const payload = buildDebugLevelPayload(input);
   const apiVersion = await getDebugLevelApiVersion(auth);
   if (auth.username) {
@@ -639,11 +669,7 @@ export async function createDebugLevel(
   return { id: String(res.id) };
 }
 
-export async function updateDebugLevel(
-  auth: OrgAuth,
-  debugLevelId: string,
-  input: DebugLevelRecord
-): Promise<void> {
+export async function updateDebugLevel(auth: OrgAuth, debugLevelId: string, input: DebugLevelRecord): Promise<void> {
   if (!isSalesforceId(debugLevelId)) {
     throw new Error('Invalid DebugLevel id.');
   }
@@ -679,8 +705,7 @@ export async function updateDebugLevel(
     }
   }
 
-  const updateUrl =
-    `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+  const updateUrl = `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
   await httpsRequestWith401Retry(
     auth,
     'PATCH',
@@ -727,8 +752,7 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
     }
   }
 
-  const deleteUrl =
-    `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
+  const deleteUrl = `${auth.instanceUrl}/services/data/v${apiVersion}/tooling/sobjects/DebugLevel/${debugLevelId}`;
   await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
     Authorization: `Bearer ${auth.accessToken}`,
     'Content-Type': 'application/json'
@@ -736,7 +760,10 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
   await invalidateDebugLevelsCache(auth);
 }
 
-async function getLatestTraceFlagRecord(auth: OrgAuth, tracedEntityId: string): Promise<any | undefined> {
+async function getLatestTraceFlagRecord(
+  auth: OrgAuth,
+  tracedEntityId: string
+): Promise<TraceFlagQueryRecord | undefined> {
   if (!isSalesforceId(tracedEntityId)) {
     return undefined;
   }
@@ -744,7 +771,7 @@ async function getLatestTraceFlagRecord(auth: OrgAuth, tracedEntityId: string): 
     `SELECT Id, DebugLevel.DeveloperName, StartDate, ExpirationDate ` +
     `FROM TraceFlag WHERE TracedEntityId = '${tracedEntityId}' AND LogType = 'USER_DEBUG' ` +
     `ORDER BY CreatedDate DESC LIMIT 1`;
-  const json = await queryTooling<any>(auth, soql);
+  const json = await queryTooling<TraceFlagQueryRecord>(auth, soql);
   return (json.records || [])[0];
 }
 
@@ -772,48 +799,124 @@ async function listTraceFlagIds(auth: OrgAuth, tracedEntityId: string): Promise<
     .filter((id): id is string => typeof id === 'string' && id.length > 0);
 }
 
+async function getLatestTraceFlagRecordsByEntityId(
+  auth: OrgAuth,
+  tracedEntityIds: readonly string[]
+): Promise<Map<string, TraceFlagQueryRecord | undefined>> {
+  const entries = await Promise.all(
+    tracedEntityIds.map(
+      async tracedEntityId => [tracedEntityId, await getLatestTraceFlagRecord(auth, tracedEntityId)] as const
+    )
+  );
+  return new Map(entries);
+}
+
+function getTraceFlagDebugLevelName(record: TraceFlagQueryRecord | undefined): string | undefined {
+  return typeof record?.DebugLevel?.DeveloperName === 'string' ? record.DebugLevel.DeveloperName : undefined;
+}
+
 export async function getTraceFlagTargetStatus(auth: OrgAuth, target: TraceFlagTarget): Promise<TraceFlagTargetStatus> {
   const resolved = await resolveTraceFlagTarget(auth, target);
-  if (!resolved.targetAvailable || !resolved.tracedEntityId) {
+  if (!resolved.targetAvailable || resolved.tracedEntityIds.length === 0) {
     return {
       target,
       targetLabel: resolved.targetLabel,
       targetAvailable: false,
+      resolvedTargetCount: 0,
+      activeTargetCount: 0,
       isActive: false
     };
   }
 
-  const record = await getLatestTraceFlagRecord(auth, resolved.tracedEntityId);
-  if (!record?.Id) {
+  if (!isSpecialTraceFlagTarget(target)) {
+    const tracedEntityId = resolved.tracedEntityIds[0];
+    const record = tracedEntityId ? await getLatestTraceFlagRecord(auth, tracedEntityId) : undefined;
+    if (!record?.Id) {
+      return {
+        target,
+        targetLabel: resolved.targetLabel,
+        targetAvailable: true,
+        resolvedTargetCount: tracedEntityId ? 1 : 0,
+        activeTargetCount: 0,
+        isActive: false
+      };
+    }
+
+    const startDate = typeof record.StartDate === 'string' ? record.StartDate : undefined;
+    const expirationDate = typeof record.ExpirationDate === 'string' ? record.ExpirationDate : undefined;
+    const isActive = isTraceFlagActive(startDate, expirationDate);
     return {
       target,
       targetLabel: resolved.targetLabel,
       targetAvailable: true,
+      traceFlagId: String(record.Id),
+      debugLevelName: getTraceFlagDebugLevelName(record) || '(unknown)',
+      startDate,
+      expirationDate,
+      resolvedTargetCount: 1,
+      activeTargetCount: isActive ? 1 : 0,
+      isActive
+    };
+  }
+
+  const recordsByEntityId = await getLatestTraceFlagRecordsByEntityId(auth, resolved.tracedEntityIds);
+  const resolvedStatuses = resolved.tracedEntityIds.map(tracedEntityId => {
+    const record = recordsByEntityId.get(tracedEntityId);
+    const startDate = typeof record?.StartDate === 'string' ? record.StartDate : undefined;
+    const expirationDate = typeof record?.ExpirationDate === 'string' ? record.ExpirationDate : undefined;
+    const isActive = Boolean(record?.Id) && isTraceFlagActive(startDate, expirationDate);
+    return {
+      tracedEntityId,
+      record,
+      startDate,
+      expirationDate,
+      debugLevelName: getTraceFlagDebugLevelName(record),
+      isActive
+    };
+  });
+  const activeStatuses = resolvedStatuses.filter(status => status.isActive);
+  if (activeStatuses.length === 0) {
+    return {
+      target,
+      targetLabel: resolved.targetLabel,
+      targetAvailable: true,
+      resolvedTargetCount: resolved.tracedEntityIds.length,
+      activeTargetCount: 0,
       isActive: false
     };
   }
 
-  const startDate = typeof record.StartDate === 'string' ? record.StartDate : undefined;
-  const expirationDate = typeof record.ExpirationDate === 'string' ? record.ExpirationDate : undefined;
+  const uniqueDebugLevels = new Set(activeStatuses.map(status => status.debugLevelName || '(unknown)'));
+  const debugLevelMixed = activeStatuses.length !== resolved.tracedEntityIds.length || uniqueDebugLevels.size > 1;
+  const firstActiveStatus = activeStatuses[0];
+  const allStartDatesMatch =
+    !debugLevelMixed &&
+    activeStatuses.every(status => String(status.startDate || '') === String(firstActiveStatus?.startDate || ''));
+  const allExpirationDatesMatch =
+    !debugLevelMixed &&
+    activeStatuses.every(
+      status => String(status.expirationDate || '') === String(firstActiveStatus?.expirationDate || '')
+    );
   return {
     target,
     targetLabel: resolved.targetLabel,
     targetAvailable: true,
-    traceFlagId: String(record.Id),
-    debugLevelName:
-      typeof record.DebugLevel?.DeveloperName === 'string' ? record.DebugLevel.DeveloperName : '(unknown)',
-    startDate,
-    expirationDate,
-    isActive: isTraceFlagActive(startDate, expirationDate)
+    debugLevelName: debugLevelMixed ? undefined : [...uniqueDebugLevels][0],
+    startDate: allStartDatesMatch ? firstActiveStatus?.startDate : undefined,
+    expirationDate: allExpirationDatesMatch ? firstActiveStatus?.expirationDate : undefined,
+    resolvedTargetCount: resolved.tracedEntityIds.length,
+    activeTargetCount: activeStatuses.length,
+    debugLevelMixed,
+    isActive: true
   };
 }
 
 export async function upsertTraceFlag(
   auth: OrgAuth,
   input: ApplyTraceFlagTargetInput
-): Promise<{ created: boolean; traceFlagId?: string }> {
+): Promise<ApplyTraceFlagTargetResult> {
   const resolved = await resolveTraceFlagTarget(auth, input.target);
-  if (!resolved.targetAvailable || !resolved.tracedEntityId) {
+  if (!resolved.targetAvailable || resolved.tracedEntityIds.length === 0) {
     throw new Error(`Trace flag target '${resolved.targetLabel}' was not found.`);
   }
   const debugLevelName = String(input.debugLevelName || '').trim();
@@ -831,67 +934,93 @@ export async function upsertTraceFlag(
   const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
   const exp = toSfDateTimeUTC(new Date(now.getTime() + ttlMinutes * 60 * 1000));
 
-  const existingId = await getLatestTraceFlagId(auth, resolved.tracedEntityId);
-  if (existingId) {
-    const patchUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${existingId}`;
-    await httpsRequestWith401Retry(
+  let createdCount = 0;
+  let updatedCount = 0;
+  const traceFlagIds: string[] = [];
+
+  for (const tracedEntityId of resolved.tracedEntityIds) {
+    const existingId = await getLatestTraceFlagId(auth, tracedEntityId);
+    if (existingId) {
+      const patchUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${existingId}`;
+      await httpsRequestWith401Retry(
+        auth,
+        'PATCH',
+        patchUrl,
+        {
+          Authorization: `Bearer ${auth.accessToken}`,
+          'Content-Type': 'application/json'
+        },
+        JSON.stringify({
+          DebugLevelId: debugLevelId,
+          StartDate: start,
+          ExpirationDate: exp
+        })
+      );
+      updatedCount += 1;
+      traceFlagIds.push(existingId);
+      continue;
+    }
+
+    const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag`;
+    const payload = {
+      TracedEntityId: tracedEntityId,
+      LogType: 'USER_DEBUG',
+      DebugLevelId: debugLevelId,
+      StartDate: start,
+      ExpirationDate: exp
+    };
+    const resBody = await httpsRequestWith401Retry(
       auth,
-      'PATCH',
-      patchUrl,
+      'POST',
+      createUrl,
       {
         Authorization: `Bearer ${auth.accessToken}`,
         'Content-Type': 'application/json'
       },
-      JSON.stringify({
-        DebugLevelId: debugLevelId,
-        StartDate: start,
-        ExpirationDate: exp
-      })
+      JSON.stringify(payload)
     );
-    return { created: false, traceFlagId: existingId };
+    const res = JSON.parse(resBody);
+    if (!res || !res.success || !res.id) {
+      throw new Error('Failed to create USER_DEBUG TraceFlag.');
+    }
+    createdCount += 1;
+    traceFlagIds.push(String(res.id));
   }
 
-  const createUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag`;
-  const payload = {
-    TracedEntityId: resolved.tracedEntityId,
-    LogType: 'USER_DEBUG',
-    DebugLevelId: debugLevelId,
-    StartDate: start,
-    ExpirationDate: exp
+  const traceFlagId = traceFlagIds.length === 1 ? traceFlagIds[0] : undefined;
+  return {
+    created: resolved.tracedEntityIds.length === 1 ? createdCount === 1 : createdCount > 0 && updatedCount === 0,
+    traceFlagId,
+    traceFlagIds,
+    createdCount,
+    updatedCount,
+    resolvedTargetCount: resolved.tracedEntityIds.length
   };
-  const resBody = await httpsRequestWith401Retry(
-    auth,
-    'POST',
-    createUrl,
-    {
-      Authorization: `Bearer ${auth.accessToken}`,
-      'Content-Type': 'application/json'
-    },
-    JSON.stringify(payload)
-  );
-  const res = JSON.parse(resBody);
-  if (res && res.success) {
-    return { created: true, traceFlagId: res.id };
-  }
-  throw new Error('Failed to create USER_DEBUG TraceFlag.');
 }
 
-export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): Promise<number> {
+export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): Promise<RemoveTraceFlagsResult> {
   const resolved = await resolveTraceFlagTarget(auth, target);
-  if (!resolved.targetAvailable || !resolved.tracedEntityId) {
+  if (!resolved.targetAvailable || resolved.tracedEntityIds.length === 0) {
     throw new Error(`Trace flag target '${resolved.targetLabel}' was not found.`);
   }
-  const ids = await listTraceFlagIds(auth, resolved.tracedEntityId);
 
-  for (const id of ids) {
-    const deleteUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${id}`;
-    await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
-      Authorization: `Bearer ${auth.accessToken}`,
-      'Content-Type': 'application/json'
-    });
+  let removedCount = 0;
+  for (const tracedEntityId of resolved.tracedEntityIds) {
+    const ids = await listTraceFlagIds(auth, tracedEntityId);
+    for (const id of ids) {
+      const deleteUrl = `${auth.instanceUrl}/services/data/v${getEffectiveApiVersion(auth)}/tooling/sobjects/TraceFlag/${id}`;
+      await httpsRequestWith401Retry(auth, 'DELETE', deleteUrl, {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'Content-Type': 'application/json'
+      });
+    }
+    removedCount += ids.length;
   }
 
-  return ids.length;
+  return {
+    removedCount,
+    resolvedTargetCount: resolved.tracedEntityIds.length
+  };
 }
 
 export async function getUserTraceFlagStatus(auth: OrgAuth, userId: string): Promise<TraceFlagTargetStatus> {
@@ -901,7 +1030,7 @@ export async function getUserTraceFlagStatus(auth: OrgAuth, userId: string): Pro
 export async function upsertUserTraceFlag(
   auth: OrgAuth,
   input: { userId: string; debugLevelName: string; ttlMinutes: number }
-): Promise<{ created: boolean; traceFlagId?: string }> {
+): Promise<ApplyTraceFlagTargetResult> {
   return upsertTraceFlag(auth, {
     target: { type: 'user', userId: input.userId },
     debugLevelName: input.debugLevelName,
@@ -910,7 +1039,8 @@ export async function upsertUserTraceFlag(
 }
 
 export async function removeUserTraceFlags(auth: OrgAuth, userId: string): Promise<number> {
-  return removeTraceFlags(auth, { type: 'user', userId });
+  const result = await removeTraceFlags(auth, { type: 'user', userId });
+  return result.removedCount;
 }
 
 export async function ensureUserTraceFlag(

--- a/src/shared/debugFlagsTypes.ts
+++ b/src/shared/debugFlagsTypes.ts
@@ -20,12 +20,29 @@ export interface TraceFlagTargetStatus {
   startDate?: string;
   expirationDate?: string;
   isActive: boolean;
+  resolvedTargetCount?: number;
+  activeTargetCount?: number;
+  debugLevelMixed?: boolean;
 }
 
 export interface ApplyTraceFlagTargetInput {
   target: TraceFlagTarget;
   debugLevelName: string;
   ttlMinutes: number;
+}
+
+export interface ApplyTraceFlagTargetResult {
+  created: boolean;
+  traceFlagId?: string;
+  traceFlagIds: string[];
+  createdCount: number;
+  updatedCount: number;
+  resolvedTargetCount: number;
+}
+
+export interface RemoveTraceFlagsResult {
+  removedCount: number;
+  resolvedTargetCount: number;
 }
 
 export function getTraceFlagTargetKey(target: TraceFlagTarget | undefined): string {

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -30,9 +30,7 @@ type StubRequest = {
   body: string;
 };
 
-function installHttpsStub(
-  responder: (req: StubRequest) => { statusCode: number; body?: unknown }
-): StubRequest[] {
+function installHttpsStub(responder: (req: StubRequest) => { statusCode: number; body?: unknown }): StubRequest[] {
   const calls: StubRequest[] = [];
   __setHttpsRequestImplForTests((options: any, cb: any) => {
     const req = new EventEmitter() as any;
@@ -256,26 +254,42 @@ suite('traceflags user management', () => {
     assert.equal(status?.isActive, true);
   });
 
-  test('getTraceFlagTargetStatus resolves Automated Process with the expected system user type and reads USER_DEBUG status', async () => {
+  test('getTraceFlagTargetStatus resolves Automated Process across all active matches and aggregates USER_DEBUG status', async () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
         if (
           soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'")
+          soql.includes("UserType = 'AutomatedProcess'") &&
+          soql.includes('IsActive = true')
         ) {
           return {
             statusCode: 200,
-            body: { records: [{ Id: '005000000000003AAA' }] }
+            body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
           };
         }
-        if (soql.includes('FROM TraceFlag')) {
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000003AAA'")) {
           return {
             statusCode: 200,
             body: {
               records: [
                 {
                   Id: '7tf000000000003AAA',
+                  StartDate: '2026-02-19T16:00:00.000Z',
+                  ExpirationDate: '2099-02-19T18:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_AUTOPROC' }
+                }
+              ]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000004AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000004AAA',
                   StartDate: '2026-02-19T16:00:00.000Z',
                   ExpirationDate: '2099-02-19T18:00:00.000Z',
                   DebugLevel: { DeveloperName: 'ALV_AUTOPROC' }
@@ -292,13 +306,20 @@ suite('traceflags user management', () => {
     assert.equal(status.target.type, 'automatedProcess');
     assert.equal(status.targetLabel, 'Automated Process');
     assert.equal(status.targetAvailable, true);
-    assert.equal(status.traceFlagId, '7tf000000000003AAA');
+    assert.equal(status.traceFlagId, undefined);
     assert.equal(status.debugLevelName, 'ALV_AUTOPROC');
+    assert.equal(status.resolvedTargetCount, 2);
+    assert.equal(status.activeTargetCount, 2);
+    assert.equal(status.debugLevelMixed, false);
     assert.equal(status.isActive, true);
     assert.ok(
       calls.some(call => {
         const soql = decodeSoql(call.path);
-        return soql.includes("FROM User WHERE Name IN ('Automated Process')") && soql.includes("UserType = 'AutomatedProcess'");
+        return (
+          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
+          soql.includes("UserType = 'AutomatedProcess'") &&
+          soql.includes('IsActive = true')
+        );
       }),
       'expected Automated Process user resolution query with system user type'
     );
@@ -310,7 +331,8 @@ suite('traceflags user management', () => {
         const soql = decodeSoql(req.path);
         if (
           soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'")
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
         ) {
           return {
             statusCode: 200,
@@ -331,32 +353,86 @@ suite('traceflags user management', () => {
     assert.equal(status.target.type, 'platformIntegration');
     assert.equal(status.targetAvailable, true);
     assert.equal(status.traceFlagId, undefined);
+    assert.equal(status.resolvedTargetCount, 1);
+    assert.equal(status.activeTargetCount, 0);
     assert.equal(status.isActive, false);
     assert.ok(
       calls.some(call => {
         const soql = decodeSoql(call.path);
-        return soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") && soql.includes("UserType = 'CloudIntegrationUser'");
+        return (
+          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
+        );
       }),
       'expected Platform Integration lookup across accepted names with cloud integration user type'
     );
   });
 
-  test('getTraceFlagTargetStatus treats ambiguous special-target matches as unavailable', async () => {
+  test('getTraceFlagTargetStatus reports mixed special-target status when resolved users differ', async () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
         if (
           soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'")
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
         ) {
           return {
             statusCode: 200,
             body: {
+              records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000003AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
               records: [
-                { Id: '005000000000003AAA' },
-                { Id: '005000000000004AAA' }
+                {
+                  Id: '7tf000000000003AAA',
+                  StartDate: '2026-02-19T16:00:00.000Z',
+                  ExpirationDate: '2099-02-19T18:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_PLATFORM_A' }
+                }
               ]
             }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000004AAA'")) {
+          return {
+            statusCode: 200,
+            body: { records: [] }
+          };
+        }
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const status = await getTraceFlagTargetStatus(auth, { type: 'platformIntegration' });
+    assert.equal(status.target.type, 'platformIntegration');
+    assert.equal(status.targetAvailable, true);
+    assert.equal(status.traceFlagId, undefined);
+    assert.equal(status.resolvedTargetCount, 2);
+    assert.equal(status.activeTargetCount, 1);
+    assert.equal(status.debugLevelMixed, true);
+    assert.equal(status.debugLevelName, undefined);
+    assert.equal(status.isActive, true);
+  });
+
+  test('getTraceFlagTargetStatus marks special target unavailable when no active users match', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/query?q=')) {
+        const soql = decodeSoql(req.path);
+        if (
+          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
+        ) {
+          return {
+            statusCode: 200,
+            body: { records: [] }
           };
         }
       }
@@ -367,6 +443,8 @@ suite('traceflags user management', () => {
     assert.equal(status.target.type, 'platformIntegration');
     assert.equal(status.targetAvailable, false);
     assert.equal(status.traceFlagId, undefined);
+    assert.equal(status.resolvedTargetCount, 0);
+    assert.equal(status.activeTargetCount, 0);
     assert.equal(status.isActive, false);
   });
 
@@ -468,7 +546,10 @@ suite('traceflags user management', () => {
     const records = await listDebugLevelDetails(legacyAuth);
 
     assert.equal(records.length, 1);
-    assert.ok(calls.some(call => call.path === '/services/data'), 'expected org API discovery request');
+    assert.ok(
+      calls.some(call => call.path === '/services/data'),
+      'expected org API discovery request'
+    );
     assert.ok(
       calls.some(call => call.path.includes('/services/data/v66.0/tooling/query')),
       'expected DebugLevel query to use upgraded API version'
@@ -530,7 +611,10 @@ suite('traceflags user management', () => {
     assert.match(createCommandText, /DeveloperName=ALV_CUSTOM/);
     assert.match(createCommandText, /MasterLabel='ALV Custom'/);
     assert.match(createCommandText, /DataAccess=INFO/);
-    assert.ok(httpCalls.some(call => call.path === '/services/data'), 'expected org API discovery before CLI create');
+    assert.ok(
+      httpCalls.some(call => call.path === '/services/data'),
+      'expected org API discovery before CLI create'
+    );
   });
 
   test('updateDebugLevel uses sf CLI with the full editable DebugLevel payload', async () => {
@@ -606,7 +690,10 @@ suite('traceflags user management', () => {
     assert.match(deleteCommandText, /--record-id/);
     assert.match(deleteCommandText, /7dl000000000001AAA/);
     assert.match(deleteCommandText, /--api-version 66\.0/);
-    assert.ok(httpCalls.some(call => call.path === '/services/data'), 'expected org API discovery before CLI delete');
+    assert.ok(
+      httpCalls.some(call => call.path === '/services/data'),
+      'expected org API discovery before CLI delete'
+    );
   });
 
   test('upsertUserTraceFlag updates existing USER_DEBUG flag', async () => {
@@ -669,31 +756,40 @@ suite('traceflags user management', () => {
     assert.equal(result.traceFlagId, '7tf000000000999AAA');
   });
 
-  test('upsertTraceFlag creates USER_DEBUG flag for Automated Process target', async () => {
-    installHttpsStub(req => {
+  test('upsertTraceFlag applies USER_DEBUG flags across all resolved Automated Process targets', async () => {
+    const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
         if (
           soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'")
+          soql.includes("UserType = 'AutomatedProcess'") &&
+          soql.includes('IsActive = true')
         ) {
           return {
             statusCode: 200,
-            body: { records: [{ Id: '005000000000003AAA' }] }
+            body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
           };
         }
         if (soql.includes('FROM DebugLevel')) {
           return { statusCode: 200, body: { records: [{ Id: '7dl000000000001AAA' }] } };
         }
-        if (soql.includes('FROM TraceFlag')) {
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000003AAA'")) {
+          return { statusCode: 200, body: { records: [{ Id: '7tf000000000003AAA' }] } };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000004AAA'")) {
           return { statusCode: 200, body: { records: [] } };
         }
       }
+      if (req.method === 'PATCH' && req.path.includes('/tooling/sobjects/TraceFlag/7tf000000000003AAA')) {
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.DebugLevelId, '7dl000000000001AAA');
+        return { statusCode: 204 };
+      }
       if (req.method === 'POST' && req.path.endsWith('/tooling/sobjects/TraceFlag')) {
         const parsed = JSON.parse(req.body);
-        assert.equal(parsed.TracedEntityId, '005000000000003AAA');
+        assert.equal(parsed.TracedEntityId, '005000000000004AAA');
         assert.equal(parsed.LogType, 'USER_DEBUG');
-        return { statusCode: 201, body: { success: true, id: '7tf000000000003AAA' } };
+        return { statusCode: 201, body: { success: true, id: '7tf000000000004AAA' } };
       }
       throw new Error(`Unexpected request: ${req.method} ${req.path}`);
     });
@@ -703,8 +799,14 @@ suite('traceflags user management', () => {
       debugLevelName: 'ALV_E2E',
       ttlMinutes: 30
     });
-    assert.equal(result.created, true);
-    assert.equal(result.traceFlagId, '7tf000000000003AAA');
+    assert.equal(result.created, false);
+    assert.equal(result.traceFlagId, undefined);
+    assert.deepEqual(result.traceFlagIds, ['7tf000000000003AAA', '7tf000000000004AAA']);
+    assert.equal(result.createdCount, 1);
+    assert.equal(result.updatedCount, 1);
+    assert.equal(result.resolvedTargetCount, 2);
+    assert.equal(calls.filter(call => call.method === 'PATCH').length, 1);
+    assert.equal(calls.filter(call => call.method === 'POST').length, 1);
   });
 
   test('removeUserTraceFlags deletes all USER_DEBUG flags for user', async () => {
@@ -724,6 +826,44 @@ suite('traceflags user management', () => {
     const removed = await removeUserTraceFlags(auth, '005000000000001AAA');
     assert.equal(removed, 2);
     assert.equal(calls.filter(call => call.method === 'DELETE').length, 2);
+  });
+
+  test('removeTraceFlags deletes USER_DEBUG flags across all resolved Platform Integration targets', async () => {
+    const calls = installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/query?q=')) {
+        const soql = decodeSoql(req.path);
+        if (
+          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
+        ) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }]
+            }
+          };
+        }
+      }
+      if (req.method === 'GET' && req.path.includes('/tooling/query')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("TracedEntityId = '005000000000003AAA'")) {
+          return { statusCode: 200, body: { records: [{ Id: '7tf000000000101AAA' }, { Id: '7tf000000000102AAA' }] } };
+        }
+        if (soql.includes("TracedEntityId = '005000000000004AAA'")) {
+          return { statusCode: 200, body: { records: [{ Id: '7tf000000000201AAA' }] } };
+        }
+      }
+      if (req.method === 'DELETE' && req.path.includes('/tooling/sobjects/TraceFlag/')) {
+        return { statusCode: 204 };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const result = await removeTraceFlags(auth, { type: 'platformIntegration' });
+    assert.equal(result.removedCount, 3);
+    assert.equal(result.resolvedTargetCount, 2);
+    assert.equal(calls.filter(call => call.method === 'DELETE').length, 3);
   });
 
   test('removeTraceFlags surfaces a friendly error when Platform Integration is unavailable', async () => {

--- a/src/webview/__tests__/debugFlagsApp.test.tsx
+++ b/src/webview/__tests__/debugFlagsApp.test.tsx
@@ -144,9 +144,7 @@ describe('DebugFlags webview App', () => {
     fireEvent.click(screen.getByTestId('debug-level-delete-confirm'));
     await waitFor(() => {
       expect(
-        posted.some(
-          msg => msg.type === 'debugFlagsManagerDelete' && msg.debugLevelId === '7dl000000000001AAA'
-        )
+        posted.some(msg => msg.type === 'debugFlagsManagerDelete' && msg.debugLevelId === '7dl000000000001AAA')
       ).toBe(true);
     });
 
@@ -204,15 +202,13 @@ describe('DebugFlags webview App', () => {
       expect(
         posted.some(
           msg =>
-            msg.type === 'debugFlagsRemove' &&
-            msg.target.type === 'user' &&
-            msg.target.userId === '005000000000001AAA'
+            msg.type === 'debugFlagsRemove' && msg.target.type === 'user' && msg.target.userId === '005000000000001AAA'
         )
       ).toBe(true);
     });
   });
 
-  it('supports special targets and disables actions when a special target is unavailable', async () => {
+  it('supports aggregated special-target status and disables actions when a special target is unavailable', async () => {
     const { vscode, posted } = createVsCodeMock();
     const bus = new EventTarget();
     render(<DebugFlagsApp vscode={vscode} messageBus={bus} />);
@@ -227,11 +223,9 @@ describe('DebugFlags webview App', () => {
 
     fireEvent.click(screen.getByTestId('debug-flags-special-target-automated-process'));
     await waitFor(() => {
-      expect(
-        posted.some(
-          msg => msg.type === 'debugFlagsSelectTarget' && msg.target.type === 'automatedProcess'
-        )
-      ).toBe(true);
+      expect(posted.some(msg => msg.type === 'debugFlagsSelectTarget' && msg.target.type === 'automatedProcess')).toBe(
+        true
+      );
     });
 
     sendMessage(bus, {
@@ -253,9 +247,7 @@ describe('DebugFlags webview App', () => {
     fireEvent.click(screen.getByTestId('debug-flags-special-target-platform-integration'));
     await waitFor(() => {
       expect(
-        posted.some(
-          msg => msg.type === 'debugFlagsSelectTarget' && msg.target.type === 'platformIntegration'
-        )
+        posted.some(msg => msg.type === 'debugFlagsSelectTarget' && msg.target.type === 'platformIntegration')
       ).toBe(true);
     });
 
@@ -266,9 +258,17 @@ describe('DebugFlags webview App', () => {
         target: { type: 'platformIntegration' },
         targetLabel: 'Platform Integration',
         targetAvailable: true,
-        isActive: false
+        resolvedTargetCount: 2,
+        activeTargetCount: 1,
+        debugLevelMixed: true,
+        isActive: true
       }
     });
+
+    await screen.findByTestId('debug-flags-status-resolved-count');
+    expect(screen.getByTestId('debug-flags-status-resolved-count')).toHaveTextContent('2');
+    expect(screen.getByTestId('debug-flags-status-active-count')).toHaveTextContent('1/2');
+    expect(screen.getByTestId('debug-flags-status-level')).toHaveTextContent('Mixed');
 
     fireEvent.click(screen.getByTestId('debug-flags-apply'));
     await waitFor(() => {
@@ -285,11 +285,9 @@ describe('DebugFlags webview App', () => {
 
     fireEvent.click(screen.getByTestId('debug-flags-remove'));
     await waitFor(() => {
-      expect(
-        posted.some(
-          msg => msg.type === 'debugFlagsRemove' && msg.target.type === 'platformIntegration'
-        )
-      ).toBe(true);
+      expect(posted.some(msg => msg.type === 'debugFlagsRemove' && msg.target.type === 'platformIntegration')).toBe(
+        true
+      );
     });
   });
 

--- a/src/webview/debugFlags.tsx
+++ b/src/webview/debugFlags.tsx
@@ -203,10 +203,7 @@ export function DebugFlagsApp({
   }, [initialized, selectedOrg, query, vscode]);
 
   const selectedUserId = selectedTarget?.type === 'user' ? selectedTarget.userId : undefined;
-  const selectedUser = useMemo(
-    () => users.find(user => user.id === selectedUserId),
-    [users, selectedUserId]
-  );
+  const selectedUser = useMemo(() => users.find(user => user.id === selectedUserId), [users, selectedUserId]);
   const selectedTargetLabel = useMemo(() => {
     if (!selectedTarget) {
       return '';
@@ -215,21 +212,26 @@ export function DebugFlagsApp({
       return selectedUser?.name || selectedUser?.username || 'User';
     }
     return selectedTarget.type === 'automatedProcess'
-      ? t.debugFlags?.specialTargetAutomatedProcess ?? 'Automated Process'
-      : t.debugFlags?.specialTargetPlatformIntegration ?? 'Platform Integration';
+      ? (t.debugFlags?.specialTargetAutomatedProcess ?? 'Automated Process')
+      : (t.debugFlags?.specialTargetPlatformIntegration ?? 'Platform Integration');
   }, [selectedTarget, selectedUser, t]);
   const specialTargetSelected = Boolean(selectedTarget && selectedTarget.type !== 'user');
   const specialTargetReady = !specialTargetSelected || status?.targetAvailable === true;
+  const specialTargetResolvedCount = specialTargetSelected ? (status?.resolvedTargetCount ?? 0) : 0;
+  const specialTargetActiveCount = specialTargetSelected ? (status?.activeTargetCount ?? 0) : 0;
+  const shouldRenderStatusDetails = Boolean(
+    status?.traceFlagId || (specialTargetSelected && specialTargetActiveCount > 0)
+  );
   const managerDraftDirty = !debugLevelDraftEquals(managerDraft, loadedManagerDraft);
 
   const canApply = Boolean(selectedTarget && debugLevel && !loading.action && !loading.orgs && specialTargetReady);
   const canRemove = Boolean(selectedTarget && !loading.action && !loading.orgs && specialTargetReady);
   const canSaveManager = Boolean(
     !loading.action &&
-      !loading.orgs &&
-      managerDraft.developerName.trim() &&
-      managerDraft.masterLabel.trim() &&
-      managerDraftDirty
+    !loading.orgs &&
+    managerDraft.developerName.trim() &&
+    managerDraft.masterLabel.trim() &&
+    managerDraftDirty
   );
   const canDeleteManager = Boolean(selectedManagerId && !loading.action && !loading.orgs);
 
@@ -250,7 +252,9 @@ export function DebugFlagsApp({
     vscode.postMessage({ type: 'debugFlagsSelectTarget', target: { type: 'user', userId } });
   };
 
-  const handleSelectSpecialTarget = (target: Extract<TraceFlagTarget, { type: 'automatedProcess' | 'platformIntegration' }>) => {
+  const handleSelectSpecialTarget = (
+    target: Extract<TraceFlagTarget, { type: 'automatedProcess' | 'platformIntegration' }>
+  ) => {
     setSelectedTarget(target);
     setStatus(undefined);
     setNotice(undefined);
@@ -354,9 +358,7 @@ export function DebugFlagsApp({
   const handleSaveManager = () => {
     if (!managerDraft.developerName.trim() || !managerDraft.masterLabel.trim()) {
       setNotice(undefined);
-      setError(
-        t.debugFlags?.managerValidation ?? 'DeveloperName and MasterLabel are required to save a DebugLevel.'
-      );
+      setError(t.debugFlags?.managerValidation ?? 'DeveloperName and MasterLabel are required to save a DebugLevel.');
       return;
     }
     setNotice(undefined);
@@ -397,9 +399,7 @@ export function DebugFlagsApp({
   return (
     <div className="flex min-h-screen flex-col gap-4 p-4 text-sm">
       <header className="rounded-lg border border-border bg-card/70 p-4 shadow-sm">
-        <h1 className="text-lg font-semibold text-foreground">
-          {t.debugFlags?.panelTitle ?? 'Apex Debug Flags'}
-        </h1>
+        <h1 className="text-lg font-semibold text-foreground">{t.debugFlags?.panelTitle ?? 'Apex Debug Flags'}</h1>
         <p className="mt-1 text-sm text-muted-foreground">
           {t.debugFlags?.panelSubtitle ?? 'Configure USER_DEBUG trace flags with room to focus.'}
         </p>
@@ -461,16 +461,15 @@ export function DebugFlagsApp({
                     {t.debugFlags?.specialTargetPlatformIntegration ?? 'Platform Integration'}
                   </span>
                   <span className="mt-1 block text-xs text-muted-foreground">
-                    {t.debugFlags?.specialTargetPlatformIntegrationHint ?? 'Capture asynchronous integration callback logs.'}
+                    {t.debugFlags?.specialTargetPlatformIntegrationHint ??
+                      'Capture asynchronous integration callback logs.'}
                   </span>
                 </button>
               </div>
             </div>
 
             <div className="flex flex-col gap-1">
-              <Label htmlFor="debug-flags-user-search">
-                {t.debugFlags?.userSearchLabel ?? 'Find user'}
-              </Label>
+              <Label htmlFor="debug-flags-user-search">{t.debugFlags?.userSearchLabel ?? 'Find user'}</Label>
               <Input
                 id="debug-flags-user-search"
                 type="search"
@@ -535,7 +534,8 @@ export function DebugFlagsApp({
 
             {!selectedTarget ? (
               <p className="mt-2 text-muted-foreground">
-                {t.debugFlags?.selectTargetHint ?? 'Select a special target or an active user to inspect and configure debug flags.'}
+                {t.debugFlags?.selectTargetHint ??
+                  'Select a special target or an active user to inspect and configure debug flags.'}
               </p>
             ) : loading.status ? (
               <div className="mt-2 flex items-center gap-2 text-muted-foreground">
@@ -549,33 +549,49 @@ export function DebugFlagsApp({
                   <span data-testid="debug-flags-selected-target-label">{selectedTargetLabel}</span>
                 </p>
                 <p className="text-amber-300" data-testid="debug-flags-target-unavailable">
-                  {status.unavailableReason ?? t.debugFlags?.targetUnavailable ?? 'This trace flag target is not available in this org.'}
+                  {status.unavailableReason ??
+                    t.debugFlags?.targetUnavailable ??
+                    'This trace flag target is not available in this org.'}
                 </p>
               </div>
-            ) : status?.traceFlagId ? (
+            ) : shouldRenderStatusDetails && status ? (
               <div className="mt-2 space-y-2">
                 <p>
                   <span className="font-semibold">{t.debugFlags?.selectedTarget ?? 'Selected target'}:</span>{' '}
                   <span data-testid="debug-flags-selected-target-label">{selectedTargetLabel}</span>
                 </p>
+                {specialTargetSelected ? (
+                  <>
+                    <p>
+                      <span className="font-semibold">{t.debugFlags?.statusMatchedTargets ?? 'Matched targets'}:</span>{' '}
+                      <span data-testid="debug-flags-status-resolved-count">{specialTargetResolvedCount}</span>
+                    </p>
+                    <p>
+                      <span className="font-semibold">{t.debugFlags?.statusActiveTargets ?? 'Active flags'}:</span>{' '}
+                      <span data-testid="debug-flags-status-active-count">
+                        {specialTargetActiveCount}/{specialTargetResolvedCount}
+                      </span>
+                    </p>
+                  </>
+                ) : null}
                 <div className="flex items-center gap-2">
                   <span
                     className={cn(
                       'inline-flex rounded-full px-2 py-0.5 text-xs font-semibold',
-                      status.isActive
-                        ? 'bg-emerald-500/15 text-emerald-300'
-                        : 'bg-zinc-500/20 text-zinc-300'
+                      status.isActive ? 'bg-emerald-500/15 text-emerald-300' : 'bg-zinc-500/20 text-zinc-300'
                     )}
                     data-testid="debug-flags-status-pill"
                   >
                     {status.isActive
-                      ? t.debugFlags?.statusActive ?? 'Active'
-                      : t.debugFlags?.statusInactive ?? 'Inactive'}
+                      ? (t.debugFlags?.statusActive ?? 'Active')
+                      : (t.debugFlags?.statusInactive ?? 'Inactive')}
                   </span>
                 </div>
                 <p>
                   <span className="font-semibold">{t.debugFlags?.statusLevel ?? 'Debug level'}:</span>{' '}
-                  <span data-testid="debug-flags-status-level">{status.debugLevelName || '-'}</span>
+                  <span data-testid="debug-flags-status-level">
+                    {status.debugLevelMixed ? (t.debugFlags?.statusMixed ?? 'Mixed') : status.debugLevelName || '-'}
+                  </span>
                 </p>
                 <p>
                   <span className="font-semibold">{t.debugFlags?.statusStart ?? 'Starts'}:</span>{' '}
@@ -583,9 +599,7 @@ export function DebugFlagsApp({
                 </p>
                 <p>
                   <span className="font-semibold">{t.debugFlags?.statusExpiration ?? 'Expires'}:</span>{' '}
-                  <span data-testid="debug-flags-status-expiration">
-                    {formatDate(status.expirationDate, locale)}
-                  </span>
+                  <span data-testid="debug-flags-status-expiration">{formatDate(status.expirationDate, locale)}</span>
                 </p>
               </div>
             ) : (
@@ -596,6 +610,22 @@ export function DebugFlagsApp({
                     {selectedTargetLabel}
                   </span>
                 </p>
+                {specialTargetSelected ? (
+                  <>
+                    <p>
+                      <span className="font-semibold">{t.debugFlags?.statusMatchedTargets ?? 'Matched targets'}:</span>{' '}
+                      <span className="text-foreground" data-testid="debug-flags-status-resolved-count">
+                        {specialTargetResolvedCount}
+                      </span>
+                    </p>
+                    <p>
+                      <span className="font-semibold">{t.debugFlags?.statusActiveTargets ?? 'Active flags'}:</span>{' '}
+                      <span className="text-foreground" data-testid="debug-flags-status-active-count">
+                        {specialTargetActiveCount}/{specialTargetResolvedCount}
+                      </span>
+                    </p>
+                  </>
+                ) : null}
                 <p>{t.debugFlags?.noStatus ?? 'No active USER_DEBUG trace flag for this target.'}</p>
               </div>
             )}
@@ -611,9 +641,7 @@ export function DebugFlagsApp({
               disabled={loading.orgs || loading.action}
             />
             <div className="flex flex-col gap-1">
-              <Label htmlFor="debug-flags-ttl">
-                {t.debugFlags?.ttlMinutes ?? 'TTL (minutes)'}
-              </Label>
+              <Label htmlFor="debug-flags-ttl">{t.debugFlags?.ttlMinutes ?? 'TTL (minutes)'}</Label>
               <Input
                 id="debug-flags-ttl"
                 type="number"
@@ -711,10 +739,7 @@ export function DebugFlagsApp({
         </article>
       </section>
 
-      <section
-        className="rounded-lg border border-border bg-card/70 p-4 shadow-sm"
-        data-testid="debug-level-manager"
-      >
+      <section className="rounded-lg border border-border bg-card/70 p-4 shadow-sm" data-testid="debug-level-manager">
         <div className="flex flex-col gap-1">
           <h2 className="text-base font-semibold text-foreground">
             {t.debugFlags?.managerTitle ?? 'Debug Level Manager'}
@@ -727,9 +752,7 @@ export function DebugFlagsApp({
 
         <div className="mt-4 grid grid-cols-1 gap-3 lg:grid-cols-[1fr_auto_1fr_auto]">
           <div className="flex flex-col gap-1">
-            <Label htmlFor="debug-level-manager-select">
-              {t.debugFlags?.managerExisting ?? 'Existing DebugLevel'}
-            </Label>
+            <Label htmlFor="debug-level-manager-select">{t.debugFlags?.managerExisting ?? 'Existing DebugLevel'}</Label>
             <select
               id="debug-level-manager-select"
               data-testid="debug-level-manager-select"
@@ -760,9 +783,7 @@ export function DebugFlagsApp({
           </div>
 
           <div className="flex flex-col gap-1">
-            <Label htmlFor="debug-level-preset-select">
-              {t.debugFlags?.managerPreset ?? 'Preset'}
-            </Label>
+            <Label htmlFor="debug-level-preset-select">{t.debugFlags?.managerPreset ?? 'Preset'}</Label>
             <select
               id="debug-level-preset-select"
               data-testid="debug-level-preset-select"
@@ -808,9 +829,7 @@ export function DebugFlagsApp({
           </div>
 
           <div className="flex flex-col gap-1">
-            <Label htmlFor="debug-level-draft-master-label">
-              {t.debugFlags?.managerMasterLabel ?? 'MasterLabel'}
-            </Label>
+            <Label htmlFor="debug-level-draft-master-label">{t.debugFlags?.managerMasterLabel ?? 'MasterLabel'}</Label>
             <Input
               id="debug-level-draft-master-label"
               data-testid="debug-level-draft-master-label"
@@ -821,9 +840,7 @@ export function DebugFlagsApp({
           </div>
 
           <div className="flex flex-col gap-1">
-            <Label htmlFor="debug-level-draft-language">
-              {t.debugFlags?.managerLanguage ?? 'Language'}
-            </Label>
+            <Label htmlFor="debug-level-draft-language">{t.debugFlags?.managerLanguage ?? 'Language'}</Label>
             <Input
               id="debug-level-draft-language"
               data-testid="debug-level-draft-language"

--- a/src/webview/i18n.ts
+++ b/src/webview/i18n.ts
@@ -97,9 +97,12 @@ export type Messages = {
     selectedTarget?: string;
     statusActive: string;
     statusInactive: string;
+    statusMatchedTargets?: string;
+    statusActiveTargets?: string;
     statusLevel: string;
     statusExpiration: string;
     statusStart: string;
+    statusMixed?: string;
     noStatus: string;
     targetUnavailable?: string;
     noticeCreated: string;
@@ -227,9 +230,12 @@ const en: Messages = {
     selectedTarget: 'Selected target',
     statusActive: 'Active',
     statusInactive: 'Inactive',
+    statusMatchedTargets: 'Matched targets',
+    statusActiveTargets: 'Active flags',
     statusLevel: 'Debug level',
     statusExpiration: 'Expires',
     statusStart: 'Starts',
+    statusMixed: 'Mixed',
     noStatus: 'No active USER_DEBUG trace flag for this target.',
     targetUnavailable: 'This trace flag target is not available in this org.',
     noticeCreated: 'Debug flag created successfully.',
@@ -357,9 +363,12 @@ const ptBR: Messages = {
     selectedTarget: 'Alvo selecionado',
     statusActive: 'Ativa',
     statusInactive: 'Inativa',
+    statusMatchedTargets: 'Alvos correspondentes',
+    statusActiveTargets: 'Flags ativas',
     statusLevel: 'Nível de depuração',
     statusExpiration: 'Expira em',
     statusStart: 'Inicia em',
+    statusMixed: 'Misto',
     noStatus: 'Nenhuma trace flag USER_DEBUG ativa para este alvo.',
     targetUnavailable: 'Este alvo de trace flag não está disponível nesta org.',
     noticeCreated: 'Debug flag criada com sucesso.',

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -14,10 +14,7 @@ import {
 } from '../utils/tooling';
 import { waitForWebviewFrame } from '../utils/webviews';
 
-const SPECIAL_TARGET_UI: Record<
-  SpecialTraceFlagTargetType,
-  { buttonTestId: string; expectedLabel: string }
-> = {
+const SPECIAL_TARGET_UI: Record<SpecialTraceFlagTargetType, { buttonTestId: string; expectedLabel: string }> = {
   automatedProcess: {
     buttonTestId: 'debug-flags-special-target-automated-process',
     expectedLabel: 'Automated Process'
@@ -97,12 +94,14 @@ async function assertSpecialTargetBehavior(
   await expect
     .poll(
       async () => {
-        const status = await getDebugTraceFlagByTracedEntityId(auth, resolvedTarget.id);
-        return status?.id || '';
+        const statuses = await Promise.all(
+          resolvedTarget.ids.map(async tracedEntityId => await getDebugTraceFlagByTracedEntityId(auth, tracedEntityId))
+        );
+        return statuses.every(status => Boolean(status?.id));
       },
       { timeout: 60_000 }
     )
-    .not.toBe('');
+    .toBe(true);
 
   await removeButton.click();
   await expect(notice).toBeVisible({ timeout: 60_000 });
@@ -110,12 +109,14 @@ async function assertSpecialTargetBehavior(
   await expect
     .poll(
       async () => {
-        const status = await getDebugTraceFlagByTracedEntityId(auth, resolvedTarget.id);
-        return status?.id || '';
+        const statuses = await Promise.all(
+          resolvedTarget.ids.map(async tracedEntityId => await getDebugTraceFlagByTracedEntityId(auth, tracedEntityId))
+        );
+        return statuses.every(status => !status?.id);
       },
       { timeout: 60_000 }
     )
-    .toBe('');
+    .toBe(true);
 }
 
 test('configures and removes debug flags from logs and tail entrypoints', async ({ vscodePage, scratchAlias }) => {
@@ -142,20 +143,26 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
     await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect
-      .poll(async () => {
-        const status = await getUserDebugTraceFlag(auth, userId);
-        return status?.id || '';
-      }, { timeout: 60_000 })
+      .poll(
+        async () => {
+          const status = await getUserDebugTraceFlag(auth, userId);
+          return status?.id || '';
+        },
+        { timeout: 60_000 }
+      )
       .not.toBe('');
 
     await debugFlagsFrame.locator('[data-testid="debug-flags-remove"]').click();
     await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect
-      .poll(async () => {
-        const status = await getUserDebugTraceFlag(auth, userId);
-        return status?.id || '';
-      }, { timeout: 60_000 })
+      .poll(
+        async () => {
+          const status = await getUserDebugTraceFlag(auth, userId);
+          return status?.id || '';
+        },
+        { timeout: 60_000 }
+      )
       .toBe('');
 
     await runCommand(vscodePage, 'Electivus Apex Logs: Tail Logs');
@@ -185,11 +192,15 @@ test('supports special trace flag targets in the debug flags panel', async ({ vs
   const automatedProcessTarget = await resolveSpecialTraceFlagTarget(auth, 'automatedProcess');
   const platformIntegrationTarget = await resolveSpecialTraceFlagTarget(auth, 'platformIntegration');
 
-  if (automatedProcessTarget?.id) {
-    await removeDebugTraceFlagsByTracedEntityId(auth, automatedProcessTarget.id).catch(() => {});
+  if (automatedProcessTarget?.ids?.length) {
+    for (const tracedEntityId of automatedProcessTarget.ids) {
+      await removeDebugTraceFlagsByTracedEntityId(auth, tracedEntityId).catch(() => {});
+    }
   }
-  if (platformIntegrationTarget?.id) {
-    await removeDebugTraceFlagsByTracedEntityId(auth, platformIntegrationTarget.id).catch(() => {});
+  if (platformIntegrationTarget?.ids?.length) {
+    for (const tracedEntityId of platformIntegrationTarget.ids) {
+      await removeDebugTraceFlagsByTracedEntityId(auth, tracedEntityId).catch(() => {});
+    }
   }
 
   try {
@@ -198,11 +209,15 @@ test('supports special trace flag targets in the debug flags panel', async ({ vs
     await assertSpecialTargetBehavior(debugFlagsFrame, auth, 'automatedProcess');
     await assertSpecialTargetBehavior(debugFlagsFrame, auth, 'platformIntegration');
   } finally {
-    if (automatedProcessTarget?.id) {
-      await removeDebugTraceFlagsByTracedEntityId(auth, automatedProcessTarget.id).catch(() => {});
+    if (automatedProcessTarget?.ids?.length) {
+      for (const tracedEntityId of automatedProcessTarget.ids) {
+        await removeDebugTraceFlagsByTracedEntityId(auth, tracedEntityId).catch(() => {});
+      }
     }
-    if (platformIntegrationTarget?.id) {
-      await removeDebugTraceFlagsByTracedEntityId(auth, platformIntegrationTarget.id).catch(() => {});
+    if (platformIntegrationTarget?.ids?.length) {
+      for (const tracedEntityId of platformIntegrationTarget.ids) {
+        await removeDebugTraceFlagsByTracedEntityId(auth, tracedEntityId).catch(() => {});
+      }
     }
   }
 });

--- a/test/e2e/specs/debugLevelManager.e2e.spec.ts
+++ b/test/e2e/specs/debugLevelManager.e2e.spec.ts
@@ -1,3 +1,4 @@
+import type { Frame } from '@playwright/test';
 import { expect, test } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
 import {
@@ -10,6 +11,11 @@ import {
 } from '../utils/tooling';
 import { dismissAllNotifications } from '../utils/notifications';
 import { waitForWebviewFrame } from '../utils/webviews';
+
+async function waitForManagerReady(debugFlagsFrame: Frame): Promise<void> {
+  await expect(debugFlagsFrame.locator('[data-testid="debug-level-manager-new"]')).toBeEnabled({ timeout: 120_000 });
+  await expect(debugFlagsFrame.locator('[data-testid="debug-level-manager-select"]')).toBeEnabled({ timeout: 120_000 });
+}
 
 test('creates, updates and deletes DebugLevel records from the manager UI', async ({ vscodePage, scratchAlias }) => {
   const auth = await getOrgAuth(scratchAlias);
@@ -57,7 +63,6 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
     await debugFlagsFrame.locator('[data-testid="debug-level-field-dataAccess"]').selectOption('FINE');
 
     await debugFlagsFrame.locator('[data-testid="debug-level-save"]').click({ force: true });
-    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect
       .poll(async () => await getDebugLevelByDeveloperName(auth, createdDeveloperName), { timeout: 60_000 })
@@ -70,6 +75,7 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
         wave: 'ERROR',
         dataAccess: 'FINE'
       });
+    await waitForManagerReady(debugFlagsFrame);
 
     const created = await getDebugLevelByDeveloperName(auth, createdDeveloperName);
     expect(created?.id).toBeTruthy();
@@ -82,7 +88,6 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
     await debugFlagsFrame.locator('[data-testid="debug-level-field-wave"]').selectOption('DEBUG');
     await debugFlagsFrame.locator('[data-testid="debug-level-field-nba"]').selectOption('ERROR');
     await debugFlagsFrame.locator('[data-testid="debug-level-save"]').click({ force: true });
-    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect
       .poll(async () => await getDebugLevelById(auth, created!.id), { timeout: 60_000 })
@@ -95,6 +100,7 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
         wave: 'DEBUG',
         nba: 'ERROR'
       });
+    await waitForManagerReady(debugFlagsFrame);
 
     await debugFlagsFrame.locator('[data-testid="debug-level-delete"]').click({ force: true });
     await debugFlagsFrame.locator('[data-testid="debug-level-delete-confirmation"]').waitFor({
@@ -102,7 +108,6 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
       timeout: 60_000
     });
     await debugFlagsFrame.locator('[data-testid="debug-level-delete-confirm"]').click({ force: true });
-    await expect(debugFlagsFrame.locator('[data-testid="debug-flags-notice"]')).toBeVisible({ timeout: 60_000 });
 
     await expect
       .poll(async () => await getDebugLevelById(auth, created!.id), { timeout: 60_000 })

--- a/test/e2e/specs/replayDebugger.e2e.spec.ts
+++ b/test/e2e/specs/replayDebugger.e2e.spec.ts
@@ -1,3 +1,4 @@
+import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
 import { dismissAllNotifications } from '../utils/notifications';
@@ -5,21 +6,28 @@ import { waitForWebviewFrame } from '../utils/webviews';
 
 test.use({ supportExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'] });
 
+async function closeQuickInputIfOpen(page: Page): Promise<void> {
+  const widget = page.locator('div.quick-input-widget');
+  const visible = await widget.isVisible().catch(() => false);
+  if (!visible) {
+    return;
+  }
+
+  await page.keyboard.press('Escape').catch(() => {});
+  await widget.waitFor({ state: 'hidden', timeout: 5_000 }).catch(() => {});
+}
+
 test('launches replay debugger from logs table without missing-extension toast', async ({ vscodePage, seededLog }) => {
   void seededLog;
 
   // Activate the extension by running a contributed command.
   await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
   await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  await closeQuickInputIfOpen(vscodePage);
 
   const logsFrame = await waitForWebviewFrame(
     vscodePage,
-    async frame => {
-      if (!/\/fake\.html\?id=/i.test(frame.url())) return false;
-      const hasRefresh = await frame.locator('text=Refresh').count().catch(() => 0);
-      const hasDownloadAll = await frame.locator('text=Download all logs').count().catch(() => 0);
-      return hasRefresh > 0 && hasDownloadAll > 0;
-    },
+    async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
     { timeoutMs: 180_000 }
   );
 
@@ -31,7 +39,8 @@ test('launches replay debugger from logs table without missing-extension toast',
   const replayButton = logsFrame.locator('button[aria-label="Apex Replay"]').first();
   await replayButton.waitFor({ state: 'visible', timeout: 60_000 });
   await dismissAllNotifications(vscodePage);
-  await replayButton.click();
+  await closeQuickInputIfOpen(vscodePage);
+  await replayButton.click({ force: true });
 
   // Historically we surfaced a toast claiming Replay Debugger was unavailable even when installed,
   // because the dependent extension registers commands at activation time.

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -1,0 +1,179 @@
+import { ensureScratchOrg } from '../scratchOrg';
+import { runSfJson } from '../sfCli';
+
+jest.mock('../sfCli', () => ({
+  runSfJson: jest.fn()
+}));
+
+const runSfJsonMock = jest.mocked(runSfJson);
+
+describe('ensureScratchOrg', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      SF_DEVHUB_ALIAS: 'VlocityIndustriesInsuranceDevHub',
+      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
+      SF_TEST_KEEP_ORG: '1'
+    };
+    runSfJsonMock.mockReset();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  test('recreates a scratch org when the local alias points to a deleted org', async () => {
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        return {
+          status: 0,
+          result: {
+            status: 'Deleted',
+            expirationDate: '2026-03-07',
+            alias: 'ALV_E2E_Scratch'
+          }
+        };
+      }
+
+      if (args[0] === 'org' && args[1] === 'logout' && args.includes('ALV_E2E_Scratch')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'alias' && args[1] === 'unset' && args.includes('ALV_E2E_Scratch')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('VlocityIndustriesInsuranceDevHub')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch') {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'data' && args[1] === 'query') {
+        return {
+          status: 0,
+          result: {
+            records: [{ Id: '7dl000000000001AAA' }]
+          }
+        };
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+
+    expect(scratch).toMatchObject({
+      devHubAlias: 'VlocityIndustriesInsuranceDevHub',
+      scratchAlias: 'ALV_E2E_Scratch',
+      created: true
+    });
+    expect(runSfJsonMock).toHaveBeenCalledWith(['org', 'logout', '--target-org', 'ALV_E2E_Scratch', '--no-prompt']);
+    expect(runSfJsonMock).toHaveBeenCalledWith(['alias', 'unset', 'ALV_E2E_Scratch']);
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch', '--alias', 'ALV_E2E_Scratch']),
+      expect.any(Object)
+    );
+    await scratch.cleanup();
+  });
+
+  test('reuses an active scratch org when the alias is still valid', async () => {
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        return {
+          status: 0,
+          result: {
+            status: 'Active',
+            expirationDate: '2099-03-07',
+            alias: 'ALV_E2E_Scratch'
+          }
+        };
+      }
+
+      if (args[0] === 'data' && args[1] === 'query') {
+        return {
+          status: 0,
+          result: {
+            records: [{ Id: '7dl000000000001AAA' }]
+          }
+        };
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+
+    expect(scratch).toMatchObject({
+      devHubAlias: 'VlocityIndustriesInsuranceDevHub',
+      scratchAlias: 'ALV_E2E_Scratch',
+      created: false
+    });
+    expect(runSfJsonMock).not.toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch']),
+      expect.anything()
+    );
+    await scratch.cleanup();
+  });
+
+  test('falls back to another authenticated dev hub when the preferred alias hits the scratch signup limit', async () => {
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        throw new Error('NamedOrgNotFoundError: No authorization information found for ALV_E2E_Scratch.');
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('VlocityIndustriesInsuranceDevHub')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHub')) {
+        return { status: 0, result: {} };
+      }
+
+      if (
+        args[0] === 'org' &&
+        args[1] === 'create' &&
+        args[2] === 'scratch' &&
+        args.includes('VlocityIndustriesInsuranceDevHub')
+      ) {
+        throw new Error('LIMIT_EXCEEDED: The signup request failed because this organization has reached its daily scratch org signup limit');
+      }
+
+      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch' && args.includes('DevHub')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'data' && args[1] === 'query') {
+        return {
+          status: 0,
+          result: {
+            records: [{ Id: '7dl000000000001AAA' }]
+          }
+        };
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+
+    expect(scratch).toMatchObject({
+      devHubAlias: 'DevHub',
+      scratchAlias: 'ALV_E2E_Scratch',
+      created: true
+    });
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'VlocityIndustriesInsuranceDevHub']),
+      expect.any(Object)
+    );
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'DevHub']),
+      expect.any(Object)
+    );
+    await scratch.cleanup();
+  });
+});

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -11,8 +11,7 @@ type MockFetchResponse = {
 };
 
 function responseFrom(spec: MockFetchResponse): Response {
-  const text =
-    spec.body === undefined ? '' : typeof spec.body === 'string' ? spec.body : JSON.stringify(spec.body);
+  const text = spec.body === undefined ? '' : typeof spec.body === 'string' ? spec.body : JSON.stringify(spec.body);
   return {
     ok: spec.status >= 200 && spec.status < 300,
     status: spec.status,
@@ -137,7 +136,7 @@ describe('ensureDebugFlagsTestUser', () => {
     expect(calls[0]).toContain('/services/data/v63.0/tooling/query');
   });
 
-  test('resolves Platform Integration via the fallback user name and cloud integration user type', async () => {
+  test('resolves Platform Integration via accepted names and returns all active matches', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -165,13 +164,13 @@ describe('ensureDebugFlagsTestUser', () => {
     const resolved = await resolveSpecialTraceFlagTarget(auth, 'platformIntegration');
 
     expect(resolved).toEqual({
-      id: '005000000000777AAA',
+      ids: ['005000000000777AAA'],
       label: 'Platform Integration',
-      matchedName: 'Platform Integration User'
+      matchedNames: ['Platform Integration User']
     });
   });
 
-  test('returns undefined when a special target query is ambiguous', async () => {
+  test('returns all active matches when a special target query finds multiple users', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -200,7 +199,11 @@ describe('ensureDebugFlagsTestUser', () => {
       throw new Error(`Unexpected request GET ${url}`);
     });
 
-    await expect(resolveSpecialTraceFlagTarget(auth, 'platformIntegration')).resolves.toBeUndefined();
+    await expect(resolveSpecialTraceFlagTarget(auth, 'platformIntegration')).resolves.toEqual({
+      ids: ['005000000000111AAA', '005000000000222AAA'],
+      label: 'Platform Integration',
+      matchedNames: ['Platform Integration', 'Platform Integration User']
+    });
   });
 
   test('returns undefined when a special trace-flag target is not available', async () => {

--- a/test/e2e/utils/fsCleanup.ts
+++ b/test/e2e/utils/fsCleanup.ts
@@ -1,0 +1,33 @@
+import { rm } from 'node:fs/promises';
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isRetryableCleanupError(error: unknown): boolean {
+  const code = String((error as NodeJS.ErrnoException | undefined)?.code || '').toUpperCase();
+  return code === 'EBUSY' || code === 'ENOTEMPTY' || code === 'EPERM';
+}
+
+export async function removePathBestEffort(
+  targetPath: string,
+  options: { attempts?: number; delayMs?: number } = {}
+): Promise<void> {
+  const attempts = Math.max(1, options.attempts ?? 8);
+  const delayMs = Math.max(50, options.delayMs ?? 250);
+
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    try {
+      await rm(targetPath, { recursive: true, force: true });
+      return;
+    } catch (error) {
+      if (!isRetryableCleanupError(error) || attempt === attempts) {
+        console.warn(
+          `[e2e] Failed to remove temporary path '${targetPath}': ${error instanceof Error ? error.message : String(error)}`
+        );
+        return;
+      }
+      await sleep(delayMs * attempt);
+    }
+  }
+}

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -10,6 +10,13 @@ type ScratchOrgResult = {
   cleanup: () => Promise<void>;
 };
 
+const LOCAL_DEV_HUB_FALLBACK_ALIASES = [
+  'DevHub',
+  'ElectivusDevHub',
+  'DevHubElectivus',
+  'InsuranceOrgTrialCreme6DevHub'
+] as const;
+
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -21,15 +28,68 @@ function envFlag(name: string): boolean {
   return value === '1' || value === 'true';
 }
 
-async function tryOrgDisplay(alias: string): Promise<boolean> {
+type OrgDisplaySummary = {
+  status?: string;
+  expirationDate?: string;
+};
+
+async function getOrgDisplay(alias: string): Promise<OrgDisplaySummary | undefined> {
   try {
-    await runSfJson(['org', 'display', '-o', alias]);
-    return true;
+    const result = await runSfJson(['org', 'display', '-o', alias]);
+    const org = result?.result ?? {};
+    return {
+      status: typeof org.status === 'string' ? org.status.trim() : undefined,
+      expirationDate: typeof org.expirationDate === 'string' ? org.expirationDate.trim() : undefined
+    };
   } catch (error) {
     console.warn(
       `[e2e] sf org display failed for alias '${alias}': ${error instanceof Error ? error.message : String(error)}`
     );
+    return undefined;
+  }
+}
+
+async function tryOrgDisplay(alias: string): Promise<boolean> {
+  return Boolean(await getOrgDisplay(alias));
+}
+
+function isReusableScratchOrg(display: OrgDisplaySummary | undefined, nowMs = Date.now()): boolean {
+  if (!display) {
     return false;
+  }
+
+  const normalizedStatus = String(display.status || '')
+    .trim()
+    .toLowerCase();
+  if (normalizedStatus === 'deleted' || normalizedStatus === 'expired') {
+    return false;
+  }
+
+  if (display.expirationDate) {
+    const expiresAt = Date.parse(display.expirationDate);
+    if (Number.isFinite(expiresAt) && expiresAt < nowMs) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+async function clearStaleScratchOrg(alias: string): Promise<void> {
+  try {
+    await runSfJson(['org', 'logout', '--target-org', alias, '--no-prompt']);
+  } catch (error) {
+    console.warn(
+      `[e2e] sf org logout failed for stale alias '${alias}': ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  try {
+    await runSfJson(['alias', 'unset', alias]);
+  } catch (error) {
+    console.warn(
+      `[e2e] sf alias unset failed for stale alias '${alias}': ${error instanceof Error ? error.message : String(error)}`
+    );
   }
 }
 
@@ -43,13 +103,92 @@ async function resolveDefaultDevHubAlias(): Promise<string> {
 
   // Local convenience: prefer the current team DevHub alias when available.
   // Keep legacy aliases as fallbacks for older local setups.
-  const preferredAliases = ['ElectivusDevHub', 'DevHubElectivus', 'InsuranceOrgTrialCreme6DevHub'];
-  for (const alias of preferredAliases) {
+  for (const alias of LOCAL_DEV_HUB_FALLBACK_ALIASES) {
     if (await tryOrgDisplay(alias)) {
       return alias;
     }
   }
   return 'DevHub';
+}
+
+async function getFallbackDevHubAliases(primaryAlias: string): Promise<string[]> {
+  const normalizedPrimary = String(primaryAlias || '').trim().toLowerCase();
+  const candidates = Array.from(
+    new Set(
+      LOCAL_DEV_HUB_FALLBACK_ALIASES.map(alias => String(alias || '').trim()).filter(Boolean).filter(
+        alias => alias.toLowerCase() !== normalizedPrimary
+      )
+    )
+  );
+
+  const available: string[] = [];
+  for (const alias of candidates) {
+    if (await tryOrgDisplay(alias)) {
+      available.push(alias);
+    }
+  }
+  return available;
+}
+
+function shouldKeepScratchOrg(): boolean {
+  if (process.env.SF_TEST_KEEP_ORG !== undefined) {
+    return envFlag('SF_TEST_KEEP_ORG');
+  }
+  return !envFlag('CI');
+}
+
+function isScratchOrgSignupLimitError(error: unknown): boolean {
+  const message = String(error instanceof Error ? error.message : error || '').toLowerCase();
+  return message.includes('limit_exceeded') && message.includes('scratch org signup limit');
+}
+
+async function createScratchOrgWithFallback(options: {
+  devHubAlias: string;
+  scratchAlias: string;
+  definitionFile: string;
+  durationDays: number;
+  cwd: string;
+}): Promise<string> {
+  const fallbackAliases = await getFallbackDevHubAliases(options.devHubAlias);
+  const candidates = [options.devHubAlias, ...fallbackAliases];
+  let lastError: unknown;
+
+  for (let index = 0; index < candidates.length; index += 1) {
+    const candidate = candidates[index]!;
+    try {
+      await runSfJson(
+        [
+          'org',
+          'create',
+          'scratch',
+          '--target-dev-hub',
+          candidate,
+          '--alias',
+          options.scratchAlias,
+          '--definition-file',
+          options.definitionFile,
+          '--duration-days',
+          String(options.durationDays),
+          '--wait',
+          '15'
+        ],
+        { cwd: options.cwd }
+      );
+      return candidate;
+    } catch (error) {
+      lastError = error;
+      const hasNextCandidate = index + 1 < candidates.length;
+      if (!hasNextCandidate || !isScratchOrgSignupLimitError(error)) {
+        throw error;
+      }
+      const nextCandidate = candidates[index + 1]!;
+      console.warn(
+        `[e2e] scratch org signup limit reached for Dev Hub '${candidate}'; trying fallback '${nextCandidate}'.`
+      );
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError || 'Unknown scratch org creation failure'));
 }
 
 async function ensureDevHubAuth(devHubAlias: string): Promise<void> {
@@ -109,14 +248,14 @@ async function waitForScratchOrgReady(targetOrg: string): Promise<void> {
 }
 
 export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
-  const devHubAlias = await resolveDefaultDevHubAlias();
+  let devHubAlias = await resolveDefaultDevHubAlias();
   const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
   const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
-  const keep = envFlag('SF_TEST_KEEP_ORG');
+  const keep = shouldKeepScratchOrg();
 
   // Reuse existing scratch org when possible to make local runs faster.
-  const alreadyExists = await tryOrgDisplay(scratchAlias);
-  if (alreadyExists) {
+  const existingScratch = await getOrgDisplay(scratchAlias);
+  if (isReusableScratchOrg(existingScratch)) {
     await waitForScratchOrgReady(scratchAlias);
     return {
       devHubAlias,
@@ -124,6 +263,12 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
       created: false,
       cleanup: async () => {}
     };
+  }
+  if (existingScratch) {
+    console.warn(
+      `[e2e] scratch alias '${scratchAlias}' points to a stale org (status='${existingScratch.status || 'unknown'}', expiration='${existingScratch.expirationDate || 'unknown'}'); recreating.`
+    );
+    await clearStaleScratchOrg(scratchAlias);
   }
 
   await ensureDevHubAuth(devHubAlias);
@@ -178,24 +323,13 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
   );
 
   try {
-    await runSfJson(
-      [
-        'org',
-        'create',
-        'scratch',
-        '--target-dev-hub',
-        devHubAlias,
-        '--alias',
-        scratchAlias,
-        '--definition-file',
-        defFile,
-        '--duration-days',
-        String(durationDays),
-        '--wait',
-        '15'
-      ],
-      { cwd: tmp }
-    );
+    devHubAlias = await createScratchOrgWithFallback({
+      devHubAlias,
+      scratchAlias,
+      definitionFile: defFile,
+      durationDays,
+      cwd: tmp
+    });
   } catch (_e) {
     await cleanup();
     const msg = _e instanceof Error ? _e.message : String(_e);

--- a/test/e2e/utils/sfCli.ts
+++ b/test/e2e/utils/sfCli.ts
@@ -1,4 +1,4 @@
-import { execFile } from 'node:child_process';
+import { exec, execFile } from 'node:child_process';
 
 export type ExecOptions = {
   cwd?: string;
@@ -120,7 +120,7 @@ export function execFileAsync(file: string, args: string[], options: ExecOptions
 
     if (process.platform === 'win32' && /\.cmd$/i.test(file)) {
       const command = [file, ...args].map(quoteWindowsCmdArg).join(' ');
-      execFile('cmd.exe', ['/d', '/s', '/c', command], execOptions, callback);
+      exec(command, { ...execOptions, shell: process.env.ComSpec || 'cmd.exe' }, callback);
       return;
     }
 

--- a/test/e2e/utils/tempWorkspace.ts
+++ b/test/e2e/utils/tempWorkspace.ts
@@ -1,6 +1,7 @@
-import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { removePathBestEffort } from './fsCleanup';
 
 export type TempWorkspace = {
   workspacePath: string;
@@ -59,7 +60,7 @@ export async function createTempWorkspace(options: {
   return {
     workspacePath,
     cleanup: async () => {
-      await rm(workspacePath, { recursive: true, force: true });
+      await removePathBestEffort(workspacePath);
     }
   };
 }

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -15,9 +15,9 @@ export type DebugFlagsE2eUser = {
 export type SpecialTraceFlagTargetType = 'automatedProcess' | 'platformIntegration';
 
 export type ResolvedSpecialTraceFlagTarget = {
-  id: string;
+  ids: string[];
   label: string;
-  matchedName: string;
+  matchedNames: string[];
 };
 
 export type DebugLevelToolingRecord = {
@@ -97,12 +97,7 @@ function toSfDateTimeUTC(d: Date): string {
   );
 }
 
-async function requestJson(
-  auth: OrgAuth,
-  method: string,
-  resourcePath: string,
-  body?: unknown
-): Promise<any> {
+async function requestJson(auth: OrgAuth, method: string, resourcePath: string, body?: unknown): Promise<any> {
   const base = stripTrailingSlash(auth.instanceUrl);
   const url = `${base}${resourcePath}`;
   const res = await fetch(url, {
@@ -164,37 +159,36 @@ async function findUserByUsername(
   };
 }
 
-async function findUserByExactNames(
+async function findUsersByExactNames(
   auth: OrgAuth,
   names: readonly string[],
   userType: string
-): Promise<{ ambiguous: boolean; user?: { id: string; name: string } }> {
+): Promise<Array<{ id: string; name: string }>> {
   const normalizedNames = names.map(name => String(name || '').trim()).filter(Boolean);
   if (normalizedNames.length === 0) {
-    return { ambiguous: false };
+    return [];
   }
   const namesEsc = normalizedNames.map(name => `'${escapeSoqlLiteral(name)}'`).join(', ');
   const userTypeEsc = escapeSoqlLiteral(userType);
   const soql = encodeURIComponent(
-    `SELECT Id, Name FROM User WHERE Name IN (${namesEsc}) AND UserType = '${userTypeEsc}' ORDER BY Id LIMIT 3`
+    `SELECT Id, Name FROM User WHERE Name IN (${namesEsc}) AND UserType = '${userTypeEsc}' AND IsActive = true ORDER BY Id LIMIT 200`
   );
   const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/query?q=${soql}`);
   const records = Array.isArray(response?.records) ? response.records : [];
-  const matchingRecords = records.filter((record: any) => isSfId(record?.Id));
-  if (matchingRecords.length > 1) {
-    return { ambiguous: true };
-  }
-  const record = matchingRecords[0];
-  if (!isSfId(record?.Id)) {
-    return { ambiguous: false };
-  }
-  return {
-    ambiguous: false,
-    user: {
+  const seen = new Set<string>();
+  return records
+    .filter((record: any) => isSfId(record?.Id))
+    .map((record: any) => ({
       id: record.Id,
-      name: typeof record?.Name === 'string' ? record.Name : name
-    }
-  };
+      name: typeof record?.Name === 'string' ? record.Name : ''
+    }))
+    .filter(record => {
+      if (seen.has(record.id)) {
+        return false;
+      }
+      seen.add(record.id);
+      return true;
+    });
 }
 
 function toUserAlias(username: string): string {
@@ -210,7 +204,10 @@ async function resolveDefaultDebugFlagsUsername(auth: OrgAuth): Promise<string> 
   const soql = encodeURIComponent('SELECT Id FROM Organization LIMIT 1');
   const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/query?q=${soql}`);
   const orgId: string | undefined = Array.isArray(response?.records) ? response.records[0]?.Id : undefined;
-  const suffix = (typeof orgId === 'string' ? orgId : 'unknownorg').replace(/[^a-zA-Z0-9]/g, '').slice(0, 15).toLowerCase();
+  const suffix = (typeof orgId === 'string' ? orgId : 'unknownorg')
+    .replace(/[^a-zA-Z0-9]/g, '')
+    .slice(0, 15)
+    .toLowerCase();
   return `alv.debugflags.${suffix}@example.com`;
 }
 
@@ -277,10 +274,7 @@ export async function ensureDebugFlagsTestUser(auth: OrgAuth): Promise<DebugFlag
         if (!isLicenseLimitExceeded(error)) {
           throw error;
         }
-        return resolveLicenseLimitFallbackUser(
-          auth,
-          'Failed to reactivate existing E2E debug flags test user'
-        );
+        return resolveLicenseLimitFallbackUser(auth, 'Failed to reactivate existing E2E debug flags test user');
       }
     }
     return {
@@ -393,16 +387,12 @@ export async function resolveSpecialTraceFlagTarget(
 ): Promise<ResolvedSpecialTraceFlagTarget | undefined> {
   const candidateNames = SPECIAL_TRACE_FLAG_TARGET_NAMES[targetType];
   const userType = SPECIAL_TRACE_FLAG_TARGET_USER_TYPES[targetType];
-  const result = await findUserByExactNames(auth, candidateNames, userType);
-  if (result.ambiguous) {
-    return undefined;
-  }
-  const user = result.user;
-  if (user) {
+  const users = await findUsersByExactNames(auth, candidateNames, userType);
+  if (users.length > 0) {
     return {
-      id: user.id,
+      ids: users.map(user => user.id),
       label: SPECIAL_TRACE_FLAG_TARGET_LABELS[targetType],
-      matchedName: user.name
+      matchedNames: users.map(user => user.name)
     };
   }
   return undefined;

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -1,9 +1,10 @@
-import { mkdtemp, rm, readFile, cp, access, readdir } from 'node:fs/promises';
+import { mkdtemp, readFile, cp, access, readdir } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
+import { removePathBestEffort } from './fsCleanup';
 import { dismissAllNotifications } from './notifications';
 
 export type VscodeLaunch = {
@@ -334,7 +335,7 @@ export async function launchVsCode(options: {
       extraExtensionIds: options.extensionIds
     });
     if (resolvedExtensionsDir !== extensionsDir) {
-      await rm(extensionsDir, { recursive: true, force: true });
+      await removePathBestEffort(extensionsDir);
       extensionsDir = resolvedExtensionsDir;
       shouldCleanupExtensionsDir = false;
     }
@@ -390,9 +391,9 @@ export async function launchVsCode(options: {
     try {
       await app.close();
     } catch {}
-    await rm(userDataDir, { recursive: true, force: true });
+    await removePathBestEffort(userDataDir);
     if (shouldCleanupExtensionsDir) {
-      await rm(extensionsDir, { recursive: true, force: true });
+      await removePathBestEffort(extensionsDir);
     }
   };
 


### PR DESCRIPTION
## Summary

This change updates the new debug flags special-entity flow so that special targets no longer resolve to a single user. Instead, Automated Process and Platform Integration now resolve every active matching user in the org, and the panel applies, removes, and reports trace-flag state across that full resolved set.

The change also hardens the Windows E2E path that validates this behavior. The Playwright launcher now uses the local Playwright CLI directly on Windows, the Salesforce CLI helper no longer hangs on `sf.cmd` execution, stale scratch-org aliases are cleaned up and recreated correctly, local scratch orgs are preserved by default for reuse, and the helper can fall back to another authenticated Dev Hub when the preferred one hits the daily scratch-org signup limit. The E2E harness also retries temporary-directory cleanup on Windows to avoid `EBUSY` failures from lingering Electron handles.

## User impact

Users can now enable special debug targets in the way Salesforce orgs actually expose them today. If an org has multiple active Platform Integration or Automated Process users, the panel treats that as the normal case instead of an ambiguity, applies flags to all resolved entities, removes flags from all resolved entities, and reports an aggregated status with matched-target counts and mixed-debug-level handling. That removes the old behavior where only one resolved user could receive the flag and the rest were silently excluded.

The Windows validation path for this feature is also materially more reliable. Before these changes, the E2E suite could fail before reaching assertions because of Windows process-launch issues, stale deleted scratch-org aliases, scratch-org readiness loops, and temporary-file cleanup races. After the changes, the suite exercises the intended product behavior end to end on Windows as well.

## Root cause

The backend special-target resolver in `traceflags.ts` modeled Automated Process and Platform Integration as if each target should collapse to a single `User.Id`. That assumption no longer holds in orgs where Salesforce exposes multiple active users with the relevant names and `UserType`. The surrounding status/apply/remove flows inherited that single-target assumption, so they could not represent aggregate availability, aggregate active state, or mixed debug-level state.

On the E2E side, there were multiple independent Windows-specific and local-environment issues. The Playwright wrapper launched the CLI through a path that produced `spawn EINVAL` on Windows. The Salesforce CLI helper path for `sf.cmd` could hang inside Playwright workers. The scratch-org bootstrap treated any locally known alias as reusable, even when it pointed to a deleted or expired org, and every local run deleted its scratch org afterward, which increased churn and exhausted the daily signup limit. Replay Debugger cleanup also surfaced Windows file-lock timing issues in temporary directories.

## Fix

The backend now resolves special targets to all active matching users, removes the old ambiguity path, and carries that list through aggregated status, apply, and remove operations. Shared debug-flag types and the debug-flags panel/webview were extended so that the UI can render matched-target counts, active-target counts, and a mixed-level summary without changing the user-facing target selection model.

The E2E and Windows support code was updated in parallel. The Playwright launcher now resolves the local `@playwright/test` CLI and runs it via Node on Windows. The Salesforce CLI wrapper uses a Windows-safe execution path for `sf.cmd`. Scratch-org setup now detects stale aliases, recreates deleted or expired scratch orgs, preserves local scratch orgs by default for reuse, and falls back to another authenticated Dev Hub when the preferred alias is rate-limited. The Replay Debugger and Debug Level Manager specs were tightened to synchronize on stable product signals rather than transient UI timing, and the temporary workspace and VS Code profile cleanup paths now tolerate transient Windows file locks.

## Validation

I ran the targeted and full validations needed for this work:

- `npm run test:e2e:utils -- --runTestsByPath test/e2e/utils/__tests__/scratchOrg.test.ts`
- `node scripts/run-playwright-e2e.js test/e2e/specs/debugFlagsPanel.e2e.spec.ts --workers=1`
- `node scripts/run-playwright-e2e.js test/e2e/specs/debugLevelManager.e2e.spec.ts test/e2e/specs/replayDebugger.e2e.spec.ts --workers=1`
- `node scripts/run-playwright-e2e.js test/e2e/specs/openLogViewer.e2e.spec.ts --workers=1`
- `npm run test:e2e`

The final full run passed on Windows with `7 passed`.
