### PR TITLE
[codex] fix serialize-javascript dependabot alert

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15692,16 +15692,6 @@
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
       "license": "MIT"
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -16399,13 +16389,13 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.4.tgz",
+      "integrity": "sha512-DuGdB+Po43Q5Jxwpzt1lhyFSYKryqoNjQSA9M92tyw0lyHIOur+XCalOUe0KTJpyqzT8+fQ5A0Jf7vCx/NKmIg==",
       "dev": true,
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/set-function-length": {

--- a/package.json
+++ b/package.json
@@ -518,6 +518,9 @@
     "tailwind-merge": "^3.5.0",
     "vscode-nls": "^5.2.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
   "files": [
     "dist/**",
     "media/main.js",


### PR DESCRIPTION
## Summary
This change addresses the open Dependabot alert for `serialize-javascript` (`GHSA-5c6j-r48x-rmvq`) in the development dependency graph.

The alert was triggered through `mocha`, which still declares `serialize-javascript` as `^6.0.2`. The repository lockfile had resolved that range to `6.0.2`, which is vulnerable to code injection when serialized output is later evaluated.

## Root Cause
The project does not depend on `serialize-javascript` directly. It is pulled in transitively by `mocha`, and without an explicit override npm resolved the vulnerable `6.0.2` release into `package-lock.json`.

## Fix
The manifest now adds an npm `overrides` entry forcing `serialize-javascript` to `^7.0.3`. Regenerating the lockfile updates the resolved package to `7.0.4`, which contains the upstream fix for this advisory.

This keeps the change narrow: the direct test dependency remains `mocha@11.7.5`, while the vulnerable transitive package is replaced with a patched version.

## Validation
I validated the change with the following checks:

- `gh api repos/Electivus/Apex-Log-Viewer/dependabot/alerts?state=open` to confirm the open alert and advisory details.
- `npm ls serialize-javascript` to confirm the graph now resolves `mocha -> serialize-javascript@7.0.4`.
- `npm run pretest` to rebuild the extension and compile the test suite with the updated dependency graph.
- `bash scripts/run-tests.sh --scope=unit --grep "package manifest"` to run the VS Code / Mocha unit suite entrypoint after the dependency update. The run completed successfully with 170 passing tests.

## Notes
`npm audit --json` still reports a separate high-severity `underscore` issue through `@vscode/vsce -> typed-rest-client`. That is distinct from this Dependabot alert and is not changed by this PR.
