### PR TITLE
[codex] test trace flag special-target timestamp aggregation

### DIFF
--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -421,6 +421,128 @@ suite('traceflags user management', () => {
     assert.equal(status.isActive, true);
   });
 
+  test('getTraceFlagTargetStatus keeps a shared start time when active special-target flags only differ by expiration', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/query?q=')) {
+        const soql = decodeSoql(req.path);
+        if (
+          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
+          soql.includes("UserType = 'CloudIntegrationUser'") &&
+          soql.includes('IsActive = true')
+        ) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000003AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000003AAA',
+                  StartDate: '2026-02-19T16:00:00.000Z',
+                  ExpirationDate: '2099-02-19T18:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_PLATFORM_SHARED' }
+                }
+              ]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000004AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000004AAA',
+                  StartDate: '2026-02-19T16:00:00.000Z',
+                  ExpirationDate: '2099-02-19T19:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_PLATFORM_SHARED' }
+                }
+              ]
+            }
+          };
+        }
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const status = await getTraceFlagTargetStatus(auth, { type: 'platformIntegration' });
+    assert.equal(status.target.type, 'platformIntegration');
+    assert.equal(status.targetAvailable, true);
+    assert.equal(status.resolvedTargetCount, 2);
+    assert.equal(status.activeTargetCount, 2);
+    assert.equal(status.debugLevelMixed, false);
+    assert.equal(status.debugLevelName, 'ALV_PLATFORM_SHARED');
+    assert.equal(status.startDate, '2026-02-19T16:00:00.000Z');
+    assert.equal(status.expirationDate, undefined);
+    assert.equal(status.isActive, true);
+  });
+
+  test('getTraceFlagTargetStatus keeps a shared expiration when active special-target flags only differ by start time', async () => {
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/query?q=')) {
+        const soql = decodeSoql(req.path);
+        if (
+          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
+          soql.includes("UserType = 'AutomatedProcess'") &&
+          soql.includes('IsActive = true')
+        ) {
+          return {
+            statusCode: 200,
+            body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000003AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000003AAA',
+                  StartDate: '2026-02-19T16:00:00.000Z',
+                  ExpirationDate: '2099-02-19T18:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_AUTOPROC_SHARED' }
+                }
+              ]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000004AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000004AAA',
+                  StartDate: '2026-02-19T17:00:00.000Z',
+                  ExpirationDate: '2099-02-19T18:00:00.000Z',
+                  DebugLevel: { DeveloperName: 'ALV_AUTOPROC_SHARED' }
+                }
+              ]
+            }
+          };
+        }
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const status = await getTraceFlagTargetStatus(auth, { type: 'automatedProcess' });
+    assert.equal(status.target.type, 'automatedProcess');
+    assert.equal(status.targetAvailable, true);
+    assert.equal(status.resolvedTargetCount, 2);
+    assert.equal(status.activeTargetCount, 2);
+    assert.equal(status.debugLevelMixed, false);
+    assert.equal(status.debugLevelName, 'ALV_AUTOPROC_SHARED');
+    assert.equal(status.startDate, undefined);
+    assert.equal(status.expirationDate, '2099-02-19T18:00:00.000Z');
+    assert.equal(status.isActive, true);
+  });
+
   test('getTraceFlagTargetStatus marks special target unavailable when no active users match', async () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {


### PR DESCRIPTION
This change adds focused regression coverage around the special-target timestamp aggregation that was introduced with the recent multi-target debug flag work.

Before this patch, `getTraceFlagTargetStatus` was covered for unavailable targets, mixed debug levels, and partially active target sets, but it was not covered for the case where all resolved targets share the same debug level while only one timestamp field differs. That left a small but important gap: a future refactor could accidentally surface one target's start or expiration date even when the aggregated status should suppress only the mismatched field.

The fix is intentionally small and test-only. It adds one unit test for the "shared start, different expiration" case and one unit test for the "different start, shared expiration" case. Together they verify that the aggregated status keeps the common debug level, preserves the shared timestamp, clears only the mismatched timestamp, and still reports the special target as active across both resolved users.

I validated the change with the repository's unit harness so it runs in the same environment as the rest of the extension tests:

- `npm run pretest`
- `bash scripts/run-tests.sh --scope=unit`
