### PR TITLE
[codex] Harden telemetry contracts and validate E2E in dedicated App Insights

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,7 +23,7 @@ Concise project knowledge so an AI can contribute productively. Keep answers spe
 - Active dev: run `npm run watch` (parallel: extension esbuild, tsc watch, webview bundler) then F5 (Extension Development Host).
 - One-off build (CI/PR): `npm run build` (bundles extension + minified webviews). Prepublish packaging uses `npm run package` (adds NLS extraction/writing) before `vsce` packaging.
 - Type checks only: `npm run check-types`; lint: `npm run lint`.
-- Telemetry key is injected only during packaging via scripts (`telemetry:inject` / `telemetry:strip`). Never hardcode connection strings.
+- Telemetry uses the checked-in `package.json.telemetryConnectionString` by default, with optional env overrides (`APPLICATIONINSIGHTS_CONNECTION_STRING` / `VSCODE_TELEMETRY_CONNECTION_STRING`) for controlled experiments. Keep the public schema in `telemetry.json` aligned with the wrapper in `src/shared/telemetry.ts`.
 
 ## Testing
 
@@ -51,7 +51,7 @@ Concise project knowledge so an AI can contribute productively. Keep answers spe
 ## CI & Release
 
 - Workflows in `.github/workflows/*.yml`: `ci.yml` (build/test), `release.yml` (tag → publish), `prerelease.yml` (nightly). Odd minor = pre-release, even minor = stable.
-- Release prep: bump `package.json`, update `CHANGELOG.md`, tag `vX.Y.Z`. CI handles packaging; telemetry key must be available as env var for production builds.
+- Release prep: bump `package.json`, update `CHANGELOG.md`, tag `vX.Y.Z`. CI handles packaging; `telemetry.json` must ship in the VSIX and telemetry schema changes should be covered by tests.
 
 ## When Editing / Submitting PRs
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -16,7 +16,7 @@ on:
       scratch_duration_days:
         description: Scratch org duration in days
         required: false
-        default: "1"
+        default: '1'
         type: string
       keep_scratch_org:
         description: Keep the scratch org after the run
@@ -30,6 +30,7 @@ concurrency:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   playwright_e2e:
@@ -58,9 +59,26 @@ jobs:
       - name: Install Linux deps for Electron (best-effort)
         run: INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh
 
+      - name: Azure login for dedicated App Insights validation
+        if: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Run Playwright E2E
-        run: npm run test:e2e -- openLogViewer.e2e.spec.ts
+        shell: bash
+        run: |
+          if [[ "${ALV_E2E_TELEMETRY_READY}" == "1" ]]; then
+            echo "Running full Playwright E2E with dedicated App Insights validation."
+            npm run test:e2e:telemetry
+          else
+            echo "Azure OIDC secrets are not configured; falling back to the smoke E2E run."
+            npm run test:e2e -- openLogViewer.e2e.spec.ts
+          fi
         env:
+          ALV_E2E_TELEMETRY_READY: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && '1' || '' }}
           VSCODE_TEST_VERSION: ${{ github.event.inputs.vscode_version || 'stable' }}
           SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
           SF_DEVHUB_ALIAS: DevHubElectivus

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -37,6 +37,10 @@ jobs:
     name: Playwright E2E (scratch org)
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -60,17 +64,17 @@ jobs:
         run: INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh
 
       - name: Azure login for dedicated App Insights validation
-        if: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' }}
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' }}
         uses: azure/login@v2
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Run Playwright E2E
         shell: bash
         run: |
-          if [[ "${ALV_E2E_TELEMETRY_READY}" == "1" ]]; then
+          if [[ -n "${AZURE_CLIENT_ID}" && -n "${AZURE_TENANT_ID}" && -n "${AZURE_SUBSCRIPTION_ID}" ]]; then
             echo "Running full Playwright E2E with dedicated App Insights validation."
             npm run test:e2e:telemetry
           else
@@ -78,7 +82,6 @@ jobs:
             npm run test:e2e -- openLogViewer.e2e.spec.ts
           fi
         env:
-          ALV_E2E_TELEMETRY_READY: ${{ secrets.AZURE_CLIENT_ID != '' && secrets.AZURE_TENANT_ID != '' && secrets.AZURE_SUBSCRIPTION_ID != '' && '1' || '' }}
           VSCODE_TEST_VERSION: ${{ github.event.inputs.vscode_version || 'stable' }}
           SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
           SF_DEVHUB_ALIAS: DevHubElectivus

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Debug Flags: add special-target facilitators for `Automated Process` and `Platform Integration` directly in the panel, including aggregated status plus apply/remove flows across all matching active `USER_DEBUG` trace-flag targets.
+- Telemetry: enforce a public telemetry schema via `telemetry.json`, standardize `outcome` handling across events, and fold activation timing into `extension.activate` instead of emitting a separate duration event.
 
 ### Bug Fixes
 
@@ -12,9 +13,14 @@
 
 ### Chores
 
+- Docs/telemetry: align maintainer guidance with the checked-in connection-string strategy, document how `common.*` metadata should be treated, and add supported KQL query examples for App Insights review.
+- Telemetry/E2E: provision and document a dedicated App Insights component for test validation (`appi-apex-log-viewer-telemetry-e2e-eastus`) while keeping production telemetry isolated.
+
 ### Tests
 
 - Webview: add coverage for platform-specific `Service Worker` cache path resolution and keep activation tests asserting the troubleshooting command stays registered.
+- Telemetry: add contract coverage for schema-declared event names, required `outcome` fields, activation-duration modeling, and wrapper-side filtering of undeclared properties and measurements.
+- Telemetry/E2E: add an explicit `npm run test:e2e:telemetry` path that injects a test-only connection string plus `testRunId` and validates that the current Playwright run reaches the dedicated App Insights resource.
 
 ## [0.32.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.30.0...v0.32.0) (2026-03-09)
 

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -3,6 +3,7 @@
 This repository uses GitHub Actions to build, test, package, and publish the extension.
 
 - Workflow CI (`.github/workflows/ci.yml`): build/test only on `push` and `pull_request`. Manual `workflow_dispatch` allows choosing the test scope (`unit`, `integration`, or `all`).
+- Workflow E2E (`.github/workflows/e2e-playwright.yml`): real scratch-org Playwright validation on `pull_request` and manual dispatch. When Azure OIDC secrets are configured, it runs the full `npm run test:e2e:telemetry` path and validates telemetry in the dedicated E2E App Insights resource. Without Azure OIDC configuration, it falls back to the existing smoke E2E run.
 - Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 
@@ -12,6 +13,16 @@ Build & Test basics:
 - `npm ci` → `npm run build` → tests. CI defaults to unit tests on manual runs; Release runs all tests.
 
 Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref.
+
+## Setup Azure OIDC for E2E Telemetry Validation
+
+The telemetry-aware Playwright workflow uses `azure/login@v2` with GitHub OIDC. Configure these repository secrets:
+
+- `AZURE_CLIENT_ID`
+- `AZURE_TENANT_ID`
+- `AZURE_SUBSCRIPTION_ID`
+
+When all three are present, the workflow authenticates to Azure, runs `npm run test:e2e:telemetry`, and validates that the current E2E run reached `appi-apex-log-viewer-telemetry-e2e-eastus`. If any are missing, the workflow still runs, but it intentionally falls back to the smoke-only Playwright path.
 
 ## Release Flow
 

--- a/docs/TELEMETRY-REVIEW-2026-03-13.md
+++ b/docs/TELEMETRY-REVIEW-2026-03-13.md
@@ -1,0 +1,194 @@
+# Telemetry Review (2026-03-13)
+
+## Scope
+
+- Reviewed the current telemetry implementation in the extension host and provider flows.
+- Queried the production Application Insights component `appi-apex-log-viewer-telemetry-eastus`.
+- Validated the current dataset shape against the new privacy-first telemetry contract.
+
+## Findings
+
+### High
+
+1. **Required `outcome` was missing from major event families in the current dataset.**
+   - Over the last 30 days, the following events were emitted without `outcome`:
+     - `extension.activate`: 160
+     - `extension.activate.duration`: 160
+     - `cli.exec`: 19
+     - `cli.getOrgAuth`: 14
+     - `command.showOutput`: 6
+     - `command.openLogInViewer`: 4
+   - This made failure rates and funnel analysis inconsistent across command and lifecycle flows.
+
+2. **Activation duration was modeled as a second event instead of a measurement on `extension.activate`.**
+   - `extension.activate.duration` duplicated every activation and doubled event volume for the same lifecycle action.
+   - This made simple volume and funnel queries noisier than necessary.
+
+### Medium
+
+3. **The public telemetry schema was implicit in code and docs, not governed by a checked-in contract.**
+   - Before this change, there was no `telemetry.json` catalog to make the event set auditable or testable.
+   - That increased the chance of drift, accidental property growth, and undocumented event additions.
+
+4. **Production data shows shallow feature coverage for several important flows.**
+   - In the last 30 days there were no observed events for:
+     - `command.selectOrg`
+     - `command.refresh`
+     - `command.tail`
+     - `command.troubleshootWebview`
+     - `command.resetCliCache`
+     - `debugFlags.remove`
+     - `logs.replay`
+     - `log.open`
+   - This is either true low usage or a visibility gap from old builds and partial instrumentation.
+
+### Low
+
+5. **Operational docs were out of sync with the actual connection string strategy.**
+   - The repo currently ships the production `telemetryConnectionString` in `package.json`, with optional environment overrides for local validation and packaging.
+   - The previous docs implied a release-time injection path that no longer matched the implementation.
+
+## Current Azure Insights
+
+These findings come from live App Insights queries run on 2026-03-13 with 30-day lookback.
+
+### Event volume
+
+| Event | Count |
+| --- | ---: |
+| `extension.activate` | 160 |
+| `extension.activate.duration` | 160 |
+| `logs.refresh` | 125 |
+| `orgs.list` | 34 |
+| `cli.exec` | 19 |
+| `cli.getOrgAuth` | 14 |
+| `debugFlags.apply` | 7 |
+| `command.showOutput` | 6 |
+| `debugLevels.load` | 6 |
+| `command.openLogInViewer` | 4 |
+| `logs.cleanup` | 4 |
+| `logs.loadMore` | 1 |
+| `logs.downloadAll` | 1 |
+
+The 7-day window returned the same counts, which indicates the current dataset is concentrated in the last week.
+
+### Outcome breakdown
+
+Only a subset of existing events currently expose `outcome` consistently:
+
+| Event | Outcome | Count |
+| --- | --- | ---: |
+| `logs.refresh` | `ok` | 122 |
+| `logs.refresh` | `error` | 3 |
+| `orgs.list` | `ok` | 33 |
+| `orgs.list` | `error` | 1 |
+| `debugFlags.apply` | `ok` | 7 |
+| `debugLevels.load` | `ok` | 6 |
+| `logs.cleanup` | `done` | 4 |
+| `logs.downloadAll` | `partial` | 1 |
+| `logs.loadMore` | `ok` | 1 |
+
+### Error rates
+
+| Event | Errors | Total | Error rate |
+| --- | ---: | ---: | ---: |
+| `orgs.list` | 1 | 34 | 2.94% |
+| `logs.refresh` | 3 | 125 | 2.40% |
+
+No exceptions were present in the `exceptions` table for the same 30-day window.
+
+### Performance snapshots
+
+| Event | p50 (ms) | p95 (ms) | Samples |
+| --- | ---: | ---: | ---: |
+| `extension.activate.duration` | 1,946 | 23,069 | 160 |
+| `logs.refresh` | 739 | 53,785 | 125 |
+| `orgs.list` | 24 | 71,637 | 34 |
+| `debugFlags.apply` | 1,891 | 2,861 | 7 |
+| `debugLevels.load` | 3,047 | 45,412 | 6 |
+| `logs.cleanup` | 16,051 | 74,607 | 4 |
+| `logs.loadMore` | 661 | 661 | 1 |
+| `logs.downloadAll` | 409,434 | 409,434 | 1 |
+
+### Version and platform spread
+
+Most events in the current window came from:
+
+- `0.32.0` on `win32`: 185 events
+- `0.32.0` on `darwin`: 116 events
+- empty `common.extversion` / `common.os`: 106 events
+- `0.33.2` on `linux`: 55 events
+
+The empty version/platform bucket is another reason to treat `common.*` as useful platform metadata rather than the primary product analytics contract.
+
+## Changes Implemented
+
+### Contract and privacy
+
+- Added a checked-in telemetry catalog in `telemetry.json`.
+- Enforced event allowlisting, property allowlisting, measurement allowlisting, and required properties in the telemetry wrapper.
+- Made schema validation fail closed for undeclared events and undeclared fields.
+- Restricted product analytics dimensions to coarse-grained values and documented banned data classes:
+  - usernames
+  - org identifiers
+  - instance URLs
+  - file paths
+  - log content
+  - raw error messages
+
+### Event model
+
+- Unified activation timing onto `extension.activate` with `durationMs`.
+- Removed the separate `extension.activate.duration` emission from the extension activation flow.
+- Added explicit `outcome` values to command events that previously omitted them.
+- Added telemetry for `command.resetCliCache`.
+- Normalized provider events so `logs.cleanup`, `logs.downloadAll`, and `log.open` always emit the declared fields expected by the schema.
+
+### Governance and docs
+
+- Updated telemetry docs to reflect the actual connection string strategy and the new contract.
+- Added KQL quick queries for event volume, outcome breakdown, performance, version/platform split, and schema hygiene.
+- Aligned maintainer instructions with the shipping telemetry model.
+
+### Tests
+
+- Expanded telemetry wrapper tests to cover:
+  - production-only activation
+  - environment override precedence
+  - swallowed reporter failures
+  - undeclared event drops
+  - undeclared field drops
+  - required `outcome`
+  - error-event normalization
+- Added a contract test that scans emitted telemetry event names in source and fails if any event is missing from `telemetry.json`.
+
+## Remaining Validation
+
+The code and tests now enforce the new contract locally, but the Azure dataset still reflects mostly pre-change telemetry. After the next build that includes these changes, run the following manual smoke flows and confirm the resulting events in App Insights:
+
+1. Activate the extension in a Salesforce project.
+2. Run:
+   - `Refresh Logs`
+   - `Select Org`
+   - `Tail Logs`
+   - `Open Log In Viewer`
+   - `Download All`
+   - `Cleanup Logs`
+   - `Apply Debug Flags`
+   - `Remove Debug Flags`
+   - `Reset CLI Cache`
+3. Verify that:
+   - `extension.activate` includes `durationMs` and no separate duration event exists
+   - every command event has `outcome`
+   - `cli.exec` and `cli.getOrgAuth` follow the declared schema
+   - no custom event arrives with undeclared properties or measurements
+
+## Recommended Next Pass
+
+1. Re-query App Insights after the next packaged build is exercised.
+2. Confirm the old missing-`outcome` buckets stop growing.
+3. If product usage analysis becomes important, add stable funnel points for:
+   - org selection success
+   - tail start/stop
+   - log open success
+   - download completion

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,63 +1,128 @@
 # Telemetry
 
-This extension uses the official `@vscode/extension-telemetry` module to emit minimal, anonymized usage and error telemetry. Telemetry helps us prioritize features and improve reliability.
+This extension uses the official `@vscode/extension-telemetry` module to emit minimal, coarse-grained usage and error telemetry. The telemetry contract is enforced by `src/shared/telemetry.ts` and documented publicly in the root `telemetry.json`.
 
 What we collect
 
-- Activation and command usage counts (e.g. `command.refresh`, `command.tail`).
-- Coarse performance timings (e.g., activation duration, log refresh time).
-- Coarse environment info (platform, VS Code version) to understand compatibility.
-- Non‑PII error categories (e.g. error names like `ETIMEDOUT`, not full messages or stacks).
+- Coarse command and workflow outcomes such as `ok`, `error`, `cancel`, `partial`, or `invoked`.
+- Coarse performance timings such as `durationMs`.
+- Small cardinality buckets such as `scope`, `view`, `sourceView`, `targetType`, and org-count buckets.
+- Coarse error codes such as `ENOENT`, `ETIMEDOUT`, `CLI_NOT_FOUND`, and `AUTH_FAILED`.
 
 What we do not collect
 
-- No source code, Apex log contents, access tokens, usernames, org IDs, or instance URLs.
-- No full error messages or stack traces that could contain PII.
+- No Apex log bodies, source code, access tokens, usernames, org IDs, instance URLs, file paths, or raw error messages.
+- No custom telemetry properties outside the schema declared in `telemetry.json`.
+
+Automatic metadata from VS Code
+
+- `@vscode/extension-telemetry` adds `common.*` fields automatically.
+- Treat these as platform metadata for diagnostics and version/platform slicing, not as primary product analytics dimensions.
+- Do not add duplicate custom properties when the same information is already available through `common.*`.
 
 Respecting user settings and modes
 
-- VS Code’s `telemetry.telemetryLevel` controls whether telemetry is sent (`off`, `crash`, `error`, `all`). When `off`, nothing is sent.
-- Telemetry is automatically disabled when the extension runs in Development or Test mode (Extension Development Host and tests).
-- The reporter respects the VS Code setting automatically; no additional configuration is required by users.
+- VS Code's `telemetry.telemetryLevel` controls whether telemetry is sent. When it is `off`, nothing is sent.
+- Telemetry is disabled automatically in Development and Test modes.
+- Development/Test mode can opt in to a dedicated non-production App Insights target only when `ALV_ENABLE_TEST_TELEMETRY=1` and `ALV_TEST_TELEMETRY_CONNECTION_STRING` is provided.
+- If `telemetry.json` is missing or invalid, telemetry becomes a no-op instead of sending schema-less data.
 
-Opt‑out
+Opt-out
 
-- Set `"telemetry.telemetryLevel": "off"` in your VS Code settings to disable telemetry globally.
+- Set `"telemetry.telemetryLevel": "off"` in VS Code settings to disable telemetry globally.
 
 For maintainers
 
-- The connection string is checked in with the extension (we surface it via `package.json.telemetryConnectionString`). No CI-time injection is required anymore; the bundler simply reads the value during activation.
+- The production connection string is intentionally checked in via `package.json.telemetryConnectionString`.
+- `APPLICATIONINSIGHTS_CONNECTION_STRING` or `VSCODE_TELEMETRY_CONNECTION_STRING` can still override it for controlled experiments.
 - Production telemetry resources live in Azure subscription `c1b4d537-c3dc-4d64-b022-a97fd1826665`, resource group `rg-apex-log-viewer-telemetry-eastus`, Application Insights `appi-apex-log-viewer-telemetry-eastus`, and Log Analytics workspace `law-apex-log-viewer-telemetry-eastus`.
-- To inspect recent events with Azure CLI, run `az monitor app-insights query -a appi-apex-log-viewer-telemetry-eastus -g rg-apex-log-viewer-telemetry-eastus --analytics-query "customEvents | order by timestamp desc | take 20"`.
-- If the field is left empty, telemetry becomes a no-op automatically.
-- When adding events, avoid PII. Prefer counts, booleans, and coarse buckets. Never include usernames, org IDs, file paths, or log content.
+- Dedicated E2E telemetry flows use Application Insights `appi-apex-log-viewer-telemetry-e2e-eastus`.
+- Every new event, property, or measurement must be added to `telemetry.json` before code is merged.
+- Keep telemetry privacy-first: prefer booleans, enums, buckets, and finite counts. Never send raw strings that can drift into PII.
+- `testRunId` is the only test-only custom property in the catalog. It is injected only during explicit E2E telemetry validation runs and only targets the dedicated E2E App Insights component.
 
-GitHub Actions integration
+KQL quick queries
 
-- Workflows can package or publish the VSIX without providing any telemetry environment variables.
-- Optional: if you need to override the baked-in connection string for an experiment, set `APPLICATIONINSIGHTS_CONNECTION_STRING` or `VSCODE_TELEMETRY_CONNECTION_STRING` in the job environment; the runtime still prefers that when present.
+Recent custom events:
 
-Example job snippet:
-
-```yaml
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-      - run: npm ci
-      - name: Build (extension + webview)
-        run: npm run package
-      - name: Package VSIX
-        run: npx --yes @vscode/vsce package
-      # Optionally upload the VSIX artifact here
+```kusto
+customEvents
+| where timestamp > ago(7d)
+| project timestamp, name, customDimensions, customMeasurements
+| order by timestamp desc
+| take 20
 ```
 
+Volume by event in the last 30 days:
+
+```kusto
+customEvents
+| where timestamp > ago(30d)
+| summarize count() by name
+| order by count_ desc
+```
+
+Breakdown by outcome:
+
+```kusto
+customEvents
+| where timestamp > ago(30d)
+| extend dims = parse_json(tostring(customDimensions))
+| summarize count() by name, tostring(dims["outcome"])
+| order by name asc, count_ desc
+```
+
+Performance by event:
+
+```kusto
+customEvents
+| where timestamp > ago(30d)
+| extend meas = parse_json(tostring(customMeasurements))
+| extend durationMs = todouble(meas["durationMs"])
+| where isfinite(durationMs)
+| summarize avgMs = avg(durationMs), p50Ms = percentile(durationMs, 50), p95Ms = percentile(durationMs, 95) by name
+| order by p95Ms desc
+```
+
+Version and platform split for activations:
+
+```kusto
+customEvents
+| where timestamp > ago(30d)
+| where name endswith "extension.activate"
+| extend dims = parse_json(tostring(customDimensions))
+| summarize count() by tostring(dims["common.extversion"]), tostring(dims["common.os"])
+| order by count_ desc
+```
+
+Schema hygiene checks:
+
+```kusto
+customEvents
+| where timestamp > ago(30d)
+| extend dims = parse_json(tostring(customDimensions))
+| summarize missingOutcome = countif(isempty(tostring(dims["outcome"]))) by name
+| where missingOutcome > 0
+```
+
+Dedicated E2E run validation:
+
+```kusto
+customEvents
+| where timestamp > ago(2h)
+| extend dims = parse_json(tostring(customDimensions))
+| where tostring(dims["testRunId"]) == "<run-id>"
+| summarize count() by name
+| order by count_ desc
+```
+
+GitHub Actions and packaging
+
+- Workflows can package or publish the VSIX without injecting telemetry secrets.
+- Keep `telemetry.json` in the packaged file list so the runtime and users can inspect the contract shipped in the VSIX.
+- `npm run test:e2e:telemetry` resolves the dedicated E2E App Insights connection string dynamically through `az`, so the test target stays out of the checked-in runtime package metadata.
 
 References
 
 - VS Code telemetry overview: https://code.visualstudio.com/docs/configure/telemetry
-- Telemetry guide for extensions: https://code.visualstudio.com/api/extension-guides/telemetry
+- VS Code extension telemetry guide: https://code.visualstudio.com/api/extension-guides/telemetry

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -115,6 +115,8 @@ Optional overrides:
 - `ALV_E2E_TELEMETRY_QUERY_DELAY_MS`
 - `ALV_E2E_TELEMETRY_LOOKBACK`
 
+When `ALV_E2E_TELEMETRY_SUBSCRIPTION` is not set, the telemetry runner falls back to `AZURE_SUBSCRIPTION_ID` before using the checked-in default subscription. This keeps GitHub Actions OIDC runs aligned with the Azure subscription selected by `azure/login`.
+
 Internal env vars used by the test runner:
 
 - `ALV_ENABLE_TEST_TELEMETRY=1`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -9,6 +9,7 @@ This project uses VS Code integration tests (Mocha running inside the Extension 
 - `npm run test:integration`: installs dependency extensions if needed and runs integration tests.
 - `npm run test:all`: runs the Jest webview suites, then both unit and integration scopes.
 - `npm run test:e2e`: runs Playwright E2E tests against a real scratch org (creates a scratch org + seeds an Apex log).
+- `npm run test:e2e:telemetry`: runs the same Playwright E2E suite, but first resolves a dedicated App Insights component for E2E and then validates that telemetry from the current run arrived there.
 
 The test orchestrator lives in `scripts/run-tests.js` and the Mocha programmatic runner in `src/test/runner.ts`.
 
@@ -66,6 +67,7 @@ The Playwright suite validates the webview UX end-to-end by:
 From the repo root:
 
 - `SF_TEST_KEEP_ORG=1 npm run test:e2e`
+- `SF_TEST_KEEP_ORG=1 npm run test:e2e:telemetry`
 
 Useful env vars:
 
@@ -81,6 +83,43 @@ Troubleshooting:
 - If the Logs panel shows **“Salesforce CLI not found”**, set the VS Code setting `electivus.apexLogs.cliPath` to the absolute path of your `sf` executable.
 
 Artifacts (screenshots/traces/videos on failure) are written under `output/playwright/`.
+
+### Playwright E2E + dedicated App Insights validation
+
+`npm run test:e2e:telemetry` is the full telemetry-validation path. It:
+
+1. Resolves or creates `appi-apex-log-viewer-telemetry-e2e-eastus`
+2. Reuses the existing Log Analytics workspace from the production telemetry resource
+3. Injects a test-only telemetry connection string plus a per-run `testRunId`
+4. Runs the full Playwright suite
+5. Queries the dedicated App Insights component and fails if the current run's telemetry does not arrive
+
+The GitHub Actions workflow `.github/workflows/e2e-playwright.yml` prefers this path automatically when `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID` are configured for OIDC-based `azure/login`. If those Azure settings are missing, the workflow falls back to the smoke-only `npm run test:e2e -- openLogViewer.e2e.spec.ts` path so PR validation remains usable.
+
+Default Azure targets:
+
+- Subscription: `c1b4d537-c3dc-4d64-b022-a97fd1826665`
+- Resource group: `rg-apex-log-viewer-telemetry-eastus`
+- Production App Insights (workspace source): `appi-apex-log-viewer-telemetry-eastus`
+- E2E App Insights target: `appi-apex-log-viewer-telemetry-e2e-eastus`
+
+Optional overrides:
+
+- `ALV_E2E_TELEMETRY_SUBSCRIPTION`
+- `ALV_E2E_TELEMETRY_RESOURCE_GROUP`
+- `ALV_E2E_TELEMETRY_LOCATION`
+- `ALV_E2E_TELEMETRY_APP`
+- `ALV_E2E_TELEMETRY_BASE_APP`
+- `ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID`
+- `ALV_E2E_TELEMETRY_QUERY_ATTEMPTS`
+- `ALV_E2E_TELEMETRY_QUERY_DELAY_MS`
+- `ALV_E2E_TELEMETRY_LOOKBACK`
+
+Internal env vars used by the test runner:
+
+- `ALV_ENABLE_TEST_TELEMETRY=1`
+- `ALV_TEST_TELEMETRY_CONNECTION_STRING`
+- `ALV_TEST_TELEMETRY_RUN_ID`
 
 ## Debugging
 

--- a/package.json
+++ b/package.json
@@ -457,6 +457,8 @@
     "test:smoke:vsix": "node scripts/run-tests.js --scope=unit --smoke-vsix",
     "pretest:e2e": "npm run build",
     "test:e2e": "node scripts/run-playwright-e2e.js",
+    "pretest:e2e:telemetry": "npm run build",
+    "test:e2e:telemetry": "node scripts/run-playwright-e2e-telemetry.js",
     "format": "prettier --write .",
     "prepare": "husky",
     "tailwind:build": "tailwindcss -c tailwind.config.js -i ./src/webview/styles/tailwind.css -o ./media/webview.css --minify",
@@ -542,6 +544,7 @@
     "README.md",
     "CHANGELOG.md",
     "LICENSE",
+    "telemetry.json",
     "package.json",
     "package.nls.json",
     "package.nls.pt-br.json"

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -210,7 +210,9 @@ async function main() {
     location: String(process.env.ALV_E2E_TELEMETRY_LOCATION || 'eastus').trim(),
     resourceGroup: String(process.env.ALV_E2E_TELEMETRY_RESOURCE_GROUP || 'rg-apex-log-viewer-telemetry-eastus').trim(),
     subscription: String(
-      process.env.ALV_E2E_TELEMETRY_SUBSCRIPTION || 'c1b4d537-c3dc-4d64-b022-a97fd1826665'
+      process.env.ALV_E2E_TELEMETRY_SUBSCRIPTION ||
+        process.env.AZURE_SUBSCRIPTION_ID ||
+        'c1b4d537-c3dc-4d64-b022-a97fd1826665'
     ).trim(),
     workspaceResourceId: String(process.env.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID || '').trim() || undefined
   };
@@ -230,11 +232,15 @@ async function main() {
     ALV_TEST_TELEMETRY_RUN_ID: runId
   };
 
-  const child = await spawnAsync(process.execPath, [path.join(__dirname, 'run-playwright-e2e.js'), ...process.argv.slice(2)], {
-    cwd: REPO_ROOT,
-    env: childEnv,
-    stdio: 'inherit'
-  });
+  const child = await spawnAsync(
+    process.execPath,
+    [path.join(__dirname, 'run-playwright-e2e.js'), ...process.argv.slice(2)],
+    {
+      cwd: REPO_ROOT,
+      env: childEnv,
+      stdio: 'inherit'
+    }
+  );
 
   if (typeof child.code === 'number' && child.code !== 0) {
     process.exit(child.code);

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -171,7 +171,7 @@ async function queryTelemetryForRun(config, runId, lookback) {
 function summarizeTelemetry(rows) {
   const totalEvents = rows.reduce((sum, row) => sum + Number(row.events || 0), 0);
   const distinctNames = rows.length;
-  const hasActivation = rows.some(row => /\/extension\.activate$/.test(String(row.name || '')));
+  const hasActivation = rows.some(row => /(^|\/)extension\.activate$/.test(String(row.name || '')));
   return { distinctNames, hasActivation, totalEvents };
 }
 

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -1,0 +1,260 @@
+#!/usr/bin/env node
+'use strict';
+
+const { randomUUID } = require('crypto');
+const { execFile, spawn } = require('child_process');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const AZ_COMMAND = 'az';
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function execFileAsync(file, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      if (error) {
+        const err = new Error(stderr || stdout || error.message || 'exec failed');
+        err.code = error.code;
+        err.stdout = stdout;
+        err.stderr = stderr;
+        reject(err);
+        return;
+      }
+      resolve({ stdout, stderr });
+    });
+  });
+}
+
+function execCommandAsync(command, args, options = {}) {
+  if (process.platform === 'win32') {
+    return execFileAsync('cmd.exe', ['/d', '/s', '/c', command, ...args], options);
+  }
+  return execFileAsync(command, args, options);
+}
+
+function spawnAsync(command, args, options = {}) {
+  return new Promise(resolve => {
+    const child = spawn(command, args, options);
+    child.on('exit', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+function parseJson(text) {
+  return JSON.parse(String(text || '').trim());
+}
+
+function toRows(result) {
+  const table = result && Array.isArray(result.tables) ? result.tables[0] : undefined;
+  if (!table || !Array.isArray(table.columns) || !Array.isArray(table.rows)) {
+    return [];
+  }
+  return table.rows.map(row => {
+    const entry = {};
+    for (let index = 0; index < table.columns.length; index++) {
+      entry[table.columns[index].name] = row[index];
+    }
+    return entry;
+  });
+}
+
+function isResourceNotFound(error) {
+  const text = [error && error.message, error && error.stderr, error && error.stdout].filter(Boolean).join('\n');
+  return /ResourceNotFound|was not found|ARMResourceNotFoundFix/i.test(text);
+}
+
+function kqlQuote(value) {
+  return `'${String(value).replace(/'/g, "''")}'`;
+}
+
+async function azJson(args) {
+  const { stdout } = await execCommandAsync(AZ_COMMAND, [...args, '-o', 'json'], {
+    cwd: REPO_ROOT,
+    maxBuffer: 10 * 1024 * 1024
+  });
+  return parseJson(stdout);
+}
+
+async function showComponent(config, appName) {
+  return azJson([
+    'monitor',
+    'app-insights',
+    'component',
+    'show',
+    '-a',
+    appName,
+    '-g',
+    config.resourceGroup,
+    '--subscription',
+    config.subscription
+  ]);
+}
+
+async function resolveWorkspaceId(config) {
+  if (config.workspaceResourceId) {
+    return config.workspaceResourceId;
+  }
+  const base = await showComponent(config, config.baseApp);
+  if (!base.workspaceResourceId) {
+    throw new Error(`Base Application Insights resource "${config.baseApp}" does not expose a workspaceResourceId.`);
+  }
+  return base.workspaceResourceId;
+}
+
+async function ensureTelemetryComponent(config) {
+  try {
+    const existing = await showComponent(config, config.appName);
+    return { component: existing, created: false };
+  } catch (error) {
+    if (!isResourceNotFound(error)) {
+      throw error;
+    }
+  }
+
+  const workspaceResourceId = await resolveWorkspaceId(config);
+  const created = await azJson([
+    'monitor',
+    'app-insights',
+    'component',
+    'create',
+    '-a',
+    config.appName,
+    '-g',
+    config.resourceGroup,
+    '-l',
+    config.location,
+    '--kind',
+    'web',
+    '--application-type',
+    'web',
+    '--workspace',
+    workspaceResourceId,
+    '--subscription',
+    config.subscription,
+    '--tags',
+    'app=apex-log-viewer',
+    'component=telemetry',
+    'env=e2e',
+    'managed-by=az-cli',
+    'repo=Apex-Log-Viewer'
+  ]);
+  return { component: created, created: true };
+}
+
+async function queryTelemetryForRun(config, runId, lookback) {
+  const query = [
+    'customEvents',
+    `| where timestamp > ago(${lookback})`,
+    `| extend runId = tostring(customDimensions['testRunId'])`,
+    `| where runId == ${kqlQuote(runId)}`,
+    '| summarize events = count() by name',
+    '| order by events desc'
+  ].join(' ');
+
+  return azJson([
+    'monitor',
+    'app-insights',
+    'query',
+    '-a',
+    config.appName,
+    '-g',
+    config.resourceGroup,
+    '--subscription',
+    config.subscription,
+    '--analytics-query',
+    query
+  ]);
+}
+
+function summarizeTelemetry(rows) {
+  const totalEvents = rows.reduce((sum, row) => sum + Number(row.events || 0), 0);
+  const distinctNames = rows.length;
+  const hasActivation = rows.some(row => /\/extension\.activate$/.test(String(row.name || '')));
+  return { distinctNames, hasActivation, totalEvents };
+}
+
+async function waitForTelemetry(config, runId) {
+  const attempts = Math.max(1, Number(process.env.ALV_E2E_TELEMETRY_QUERY_ATTEMPTS || 18) || 18);
+  const delayMs = Math.max(1000, Number(process.env.ALV_E2E_TELEMETRY_QUERY_DELAY_MS || 10000) || 10000);
+  const lookback = String(process.env.ALV_E2E_TELEMETRY_LOOKBACK || '2h').trim() || '2h';
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = await queryTelemetryForRun(config, runId, lookback);
+    const rows = toRows(result);
+    const summary = summarizeTelemetry(rows);
+    if (summary.hasActivation && summary.totalEvents >= 5 && summary.distinctNames >= 3) {
+      return { rows, summary, attempt };
+    }
+    if (attempt < attempts) {
+      console.log(
+        `[e2e] Waiting for App Insights ingestion (${attempt}/${attempts}) -> ${summary.totalEvents} events, ${summary.distinctNames} names`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  const finalResult = await queryTelemetryForRun(config, runId, lookback);
+  const finalRows = toRows(finalResult);
+  const finalSummary = summarizeTelemetry(finalRows);
+  throw new Error(
+    `Telemetry validation failed for run ${runId}. Expected at least one activation event, 5 total events, and 3 distinct names, but observed ${finalSummary.totalEvents} events across ${finalSummary.distinctNames} names.`
+  );
+}
+
+async function main() {
+  const config = {
+    appName: String(process.env.ALV_E2E_TELEMETRY_APP || 'appi-apex-log-viewer-telemetry-e2e-eastus').trim(),
+    baseApp: String(process.env.ALV_E2E_TELEMETRY_BASE_APP || 'appi-apex-log-viewer-telemetry-eastus').trim(),
+    location: String(process.env.ALV_E2E_TELEMETRY_LOCATION || 'eastus').trim(),
+    resourceGroup: String(process.env.ALV_E2E_TELEMETRY_RESOURCE_GROUP || 'rg-apex-log-viewer-telemetry-eastus').trim(),
+    subscription: String(
+      process.env.ALV_E2E_TELEMETRY_SUBSCRIPTION || 'c1b4d537-c3dc-4d64-b022-a97fd1826665'
+    ).trim(),
+    workspaceResourceId: String(process.env.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID || '').trim() || undefined
+  };
+
+  const { component, created } = await ensureTelemetryComponent(config);
+  const runId = randomUUID();
+
+  console.log(
+    `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
+  );
+  console.log(`[e2e] Test telemetry run id: ${runId}`);
+
+  const childEnv = {
+    ...process.env,
+    ALV_ENABLE_TEST_TELEMETRY: '1',
+    ALV_TEST_TELEMETRY_CONNECTION_STRING: component.connectionString,
+    ALV_TEST_TELEMETRY_RUN_ID: runId
+  };
+
+  const child = await spawnAsync(process.execPath, [path.join(__dirname, 'run-playwright-e2e.js'), ...process.argv.slice(2)], {
+    cwd: REPO_ROOT,
+    env: childEnv,
+    stdio: 'inherit'
+  });
+
+  if (typeof child.code === 'number' && child.code !== 0) {
+    process.exit(child.code);
+    return;
+  }
+  if (child.signal) {
+    throw new Error(`Playwright E2E process exited via signal ${child.signal}.`);
+  }
+
+  console.log('[e2e] Playwright suite passed. Validating telemetry arrival in the dedicated App Insights resource...');
+  const validation = await waitForTelemetry(config, runId);
+  console.log(
+    `[e2e] Telemetry validated after ${validation.attempt} query attempt(s): ${validation.summary.totalEvents} events across ${validation.summary.distinctNames} event names.`
+  );
+  for (const row of validation.rows) {
+    console.log(`[e2e] ${row.name}: ${row.events}`);
+  }
+}
+
+main().catch(error => {
+  console.error('[e2e] Telemetry validation failed:', error && error.message ? error.message : error);
+  process.exit(1);
+});

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -52,12 +52,6 @@ export async function activate(context: vscode.ExtensionContext) {
   } catch {
     // ignore telemetry init errors
   }
-  safeSendEvent('extension.activate', {
-    vscodeVersion: vscode.version,
-    platform: process.platform,
-    hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0),
-    hasSalesforceProject: String(hasSalesforceProject)
-  });
   // Keep Salesforce SDKs and CLI helpers from attempting on-disk log files inside the VS Code host.
   try {
     if (!process.env.SF_DISABLE_LOG_FILE) process.env.SF_DISABLE_LOG_FILE = 'true';
@@ -106,7 +100,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.refresh', async () => {
-      safeSendEvent('command.refresh');
+      safeSendEvent('command.refresh', { outcome: 'invoked' });
       const viewAlreadyResolved = provider.hasResolvedView();
       try {
         await vscode.commands.executeCommand('workbench.view.extension.salesforceLogsPanel');
@@ -166,7 +160,7 @@ export async function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.tail', async () => {
       logInfo('Command sfLogs.tail invoked. Opening Tail view and starting…');
-      safeSendEvent('command.tail');
+      safeSendEvent('command.tail', { outcome: 'invoked' });
       try {
         await provider.tailLogs();
       } catch (e) {
@@ -183,7 +177,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.openLogInViewer', async (uri?: vscode.Uri) => {
-      safeSendEvent('command.openLogInViewer');
+      safeSendEvent('command.openLogInViewer', { outcome: 'invoked' });
       try {
         const doc = uri ? await vscode.workspace.openTextDocument(uri) : vscode.window.activeTextEditor?.document;
         if (!doc || doc.isClosed) {
@@ -227,14 +221,14 @@ export async function activate(context: vscode.ExtensionContext) {
   // Convenience: command to show the output channel
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.showOutput', () => {
-      safeSendEvent('command.showOutput');
+      safeSendEvent('command.showOutput', { outcome: 'invoked' });
       showOutput(true);
     })
   );
 
   context.subscriptions.push(
     vscode.commands.registerCommand('sfLogs.troubleshootWebview', async () => {
-      safeSendEvent('command.troubleshootWebview');
+      safeSendEvent('command.troubleshootWebview', { outcome: 'invoked' });
       const appName = vscode.env.appName || 'VS Code';
       const remoteName = vscode.env.remoteName;
       const showOutputLabel = localize('webviewTroubleshooting.showOutput', 'Show Extension Output');
@@ -317,10 +311,12 @@ export async function activate(context: vscode.ExtensionContext) {
         await CacheManager.delete('cli');
         logInfo('CLI cache cleared.');
         vscode.window.showInformationMessage('Electivus Apex Logs: CLI cache cleared');
+        safeSendEvent('command.resetCliCache', { outcome: 'ok' });
       } catch (e) {
         const msg = getErrorMessage(e);
         logWarn('Failed clearing CLI cache ->', msg);
         vscode.window.showErrorMessage('Electivus Apex Logs: Failed to clear CLI cache');
+        safeSendEvent('command.resetCliCache', { outcome: 'error' });
       }
     })
   );
@@ -363,8 +359,15 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Return exports for tests and programmatic use
   try {
-    const activationMs = Date.now() - activationStart;
-    safeSendEvent('extension.activate.duration', undefined, { activationMs });
+    safeSendEvent(
+      'extension.activate',
+      {
+        outcome: 'ok',
+        hasWorkspace: String(!!vscode.workspace.workspaceFolders && vscode.workspace.workspaceFolders.length > 0),
+        hasSalesforceProject: String(hasSalesforceProject)
+      },
+      { durationMs: Date.now() - activationStart }
+    );
   } catch {}
   return {
     getApiVersion

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -244,7 +244,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
       logInfo('Tail: opened log', logId);
       try {
         const durationMs = Date.now() - t0;
-        safeSendEvent('log.open', { view: 'tail' }, { durationMs });
+        safeSendEvent('log.open', { outcome: 'ok', view: 'tail' }, { durationMs });
       } catch {}
     } catch (e) {
       const msg = getErrorMessage(e);

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -869,7 +869,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       );
       if (confirmation !== confirmAction) {
         try {
-          safeSendEvent('logs.cleanup', { outcome: 'cancel', scope }, { durationMs: Date.now() - t0 });
+          safeSendEvent(
+            'logs.cleanup',
+            { outcome: 'cancel', scope, sourceView: 'logs' },
+            { durationMs: Date.now() - t0 }
+          );
         } catch {}
         return;
       }
@@ -992,7 +996,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       try {
         safeSendEvent(
           'logs.cleanup',
-          { outcome: result.kind, scope },
+          { outcome: result.kind, scope, sourceView: 'logs' },
           { durationMs: Date.now() - t0 }
         );
       } catch {}
@@ -1003,7 +1007,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       logError('Logs: cleanup failed ->', msg);
       void vscode.window.showErrorMessage(localize('logsCleanup.failed', 'Failed to clear logs: {0}', msg));
       try {
-        safeSendEvent('logs.cleanup', { outcome: 'error', scope }, { durationMs: Date.now() - t0 });
+        safeSendEvent(
+          'logs.cleanup',
+          { outcome: 'error', scope, sourceView: 'logs' },
+          { durationMs: Date.now() - t0 }
+        );
       } catch {}
     } finally {
       this.clearLogsInProgress = false;
@@ -1038,7 +1046,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       );
       if (confirmation !== confirmAction) {
         try {
-          safeSendEvent('logs.downloadAll', { outcome: 'cancel' }, { durationMs: Date.now() - t0 });
+          safeSendEvent(
+            'logs.downloadAll',
+            { outcome: 'cancel', sourceView: 'logs' },
+            { durationMs: Date.now() - t0 }
+          );
         } catch {}
         return;
       }
@@ -1126,7 +1138,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         try {
           safeSendEvent(
             'logs.downloadAll',
-            { outcome: 'cancelled' },
+            { outcome: 'cancelled', sourceView: 'logs' },
             {
               durationMs: Date.now() - t0,
               total: runResult.listed,
@@ -1144,7 +1156,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
           localize('downloadAllLogsNoLogs', 'No Apex logs were found for the selected org.')
         );
         try {
-          safeSendEvent('logs.downloadAll', { outcome: 'empty' }, { durationMs: Date.now() - t0 });
+          safeSendEvent(
+            'logs.downloadAll',
+            { outcome: 'empty', sourceView: 'logs' },
+            { durationMs: Date.now() - t0 }
+          );
         } catch {}
         return;
       }
@@ -1168,7 +1184,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         try {
           safeSendEvent(
             'logs.downloadAll',
-            { outcome: 'cancelled' },
+            { outcome: 'cancelled', sourceView: 'logs' },
             { durationMs: Date.now() - t0, total, success, failed: summary.failed, cancelled: summary.cancelled }
           );
         } catch {}
@@ -1184,7 +1200,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
           )
         );
         try {
-          safeSendEvent('logs.downloadAll', { outcome: 'partial' }, { durationMs: Date.now() - t0, total, success, failed: summary.failed });
+          safeSendEvent(
+            'logs.downloadAll',
+            { outcome: 'partial', sourceView: 'logs' },
+            { durationMs: Date.now() - t0, total, success, failed: summary.failed }
+          );
         } catch {}
         return;
       }
@@ -1199,7 +1219,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         )
       );
       try {
-        safeSendEvent('logs.downloadAll', { outcome: 'ok' }, { durationMs: Date.now() - t0, total, success });
+        safeSendEvent(
+          'logs.downloadAll',
+          { outcome: 'ok', sourceView: 'logs' },
+          { durationMs: Date.now() - t0, total, success }
+        );
       } catch {}
     } catch (e) {
       const msg = getErrorMessage(e);
@@ -1208,7 +1232,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
         localize('downloadAllLogsFailed', 'Failed to download all org logs: {0}', msg)
       );
       try {
-        safeSendEvent('logs.downloadAll', { outcome: 'error' }, { durationMs: Date.now() - t0 });
+        safeSendEvent(
+          'logs.downloadAll',
+          { outcome: 'error', sourceView: 'logs' },
+          { durationMs: Date.now() - t0 }
+        );
       } catch {}
     } finally {
       this.bulkDownloadInProgress = false;

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -2,7 +2,6 @@ import { logTrace } from '../utils/logger';
 import { localize } from '../utils/localize';
 import { safeSendException } from '../shared/telemetry';
 import type { OrgAuth, OrgItem } from './types';
-import * as vscode from 'vscode';
 import { CacheManager } from '../utils/cacheManager';
 import { getBooleanConfig, getConfig, getNumberConfig } from '../utils/config';
 import {

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -1,38 +1,261 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as vscode from 'vscode';
 import { TelemetryReporter } from '@vscode/extension-telemetry';
 import { logWarn } from '../utils/logger';
 
+interface TelemetryFieldSchema {
+  required?: boolean;
+  values?: string[];
+  pattern?: string;
+}
+
+interface TelemetryEventSchema {
+  properties?: Record<string, TelemetryFieldSchema>;
+  measurements?: Record<string, TelemetryFieldSchema>;
+}
+
+interface TelemetryCatalog {
+  commonProperties?: Record<string, TelemetryFieldSchema>;
+  extensionId?: string;
+  events?: Record<string, TelemetryEventSchema>;
+}
+
+type PreparedEvent = {
+  measurements?: Record<string, number>;
+  properties?: Record<string, string>;
+};
+
 let reporter: TelemetryReporter | undefined;
+let catalog: TelemetryCatalog | undefined;
+const warningKeys = new Set<string>();
+
+function isExplicitTestTelemetryEnabled(): boolean {
+  return process.env.ALV_ENABLE_TEST_TELEMETRY === '1';
+}
+
+function isNonProductionMode(context: vscode.ExtensionContext): boolean {
+  return (
+    context.extensionMode === vscode.ExtensionMode.Development || context.extensionMode === vscode.ExtensionMode.Test
+  );
+}
+
+function warnOnce(key: string, message: string): void {
+  if (warningKeys.has(key)) {
+    return;
+  }
+  warningKeys.add(key);
+  logWarn(message);
+}
 
 function getConnectionString(context: vscode.ExtensionContext): string | undefined {
-  // Prefer environment variables configured during packaging.
+  if (isNonProductionMode(context)) {
+    const testConn = process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING?.trim();
+    return testConn || undefined;
+  }
   const envConn = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING || process.env.VSCODE_TELEMETRY_CONNECTION_STRING;
   if (envConn) return envConn;
-  // Fallback to packaged field set by CI (non-legacy): package.json.telemetryConnectionString
-  const anyPkg = context.extension.packageJSON as any;
-  const conn: string | undefined =
+  const anyPkg = context.extension.packageJSON as Record<string, unknown>;
+  const conn =
     anyPkg && typeof anyPkg.telemetryConnectionString === 'string' ? anyPkg.telemetryConnectionString : undefined;
   return conn;
 }
 
+function getTelemetrySchemaPath(context: vscode.ExtensionContext): string {
+  const extensionPath =
+    (context.extension as { extensionPath?: string } | undefined)?.extensionPath ||
+    (context as { extensionPath?: string } | undefined)?.extensionPath ||
+    process.cwd();
+  return path.join(extensionPath, 'telemetry.json');
+}
+
+function loadTelemetryCatalog(context: vscode.ExtensionContext): TelemetryCatalog | undefined {
+  try {
+    const schemaPath = getTelemetrySchemaPath(context);
+    const raw = fs.readFileSync(schemaPath, 'utf8');
+    const parsed = JSON.parse(raw) as TelemetryCatalog;
+    if (!parsed || typeof parsed !== 'object' || !parsed.events || typeof parsed.events !== 'object') {
+      warnOnce('telemetry:schema:invalid', 'Telemetry schema is missing the events catalog; telemetry is disabled.');
+      return undefined;
+    }
+    return parsed;
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    warnOnce('telemetry:schema:load', `Failed loading telemetry schema; telemetry is disabled. ${msg}`);
+    return undefined;
+  }
+}
+
+function getEventSchema(name: string): TelemetryEventSchema | undefined {
+  const schema = catalog?.events?.[name];
+  if (!schema) {
+    warnOnce(`telemetry:event:${name}`, `Telemetry event "${name}" is not declared in telemetry.json; dropping it.`);
+    return undefined;
+  }
+  return schema;
+}
+
+function isAllowedString(value: string, schema: TelemetryFieldSchema): boolean {
+  if (Array.isArray(schema.values) && schema.values.length > 0 && !schema.values.includes(value)) {
+    return false;
+  }
+  if (schema.pattern) {
+    return new RegExp(schema.pattern).test(value);
+  }
+  return true;
+}
+
+function getPropertySchema(eventSchema: TelemetryEventSchema): Record<string, TelemetryFieldSchema> {
+  return {
+    ...(catalog?.commonProperties || {}),
+    ...(eventSchema.properties || {})
+  };
+}
+
+function prepareProperties(
+  eventName: string,
+  eventSchema: TelemetryEventSchema,
+  properties: Record<string, string> | undefined,
+  kind: 'error' | 'usage'
+): Record<string, string> | null | undefined {
+  const input: Record<string, string> = {};
+  if (properties) {
+    for (const [key, value] of Object.entries(properties)) {
+      input[key] = String(value);
+    }
+  }
+  if (kind === 'error') {
+    input.outcome = input.outcome || 'error';
+  }
+  if (isExplicitTestTelemetryEnabled()) {
+    const testRunId = process.env.ALV_TEST_TELEMETRY_RUN_ID?.trim();
+    if (testRunId) {
+      input.testRunId = testRunId;
+    }
+  }
+
+  const propertySchema = getPropertySchema(eventSchema);
+  const output: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(input)) {
+    const fieldSchema = propertySchema[key];
+    if (!fieldSchema) {
+      warnOnce(
+        `telemetry:property:${eventName}:${key}`,
+        `Telemetry property "${key}" is not declared for "${eventName}"; dropping it.`
+      );
+      continue;
+    }
+    const normalized = String(value ?? '').trim();
+    if (!normalized) {
+      continue;
+    }
+    if (!isAllowedString(normalized, fieldSchema)) {
+      warnOnce(
+        `telemetry:property:value:${eventName}:${key}:${normalized}`,
+        `Telemetry property "${key}" for "${eventName}" has a disallowed value; dropping it.`
+      );
+      continue;
+    }
+    output[key] = normalized;
+  }
+
+  for (const [key, fieldSchema] of Object.entries(propertySchema)) {
+    if (fieldSchema.required && !output[key]) {
+      warnOnce(
+        `telemetry:property:required:${eventName}:${key}`,
+        `Telemetry event "${eventName}" is missing required property "${key}"; dropping it.`
+      );
+      return null;
+    }
+  }
+
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function prepareMeasurements(
+  eventName: string,
+  eventSchema: TelemetryEventSchema,
+  measurements: Record<string, number> | undefined
+): Record<string, number> | undefined {
+  if (!measurements) {
+    return undefined;
+  }
+  const measurementSchema = eventSchema.measurements || {};
+  const output: Record<string, number> = {};
+
+  for (const [key, value] of Object.entries(measurements)) {
+    const fieldSchema = measurementSchema[key];
+    if (!fieldSchema) {
+      warnOnce(
+        `telemetry:measurement:${eventName}:${key}`,
+        `Telemetry measurement "${key}" is not declared for "${eventName}"; dropping it.`
+      );
+      continue;
+    }
+    if (!Number.isFinite(value)) {
+      warnOnce(
+        `telemetry:measurement:value:${eventName}:${key}`,
+        `Telemetry measurement "${key}" for "${eventName}" is not finite; dropping it.`
+      );
+      continue;
+    }
+    output[key] = value;
+  }
+
+  return Object.keys(output).length > 0 ? output : undefined;
+}
+
+function prepareEvent(
+  name: string,
+  properties: Record<string, string> | undefined,
+  measurements: Record<string, number> | undefined,
+  kind: 'error' | 'usage'
+): PreparedEvent | undefined {
+  if (!catalog) {
+    return undefined;
+  }
+  const eventSchema = getEventSchema(name);
+  if (!eventSchema) {
+    return undefined;
+  }
+  const preparedProperties = prepareProperties(name, eventSchema, properties, kind);
+  if (preparedProperties === null) {
+    return undefined;
+  }
+  const preparedMeasurements = prepareMeasurements(name, eventSchema, measurements);
+  return {
+    properties: preparedProperties,
+    measurements: preparedMeasurements
+  };
+}
+
 export function activateTelemetry(context: vscode.ExtensionContext) {
   try {
-    // Never send telemetry in Development or Test modes
-    if (
-      context.extensionMode === vscode.ExtensionMode.Development ||
-      context.extensionMode === vscode.ExtensionMode.Test
-    ) {
+    if (isNonProductionMode(context) && !isExplicitTestTelemetryEnabled()) {
       return;
     }
+
+    catalog = loadTelemetryCatalog(context);
+    if (!catalog) {
+      return;
+    }
+
     const keyOrConn = getConnectionString(context);
     if (!keyOrConn) {
-      return; // No telemetry key configured – gracefully no-op
+      if (isNonProductionMode(context) && isExplicitTestTelemetryEnabled()) {
+        warnOnce(
+          'telemetry:test:missing-connection',
+          'Explicit test telemetry was enabled, but ALV_TEST_TELEMETRY_CONNECTION_STRING is missing.'
+        );
+      }
+      return;
     }
     reporter = new TelemetryReporter(keyOrConn);
     context.subscriptions.push({
       dispose: () => reporter?.dispose()
     });
-  } catch (e) {
+  } catch {
     // Never throw from telemetry init
   }
 }
@@ -44,6 +267,8 @@ export function disposeTelemetry(): void {
     // ignore
   } finally {
     reporter = undefined;
+    catalog = undefined;
+    warningKeys.clear();
   }
 }
 
@@ -52,12 +277,19 @@ export function sendEvent(
   properties?: Record<string, string>,
   measurements?: Record<string, number>
 ): void {
-  reporter?.sendTelemetryEvent(name, properties, measurements);
+  const event = prepareEvent(name, properties, measurements, 'usage');
+  if (!event) {
+    return;
+  }
+  reporter?.sendTelemetryEvent(name, event.properties, event.measurements);
 }
 
 export function sendException(name: string, properties?: Record<string, string>): void {
-  // Avoid sending raw messages/stacks; send only a coarse-grained name/code.
-  reporter?.sendTelemetryErrorEvent(name, properties);
+  const event = prepareEvent(name, properties, undefined, 'error');
+  if (!event) {
+    return;
+  }
+  reporter?.sendTelemetryErrorEvent(name, event.properties);
 }
 
 export function safeSendEvent(

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert/strict';
-const proxyquire: any = require('proxyquire');
+const proxyquire: any = require('proxyquire').noCallThru();
 
 suite('cli telemetry', () => {
   test('sends telemetry on ENOENT', async () => {
@@ -7,12 +7,36 @@ suite('cli telemetry', () => {
     const telemetry = (name: string, properties: Record<string, string>) => {
       calls.push({ name, properties });
     };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
     const execModule = proxyquire('../salesforce/exec', {
-      '../shared/telemetry': { safeSendException: telemetry }
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
     });
     const { getOrgAuth } = proxyquire('../salesforce/cli', {
-      '../shared/telemetry': { safeSendException: telemetry },
-      './exec': execModule
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
     });
     const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
 
@@ -33,12 +57,36 @@ suite('cli telemetry', () => {
     const telemetry = (name: string, properties: Record<string, string>) => {
       calls.push({ name, properties });
     };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
     const execModule = proxyquire('../salesforce/exec', {
-      '../shared/telemetry': { safeSendException: telemetry }
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
     });
     const { getOrgAuth } = proxyquire('../salesforce/cli', {
-      '../shared/telemetry': { safeSendException: telemetry },
-      './exec': execModule
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
     });
     const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
 

--- a/src/test/telemetry.contract.test.ts
+++ b/src/test/telemetry.contract.test.ts
@@ -1,0 +1,94 @@
+import assert from 'assert/strict';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface TelemetryFieldSchema {
+  required?: boolean;
+}
+
+interface TelemetryEventSchema {
+  measurements?: Record<string, TelemetryFieldSchema>;
+  properties?: Record<string, TelemetryFieldSchema>;
+}
+
+interface TelemetryCatalog {
+  commonProperties?: Record<string, TelemetryFieldSchema>;
+  events: Record<string, TelemetryEventSchema>;
+}
+
+function readTelemetryCatalog(): TelemetryCatalog {
+  const schemaPath = path.resolve(__dirname, '../../telemetry.json');
+  const raw = fs.readFileSync(schemaPath, 'utf8');
+  return JSON.parse(raw) as TelemetryCatalog;
+}
+
+function collectSourceFiles(dir: string, acc: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'test') {
+        continue;
+      }
+      collectSourceFiles(fullPath, acc);
+      continue;
+    }
+    if (/\.(ts|tsx)$/.test(entry.name)) {
+      acc.push(fullPath);
+    }
+  }
+  return acc;
+}
+
+function collectEmittedEventNames(): string[] {
+  const srcRoot = path.resolve(__dirname, '../../src');
+  const matcher = /safeSend(?:Event|Exception)\(\s*['"]([^'"]+)['"]/g;
+  const emitted = new Set<string>();
+
+  for (const filePath of collectSourceFiles(srcRoot)) {
+    const content = fs.readFileSync(filePath, 'utf8');
+    for (const match of content.matchAll(matcher)) {
+      const name = match[1];
+      if (name) {
+        emitted.add(name);
+      }
+    }
+  }
+
+  return [...emitted].sort((left, right) => left.localeCompare(right));
+}
+
+suite('telemetry contract', () => {
+  test('catalog covers every emitted telemetry event', () => {
+    const catalog = readTelemetryCatalog();
+    const emitted = collectEmittedEventNames();
+    const missing = emitted.filter(name => !catalog.events[name]);
+
+    assert.deepEqual(missing, []);
+  });
+
+  test('catalog requires outcome for every declared event', () => {
+    const catalog = readTelemetryCatalog();
+
+    for (const [name, schema] of Object.entries(catalog.events)) {
+      assert.equal(
+        schema.properties?.outcome?.required,
+        true,
+        `Expected telemetry event "${name}" to require outcome.`
+      );
+    }
+  });
+
+  test('activation duration is modeled on extension.activate, not as a separate event', () => {
+    const catalog = readTelemetryCatalog();
+
+    assert.ok(catalog.events['extension.activate']);
+    assert.ok(catalog.events['extension.activate']?.measurements?.durationMs);
+    assert.equal(catalog.events['extension.activate.duration'], undefined);
+  });
+
+  test('catalog declares the test-only run identifier used by E2E telemetry validation', () => {
+    const catalog = readTelemetryCatalog();
+
+    assert.ok(catalog.commonProperties?.testRunId);
+  });
+});

--- a/src/test/telemetry.test.ts
+++ b/src/test/telemetry.test.ts
@@ -11,6 +11,12 @@ const extensionMode = {
 
 function loadTelemetryModule() {
   const created: string[] = [];
+  const errorEvents: Array<{ name: string; properties?: Record<string, string> }> = [];
+  const usageEvents: Array<{
+    measurements?: Record<string, number>;
+    name: string;
+    properties?: Record<string, string>;
+  }> = [];
   const warnings: string[][] = [];
   let disposeCount = 0;
   let throwOnSendEvent = false;
@@ -24,10 +30,12 @@ function loadTelemetryModule() {
       if (throwOnSendEvent) {
         throw new Error('send failed');
       }
+      usageEvents.push({ name, properties, measurements });
       return { name, properties, measurements };
     }
 
     sendTelemetryErrorEvent(name: string, properties?: Record<string, string>) {
+      errorEvents.push({ name, properties });
       return { name, properties };
     }
 
@@ -46,18 +54,34 @@ function loadTelemetryModule() {
   }) as TelemetryModule;
 
   return {
-    telemetry,
     created,
-    warnings,
+    errorEvents,
     getDisposeCount: () => disposeCount,
     setThrowOnSendEvent: (value: boolean) => {
       throwOnSendEvent = value;
-    }
+    },
+    telemetry,
+    usageEvents,
+    warnings
   };
+}
+
+function createContext(mode: number) {
+  return {
+    extension: {
+      extensionPath: process.cwd(),
+      packageJSON: { telemetryConnectionString: 'pkg-conn' }
+    },
+    extensionMode: mode,
+    subscriptions: []
+  } as any;
 }
 
 suite('telemetry', () => {
   const originalAppInsights = process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+  const originalEnableTestTelemetry = process.env.ALV_ENABLE_TEST_TELEMETRY;
+  const originalTestTelemetryConnection = process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING;
+  const originalTestTelemetryRunId = process.env.ALV_TEST_TELEMETRY_RUN_ID;
   const originalVsCodeTelemetry = process.env.VSCODE_TELEMETRY_CONNECTION_STRING;
 
   teardown(() => {
@@ -72,6 +96,24 @@ suite('telemetry', () => {
     } else {
       process.env.VSCODE_TELEMETRY_CONNECTION_STRING = originalVsCodeTelemetry;
     }
+
+    if (originalEnableTestTelemetry === undefined) {
+      delete process.env.ALV_ENABLE_TEST_TELEMETRY;
+    } else {
+      process.env.ALV_ENABLE_TEST_TELEMETRY = originalEnableTestTelemetry;
+    }
+
+    if (originalTestTelemetryConnection === undefined) {
+      delete process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING;
+    } else {
+      process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING = originalTestTelemetryConnection;
+    }
+
+    if (originalTestTelemetryRunId === undefined) {
+      delete process.env.ALV_TEST_TELEMETRY_RUN_ID;
+    } else {
+      process.env.ALV_TEST_TELEMETRY_RUN_ID = originalTestTelemetryRunId;
+    }
   });
 
   test('does not activate reporter outside production mode', () => {
@@ -81,17 +123,8 @@ suite('telemetry', () => {
     const { telemetry, created } = loadTelemetryModule();
     const subscriptions: Array<{ dispose: () => void }> = [];
 
-    telemetry.activateTelemetry({
-      extensionMode: extensionMode.Development,
-      extension: { packageJSON: { telemetryConnectionString: 'pkg-conn' } },
-      subscriptions
-    } as any);
-
-    telemetry.activateTelemetry({
-      extensionMode: extensionMode.Test,
-      extension: { packageJSON: { telemetryConnectionString: 'pkg-conn' } },
-      subscriptions
-    } as any);
+    telemetry.activateTelemetry({ ...createContext(extensionMode.Development), subscriptions });
+    telemetry.activateTelemetry({ ...createContext(extensionMode.Test), subscriptions });
 
     assert.deepEqual(created, []);
     assert.equal(subscriptions.length, 0);
@@ -105,11 +138,7 @@ suite('telemetry', () => {
     const { telemetry, created, getDisposeCount } = loadTelemetryModule();
     const subscriptions: Array<{ dispose: () => void }> = [];
 
-    telemetry.activateTelemetry({
-      extensionMode: extensionMode.Production,
-      extension: { packageJSON: { telemetryConnectionString: 'pkg-conn' } },
-      subscriptions
-    } as any);
+    telemetry.activateTelemetry({ ...createContext(extensionMode.Production), subscriptions });
 
     assert.deepEqual(created, ['pkg-conn']);
     assert.equal(subscriptions.length, 1);
@@ -124,13 +153,23 @@ suite('telemetry', () => {
 
     const { telemetry, created } = loadTelemetryModule();
 
-    telemetry.activateTelemetry({
-      extensionMode: extensionMode.Production,
-      extension: { packageJSON: { telemetryConnectionString: 'pkg-conn' } },
-      subscriptions: []
-    } as any);
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
 
     assert.deepEqual(created, ['env-conn']);
+    telemetry.disposeTelemetry();
+  });
+
+  test('allows explicit telemetry in test mode only with the dedicated test connection string', () => {
+    delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    delete process.env.VSCODE_TELEMETRY_CONNECTION_STRING;
+    process.env.ALV_ENABLE_TEST_TELEMETRY = '1';
+    process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING = 'test-conn';
+
+    const { telemetry, created } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Test));
+
+    assert.deepEqual(created, ['test-conn']);
     telemetry.disposeTelemetry();
   });
 
@@ -140,18 +179,106 @@ suite('telemetry', () => {
 
     const { telemetry, warnings, setThrowOnSendEvent } = loadTelemetryModule();
 
-    telemetry.activateTelemetry({
-      extensionMode: extensionMode.Production,
-      extension: { packageJSON: { telemetryConnectionString: 'pkg-conn' } },
-      subscriptions: []
-    } as any);
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
 
     setThrowOnSendEvent(true);
-    telemetry.safeSendEvent('logs.refresh');
+    telemetry.safeSendEvent('logs.refresh', { outcome: 'ok' });
 
     assert.equal(warnings.length, 1);
     assert.equal(warnings[0]?.[0], 'Failed sending telemetry ->');
     assert.equal(warnings[0]?.[1], 'send failed');
+    telemetry.disposeTelemetry();
+  });
+
+  test('drops undeclared events before sending telemetry', () => {
+    const { telemetry, usageEvents, warnings } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
+    telemetry.safeSendEvent('unknown.event', { outcome: 'ok' });
+
+    assert.deepEqual(usageEvents, []);
+    assert.ok(
+      warnings.some(entry => String(entry[0]).includes('Telemetry event "unknown.event" is not declared')),
+      'should warn about undeclared events'
+    );
+    telemetry.disposeTelemetry();
+  });
+
+  test('drops undeclared properties but keeps declared telemetry fields', () => {
+    const { telemetry, usageEvents, warnings } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
+    telemetry.safeSendEvent(
+      'logs.refresh',
+      { outcome: 'ok', extra: 'ignored' } as Record<string, string>,
+      { durationMs: 12, pageSize: 100, bogus: 1 } as Record<string, number>
+    );
+
+    assert.equal(usageEvents.length, 1);
+    assert.deepEqual(usageEvents[0]?.properties, { outcome: 'ok' });
+    assert.deepEqual(usageEvents[0]?.measurements, { durationMs: 12, pageSize: 100 });
+    assert.ok(
+      warnings.some(entry => String(entry[0]).includes('Telemetry property "extra"')),
+      'should warn about undeclared properties'
+    );
+    assert.ok(
+      warnings.some(entry => String(entry[0]).includes('Telemetry measurement "bogus"')),
+      'should warn about undeclared measurements'
+    );
+    telemetry.disposeTelemetry();
+  });
+
+  test('drops usage events that miss required outcome', () => {
+    const { telemetry, usageEvents, warnings } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
+    telemetry.safeSendEvent('command.refresh');
+
+    assert.deepEqual(usageEvents, []);
+    assert.ok(
+      warnings.some(entry => String(entry[0]).includes('missing required property "outcome"')),
+      'should warn about missing required outcome'
+    );
+    telemetry.disposeTelemetry();
+  });
+
+  test('injects outcome=error and filters invalid error-event values', () => {
+    const { telemetry, errorEvents } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Production));
+    telemetry.safeSendException('cli.exec', {
+      code: 'ENOENT',
+      command: 'C:/Users/example/AppData/Local/sf.exe'
+    });
+
+    assert.equal(errorEvents.length, 1);
+    assert.deepEqual(errorEvents[0], {
+      name: 'cli.exec',
+      properties: {
+        code: 'ENOENT',
+        outcome: 'error'
+      }
+    });
+    telemetry.disposeTelemetry();
+  });
+
+  test('adds testRunId to telemetry only during explicit test telemetry runs', () => {
+    delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    delete process.env.VSCODE_TELEMETRY_CONNECTION_STRING;
+    process.env.ALV_ENABLE_TEST_TELEMETRY = '1';
+    process.env.ALV_TEST_TELEMETRY_CONNECTION_STRING = 'test-conn';
+    process.env.ALV_TEST_TELEMETRY_RUN_ID = '123e4567-e89b-12d3-a456-426614174000';
+
+    const { telemetry, usageEvents } = loadTelemetryModule();
+
+    telemetry.activateTelemetry(createContext(extensionMode.Test));
+    telemetry.safeSendEvent('logs.refresh', { outcome: 'ok' });
+
+    assert.equal(usageEvents.length, 1);
+    assert.deepEqual(usageEvents[0]?.properties, {
+      outcome: 'ok',
+      testRunId: '123e4567-e89b-12d3-a456-426614174000'
+    });
     telemetry.disposeTelemetry();
   });
 });

--- a/telemetry.json
+++ b/telemetry.json
@@ -1,0 +1,451 @@
+{
+  "extensionId": "electivus.apex-log-viewer",
+  "policy": {
+    "privacyMode": "privacy-first",
+    "notes": [
+      "Only coarse-grained custom properties are allowed.",
+      "Automatic common.* fields emitted by @vscode/extension-telemetry are treated as platform metadata, not as product analytics dimensions.",
+      "testRunId is a test-only property used by explicit E2E telemetry validation runs that target the dedicated App Insights component."
+    ]
+  },
+  "commonProperties": {
+    "testRunId": {
+      "classification": "SystemMetaData",
+      "purpose": "FeatureInsight",
+      "pattern": "^[a-f0-9-]{36}$"
+    }
+  },
+  "events": {
+    "extension.activate": {
+      "description": "Production extension activation completed.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok"]
+        },
+        "hasWorkspace": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["true", "false"]
+        },
+        "hasSalesforceProject": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["true", "false"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        }
+      }
+    },
+    "command.refresh": {
+      "description": "Logs refresh command was invoked from VS Code.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked"]
+        }
+      }
+    },
+    "command.selectOrg": {
+      "description": "Select-org command outcome and coarse error classification.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["cancel", "picked", "error"]
+        },
+        "orgs": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["0", "1", "2-5", "6-10", "10+"]
+        },
+        "hasDefault": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        },
+        "code": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "pattern": "^[A-Z0-9_]+$"
+        }
+      }
+    },
+    "command.tail": {
+      "description": "Tail command was invoked from VS Code.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked"]
+        }
+      }
+    },
+    "command.openLogInViewer": {
+      "description": "Open-log-in-viewer command was invoked from VS Code.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked"]
+        }
+      }
+    },
+    "command.showOutput": {
+      "description": "Show-output command was invoked from VS Code.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked"]
+        }
+      }
+    },
+    "command.troubleshootWebview": {
+      "description": "Troubleshoot-webview command was invoked from VS Code.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked"]
+        }
+      }
+    },
+    "command.resetCliCache": {
+      "description": "Reset-CLI-cache command outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        }
+      }
+    },
+    "orgs.list": {
+      "description": "Org-list loading outcome for logs and tail views.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "view": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs", "tail"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "count": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "debugLevels.load": {
+      "description": "Debug-level loading outcome in the tail view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "count": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "log.open": {
+      "description": "Open-log flow from the tail view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "view": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["tail"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        }
+      }
+    },
+    "logs.replay": {
+      "description": "Replay flow from the tail view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "view": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["tail"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        }
+      }
+    },
+    "logs.refresh": {
+      "description": "Logs refresh outcome in the logs view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "pageSize": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "logs.loadMore": {
+      "description": "Load-more outcome in the logs view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "count": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "logs.cleanup": {
+      "description": "Log-cleanup outcome from the logs or debug-flags views.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["cancel", "cancelled", "done", "empty", "error"]
+        },
+        "scope": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["all", "mine"]
+        },
+        "sourceView": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs", "tail", "unknown"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        }
+      }
+    },
+    "logs.downloadAll": {
+      "description": "Bulk-download outcome from the logs view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["cancel", "cancelled", "empty", "error", "ok", "partial"]
+        },
+        "sourceView": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "total": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        },
+        "success": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        },
+        "failed": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        },
+        "cancelled": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "debugFlags.apply": {
+      "description": "Debug-flag apply outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "sourceView": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs", "tail", "unknown"]
+        },
+        "targetType": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["automatedProcess", "platformIntegration", "user"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        }
+      }
+    },
+    "debugFlags.remove": {
+      "description": "Debug-flag removal outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "sourceView": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs", "tail", "unknown"]
+        },
+        "targetType": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["automatedProcess", "platformIntegration", "user"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "removedCount": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "cli.getOrgAuth": {
+      "description": "Coarse-grained Salesforce CLI auth failures.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "required": true,
+          "values": ["error"]
+        },
+        "code": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "required": true,
+          "pattern": "^[A-Z0-9_]+$"
+        },
+        "command": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "values": ["sf", "sfdx"]
+        }
+      }
+    },
+    "cli.exec": {
+      "description": "Coarse-grained Salesforce CLI execution failures.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "required": true,
+          "values": ["error"]
+        },
+        "code": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "required": true,
+          "pattern": "^[A-Z0-9_]+$"
+        },
+        "command": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth",
+          "values": ["sf", "sfdx"]
+        }
+      }
+    }
+  }
+}

--- a/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from '../fixtures/alvE2E';
 import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
 import { dismissAllNotifications } from '../utils/notifications';
-import { ensureDebugFlagsTestUser, getOrgAuth } from '../utils/tooling';
+import { ensureDebugFlagsTestUser, getOrgAuth, removeUserDebugTraceFlags } from '../utils/tooling';
 import { waitForWebviewFrame } from '../utils/webviews';
 
 async function assertUserSearchFiltering(
@@ -36,45 +36,50 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
   const testUser = await ensureDebugFlagsTestUser(auth);
   const userId = testUser.id;
   const searchToken = testUser.username.split('@')[0] || testUser.username;
+  await removeUserDebugTraceFlags(auth, userId).catch(() => {});
 
-  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  try {
+    await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
+    await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
 
-  const logsFrame = await waitForWebviewFrame(
-    vscodePage,
-    async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
-    { timeoutMs: 180_000 }
-  );
-  const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
-  await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
-  await dismissAllNotifications(vscodePage);
-  await openDebugFlags.click();
+    const logsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="logs-open-debug-flags"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    const openDebugFlags = logsFrame.locator('[data-testid="logs-open-debug-flags"]').first();
+    await expect(openDebugFlags).toBeEnabled({ timeout: 180_000 });
+    await dismissAllNotifications(vscodePage);
+    await openDebugFlags.click();
 
-  const debugFlagsFrame = await waitForWebviewFrame(
-    vscodePage,
-    async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
-    { timeoutMs: 180_000 }
-  );
+    const debugFlagsFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
 
-  const searchInput = debugFlagsFrame.locator('[data-testid="debug-flags-user-search"]');
-  await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
-  await assertUserSearchFiltering(debugFlagsFrame, userId, searchToken);
+    const searchInput = debugFlagsFrame.locator('[data-testid="debug-flags-user-search"]');
+    await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+    await assertUserSearchFiltering(debugFlagsFrame, userId, searchToken);
 
-  await runCommand(vscodePage, 'Electivus Apex Logs: Tail Logs');
-  const tailFrame = await waitForWebviewFrame(
-    vscodePage,
-    async frame => await frame.locator('[data-testid="tail-open-debug-flags"]').first().isVisible(),
-    { timeoutMs: 180_000 }
-  );
-  await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
-  await dismissAllNotifications(vscodePage);
-  await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
+    await runCommand(vscodePage, 'Electivus Apex Logs: Tail Logs');
+    const tailFrame = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('[data-testid="tail-open-debug-flags"]').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    await expect(tailFrame.locator('[data-testid="tail-open-debug-flags"]').first()).toBeEnabled({ timeout: 180_000 });
+    await dismissAllNotifications(vscodePage);
+    await tailFrame.locator('[data-testid="tail-open-debug-flags"]').first().click();
 
-  const debugFlagsFrameFromTail = await waitForWebviewFrame(
-    vscodePage,
-    async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
-    { timeoutMs: 180_000 }
-  );
-  await expect(debugFlagsFrameFromTail.locator('text=Apex Debug Flags').first()).toBeVisible();
-  await assertUserSearchFiltering(debugFlagsFrameFromTail, userId, searchToken);
+    const debugFlagsFrameFromTail = await waitForWebviewFrame(
+      vscodePage,
+      async frame => await frame.locator('text=Apex Debug Flags').first().isVisible(),
+      { timeoutMs: 180_000 }
+    );
+    await expect(debugFlagsFrameFromTail.locator('text=Apex Debug Flags').first()).toBeVisible();
+    await assertUserSearchFiltering(debugFlagsFrameFromTail, userId, searchToken);
+  } finally {
+    await removeUserDebugTraceFlags(auth, userId).catch(() => {});
+  }
 });

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -39,6 +39,8 @@ export type DebugLevelToolingRecord = {
 };
 
 const DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION = '63.0';
+const TRACE_FLAG_REMOVAL_TIMEOUT_MS = 30_000;
+const TRACE_FLAG_REMOVAL_POLL_INTERVAL_MS = 1_000;
 const SPECIAL_TRACE_FLAG_TARGET_NAMES: Record<SpecialTraceFlagTargetType, readonly string[]> = {
   automatedProcess: ['Automated Process'],
   platformIntegration: ['Platform Integration', 'Platform Integration User']
@@ -95,6 +97,10 @@ function toSfDateTimeUTC(d: Date): string {
     `${pad(d.getUTCSeconds())}.` +
     `${pad(d.getUTCMilliseconds(), 3)}+0000`
   );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function requestJson(auth: OrgAuth, method: string, resourcePath: string, body?: unknown): Promise<any> {
@@ -364,18 +370,42 @@ export async function removeUserDebugTraceFlags(auth: OrgAuth, userId: string): 
   return removeDebugTraceFlagsByTracedEntityId(auth, userId);
 }
 
-export async function removeDebugTraceFlagsByTracedEntityId(auth: OrgAuth, tracedEntityId: string): Promise<number> {
+async function listDebugTraceFlagIdsByTracedEntityId(auth: OrgAuth, tracedEntityId: string): Promise<string[]> {
   const userEsc = escapeSoqlLiteral(tracedEntityId);
   const tfSoql = encodeURIComponent(
     `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userEsc}' AND LogType = 'USER_DEBUG' ORDER BY CreatedDate DESC LIMIT 200`
   );
   const tfRes = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${tfSoql}`);
-  const ids = (Array.isArray(tfRes?.records) ? tfRes.records : [])
+  return (Array.isArray(tfRes?.records) ? tfRes.records : [])
     .map((record: any) => record?.Id)
     .filter((id: unknown): id is string => isSfId(id));
+}
+
+export async function removeDebugTraceFlagsByTracedEntityId(auth: OrgAuth, tracedEntityId: string): Promise<number> {
+  const ids = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
 
   for (const id of ids) {
     await requestJson(auth, 'DELETE', `/services/data/v${auth.apiVersion}/tooling/sobjects/TraceFlag/${id}`);
+  }
+
+  if (ids.length === 0) {
+    return 0;
+  }
+
+  const deadline = Date.now() + TRACE_FLAG_REMOVAL_TIMEOUT_MS;
+  while (Date.now() < deadline) {
+    const remainingIds = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
+    if (remainingIds.length === 0) {
+      return ids.length;
+    }
+    await sleep(TRACE_FLAG_REMOVAL_POLL_INTERVAL_MS);
+  }
+
+  const remainingIds = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
+  if (remainingIds.length > 0) {
+    throw new Error(
+      `Timed out waiting for TraceFlags to be removed for traced entity ${tracedEntityId}. Remaining TraceFlag ids: ${remainingIds.join(', ')}`
+    );
   }
 
   return ids.length;

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -382,22 +382,23 @@ async function listDebugTraceFlagIdsByTracedEntityId(auth: OrgAuth, tracedEntity
 }
 
 export async function removeDebugTraceFlagsByTracedEntityId(auth: OrgAuth, tracedEntityId: string): Promise<number> {
-  const ids = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
-
-  for (const id of ids) {
-    await requestJson(auth, 'DELETE', `/services/data/v${auth.apiVersion}/tooling/sobjects/TraceFlag/${id}`);
-  }
-
-  if (ids.length === 0) {
-    return 0;
-  }
-
+  let removedCount = 0;
   const deadline = Date.now() + TRACE_FLAG_REMOVAL_TIMEOUT_MS;
+  const attemptedDeletes = new Set<string>();
+
   while (Date.now() < deadline) {
-    const remainingIds = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
-    if (remainingIds.length === 0) {
-      return ids.length;
+    const listedIds = await listDebugTraceFlagIdsByTracedEntityId(auth, tracedEntityId);
+    if (listedIds.length === 0) {
+      return removedCount;
     }
+
+    const idsToDelete = listedIds.filter(id => !attemptedDeletes.has(id));
+    for (const id of idsToDelete) {
+      await requestJson(auth, 'DELETE', `/services/data/v${auth.apiVersion}/tooling/sobjects/TraceFlag/${id}`);
+      attemptedDeletes.add(id);
+      removedCount += 1;
+    }
+
     await sleep(TRACE_FLAG_REMOVAL_POLL_INTERVAL_MS);
   }
 
@@ -408,7 +409,7 @@ export async function removeDebugTraceFlagsByTracedEntityId(auth: OrgAuth, trace
     );
   }
 
-  return ids.length;
+  return removedCount;
 }
 
 export async function resolveSpecialTraceFlagTarget(


### PR DESCRIPTION
## Summary
This PR hardens the extension telemetry contract, adds a dedicated Application Insights validation path for Playwright E2E runs, and makes the scratch-org debug-flags flows more stable.

The original problem had two parts. First, the telemetry shape had drifted over time: event names, required properties, and duration handling were not governed by a checked-in schema, which made it harder to reason about privacy guarantees and analytics quality. Second, the full end-to-end telemetry path was not being validated in isolation, so we could prove that the app emitted events locally but not that a real E2E run reached Azure Monitor/Application Insights cleanly.

This change introduces a schema-backed telemetry wrapper with a checked-in `telemetry.json`, aligns event payloads around predictable `outcome` and measurement fields, documents the privacy guardrails, and records the operational review in the repo. On the E2E side, it adds a dedicated App Insights target plus a `test:e2e:telemetry` runner that provisions or resolves the E2E App Insights component, injects a test-only connection string and `testRunId`, runs Playwright, and fails if telemetry from that run does not arrive.

While validating that path, I also hardened the debug-flags E2E utilities. The TraceFlag cleanup now waits for the Tooling API to reflect actual deletion before continuing, and the filter spec now cleans up before and after the run. That removed the overlap flake we were seeing when scratch org state was reused.

The GitHub Actions Playwright workflow now prefers the full telemetry-aware path when Azure OIDC secrets are configured (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`). If that Azure configuration is not present yet, the workflow falls back to the existing smoke-only Playwright run so PR validation stays usable while the repo secrets are being wired up.

## Validation
- `npm run compile`
- `npm run test:e2e:telemetry`
- `npx prettier --check .github/workflows/e2e-playwright.yml docs/CI.md docs/TESTING.md`
- Direct App Insights query for `testRunId` `bbec98ef-b03c-4673-aaa3-1194a3cba671`, confirming 57 events across 9 event names in the dedicated E2E App Insights resource

## Notes
The local `test:e2e:telemetry` validation passed 7/7 Playwright specs and confirmed dedicated App Insights ingestion for events such as `extension.activate`, `orgs.list`, `logs.refresh`, `debugFlags.apply`, and `debugFlags.remove`, including `outcome` and `durationMs` on `extension.activate`.
