### PR TITLE
[codex] speed up e2e harness setup

### DIFF
--- a/config/user/.sfdx-hardis.k3.yml
+++ b/config/user/.sfdx-hardis.k3.yml
@@ -1,0 +1,2 @@
+installedApps:
+  - git

--- a/config/user/.sfdx-hardis.k3.yml
+++ b/config/user/.sfdx-hardis.k3.yml
@@ -1,2 +1,0 @@
-installedApps:
-  - git

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,6 +22,7 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 - VS Code is downloaded via `@vscode/test-electron` and launched with `--extensionDevelopmentPath` and `--extensionTestsPath` (the compiled runner).
 - A temporary workspace is created with a minimal `sfdx-project.json` (including `sourceApiVersion`) and opened during tests.
 - Playwright E2E runs keep the isolated VS Code profile intentionally minimal. Support extensions are installed per scenario instead of pulling the full Salesforce Extension Pack by default. Replay-specific specs opt into `salesforce.salesforcedx-vscode-apex-replay-debugger`, and the harness dismisses visible VS Code notifications during startup to reduce click interception flakiness.
+- By default, Playwright E2E keeps `--extensions-dir` isolated even when a support extension is missing. To intentionally reuse your machine-wide VS Code extensions dir as a fallback, set `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`.
 - On headless Linux, the script re‑executes under `xvfb-run` if available and sets Electron flags to reduce GPU/DBus issues.
 
 ## Environment variables
@@ -77,6 +78,8 @@ Useful env vars:
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).
 - `SF_E2E_DEBUG_FLAGS_USERNAME`: Optional username for the Debug Flags E2E user. If unset, tests auto-manage `alv.debugflags.<orgid>@example.com` (create if missing, reuse if present). If the org has no spare Salesforce licenses, tests fall back to the authenticated user.
+- `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`: Opt-in fallback that points the isolated VS Code run at your machine-wide extensions dir when a required support extension cannot be copied or installed into the temporary E2E profile.
+- `ALV_E2E_TIMING=1`: Prints per-step harness timings for scratch-org setup, VS Code startup, command-palette activation, and webview discovery.
 
 Troubleshooting:
 

--- a/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsFilter.e2e.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { runCommand, runCommandWhenAvailable } from '../utils/commandPalette';
 import { dismissAllNotifications } from '../utils/notifications';
 import { ensureDebugFlagsTestUser, getOrgAuth, removeUserDebugTraceFlags } from '../utils/tooling';
 import { waitForWebviewFrame } from '../utils/webviews';
@@ -39,8 +39,7 @@ test('filters users correctly in debug flags panel from logs and tail entrypoint
   await removeUserDebugTraceFlags(auth, userId).catch(() => {});
 
   try {
-    await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-    await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+    await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
 
     const logsFrame = await waitForWebviewFrame(
       vscodePage,

--- a/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
+++ b/test/e2e/specs/debugFlagsPanel.e2e.spec.ts
@@ -1,7 +1,10 @@
-import type { Frame, Page } from '@playwright/test';
-import { expect, test } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import path from 'node:path';
+import { expect, test, type Frame, type Page } from '@playwright/test';
+import { runCommand, runCommandWhenAvailable } from '../utils/commandPalette';
 import { dismissAllNotifications } from '../utils/notifications';
+import { ensureScratchOrg } from '../utils/scratchOrg';
+import { resolveSfCliInvocation } from '../utils/sfCli';
+import { createTempWorkspace } from '../utils/tempWorkspace';
 import {
   ensureDebugFlagsTestUser,
   getDebugTraceFlagByTracedEntityId,
@@ -12,6 +15,7 @@ import {
   resolveSpecialTraceFlagTarget,
   type SpecialTraceFlagTargetType
 } from '../utils/tooling';
+import { launchVsCode } from '../utils/vscode';
 import { waitForWebviewFrame } from '../utils/webviews';
 
 const SPECIAL_TARGET_UI: Record<SpecialTraceFlagTargetType, { buttonTestId: string; expectedLabel: string }> = {
@@ -25,9 +29,39 @@ const SPECIAL_TARGET_UI: Record<SpecialTraceFlagTargetType, { buttonTestId: stri
   }
 };
 
+test.describe.configure({ mode: 'serial' });
+
+let scratchAlias = '';
+let vscodePage: Page;
+let cleanupScratchOrg: undefined | (() => Promise<void>);
+let cleanupWorkspace: undefined | (() => Promise<void>);
+let cleanupVsCode: undefined | (() => Promise<void>);
+
+test.beforeAll(async () => {
+  const scratch = await ensureScratchOrg();
+  cleanupScratchOrg = scratch.cleanup;
+  scratchAlias = scratch.scratchAlias;
+
+  const sfCli = await resolveSfCliInvocation();
+  const workspace = await createTempWorkspace({ targetOrg: scratchAlias, sfCli: sfCli ?? undefined });
+  cleanupWorkspace = workspace.cleanup;
+
+  const launch = await launchVsCode({
+    workspacePath: workspace.workspacePath,
+    extensionDevelopmentPath: path.join(__dirname, '..', '..', '..')
+  });
+  cleanupVsCode = launch.cleanup;
+  vscodePage = launch.page;
+});
+
+test.afterAll(async () => {
+  await cleanupVsCode?.().catch(() => {});
+  await cleanupWorkspace?.().catch(() => {});
+  await cleanupScratchOrg?.().catch(() => {});
+});
+
 async function openDebugFlagsFromLogs(vscodePage: Parameters<typeof waitForWebviewFrame>[0]): Promise<Frame> {
-  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
   await closeQuickInputIfOpen(vscodePage);
 
   const logsFrame = await waitForWebviewFrame(
@@ -119,7 +153,7 @@ async function assertSpecialTargetBehavior(
     .toBe(true);
 }
 
-test('configures and removes debug flags from logs and tail entrypoints', async ({ vscodePage, scratchAlias }) => {
+test('configures and removes debug flags from logs and tail entrypoints', async () => {
   const auth = await getOrgAuth(scratchAlias);
   const testUser = await ensureDebugFlagsTestUser(auth);
   const userId = testUser.id;
@@ -187,7 +221,7 @@ test('configures and removes debug flags from logs and tail entrypoints', async 
   }
 });
 
-test('supports special trace flag targets in the debug flags panel', async ({ vscodePage, scratchAlias }) => {
+test('supports special trace flag targets in the debug flags panel', async () => {
   const auth = await getOrgAuth(scratchAlias);
   const automatedProcessTarget = await resolveSpecialTraceFlagTarget(auth, 'automatedProcess');
   const platformIntegrationTarget = await resolveSpecialTraceFlagTarget(auth, 'platformIntegration');

--- a/test/e2e/specs/debugLevelManager.e2e.spec.ts
+++ b/test/e2e/specs/debugLevelManager.e2e.spec.ts
@@ -1,6 +1,6 @@
 import type { Frame } from '@playwright/test';
 import { expect, test } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { runCommand, runCommandWhenAvailable } from '../utils/commandPalette';
 import {
   deleteDebugLevelByDeveloperName,
   ensureDebugFlagsTestUser,
@@ -30,8 +30,7 @@ test('creates, updates and deletes DebugLevel records from the manager UI', asyn
   await deleteDebugLevelByDeveloperName(auth, updatedDeveloperName).catch(() => {});
 
   try {
-    await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-    await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+    await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
 
     const logsFrame = await waitForWebviewFrame(
       vscodePage,

--- a/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
+++ b/test/e2e/specs/errorsOnlyFilter.e2e.spec.ts
@@ -1,6 +1,6 @@
 import type { Locator } from '@playwright/test';
 import { expect, test } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { runCommandWhenAvailable } from '../utils/commandPalette';
 import { seedApexErrorLog } from '../utils/seedLog';
 import { waitForWebviewFrame } from '../utils/webviews';
 
@@ -19,8 +19,7 @@ async function setErrorsOnlyEnabled(
 test('filters logs using errors-only toggle', async ({ vscodePage, scratchAlias, seededLog }) => {
   const seededErrorLog = await seedApexErrorLog(scratchAlias);
 
-  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
 
   const logsFrame = await waitForWebviewFrame(
     vscodePage,

--- a/test/e2e/specs/openLogViewer.e2e.spec.ts
+++ b/test/e2e/specs/openLogViewer.e2e.spec.ts
@@ -1,12 +1,11 @@
 import { test, expect } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { runCommandWhenAvailable } from '../utils/commandPalette';
 import { waitForWebviewFrame } from '../utils/webviews';
 
 test('opens the seeded Apex log in the Log Viewer panel', async ({ vscodePage, seededLog }) => {
   // Activate the extension by running a contributed command.
   // (The command will be updated to ensure the Logs view is visible.)
-  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
 
   // VS Code webviews often load their actual content in a child frame hosted on
   // a `.../fake.html?...` URL. Grab that frame first, then wait for log rows.

--- a/test/e2e/specs/replayDebugger.e2e.spec.ts
+++ b/test/e2e/specs/replayDebugger.e2e.spec.ts
@@ -1,6 +1,6 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from '../fixtures/alvE2E';
-import { runCommand, waitForCommandAvailable } from '../utils/commandPalette';
+import { runCommandWhenAvailable } from '../utils/commandPalette';
 import { dismissAllNotifications } from '../utils/notifications';
 import { waitForWebviewFrame } from '../utils/webviews';
 
@@ -21,8 +21,7 @@ test('launches replay debugger from logs table without missing-extension toast',
   void seededLog;
 
   // Activate the extension by running a contributed command.
-  await waitForCommandAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
-  await runCommand(vscodePage, 'Electivus Apex Logs: Refresh Logs');
+  await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
   await closeQuickInputIfOpen(vscodePage);
 
   const logsFrame = await waitForWebviewFrame(

--- a/test/e2e/utils/__tests__/commandPalette.test.ts
+++ b/test/e2e/utils/__tests__/commandPalette.test.ts
@@ -1,0 +1,80 @@
+import { runCommandWhenAvailable } from '../commandPalette';
+
+function createFakePage(noMatchVisibility: boolean[]) {
+  const keyboardPress = jest.fn(async () => {});
+  const waitForTimeout = jest.fn(async () => {});
+  const inputWaitFor = jest.fn(async () => {});
+  const inputFill = jest.fn(async () => {});
+  const isVisible = jest.fn(async () => noMatchVisibility.shift() ?? false);
+
+  const inputLocator = {
+    waitFor: inputWaitFor,
+    fill: inputFill
+  };
+
+  const widgetLocator = {
+    locator: jest.fn((selector: string) => {
+      if (selector !== 'input') {
+        throw new Error(`Unexpected widget selector: ${selector}`);
+      }
+      return inputLocator;
+    }),
+    getByText: jest.fn(() => ({
+      isVisible
+    }))
+  };
+
+  const locator = jest.fn((selector: string) => {
+    if (selector === 'div.quick-input-widget input') {
+      return inputLocator;
+    }
+    if (selector === 'div.quick-input-widget') {
+      return widgetLocator;
+    }
+    throw new Error(`Unexpected selector: ${selector}`);
+  });
+
+  return {
+    page: {
+      keyboard: { press: keyboardPress },
+      locator,
+      waitForTimeout
+    } as any,
+    keyboardPress,
+    waitForTimeout,
+    inputWaitFor,
+    inputFill,
+    isVisible
+  };
+}
+
+describe('runCommandWhenAvailable', () => {
+  test('retries until the command appears and executes from the successful quick-open session', async () => {
+    const fake = createFakePage([true, true, false]);
+
+    await runCommandWhenAvailable(fake.page, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 5_000 });
+
+    expect(fake.inputFill).toHaveBeenNthCalledWith(1, '> Electivus Apex Logs: Refresh Logs');
+    expect(fake.inputFill).toHaveBeenNthCalledWith(2, '> Electivus Apex Logs: Refresh Logs');
+    expect(fake.inputFill).toHaveBeenNthCalledWith(3, '> Electivus Apex Logs: Refresh Logs');
+
+    const modifierShortcut = process.platform === 'darwin' ? 'Meta+P' : 'Control+P';
+    expect(fake.keyboardPress.mock.calls.map(call => call[0])).toEqual([
+      modifierShortcut,
+      'Escape',
+      modifierShortcut,
+      'Escape',
+      modifierShortcut,
+      'Enter'
+    ]);
+    expect(fake.waitForTimeout.mock.calls.map(call => call[0])).toEqual([50, 500, 50, 500, 50]);
+  });
+
+  test('preserves an explicit command prefix', async () => {
+    const fake = createFakePage([false]);
+
+    await runCommandWhenAvailable(fake.page, '> View: Open View...', { timeoutMs: 1_000 });
+
+    expect(fake.inputFill).toHaveBeenCalledWith('> View: Open View...');
+  });
+});

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -120,6 +120,63 @@ describe('ensureScratchOrg', () => {
     await scratch.cleanup();
   });
 
+  test('prefers DevHubElectivus locally when multiple fallback dev hubs are authenticated', async () => {
+    process.env = {
+      ...originalEnv,
+      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
+      SF_TEST_KEEP_ORG: '1'
+    };
+
+    delete process.env.SF_DEVHUB_ALIAS;
+    delete process.env.SF_DEVHUB_AUTH_URL;
+
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        throw new Error('NamedOrgNotFoundError: No authorization information found for ALV_E2E_Scratch.');
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHub')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ElectivusDevHub')) {
+        throw new Error('NamedOrgNotFoundError: No authorization information found for ElectivusDevHub.');
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHubElectivus')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch' && args.includes('DevHubElectivus')) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'data' && args[1] === 'query') {
+        return {
+          status: 0,
+          result: {
+            records: [{ Id: '7dl000000000001AAA' }]
+          }
+        };
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+
+    expect(scratch).toMatchObject({
+      devHubAlias: 'DevHubElectivus',
+      scratchAlias: 'ALV_E2E_Scratch',
+      created: true
+    });
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'DevHubElectivus']),
+      expect.any(Object)
+    );
+    await scratch.cleanup();
+  });
+
   test('falls back to another authenticated dev hub when the preferred alias hits the scratch signup limit', async () => {
     runSfJsonMock.mockImplementation(async args => {
       if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -16,6 +16,7 @@ import {
   getDebugLevelByDeveloperName,
   getCurrentUserId,
   getOrgAuth,
+  removeUserDebugTraceFlags,
   resolveSpecialTraceFlagTarget,
   type OrgAuth
 } from '../tooling';
@@ -229,7 +230,7 @@ describe('ensureDebugFlagsTestUser', () => {
     expect(calls).toBe(1);
   });
 
-  test('skips repeated trace flag provisioning within the fast-path window', async () => {
+  test('revalidates the trace flag before using the fast-path window', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -275,7 +276,91 @@ describe('ensureDebugFlagsTestUser', () => {
     await ensureE2eTraceFlag(auth);
     await ensureE2eTraceFlag(auth);
 
-    expect(calls).toBe(4);
+    expect(calls).toBe(5);
+  });
+
+  test('recreates the trace flag after cleanup removes the cached auth-user flag', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+    let calls = 0;
+    let traceFlagLookupCount = 0;
+    let traceFlagListCount = 0;
+
+    globalThis.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls += 1;
+      const url = String(input);
+      const method = String(init?.method || 'GET').toUpperCase();
+      const soql = url.includes('?q=') ? decodeURIComponent(url.slice(url.indexOf('?q=') + 3)) : '';
+
+      if (method === 'GET' && soql.includes("FROM User WHERE Username = 'auth.user@example.com'")) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '005000000000999AAA' }] }
+        });
+      }
+
+      if (method === 'GET' && soql.includes("FROM DebugLevel WHERE DeveloperName = 'ALV_E2E'")) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '7dl000000000001AAA' }] }
+        });
+      }
+
+      if (
+        method === 'GET' &&
+        soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000999AAA'") &&
+        soql.includes("DebugLevelId = '7dl000000000001AAA'")
+      ) {
+        traceFlagLookupCount += 1;
+        return responseFrom({
+          status: 200,
+          body: {
+            records: traceFlagLookupCount === 1 ? [{ Id: '7tf000000000001AAA' }] : []
+          }
+        });
+      }
+
+      if (
+        method === 'GET' &&
+        soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000999AAA'") &&
+        !soql.includes('DebugLevelId =')
+      ) {
+        traceFlagListCount += 1;
+        return responseFrom({
+          status: 200,
+          body: {
+            records: traceFlagListCount === 1 ? [{ Id: '7tf000000000001AAA' }] : []
+          }
+        });
+      }
+
+      if (method === 'PATCH' && url.endsWith('/tooling/sobjects/TraceFlag/7tf000000000001AAA')) {
+        return responseFrom({ status: 204 });
+      }
+
+      if (method === 'DELETE' && url.endsWith('/tooling/sobjects/TraceFlag/7tf000000000001AAA')) {
+        return responseFrom({ status: 204 });
+      }
+
+      if (method === 'POST' && url.endsWith('/tooling/sobjects/TraceFlag')) {
+        return responseFrom({
+          status: 201,
+          body: { success: true, id: '7tf000000000002AAA' }
+        });
+      }
+
+      throw new Error(`Unexpected request ${method} ${url}`);
+    });
+
+    await ensureE2eTraceFlag(auth);
+    await removeUserDebugTraceFlags(auth, '005000000000999AAA');
+    await ensureE2eTraceFlag(auth);
+
+    expect(calls).toBe(9);
   });
 
   test('executes anonymous Apex via the jsforce-backed request helper', async () => {

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -1,6 +1,21 @@
+const runSfJsonMock = jest.fn();
+const queryToolingMock = jest.fn();
+const connectionRequestMock = jest.fn();
+
+jest.mock('../sfCli', () => ({
+  runSfJson: (...args: unknown[]) => runSfJsonMock(...args)
+}));
+
 import {
+  __resetToolingCachesForTests,
+  __setToolingConnectionFactoryForTests,
+  ensureE2eTraceFlag,
   ensureDebugFlagsTestUser,
+  executeAnonymousApex,
+  findRecentApexLogId,
   getDebugLevelByDeveloperName,
+  getCurrentUserId,
+  getOrgAuth,
   resolveSpecialTraceFlagTarget,
   type OrgAuth
 } from '../tooling';
@@ -22,6 +37,11 @@ function responseFrom(spec: MockFetchResponse): Response {
 describe('ensureDebugFlagsTestUser', () => {
   const originalFetch = globalThis.fetch;
   const originalUsernameEnv = process.env.SF_E2E_DEBUG_FLAGS_USERNAME;
+  const originalTargetOrgAlias = process.env.SF_E2E_TARGET_ORG_ALIAS;
+  const originalAccessToken = process.env.SF_E2E_ACCESS_TOKEN;
+  const originalInstanceUrl = process.env.SF_E2E_INSTANCE_URL;
+  const originalApiVersion = process.env.SF_E2E_API_VERSION;
+  const originalUsername = process.env.SF_E2E_USERNAME;
 
   afterEach(() => {
     if (originalFetch) {
@@ -34,6 +54,35 @@ describe('ensureDebugFlagsTestUser', () => {
     } else {
       process.env.SF_E2E_DEBUG_FLAGS_USERNAME = originalUsernameEnv;
     }
+    if (originalTargetOrgAlias === undefined) {
+      delete process.env.SF_E2E_TARGET_ORG_ALIAS;
+    } else {
+      process.env.SF_E2E_TARGET_ORG_ALIAS = originalTargetOrgAlias;
+    }
+    if (originalAccessToken === undefined) {
+      delete process.env.SF_E2E_ACCESS_TOKEN;
+    } else {
+      process.env.SF_E2E_ACCESS_TOKEN = originalAccessToken;
+    }
+    if (originalInstanceUrl === undefined) {
+      delete process.env.SF_E2E_INSTANCE_URL;
+    } else {
+      process.env.SF_E2E_INSTANCE_URL = originalInstanceUrl;
+    }
+    if (originalApiVersion === undefined) {
+      delete process.env.SF_E2E_API_VERSION;
+    } else {
+      process.env.SF_E2E_API_VERSION = originalApiVersion;
+    }
+    if (originalUsername === undefined) {
+      delete process.env.SF_E2E_USERNAME;
+    } else {
+      process.env.SF_E2E_USERNAME = originalUsername;
+    }
+    runSfJsonMock.mockReset();
+    queryToolingMock.mockReset();
+    connectionRequestMock.mockReset();
+    __resetToolingCachesForTests();
   });
 
   test('falls back to authenticated user when reactivating inactive user hits LICENSE_LIMIT_EXCEEDED', async () => {
@@ -134,6 +183,167 @@ describe('ensureDebugFlagsTestUser', () => {
     expect(record?.id).toBe('7dl000000000001AAA');
     expect(calls).toHaveLength(1);
     expect(calls[0]).toContain('/services/data/v63.0/tooling/query');
+  });
+
+  test('caches org auth lookups per target org', async () => {
+    runSfJsonMock.mockResolvedValue({
+      result: {
+        accessToken: 'token',
+        instanceUrl: 'https://example.my.salesforce.com',
+        username: 'auth.user@example.com'
+      }
+    });
+
+    const first = await getOrgAuth('ALV_E2E_Scratch');
+    const second = await getOrgAuth('ALV_E2E_Scratch');
+
+    expect(first).toEqual(second);
+    expect(runSfJsonMock).toHaveBeenCalledTimes(1);
+    expect(runSfJsonMock).toHaveBeenCalledWith(['org', 'display', '-o', 'ALV_E2E_Scratch']);
+  });
+
+  test('caches current user id lookups per authenticated user', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+    let calls = 0;
+
+    globalThis.fetch = jest.fn(async () => {
+      calls += 1;
+      return responseFrom({
+        status: 200,
+        body: {
+          records: [{ Id: '005000000000999AAA' }]
+        }
+      });
+    });
+
+    const first = await getCurrentUserId(auth);
+    const second = await getCurrentUserId(auth);
+
+    expect(first).toBe('005000000000999AAA');
+    expect(second).toBe('005000000000999AAA');
+    expect(calls).toBe(1);
+  });
+
+  test('skips repeated trace flag provisioning within the fast-path window', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+    let calls = 0;
+
+    globalThis.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      calls += 1;
+      const url = String(input);
+      const method = String(init?.method || 'GET').toUpperCase();
+      const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
+
+      if (method === 'GET' && soql.includes("FROM User WHERE Username = 'auth.user@example.com'")) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '005000000000999AAA' }] }
+        });
+      }
+
+      if (method === 'GET' && soql.includes("FROM DebugLevel WHERE DeveloperName = 'ALV_E2E'")) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '7dl000000000001AAA' }] }
+        });
+      }
+
+      if (method === 'GET' && soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000999AAA'")) {
+        return responseFrom({
+          status: 200,
+          body: { records: [{ Id: '7tf000000000001AAA' }] }
+        });
+      }
+
+      if (method === 'PATCH' && url.endsWith('/tooling/sobjects/TraceFlag/7tf000000000001AAA')) {
+        return responseFrom({ status: 204 });
+      }
+
+      throw new Error(`Unexpected request ${method} ${url}`);
+    });
+
+    await ensureE2eTraceFlag(auth);
+    await ensureE2eTraceFlag(auth);
+
+    expect(calls).toBe(4);
+  });
+
+  test('executes anonymous Apex via the jsforce-backed request helper', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+    __setToolingConnectionFactoryForTests(async () => ({
+      request: connectionRequestMock.mockResolvedValue({
+        compiled: true,
+        success: true
+      }),
+      tooling: {
+        query: queryToolingMock
+      }
+    }));
+
+    await executeAnonymousApex(auth, "System.debug('ALV');");
+
+    expect(connectionRequestMock).toHaveBeenCalledTimes(1);
+    expect(connectionRequestMock.mock.calls[0]?.[0]).toMatchObject({
+      method: 'GET'
+    });
+    expect(String(connectionRequestMock.mock.calls[0]?.[0]?.url || '')).toContain('/tooling/executeAnonymous?');
+  });
+
+  test('finds the recent ApexLog by matching the seeded marker in the body', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+
+    globalThis.fetch = jest.fn(async () =>
+      responseFrom({
+        status: 200,
+        body: { records: [{ Id: '005000000000999AAA' }] }
+      })
+    );
+    __setToolingConnectionFactoryForTests(async () => ({
+      request: connectionRequestMock.mockImplementation(async (request: { url?: string }) => {
+        if (String(request?.url || '').includes('/07L000000000002AAA/Body')) {
+          return 'other log body';
+        }
+        if (String(request?.url || '').includes('/07L000000000001AAA/Body')) {
+          return '... ALV_E2E_MARKER_123 ...';
+        }
+        return '';
+      }),
+      tooling: {
+        query: queryToolingMock.mockResolvedValue({
+          records: [
+            { Id: '07L000000000002AAA', StartTime: '2026-03-14T20:23:54.000+0000' },
+            { Id: '07L000000000001AAA', StartTime: '2026-03-14T20:23:54.000+0000' }
+          ]
+        })
+      }
+    }));
+
+    const id = await findRecentApexLogId(auth, Date.parse('2026-03-14T20:23:54.381Z'), 'ALV_E2E_MARKER_123');
+
+    expect(id).toBe('07L000000000001AAA');
+    expect(queryToolingMock).toHaveBeenCalledWith(
+      expect.stringContaining("FROM ApexLog WHERE LogUserId = '005000000000999AAA'")
+    );
   });
 
   test('resolves Platform Integration via accepted names and returns all active matches', async () => {

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -363,6 +363,69 @@ describe('ensureDebugFlagsTestUser', () => {
     expect(calls).toBe(9);
   });
 
+  test('does not slide the fast-path cache forward when it skips the patch branch', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+    let nowMs = Date.parse('2026-03-14T20:00:00.000Z');
+    const dateNowSpy = jest.spyOn(Date, 'now').mockImplementation(() => nowMs);
+    let calls = 0;
+    let patchCalls = 0;
+
+    try {
+      globalThis.fetch = jest.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        calls += 1;
+        const url = String(input);
+        const method = String(init?.method || 'GET').toUpperCase();
+        const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
+
+        if (method === 'GET' && soql.includes("FROM User WHERE Username = 'auth.user@example.com'")) {
+          return responseFrom({
+            status: 200,
+            body: { records: [{ Id: '005000000000999AAA' }] }
+          });
+        }
+
+        if (method === 'GET' && soql.includes("FROM DebugLevel WHERE DeveloperName = 'ALV_E2E'")) {
+          return responseFrom({
+            status: 200,
+            body: { records: [{ Id: '7dl000000000001AAA' }] }
+          });
+        }
+
+        if (method === 'GET' && soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000999AAA'")) {
+          return responseFrom({
+            status: 200,
+            body: { records: [{ Id: '7tf000000000001AAA' }] }
+          });
+        }
+
+        if (method === 'PATCH' && url.endsWith('/tooling/sobjects/TraceFlag/7tf000000000001AAA')) {
+          patchCalls += 1;
+          return responseFrom({ status: 204 });
+        }
+
+        throw new Error(`Unexpected request ${method} ${url}`);
+      });
+
+      await ensureE2eTraceFlag(auth);
+
+      nowMs += 4 * 60 * 1000;
+      await ensureE2eTraceFlag(auth);
+
+      nowMs += 61 * 1000;
+      await ensureE2eTraceFlag(auth);
+    } finally {
+      dateNowSpy.mockRestore();
+    }
+
+    expect(patchCalls).toBe(2);
+    expect(calls).toBe(7);
+  });
+
   test('executes anonymous Apex via the jsforce-backed request helper', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -555,7 +555,7 @@ describe('ensureDebugFlagsTestUser', () => {
     );
   });
 
-  test('finds the recent ApexLog by matching the seeded marker in the body', async () => {
+  test('finds the recent ApexLog by marker even when Salesforce and local clocks are skewed', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -589,7 +589,7 @@ describe('ensureDebugFlagsTestUser', () => {
       }
     }));
 
-    const id = await findRecentApexLogId(auth, Date.parse('2026-03-14T20:23:54.381Z'), 'ALV_E2E_MARKER_123');
+    const id = await findRecentApexLogId(auth, Date.parse('2026-03-14T20:24:59.381Z'), 'ALV_E2E_MARKER_123');
 
     expect(id).toBe('07L000000000001AAA');
     expect(queryToolingMock).toHaveBeenCalledWith(

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -7,6 +7,7 @@ jest.mock('../sfCli', () => ({
 }));
 
 import {
+  assertToolingReady,
   __resetToolingCachesForTests,
   __setToolingConnectionFactoryForTests,
   ensureE2eTraceFlag,
@@ -201,6 +202,46 @@ describe('ensureDebugFlagsTestUser', () => {
     expect(first).toEqual(second);
     expect(runSfJsonMock).toHaveBeenCalledTimes(1);
     expect(runSfJsonMock).toHaveBeenCalledWith(['org', 'display', '-o', 'ALV_E2E_Scratch']);
+  });
+
+  test('refreshes cached org auth after an auth failure in REST tooling requests', async () => {
+    runSfJsonMock
+      .mockResolvedValueOnce({
+        result: {
+          accessToken: 'stale-token',
+          instanceUrl: 'https://example.my.salesforce.com',
+          username: 'auth.user@example.com'
+        }
+      })
+      .mockResolvedValueOnce({
+        result: {
+          accessToken: 'fresh-token',
+          instanceUrl: 'https://example.my.salesforce.com',
+          username: 'auth.user@example.com'
+        }
+      });
+
+    const auth = await getOrgAuth('ALV_E2E_Scratch');
+    const seenAuthHeaders: string[] = [];
+
+    globalThis.fetch = jest.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      seenAuthHeaders.push(String((init?.headers as Record<string, string> | undefined)?.Authorization || ''));
+      if (seenAuthHeaders.length === 1) {
+        return responseFrom({
+          status: 401,
+          body: [{ errorCode: 'INVALID_SESSION_ID', message: 'Session expired or invalid' }]
+        });
+      }
+      return responseFrom({
+        status: 200,
+        body: { records: [{ Id: '005000000000999AAA' }] }
+      });
+    });
+
+    await expect(getCurrentUserId(auth)).resolves.toBe('005000000000999AAA');
+    expect(auth.accessToken).toBe('fresh-token');
+    expect(seenAuthHeaders).toEqual(['Bearer stale-token', 'Bearer fresh-token']);
+    expect(runSfJsonMock).toHaveBeenCalledTimes(2);
   });
 
   test('caches current user id lookups per authenticated user', async () => {
@@ -450,6 +491,68 @@ describe('ensureDebugFlagsTestUser', () => {
       method: 'GET'
     });
     expect(String(connectionRequestMock.mock.calls[0]?.[0]?.url || '')).toContain('/tooling/executeAnonymous?');
+  });
+
+  test('refreshes cached org auth after an auth failure in jsforce tooling requests', async () => {
+    runSfJsonMock
+      .mockResolvedValueOnce({
+        result: {
+          accessToken: 'stale-token',
+          instanceUrl: 'https://example.my.salesforce.com',
+          username: 'auth.user@example.com'
+        }
+      })
+      .mockResolvedValueOnce({
+        result: {
+          accessToken: 'fresh-token',
+          instanceUrl: 'https://example.my.salesforce.com',
+          username: 'auth.user@example.com'
+        }
+      });
+
+    const auth = await getOrgAuth('ALV_E2E_Scratch');
+    __setToolingConnectionFactoryForTests(async currentAuth => ({
+      request: connectionRequestMock.mockImplementation(async () => {
+        if (currentAuth.accessToken === 'stale-token') {
+          const error = new Error('Session expired or invalid') as Error & {
+            statusCode?: number;
+            errorCode?: string;
+          };
+          error.statusCode = 401;
+          error.errorCode = 'INVALID_SESSION_ID';
+          throw error;
+        }
+        return { compiled: true, success: true };
+      }),
+      tooling: {
+        query: queryToolingMock
+      }
+    }));
+
+    await executeAnonymousApex(auth, "System.debug('ALV');");
+
+    expect(auth.accessToken).toBe('fresh-token');
+    expect(runSfJsonMock).toHaveBeenCalledTimes(2);
+  });
+
+  test('bounds auth-based tooling readiness probes with a timeout', async () => {
+    const auth: OrgAuth = {
+      accessToken: 'token',
+      instanceUrl: 'https://example.my.salesforce.com',
+      username: 'auth.user@example.com',
+      apiVersion: '62.0'
+    };
+
+    __setToolingConnectionFactoryForTests(async () => ({
+      request: connectionRequestMock,
+      tooling: {
+        query: queryToolingMock.mockImplementation(async () => await new Promise(() => {}))
+      }
+    }));
+
+    await expect(assertToolingReady(auth, { timeoutMs: 10 })).rejects.toThrow(
+      'Tooling readiness probe timed out after 10ms.'
+    );
   });
 
   test('finds the recent ApexLog by matching the seeded marker in the body', async () => {

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -1,4 +1,8 @@
-import { resolveSupportExtensionIds } from '../vscode';
+import {
+  resolveExtensionsDirForMissingDependencies,
+  resolveSupportExtensionIds,
+  shouldAllowLocalExtensionsDirFallback
+} from '../vscode';
 
 describe('resolveSupportExtensionIds', () => {
   test('keeps replay debugger support local to the scenario', () => {
@@ -14,5 +18,47 @@ describe('resolveSupportExtensionIds', () => {
         ['salesforce.salesforcedx-vscode-apex-replay-debugger', 'salesforce.salesforcedx-vscode-core']
       )
     ).toEqual(['salesforce.salesforcedx-vscode-core', 'salesforce.salesforcedx-vscode-apex-replay-debugger']);
+  });
+});
+
+describe('extensions dir fallback policy', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test('keeps the isolated extensions dir by default when support extensions are still missing', () => {
+    delete process.env.ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR;
+
+    expect(shouldAllowLocalExtensionsDirFallback()).toBe(false);
+    expect(
+      resolveExtensionsDirForMissingDependencies({
+        isolatedExtensionsDir: '/tmp/alv-e2e-exts',
+        missingExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'],
+        localExtensionsRoot: '/home/test/.vscode/extensions'
+      })
+    ).toEqual({
+      extensionsDir: '/tmp/alv-e2e-exts',
+      warning:
+        '[e2e] Support extensions still missing in isolated profile: salesforce.salesforcedx-vscode-apex-replay-debugger.' +
+        ' Set ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1 to opt into using the local VS Code extensions dir.'
+    });
+  });
+
+  test('allows whole-dir fallback only when explicitly opted in', () => {
+    process.env.ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR = '1';
+
+    expect(shouldAllowLocalExtensionsDirFallback()).toBe(true);
+    expect(
+      resolveExtensionsDirForMissingDependencies({
+        isolatedExtensionsDir: '/tmp/alv-e2e-exts',
+        missingExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'],
+        localExtensionsRoot: '/home/test/.vscode/extensions'
+      })
+    ).toEqual({
+      extensionsDir: '/home/test/.vscode/extensions',
+      warning: '[e2e] Falling back to local VS Code extensions dir: /home/test/.vscode/extensions'
+    });
   });
 });

--- a/test/e2e/utils/commandPalette.ts
+++ b/test/e2e/utils/commandPalette.ts
@@ -1,4 +1,5 @@
 import type { Page } from '@playwright/test';
+import { timeE2eStep } from './timing';
 
 function getModifierKey(): 'Control' | 'Meta' {
   return process.platform === 'darwin' ? 'Meta' : 'Control';
@@ -16,16 +17,21 @@ function noMatchingResults(widget: ReturnType<Page['locator']>) {
   return widget.getByText('No matching results', { exact: true });
 }
 
-export async function runCommand(page: Page, command: string): Promise<void> {
+function normalizeCommandQuery(command: string): string {
+  return command.trim().startsWith('>') ? command.trim() : `> ${command}`;
+}
+
+async function openQuickOpenWithCommand(page: Page, command: string): Promise<boolean> {
   await openQuickOpen(page);
   const widget = page.locator('div.quick-input-widget');
   const input = widget.locator('input');
-  const query = command.trim().startsWith('>') ? command.trim() : `> ${command}`;
-  await input.fill(query);
+  await input.fill(normalizeCommandQuery(command));
   await page.waitForTimeout(50);
+  return !(await noMatchingResults(widget).isVisible());
+}
 
-  const noMatches = noMatchingResults(widget);
-  if (await noMatches.isVisible()) {
+export async function runCommand(page: Page, command: string): Promise<void> {
+  if (!(await openQuickOpenWithCommand(page, command))) {
     await page.keyboard.press('Escape');
     throw new Error(`Command not found in palette: "${command}"`);
   }
@@ -42,14 +48,7 @@ export async function waitForCommandAvailable(
   const deadline = Date.now() + timeoutMs;
 
   while (Date.now() < deadline) {
-    await openQuickOpen(page);
-    const widget = page.locator('div.quick-input-widget');
-    const input = widget.locator('input');
-    const q = query.trim().startsWith('>') ? query.trim() : `> ${query}`;
-    await input.fill(q);
-    await page.waitForTimeout(50);
-    const noMatches = noMatchingResults(widget);
-    const ok = !(await noMatches.isVisible());
+    const ok = await openQuickOpenWithCommand(page, query);
     await page.keyboard.press('Escape');
     if (ok) {
       return;
@@ -57,6 +56,28 @@ export async function waitForCommandAvailable(
     await page.waitForTimeout(500);
   }
   throw new Error(`Timed out waiting for command to appear in palette: "${query}"`);
+}
+
+export async function runCommandWhenAvailable(
+  page: Page,
+  command: string,
+  options?: { timeoutMs?: number }
+): Promise<void> {
+  await timeE2eStep(`commandPalette.runWhenAvailable:${command}`, async () => {
+    const timeoutMs = options?.timeoutMs ?? 60_000;
+    const deadline = Date.now() + timeoutMs;
+
+    while (Date.now() < deadline) {
+      const ok = await openQuickOpenWithCommand(page, command);
+      if (ok) {
+        await page.keyboard.press('Enter');
+        return;
+      }
+      await page.keyboard.press('Escape');
+      await page.waitForTimeout(500);
+    }
+    throw new Error(`Timed out waiting for command to appear in palette: "${command}"`);
+  });
 }
 
 export async function executeCommandId(page: Page, commandId: string): Promise<void> {

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -2,6 +2,8 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { runSfJson } from './sfCli';
+import { timeE2eStep } from './timing';
+import { assertToolingReady, primeOrgAuthCache, type OrgAuth } from './tooling';
 
 type ScratchOrgResult = {
   devHubAlias: string;
@@ -11,9 +13,9 @@ type ScratchOrgResult = {
 };
 
 const LOCAL_DEV_HUB_FALLBACK_ALIASES = [
+  'DevHubElectivus',
   'DevHub',
   'ElectivusDevHub',
-  'DevHubElectivus',
   'InsuranceOrgTrialCreme6DevHub'
 ] as const;
 
@@ -31,7 +33,22 @@ function envFlag(name: string): boolean {
 type OrgDisplaySummary = {
   status?: string;
   expirationDate?: string;
+  accessToken?: string;
+  instanceUrl?: string;
+  username?: string;
 };
+
+function toOrgAuth(display: OrgDisplaySummary | undefined): OrgAuth | undefined {
+  if (!display?.accessToken || !display.instanceUrl) {
+    return undefined;
+  }
+  return {
+    accessToken: display.accessToken,
+    instanceUrl: display.instanceUrl,
+    username: display.username,
+    apiVersion: String(process.env.SF_TEST_API_VERSION || process.env.SF_API_VERSION || '60.0')
+  };
+}
 
 async function getOrgDisplay(alias: string): Promise<OrgDisplaySummary | undefined> {
   try {
@@ -39,7 +56,17 @@ async function getOrgDisplay(alias: string): Promise<OrgDisplaySummary | undefin
     const org = result?.result ?? {};
     return {
       status: typeof org.status === 'string' ? org.status.trim() : undefined,
-      expirationDate: typeof org.expirationDate === 'string' ? org.expirationDate.trim() : undefined
+      expirationDate: typeof org.expirationDate === 'string' ? org.expirationDate.trim() : undefined,
+      accessToken: typeof org.accessToken === 'string' ? org.accessToken : undefined,
+      instanceUrl:
+        typeof org.instanceUrl === 'string'
+          ? org.instanceUrl
+          : typeof org.instance_url === 'string'
+            ? org.instance_url
+            : typeof org.loginUrl === 'string'
+              ? org.loginUrl
+              : undefined,
+      username: typeof org.username === 'string' ? org.username : undefined
     };
   } catch (error) {
     console.warn(
@@ -214,32 +241,36 @@ async function ensureDevHubAuth(devHubAlias: string): Promise<void> {
   }
 }
 
-async function waitForScratchOrgReady(targetOrg: string): Promise<void> {
+async function waitForScratchOrgReady(targetOrg: string, auth?: OrgAuth): Promise<void> {
   const timeoutMs = Math.max(30_000, Number(process.env.SF_SCRATCH_READY_TIMEOUT_MS || 240_000) || 240_000);
   const deadline = Date.now() + timeoutMs;
   let lastError: unknown;
 
   while (Date.now() < deadline) {
     try {
-      // Some scratch orgs return interstitial HTML ("Stay tuned...") for a short
-      // period after creation. Poll a lightweight Tooling API query until it
-      // returns JSON successfully.
-      await runSfJson(
-        [
-          'data',
-          'query',
-          '--query',
-          'SELECT Id FROM DebugLevel LIMIT 1',
-          '--use-tooling-api',
-          '--target-org',
-          targetOrg,
-        ],
-        { timeoutMs: 30_000 }
-      );
+      if (auth) {
+        await assertToolingReady(auth);
+      } else {
+        // Some scratch orgs return interstitial HTML ("Stay tuned...") for a short
+        // period after creation. Poll a lightweight Tooling API query until it
+        // returns JSON successfully.
+        await runSfJson(
+          [
+            'data',
+            'query',
+            '--query',
+            'SELECT Id FROM DebugLevel LIMIT 1',
+            '--use-tooling-api',
+            '--target-org',
+            targetOrg,
+          ],
+          { timeoutMs: 30_000 }
+        );
+      }
       return;
     } catch (error) {
       lastError = error;
-      await sleep(5_000);
+      await sleep(auth ? 1_000 : 5_000);
     }
   }
 
@@ -248,100 +279,118 @@ async function waitForScratchOrgReady(targetOrg: string): Promise<void> {
 }
 
 export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
-  let devHubAlias = await resolveDefaultDevHubAlias();
-  const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
-  const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
-  const keep = shouldKeepScratchOrg();
+  return await timeE2eStep('scratch.ensure', async () => {
+    let devHubAlias = await resolveDefaultDevHubAlias();
+    const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
+    const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
+    const keep = shouldKeepScratchOrg();
 
-  // Reuse existing scratch org when possible to make local runs faster.
-  const existingScratch = await getOrgDisplay(scratchAlias);
-  if (isReusableScratchOrg(existingScratch)) {
-    await waitForScratchOrgReady(scratchAlias);
-    return {
-      devHubAlias,
-      scratchAlias,
-      created: false,
-      cleanup: async () => {}
+    // Reuse existing scratch org when possible to make local runs faster.
+    const existingScratch = await getOrgDisplay(scratchAlias);
+    if (isReusableScratchOrg(existingScratch)) {
+      const auth = toOrgAuth(existingScratch);
+      if (auth) {
+        primeOrgAuthCache(scratchAlias, auth);
+      }
+      await waitForScratchOrgReady(scratchAlias, auth);
+      return {
+        devHubAlias,
+        scratchAlias,
+        created: false,
+        cleanup: async () => {}
+      };
+    }
+    if (existingScratch) {
+      console.warn(
+        `[e2e] scratch alias '${scratchAlias}' points to a stale org (status='${existingScratch.status || 'unknown'}', expiration='${existingScratch.expirationDate || 'unknown'}'); recreating.`
+      );
+      await clearStaleScratchOrg(scratchAlias);
+    }
+
+    await ensureDevHubAuth(devHubAlias);
+
+    const tmp = await mkdtemp(path.join(tmpdir(), 'alv-scratch-'));
+    const defFile = path.join(tmp, 'project-scratch-def.json');
+    const projectFile = path.join(tmp, 'sfdx-project.json');
+    const def = {
+      orgName: 'apex-log-viewer-e2e',
+      edition: 'Developer',
+      hasSampleData: false
     };
-  }
-  if (existingScratch) {
-    console.warn(
-      `[e2e] scratch alias '${scratchAlias}' points to a stale org (status='${existingScratch.status || 'unknown'}', expiration='${existingScratch.expirationDate || 'unknown'}'); recreating.`
-    );
-    await clearStaleScratchOrg(scratchAlias);
-  }
+    await writeFile(defFile, JSON.stringify(def), 'utf8');
 
-  await ensureDevHubAuth(devHubAlias);
-
-  const tmp = await mkdtemp(path.join(tmpdir(), 'alv-scratch-'));
-  const defFile = path.join(tmp, 'project-scratch-def.json');
-  const projectFile = path.join(tmp, 'sfdx-project.json');
-  const def = {
-    orgName: 'apex-log-viewer-e2e',
-    edition: 'Developer',
-    hasSampleData: false
-  };
-  await writeFile(defFile, JSON.stringify(def), 'utf8');
-
-  const cleanup = async () => {
-    try {
-      if (!keep) {
+    const cleanup = async () => {
+      try {
+        if (!keep) {
+          try {
+            await runSfJson(['org', 'delete', 'scratch', '-o', scratchAlias, '--no-prompt'], { cwd: tmp });
+          } catch {
+            // Best-effort cleanup.
+          }
+        }
+      } catch {
+        // Best-effort cleanup.
+      } finally {
         try {
-          await runSfJson(['org', 'delete', 'scratch', '-o', scratchAlias, '--no-prompt'], { cwd: tmp });
+          await rm(tmp, { recursive: true, force: true });
         } catch {
           // Best-effort cleanup.
         }
       }
-    } catch {
-      // Best-effort cleanup.
-    } finally {
-      try {
-        await rm(tmp, { recursive: true, force: true });
-      } catch {
-        // Best-effort cleanup.
+    };
+
+    // `sf org create scratch` requires a Salesforce DX project. This repo is not
+    // itself a Salesforce project, so create a minimal temporary project context.
+    await mkdir(path.join(tmp, 'force-app'), { recursive: true });
+    await writeFile(
+      projectFile,
+      JSON.stringify(
+        {
+          packageDirectories: [{ path: 'force-app', default: true }],
+          name: 'apex-log-viewer-e2e',
+          namespace: '',
+          sfdcLoginUrl: 'https://login.salesforce.com',
+          sourceApiVersion: '61.0'
+        },
+        null,
+        2
+      ),
+      'utf8'
+    );
+
+    try {
+      devHubAlias = await createScratchOrgWithFallback({
+        devHubAlias,
+        scratchAlias,
+        definitionFile: defFile,
+        durationDays,
+        cwd: tmp
+      });
+    } catch (_e) {
+      await cleanup();
+      const msg = _e instanceof Error ? _e.message : String(_e);
+      throw new Error(`Failed to create scratch org '${scratchAlias}': ${msg}`);
+    }
+
+    const auth = toOrgAuth(await getOrgDisplay(scratchAlias));
+    if (auth) {
+      primeOrgAuthCache(scratchAlias, auth);
+    }
+    await waitForScratchOrgReady(scratchAlias, auth);
+
+    if (!auth) {
+      const refreshedScratch = await getOrgDisplay(scratchAlias);
+      const refreshedAuth = toOrgAuth(refreshedScratch);
+      if (refreshedAuth) {
+        primeOrgAuthCache(scratchAlias, refreshedAuth);
       }
     }
-  };
 
-  // `sf org create scratch` requires a Salesforce DX project. This repo is not
-  // itself a Salesforce project, so create a minimal temporary project context.
-  await mkdir(path.join(tmp, 'force-app'), { recursive: true });
-  await writeFile(
-    projectFile,
-    JSON.stringify(
-      {
-        packageDirectories: [{ path: 'force-app', default: true }],
-        name: 'apex-log-viewer-e2e',
-        namespace: '',
-        sfdcLoginUrl: 'https://login.salesforce.com',
-        sourceApiVersion: '61.0'
-      },
-      null,
-      2
-    ),
-    'utf8'
-  );
-
-  try {
-    devHubAlias = await createScratchOrgWithFallback({
+    return {
       devHubAlias,
       scratchAlias,
-      definitionFile: defFile,
-      durationDays,
-      cwd: tmp
-    });
-  } catch (_e) {
-    await cleanup();
-    const msg = _e instanceof Error ? _e.message : String(_e);
-    throw new Error(`Failed to create scratch org '${scratchAlias}': ${msg}`);
-  }
-
-  await waitForScratchOrgReady(scratchAlias);
-
-  return {
-    devHubAlias,
-    scratchAlias,
-    created: true,
-    cleanup
-  };
+      created: true,
+      cleanup
+    };
+  });
 }

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -249,7 +249,7 @@ async function waitForScratchOrgReady(targetOrg: string, auth?: OrgAuth): Promis
   while (Date.now() < deadline) {
     try {
       if (auth) {
-        await assertToolingReady(auth);
+        await assertToolingReady(auth, { timeoutMs: 30_000 });
       } else {
         // Some scratch orgs return interstitial HTML ("Stay tuned...") for a short
         // period after creation. Poll a lightweight Tooling API query until it

--- a/test/e2e/utils/seedLog.ts
+++ b/test/e2e/utils/seedLog.ts
@@ -1,8 +1,5 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises';
-import path from 'node:path';
-import { tmpdir } from 'node:os';
-import { runSfJson } from './sfCli';
-import { ensureE2eTraceFlag, getOrgAuth } from './tooling';
+import { timeE2eStep } from './timing';
+import { ensureE2eTraceFlag, executeAnonymousApex, findRecentApexLogId, getOrgAuth } from './tooling';
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -13,76 +10,65 @@ type SeedResult = {
   logId: string;
 };
 
-function parseLogIds(listResult: any): string[] {
-  const rows = listResult?.result || listResult?.records || listResult;
-  if (!Array.isArray(rows)) {
-    return [];
-  }
-  return rows.map((r: any) => r?.Id).filter((v: any): v is string => typeof v === 'string' && v.length > 0);
-}
-
 export async function seedApexLog(targetOrg: string): Promise<SeedResult> {
-  const auth = await getOrgAuth(targetOrg);
-  await ensureE2eTraceFlag(auth);
+  return await timeE2eStep('seed.log', async () => {
+    const auth = await getOrgAuth(targetOrg);
+    await ensureE2eTraceFlag(auth);
 
-  const before = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
-  const beforeIds = new Set(parseLogIds(before));
-
-  const marker = `ALV_E2E_MARKER_${Date.now()}`;
-  await runAnonymousApex(targetOrg, `System.debug('${marker}');\n`);
-  const logId = await waitForCreatedLogId(targetOrg, beforeIds);
-  return { marker, logId };
+    const marker = `ALV_E2E_MARKER_${Date.now()}`;
+    const startedAtMs = Date.now();
+    await runAnonymousApex(auth, `System.debug('${marker}');\n`);
+    const logId = await waitForCreatedLogId(auth, startedAtMs, marker);
+    return { marker, logId };
+  });
 }
 
 export async function seedApexErrorLog(targetOrg: string): Promise<SeedResult> {
-  const auth = await getOrgAuth(targetOrg);
-  await ensureE2eTraceFlag(auth);
+  return await timeE2eStep('seed.errorLog', async () => {
+    const auth = await getOrgAuth(targetOrg);
+    await ensureE2eTraceFlag(auth);
 
-  const before = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
-  const beforeIds = new Set(parseLogIds(before));
-
-  const marker = `ALV_E2E_ERROR_MARKER_${Date.now()}`;
-  const anonymousApex =
-    `System.debug('${marker}');\n` +
-    'try {\n' +
-    '  Object alvFail = null;\n' +
-    '  System.debug(alvFail.toString());\n' +
-    '} catch (Exception e) {\n' +
-    "  System.debug('ALV_E2E_ERROR_CAUGHT:' + e.getMessage());\n" +
-    '}\n';
-  // Generate a real log with EXCEPTION_* events but keep the anonymous Apex run successful.
-  await runAnonymousApex(targetOrg, anonymousApex);
-  const logId = await waitForCreatedLogId(targetOrg, beforeIds);
-  return { marker, logId };
+    const marker = `ALV_E2E_ERROR_MARKER_${Date.now()}`;
+    const anonymousApex =
+      `System.debug('${marker}');\n` +
+      'try {\n' +
+      '  Object alvFail = null;\n' +
+      '  System.debug(alvFail.toString());\n' +
+      '} catch (Exception e) {\n' +
+      "  System.debug('ALV_E2E_ERROR_CAUGHT:' + e.getMessage());\n" +
+      '}\n';
+    // Generate a real log with EXCEPTION_* events but keep the anonymous Apex run successful.
+    const startedAtMs = Date.now();
+    await runAnonymousApex(auth, anonymousApex);
+    const logId = await waitForCreatedLogId(auth, startedAtMs, marker);
+    return { marker, logId };
+  });
 }
 
-async function runAnonymousApex(targetOrg: string, anonymousApex: string, options?: { allowFailure?: boolean }): Promise<void> {
-  const tmp = await mkdtemp(path.join(tmpdir(), 'alv-apex-'));
-  const apexFile = path.join(tmp, 'seed.apex');
-  await writeFile(apexFile, anonymousApex, 'utf8');
-  try {
-    try {
-      await runSfJson(['apex', 'run', '-o', targetOrg, '--file', apexFile]);
-    } catch (e) {
-      if (!options?.allowFailure) {
-        throw e;
+async function runAnonymousApex(
+  auth: Awaited<ReturnType<typeof getOrgAuth>>,
+  anonymousApex: string,
+  options?: { allowFailure?: boolean }
+): Promise<void> {
+  await timeE2eStep('seed.runAnonymousApex', async () => {
+    await executeAnonymousApex(auth, anonymousApex, options);
+  });
+}
+
+async function waitForCreatedLogId(
+  auth: Awaited<ReturnType<typeof getOrgAuth>>,
+  startedAtMs: number,
+  marker: string
+): Promise<string> {
+  return await timeE2eStep('seed.waitForCreatedLogId', async () => {
+    const deadline = Date.now() + 45_000;
+    while (Date.now() < deadline) {
+      const created = await findRecentApexLogId(auth, startedAtMs, marker);
+      if (created) {
+        return created;
       }
+      await sleep(300);
     }
-  } finally {
-    await rm(tmp, { recursive: true, force: true });
-  }
-}
-
-async function waitForCreatedLogId(targetOrg: string, beforeIds: Set<string>): Promise<string> {
-  const deadline = Date.now() + 45_000;
-  while (Date.now() < deadline) {
-    const after = await runSfJson(['apex', 'list', 'log', '-o', targetOrg]);
-    const afterIds = parseLogIds(after);
-    const created = afterIds.find(id => !beforeIds.has(id));
-    if (created) {
-      return created;
-    }
-    await sleep(2_000);
-  }
-  throw new Error('Failed to detect a newly created ApexLog after seeding anonymous Apex.');
+    throw new Error('Failed to detect a newly created ApexLog after seeding anonymous Apex.');
+  });
 }

--- a/test/e2e/utils/sfCli.ts
+++ b/test/e2e/utils/sfCli.ts
@@ -63,23 +63,34 @@ function quoteWindowsCmdArg(value: string): string {
   return `"${raw.replace(/"/g, '""')}"`;
 }
 
+let resolvedSfBinAbsolutePathPromise: Promise<string | undefined> | undefined;
+
+export function __resetResolvedSfBinAbsolutePathCacheForTests(): void {
+  resolvedSfBinAbsolutePathPromise = undefined;
+}
+
 export async function resolveSfBinAbsolutePath(): Promise<string | undefined> {
-  try {
-    if (process.platform === 'win32') {
-      const { stdout } = await execFileAsync('cmd.exe', ['/d', '/s', '/c', 'where sf'], { timeoutMs: 10_000 });
-      const candidates = String(stdout || '')
-        .split(/\r?\n/)
-        .map(l => l.trim())
-        .filter(Boolean);
-      const preferred = candidates.find(value => /\.cmd$/i.test(value));
-      return preferred || candidates[0] || undefined;
-    }
-    const { stdout } = await execFileAsync('bash', ['-lc', 'command -v sf'], { timeoutMs: 10_000 });
-    const resolved = String(stdout || '').trim();
-    return resolved || undefined;
-  } catch {
-    return undefined;
+  if (!resolvedSfBinAbsolutePathPromise) {
+    resolvedSfBinAbsolutePathPromise = (async () => {
+      try {
+        if (process.platform === 'win32') {
+          const { stdout } = await execFileAsync('cmd.exe', ['/d', '/s', '/c', 'where sf'], { timeoutMs: 10_000 });
+          const candidates = String(stdout || '')
+            .split(/\r?\n/)
+            .map(l => l.trim())
+            .filter(Boolean);
+          const preferred = candidates.find(value => /\.cmd$/i.test(value));
+          return preferred || candidates[0] || undefined;
+        }
+        const { stdout } = await execFileAsync('bash', ['-lc', 'command -v sf'], { timeoutMs: 10_000 });
+        const resolved = String(stdout || '').trim();
+        return resolved || undefined;
+      } catch {
+        return undefined;
+      }
+    })();
   }
+  return await resolvedSfBinAbsolutePathPromise;
 }
 
 export async function resolveSfCliInvocation(): Promise<{ sfBinPath: string; nodeBinPath: string } | undefined> {

--- a/test/e2e/utils/tempWorkspace.ts
+++ b/test/e2e/utils/tempWorkspace.ts
@@ -2,6 +2,7 @@ import { chmod, mkdir, mkdtemp, writeFile } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { removePathBestEffort } from './fsCleanup';
+import { timeE2eStep } from './timing';
 
 export type TempWorkspace = {
   workspacePath: string;
@@ -12,55 +13,57 @@ export async function createTempWorkspace(options: {
   targetOrg: string;
   sfCli?: { sfBinPath: string; nodeBinPath: string };
 }): Promise<TempWorkspace> {
-  const workspacePath = await mkdtemp(path.join(tmpdir(), 'alv-e2e-ws-'));
+  return await timeE2eStep('workspace.create', async () => {
+    const workspacePath = await mkdtemp(path.join(tmpdir(), 'alv-e2e-ws-'));
 
-  const proj = {
-    packageDirectories: [{ path: 'force-app', default: true }],
-    name: 'apex-log-viewer-e2e',
-    namespace: '',
-    sfdcLoginUrl: 'https://login.salesforce.com',
-    sourceApiVersion: String(process.env.SF_TEST_API_VERSION || '60.0')
-  };
-  await writeFile(path.join(workspacePath, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
-  await mkdir(path.join(workspacePath, 'force-app'), { recursive: true });
-
-  const sfDir = path.join(workspacePath, '.sf');
-  await mkdir(sfDir, { recursive: true });
-  await writeFile(path.join(sfDir, 'config.json'), JSON.stringify({ 'target-org': options.targetOrg }, null, 2), 'utf8');
-
-  // Ensure the extension host can locate the Salesforce CLI even when VS Code
-  // is launched in an environment with a minimal PATH.
-  if (options.sfCli?.sfBinPath) {
-    const vscodeDir = path.join(workspacePath, '.vscode');
-    await mkdir(vscodeDir, { recursive: true });
-
-    let cliPath = options.sfCli.sfBinPath;
-    // On Unix-like systems, wrap `sf` so it can find `node` even if VS Code
-    // starts with a minimal PATH.
-    if (process.platform !== 'win32' && options.sfCli.nodeBinPath) {
-      const wrapperPath = path.join(vscodeDir, 'sf-cli.sh');
-      const nodeDir = path.dirname(options.sfCli.nodeBinPath);
-      const script = [
-        '#!/bin/bash',
-        'set -euo pipefail',
-        `export PATH="${nodeDir}:$PATH"`,
-        `exec "${options.sfCli.sfBinPath}" "$@"`,
-        ''
-      ].join('\n');
-      await writeFile(wrapperPath, script, 'utf8');
-      await chmod(wrapperPath, 0o755);
-      cliPath = wrapperPath;
-    }
-    const settings = {
-      'electivus.apexLogs.cliPath': cliPath
+    const proj = {
+      packageDirectories: [{ path: 'force-app', default: true }],
+      name: 'apex-log-viewer-e2e',
+      namespace: '',
+      sfdcLoginUrl: 'https://login.salesforce.com',
+      sourceApiVersion: String(process.env.SF_TEST_API_VERSION || '60.0')
     };
-    await writeFile(path.join(vscodeDir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf8');
-  }
+    await writeFile(path.join(workspacePath, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
+    await mkdir(path.join(workspacePath, 'force-app'), { recursive: true });
 
-  return {
-    workspacePath,
-    cleanup: async () => {
-      await removePathBestEffort(workspacePath);
+    const sfDir = path.join(workspacePath, '.sf');
+    await mkdir(sfDir, { recursive: true });
+    await writeFile(path.join(sfDir, 'config.json'), JSON.stringify({ 'target-org': options.targetOrg }, null, 2), 'utf8');
+
+    // Ensure the extension host can locate the Salesforce CLI even when VS Code
+    // is launched in an environment with a minimal PATH.
+    if (options.sfCli?.sfBinPath) {
+      const vscodeDir = path.join(workspacePath, '.vscode');
+      await mkdir(vscodeDir, { recursive: true });
+
+      let cliPath = options.sfCli.sfBinPath;
+      // On Unix-like systems, wrap `sf` so it can find `node` even if VS Code
+      // starts with a minimal PATH.
+      if (process.platform !== 'win32' && options.sfCli.nodeBinPath) {
+        const wrapperPath = path.join(vscodeDir, 'sf-cli.sh');
+        const nodeDir = path.dirname(options.sfCli.nodeBinPath);
+        const script = [
+          '#!/bin/bash',
+          'set -euo pipefail',
+          `export PATH="${nodeDir}:$PATH"`,
+          `exec "${options.sfCli.sfBinPath}" "$@"`,
+          ''
+        ].join('\n');
+        await writeFile(wrapperPath, script, 'utf8');
+        await chmod(wrapperPath, 0o755);
+        cliPath = wrapperPath;
+      }
+      const settings = {
+        'electivus.apexLogs.cliPath': cliPath
+      };
+      await writeFile(path.join(vscodeDir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf8');
     }
-  };
+
+    return {
+      workspacePath,
+      cleanup: async () => {
+        await removePathBestEffort(workspacePath);
+      }
+    };
+  });
 }

--- a/test/e2e/utils/timing.ts
+++ b/test/e2e/utils/timing.ts
@@ -1,0 +1,23 @@
+function envFlag(name: string): boolean {
+  const value = String(process.env[name] || '')
+    .trim()
+    .toLowerCase();
+  return value === '1' || value === 'true';
+}
+
+export function isE2eTimingEnabled(): boolean {
+  return envFlag('ALV_E2E_TIMING');
+}
+
+export async function timeE2eStep<T>(label: string, run: () => Promise<T>): Promise<T> {
+  if (!isE2eTimingEnabled()) {
+    return await run();
+  }
+
+  const startedAt = Date.now();
+  try {
+    return await run();
+  } finally {
+    console.log(`[e2e][timing] ${label}: ${Date.now() - startedAt}ms`);
+  }
+}

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -1,4 +1,6 @@
+import { Connection } from '@jsforce/jsforce-node';
 import { runSfJson } from './sfCli';
+import { timeE2eStep } from './timing';
 
 export type OrgAuth = {
   accessToken: string;
@@ -53,6 +55,125 @@ const SPECIAL_TRACE_FLAG_TARGET_LABELS: Record<SpecialTraceFlagTargetType, strin
   automatedProcess: 'Automated Process',
   platformIntegration: 'Platform Integration'
 };
+const TRACE_FLAG_FAST_PATH_MAX_MS = 5 * 60 * 1000;
+const TRACE_FLAG_FAST_PATH_SAFETY_MS = 60_000;
+
+const orgAuthCache = new Map<string, Promise<OrgAuth>>();
+const currentUserIdCache = new Map<string, Promise<string>>();
+const debugLevelIdCache = new Map<string, Promise<string>>();
+const ensuredTraceFlagCache = new Map<string, number>();
+const jsforceConnectionCache = new Map<string, Promise<ToolingConnectionLike>>();
+
+type ToolingConnectionLike = Pick<Connection, 'request' | 'tooling'>;
+type ToolingConnectionFactory = (auth: OrgAuth) => Promise<ToolingConnectionLike> | ToolingConnectionLike;
+
+let toolingConnectionFactoryForTests: ToolingConnectionFactory | undefined;
+
+function getOrgAuthCacheKey(targetOrg: string): string {
+  return String(targetOrg || '').trim() || '__default__';
+}
+
+function getAuthIdentityKey(auth: OrgAuth): string {
+  return [stripTrailingSlash(auth.instanceUrl), String(auth.username || '').trim(), String(auth.apiVersion || '').trim()].join('|');
+}
+
+async function getOrCreateCached<T>(cache: Map<string, Promise<T>>, key: string, load: () => Promise<T>): Promise<T> {
+  const cached = cache.get(key);
+  if (cached) {
+    return await cached;
+  }
+
+  const promise = load();
+  cache.set(key, promise);
+  try {
+    return await promise;
+  } catch (error) {
+    cache.delete(key);
+    throw error;
+  }
+}
+
+async function createToolingConnection(auth: OrgAuth): Promise<ToolingConnectionLike> {
+  if (toolingConnectionFactoryForTests) {
+    return await toolingConnectionFactoryForTests(auth);
+  }
+  return new Connection({
+    version: auth.apiVersion,
+    instanceUrl: auth.instanceUrl,
+    accessToken: auth.accessToken
+  }) as ToolingConnectionLike;
+}
+
+async function getToolingConnection(auth: OrgAuth): Promise<ToolingConnectionLike> {
+  return await getOrCreateCached(jsforceConnectionCache, getAuthIdentityKey(auth), async () => {
+    return await createToolingConnection(auth);
+  });
+}
+
+function getTraceFlagFastPathUntil(ttlMinutes: number, nowMs: number): number {
+  const ttlMs = ttlMinutes * 60 * 1000;
+  const fastPathWindowMs = Math.max(0, Math.min(ttlMs - TRACE_FLAG_FAST_PATH_SAFETY_MS, TRACE_FLAG_FAST_PATH_MAX_MS));
+  return nowMs + fastPathWindowMs;
+}
+
+async function ensureDebugLevelId(auth: OrgAuth, debugLevelName: string): Promise<string> {
+  const cacheKey = `${getAuthIdentityKey(auth)}|${debugLevelName}`;
+  return await getOrCreateCached(debugLevelIdCache, cacheKey, async () => {
+    const apiVersion = auth.apiVersion;
+    const dlEsc = escapeSoqlLiteral(debugLevelName);
+    const dlSoql = encodeURIComponent(`SELECT Id FROM DebugLevel WHERE DeveloperName = '${dlEsc}' LIMIT 1`);
+    const dlQuery = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:queryDebugLevel`, async () => {
+      return await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${dlSoql}`);
+    });
+    const existingDebugLevelId: string | undefined = Array.isArray(dlQuery?.records) ? dlQuery.records[0]?.Id : undefined;
+    if (existingDebugLevelId) {
+      return existingDebugLevelId;
+    }
+
+    const createRes = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:createDebugLevel`, async () => {
+      return await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/DebugLevel`, {
+        DeveloperName: debugLevelName,
+        MasterLabel: debugLevelName,
+        ApexCode: 'DEBUG',
+        ApexProfiling: 'ERROR',
+        Callout: 'ERROR',
+        Database: 'ERROR',
+        System: 'DEBUG',
+        Validation: 'ERROR',
+        Visualforce: 'ERROR',
+        Workflow: 'ERROR'
+      });
+    });
+    if (!createRes?.success || !createRes?.id) {
+      throw new Error('Failed to create DebugLevel for E2E TraceFlag.');
+    }
+    return String(createRes.id);
+  });
+}
+
+export function __resetToolingCachesForTests(): void {
+  orgAuthCache.clear();
+  currentUserIdCache.clear();
+  debugLevelIdCache.clear();
+  ensuredTraceFlagCache.clear();
+  jsforceConnectionCache.clear();
+  toolingConnectionFactoryForTests = undefined;
+}
+
+export function primeOrgAuthCache(targetOrg: string, auth: OrgAuth): void {
+  const cacheKey = getOrgAuthCacheKey(targetOrg);
+  orgAuthCache.set(cacheKey, Promise.resolve(auth));
+}
+
+export function __setToolingConnectionFactoryForTests(factory: ToolingConnectionFactory | undefined): void {
+  toolingConnectionFactoryForTests = factory;
+  jsforceConnectionCache.clear();
+}
+
+export async function assertToolingReady(auth: OrgAuth): Promise<void> {
+  const connection = await getToolingConnection(auth);
+  await connection.tooling.query<{ Id?: string }>('SELECT Id FROM DebugLevel LIMIT 1');
+}
 
 function getApiVersion(): string {
   const v = String(process.env.SF_TEST_API_VERSION || process.env.SF_API_VERSION || '60.0').trim();
@@ -137,14 +258,19 @@ export async function getCurrentUserId(auth: OrgAuth): Promise<string> {
   if (!auth.username) {
     throw new Error('Cannot resolve current user id without username.');
   }
-  const usernameEsc = escapeSoqlLiteral(auth.username);
-  const userSoql = encodeURIComponent(`SELECT Id FROM User WHERE Username = '${usernameEsc}' LIMIT 1`);
-  const userRes = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/query?q=${userSoql}`);
-  const userId: string | undefined = Array.isArray(userRes?.records) ? userRes.records[0]?.Id : undefined;
-  if (!isSfId(userId)) {
-    throw new Error('Failed to resolve current user id for tooling operations.');
-  }
-  return userId;
+  const cacheKey = getAuthIdentityKey(auth);
+  return await getOrCreateCached(currentUserIdCache, cacheKey, async () => {
+    return await timeE2eStep('tooling.getCurrentUserId', async () => {
+      const usernameEsc = escapeSoqlLiteral(auth.username!);
+      const userSoql = encodeURIComponent(`SELECT Id FROM User WHERE Username = '${usernameEsc}' LIMIT 1`);
+      const userRes = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/query?q=${userSoql}`);
+      const userId: string | undefined = Array.isArray(userRes?.records) ? userRes.records[0]?.Id : undefined;
+      if (!isSfId(userId)) {
+        throw new Error('Failed to resolve current user id for tooling operations.');
+      }
+      return userId;
+    });
+  });
 }
 
 async function findUserByUsername(
@@ -494,91 +620,148 @@ export async function deleteDebugLevelByDeveloperName(auth: OrgAuth, developerNa
 }
 
 export async function getOrgAuth(targetOrg: string): Promise<OrgAuth> {
-  const envAlias = String(process.env.SF_E2E_TARGET_ORG_ALIAS || process.env.SF_SCRATCH_ALIAS || '').trim();
-  const envAccessToken = String(process.env.SF_E2E_ACCESS_TOKEN || '').trim();
-  const envInstanceUrl = String(process.env.SF_E2E_INSTANCE_URL || '').trim();
-  if (envAccessToken && envInstanceUrl && (!envAlias || envAlias === targetOrg)) {
-    return {
-      accessToken: envAccessToken,
-      instanceUrl: envInstanceUrl,
-      username: String(process.env.SF_E2E_USERNAME || '').trim() || undefined,
-      apiVersion: String(process.env.SF_E2E_API_VERSION || getApiVersion()).trim() || getApiVersion()
-    };
+  const cacheKey = getOrgAuthCacheKey(targetOrg);
+  return await getOrCreateCached(orgAuthCache, cacheKey, async () => {
+    return await timeE2eStep(`tooling.getOrgAuth:${targetOrg}`, async () => {
+      const envAlias = String(process.env.SF_E2E_TARGET_ORG_ALIAS || process.env.SF_SCRATCH_ALIAS || '').trim();
+      const envAccessToken = String(process.env.SF_E2E_ACCESS_TOKEN || '').trim();
+      const envInstanceUrl = String(process.env.SF_E2E_INSTANCE_URL || '').trim();
+      if (envAccessToken && envInstanceUrl && (!envAlias || envAlias === targetOrg)) {
+        return {
+          accessToken: envAccessToken,
+          instanceUrl: envInstanceUrl,
+          username: String(process.env.SF_E2E_USERNAME || '').trim() || undefined,
+          apiVersion: String(process.env.SF_E2E_API_VERSION || getApiVersion()).trim() || getApiVersion()
+        };
+      }
+
+      const apiVersion = getApiVersion();
+      const display = await runSfJson(['org', 'display', '-o', targetOrg]);
+      const result = display?.result || display;
+      const accessToken: string | undefined = result?.accessToken || result?.access_token;
+      const instanceUrl: string | undefined = result?.instanceUrl || result?.instance_url || result?.loginUrl;
+      const username: string | undefined = result?.username;
+      if (!accessToken || !instanceUrl) {
+        throw new Error(`Failed to resolve org auth for '${targetOrg}' (missing accessToken/instanceUrl).`);
+      }
+      return {
+        accessToken,
+        instanceUrl,
+        username,
+        apiVersion
+      };
+    });
+  });
+}
+
+export async function executeAnonymousApex(
+  auth: OrgAuth,
+  anonymousApex: string,
+  options?: { allowFailure?: boolean }
+): Promise<void> {
+  const connection = await getToolingConnection(auth);
+  const encodedBody = encodeURIComponent(anonymousApex);
+  const result = await connection.request<{
+    compiled?: boolean;
+    success?: boolean;
+    compileProblem?: string | null;
+    exceptionMessage?: string | null;
+    exceptionStackTrace?: string | null;
+  }>({
+    method: 'GET',
+    url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/executeAnonymous?anonymousBody=${encodedBody}`,
+    headers: { 'Content-Type': 'application/json' }
+  });
+  if (result?.compiled === false) {
+    throw new Error(`Anonymous Apex compile failed: ${String(result?.compileProblem || 'unknown problem')}`.trim());
+  }
+  if (result?.success === false && !options?.allowFailure) {
+    const message = String(result?.exceptionMessage || result?.exceptionStackTrace || 'unknown failure');
+    throw new Error(`Anonymous Apex execution failed: ${message}`.trim());
+  }
+}
+
+export async function findRecentApexLogId(auth: OrgAuth, startedAtMs: number, marker: string): Promise<string | undefined> {
+  const userId = await getCurrentUserId(auth);
+  const connection = await getToolingConnection(auth);
+  const soql = `SELECT Id, StartTime FROM ApexLog WHERE LogUserId = '${userId}' ORDER BY StartTime DESC LIMIT 10`;
+  const response = await connection.tooling.query<{ Id?: string; StartTime?: string }>(soql);
+  const rows = Array.isArray(response?.records) ? response.records : [];
+  const thresholdMs = startedAtMs - 1_000;
+
+  for (const row of rows) {
+    if (!isSfId(row?.Id) || typeof row?.StartTime !== 'string') {
+      continue;
+    }
+    const startedAt = Date.parse(String(row.StartTime).replace(/([+-]\d{2})(\d{2})$/, '$1:$2'));
+    if (!Number.isFinite(startedAt) || startedAt < thresholdMs) {
+      continue;
+    }
+
+    const body = await connection.request<string>(
+      {
+        method: 'GET',
+        url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/sobjects/ApexLog/${row.Id}/Body`
+      },
+      { responseType: 'text/plain', encoding: 'utf8' } as any
+    );
+    if (String(body || '').includes(marker)) {
+      return row.Id;
+    }
   }
 
-  const apiVersion = getApiVersion();
-  const display = await runSfJson(['org', 'display', '-o', targetOrg]);
-  const result = display?.result || display;
-  const accessToken: string | undefined = result?.accessToken || result?.access_token;
-  const instanceUrl: string | undefined = result?.instanceUrl || result?.instance_url || result?.loginUrl;
-  const username: string | undefined = result?.username;
-  if (!accessToken || !instanceUrl) {
-    throw new Error(`Failed to resolve org auth for '${targetOrg}' (missing accessToken/instanceUrl).`);
-  }
-  return {
-    accessToken,
-    instanceUrl,
-    username,
-    apiVersion
-  };
+  return undefined;
 }
 
 export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelName?: string; ttlMinutes?: number }) {
   const debugLevelName = String(options?.debugLevelName || process.env.SF_E2E_DEBUG_LEVEL || 'ALV_E2E').trim();
   const ttlMinutes = Math.max(5, Number(options?.ttlMinutes || process.env.SF_E2E_TRACE_TTL_MINUTES || 60) || 60);
-  const apiVersion = auth.apiVersion;
-  const userId = await getCurrentUserId(auth);
-
-  const dlEsc = escapeSoqlLiteral(debugLevelName);
-  const dlSoql = encodeURIComponent(`SELECT Id FROM DebugLevel WHERE DeveloperName = '${dlEsc}' LIMIT 1`);
-  const dlQuery = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${dlSoql}`);
-  let debugLevelId: string | undefined = Array.isArray(dlQuery?.records) ? dlQuery.records[0]?.Id : undefined;
-
-  if (!debugLevelId) {
-    const createRes = await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/DebugLevel`, {
-      DeveloperName: debugLevelName,
-      MasterLabel: debugLevelName,
-      ApexCode: 'DEBUG',
-      ApexProfiling: 'ERROR',
-      Callout: 'ERROR',
-      Database: 'ERROR',
-      System: 'DEBUG',
-      Validation: 'ERROR',
-      Visualforce: 'ERROR',
-      Workflow: 'ERROR'
-    });
-    if (!createRes?.success || !createRes?.id) {
-      throw new Error('Failed to create DebugLevel for E2E TraceFlag.');
-    }
-    debugLevelId = String(createRes.id);
-  }
-
-  const tfSoql = encodeURIComponent(
-    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
-  );
-  const tfQuery = await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${tfSoql}`);
-  const existingTfId: string | undefined = Array.isArray(tfQuery?.records) ? tfQuery.records[0]?.Id : undefined;
-
-  const now = new Date();
-  const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
-  const exp = toSfDateTimeUTC(new Date(now.getTime() + ttlMinutes * 60 * 1000));
-
-  if (existingTfId) {
-    await requestJson(auth, 'PATCH', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag/${existingTfId}`, {
-      StartDate: start,
-      ExpirationDate: exp
-    });
+  const traceFlagCacheKey = `${getAuthIdentityKey(auth)}|${debugLevelName}|${ttlMinutes}`;
+  const cachedFastPathUntil = ensuredTraceFlagCache.get(traceFlagCacheKey);
+  if (cachedFastPathUntil && cachedFastPathUntil > Date.now()) {
     return;
   }
 
-  const createTf = await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag`, {
-    TracedEntityId: userId,
-    LogType: 'USER_DEBUG',
-    DebugLevelId: debugLevelId,
-    StartDate: start,
-    ExpirationDate: exp
+  await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}`, async () => {
+    const apiVersion = auth.apiVersion;
+    const userId = await getCurrentUserId(auth);
+    const debugLevelId = await ensureDebugLevelId(auth, debugLevelName);
+
+    const tfSoql = encodeURIComponent(
+      `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
+    );
+    const tfQuery = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:queryTraceFlag`, async () => {
+      return await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${tfSoql}`);
+    });
+    const existingTfId: string | undefined = Array.isArray(tfQuery?.records) ? tfQuery.records[0]?.Id : undefined;
+
+    const now = new Date();
+    const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));
+    const exp = toSfDateTimeUTC(new Date(now.getTime() + ttlMinutes * 60 * 1000));
+
+    if (existingTfId) {
+      await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:patchTraceFlag`, async () => {
+        await requestJson(auth, 'PATCH', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag/${existingTfId}`, {
+          StartDate: start,
+          ExpirationDate: exp
+        });
+      });
+      return;
+    }
+
+    const createTf = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:createTraceFlag`, async () => {
+      return await requestJson(auth, 'POST', `/services/data/v${apiVersion}/tooling/sobjects/TraceFlag`, {
+        TracedEntityId: userId,
+        LogType: 'USER_DEBUG',
+        DebugLevelId: debugLevelId,
+        StartDate: start,
+        ExpirationDate: exp
+      });
+    });
+    if (!createTf?.success) {
+      throw new Error('Failed to create TraceFlag for E2E.');
+    }
   });
-  if (!createTf?.success) {
-    throw new Error('Failed to create TraceFlag for E2E.');
-  }
+
+  ensuredTraceFlagCache.set(traceFlagCacheKey, getTraceFlagFastPathUntil(ttlMinutes, Date.now()));
 }

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -806,20 +806,15 @@ export async function executeAnonymousApex(
   }
 }
 
-export async function findRecentApexLogId(auth: OrgAuth, startedAtMs: number, marker: string): Promise<string | undefined> {
+export async function findRecentApexLogId(auth: OrgAuth, _startedAtMs: number, marker: string): Promise<string | undefined> {
   const userId = await getCurrentUserId(auth);
   return await withToolingConnection(auth, async connection => {
     const soql = `SELECT Id, StartTime FROM ApexLog WHERE LogUserId = '${userId}' ORDER BY StartTime DESC LIMIT 10`;
     const response = await connection.tooling.query<{ Id?: string; StartTime?: string }>(soql);
     const rows = Array.isArray(response?.records) ? response.records : [];
-    const thresholdMs = startedAtMs - 1_000;
 
     for (const row of rows) {
       if (!isSfId(row?.Id) || typeof row?.StartTime !== 'string') {
-        continue;
-      }
-      const startedAt = Date.parse(String(row.StartTime).replace(/([+-]\d{2})(\d{2})$/, '$1:$2'));
-      if (!Number.isFinite(startedAt) || startedAt < thresholdMs) {
         continue;
       }
 

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -116,6 +116,15 @@ function getTraceFlagFastPathUntil(ttlMinutes: number, nowMs: number): number {
   return nowMs + fastPathWindowMs;
 }
 
+function invalidateEnsuredTraceFlagCache(auth: OrgAuth): void {
+  const authIdentityKey = getAuthIdentityKey(auth);
+  for (const key of Array.from(ensuredTraceFlagCache.keys())) {
+    if (key.startsWith(`${authIdentityKey}|`)) {
+      ensuredTraceFlagCache.delete(key);
+    }
+  }
+}
+
 async function ensureDebugLevelId(auth: OrgAuth, debugLevelName: string): Promise<string> {
   const cacheKey = `${getAuthIdentityKey(auth)}|${debugLevelName}`;
   return await getOrCreateCached(debugLevelIdCache, cacheKey, async () => {
@@ -149,6 +158,21 @@ async function ensureDebugLevelId(auth: OrgAuth, debugLevelName: string): Promis
     }
     return String(createRes.id);
   });
+}
+
+async function queryExistingTraceFlagId(
+  auth: OrgAuth,
+  userId: string,
+  debugLevelId: string,
+  debugLevelName: string
+): Promise<string | undefined> {
+  const tfSoql = encodeURIComponent(
+    `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
+  );
+  const tfQuery = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:queryTraceFlag`, async () => {
+    return await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/tooling/query?q=${tfSoql}`);
+  });
+  return Array.isArray(tfQuery?.records) ? tfQuery.records[0]?.Id : undefined;
 }
 
 export function __resetToolingCachesForTests(): void {
@@ -508,6 +532,7 @@ async function listDebugTraceFlagIdsByTracedEntityId(auth: OrgAuth, tracedEntity
 }
 
 export async function removeDebugTraceFlagsByTracedEntityId(auth: OrgAuth, tracedEntityId: string): Promise<number> {
+  invalidateEnsuredTraceFlagCache(auth);
   let removedCount = 0;
   const deadline = Date.now() + TRACE_FLAG_REMOVAL_TIMEOUT_MS;
   const attemptedDeletes = new Set<string>();
@@ -717,23 +742,15 @@ export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelNa
   const debugLevelName = String(options?.debugLevelName || process.env.SF_E2E_DEBUG_LEVEL || 'ALV_E2E').trim();
   const ttlMinutes = Math.max(5, Number(options?.ttlMinutes || process.env.SF_E2E_TRACE_TTL_MINUTES || 60) || 60);
   const traceFlagCacheKey = `${getAuthIdentityKey(auth)}|${debugLevelName}|${ttlMinutes}`;
-  const cachedFastPathUntil = ensuredTraceFlagCache.get(traceFlagCacheKey);
-  if (cachedFastPathUntil && cachedFastPathUntil > Date.now()) {
-    return;
-  }
-
   await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}`, async () => {
     const apiVersion = auth.apiVersion;
     const userId = await getCurrentUserId(auth);
     const debugLevelId = await ensureDebugLevelId(auth, debugLevelName);
-
-    const tfSoql = encodeURIComponent(
-      `SELECT Id FROM TraceFlag WHERE TracedEntityId = '${userId}' AND LogType = 'USER_DEBUG' AND DebugLevelId = '${debugLevelId}' ORDER BY CreatedDate DESC LIMIT 1`
-    );
-    const tfQuery = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:queryTraceFlag`, async () => {
-      return await requestJson(auth, 'GET', `/services/data/v${apiVersion}/tooling/query?q=${tfSoql}`);
-    });
-    const existingTfId: string | undefined = Array.isArray(tfQuery?.records) ? tfQuery.records[0]?.Id : undefined;
+    const existingTfId = await queryExistingTraceFlagId(auth, userId, debugLevelId, debugLevelName);
+    const cachedFastPathUntil = ensuredTraceFlagCache.get(traceFlagCacheKey);
+    if (cachedFastPathUntil && cachedFastPathUntil > Date.now() && existingTfId) {
+      return;
+    }
 
     const now = new Date();
     const start = toSfDateTimeUTC(new Date(now.getTime() - 1000));

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -742,14 +742,14 @@ export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelNa
   const debugLevelName = String(options?.debugLevelName || process.env.SF_E2E_DEBUG_LEVEL || 'ALV_E2E').trim();
   const ttlMinutes = Math.max(5, Number(options?.ttlMinutes || process.env.SF_E2E_TRACE_TTL_MINUTES || 60) || 60);
   const traceFlagCacheKey = `${getAuthIdentityKey(auth)}|${debugLevelName}|${ttlMinutes}`;
-  await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}`, async () => {
+  const extendedTraceFlagExpiry = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}`, async () => {
     const apiVersion = auth.apiVersion;
     const userId = await getCurrentUserId(auth);
     const debugLevelId = await ensureDebugLevelId(auth, debugLevelName);
     const existingTfId = await queryExistingTraceFlagId(auth, userId, debugLevelId, debugLevelName);
     const cachedFastPathUntil = ensuredTraceFlagCache.get(traceFlagCacheKey);
     if (cachedFastPathUntil && cachedFastPathUntil > Date.now() && existingTfId) {
-      return;
+      return false;
     }
 
     const now = new Date();
@@ -763,7 +763,7 @@ export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelNa
           ExpirationDate: exp
         });
       });
-      return;
+      return true;
     }
 
     const createTf = await timeE2eStep(`tooling.ensureTraceFlag:${debugLevelName}:createTraceFlag`, async () => {
@@ -778,7 +778,10 @@ export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelNa
     if (!createTf?.success) {
       throw new Error('Failed to create TraceFlag for E2E.');
     }
+    return true;
   });
 
-  ensuredTraceFlagCache.set(traceFlagCacheKey, getTraceFlagFastPathUntil(ttlMinutes, Date.now()));
+  if (extendedTraceFlagExpiry) {
+    ensuredTraceFlagCache.set(traceFlagCacheKey, getTraceFlagFastPathUntil(ttlMinutes, Date.now()));
+  }
 }

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -63,6 +63,7 @@ const currentUserIdCache = new Map<string, Promise<string>>();
 const debugLevelIdCache = new Map<string, Promise<string>>();
 const ensuredTraceFlagCache = new Map<string, number>();
 const jsforceConnectionCache = new Map<string, Promise<ToolingConnectionLike>>();
+const orgAuthTargetOrgByIdentity = new Map<string, string>();
 
 type ToolingConnectionLike = Pick<Connection, 'request' | 'tooling'>;
 type ToolingConnectionFactory = (auth: OrgAuth) => Promise<ToolingConnectionLike> | ToolingConnectionLike;
@@ -114,6 +115,68 @@ function getTraceFlagFastPathUntil(ttlMinutes: number, nowMs: number): number {
   const ttlMs = ttlMinutes * 60 * 1000;
   const fastPathWindowMs = Math.max(0, Math.min(ttlMs - TRACE_FLAG_FAST_PATH_SAFETY_MS, TRACE_FLAG_FAST_PATH_MAX_MS));
   return nowMs + fastPathWindowMs;
+}
+
+function rememberOrgAuthTarget(targetOrg: string, auth: OrgAuth): void {
+  orgAuthTargetOrgByIdentity.set(getAuthIdentityKey(auth), getOrgAuthCacheKey(targetOrg));
+}
+
+function replaceOrgAuth(target: OrgAuth, next: OrgAuth): void {
+  target.accessToken = next.accessToken;
+  target.instanceUrl = next.instanceUrl;
+  target.username = next.username;
+  target.apiVersion = next.apiVersion;
+}
+
+function isAuthFailure(status: number | undefined, detail: string): boolean {
+  const normalized = String(detail || '').toLowerCase();
+  return (
+    status === 401 ||
+    normalized.includes('invalid_session_id') ||
+    normalized.includes('session expired or invalid') ||
+    normalized.includes('expired access/refresh token')
+  );
+}
+
+function isToolingAuthError(error: unknown): boolean {
+  const statusCode = typeof (error as any)?.statusCode === 'number' ? Number((error as any).statusCode) : undefined;
+  const errorCode = String((error as any)?.errorCode || '');
+  const message = String(error instanceof Error ? error.message : error || '');
+  return isAuthFailure(statusCode, `${errorCode} ${message}`.trim());
+}
+
+async function refreshOrgAuth(auth: OrgAuth): Promise<boolean> {
+  const targetOrg = orgAuthTargetOrgByIdentity.get(getAuthIdentityKey(auth));
+  if (!targetOrg) {
+    return false;
+  }
+  const staleIdentityKey = getAuthIdentityKey(auth);
+  orgAuthCache.delete(targetOrg);
+  jsforceConnectionCache.delete(staleIdentityKey);
+  const refreshed = await getOrgAuth(targetOrg, { forceRefresh: true });
+  replaceOrgAuth(auth, refreshed);
+  rememberOrgAuthTarget(targetOrg, auth);
+  jsforceConnectionCache.delete(getAuthIdentityKey(auth));
+  return true;
+}
+
+function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => {
+      reject(new Error(`${label} timed out after ${timeoutMs}ms.`));
+    }, timeoutMs);
+
+    promise.then(
+      value => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      error => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
 }
 
 function invalidateEnsuredTraceFlagCache(auth: OrgAuth): void {
@@ -181,12 +244,14 @@ export function __resetToolingCachesForTests(): void {
   debugLevelIdCache.clear();
   ensuredTraceFlagCache.clear();
   jsforceConnectionCache.clear();
+  orgAuthTargetOrgByIdentity.clear();
   toolingConnectionFactoryForTests = undefined;
 }
 
 export function primeOrgAuthCache(targetOrg: string, auth: OrgAuth): void {
   const cacheKey = getOrgAuthCacheKey(targetOrg);
   orgAuthCache.set(cacheKey, Promise.resolve(auth));
+  rememberOrgAuthTarget(targetOrg, auth);
 }
 
 export function __setToolingConnectionFactoryForTests(factory: ToolingConnectionFactory | undefined): void {
@@ -194,9 +259,31 @@ export function __setToolingConnectionFactoryForTests(factory: ToolingConnection
   jsforceConnectionCache.clear();
 }
 
-export async function assertToolingReady(auth: OrgAuth): Promise<void> {
-  const connection = await getToolingConnection(auth);
-  await connection.tooling.query<{ Id?: string }>('SELECT Id FROM DebugLevel LIMIT 1');
+async function withToolingConnection<T>(
+  auth: OrgAuth,
+  run: (connection: ToolingConnectionLike) => Promise<T>
+): Promise<T> {
+  const runOnce = async () => await run(await getToolingConnection(auth));
+
+  try {
+    return await runOnce();
+  } catch (error) {
+    if (!isToolingAuthError(error) || !(await refreshOrgAuth(auth))) {
+      throw error;
+    }
+    return await runOnce();
+  }
+}
+
+export async function assertToolingReady(auth: OrgAuth, options?: { timeoutMs?: number }): Promise<void> {
+  const timeoutMs = options?.timeoutMs ?? 30_000;
+  await withTimeout(
+    withToolingConnection(auth, async connection => {
+      await connection.tooling.query<{ Id?: string }>('SELECT Id FROM DebugLevel LIMIT 1');
+    }),
+    timeoutMs,
+    'Tooling readiness probe'
+  );
 }
 
 function getApiVersion(): string {
@@ -249,29 +336,36 @@ function sleep(ms: number): Promise<void> {
 }
 
 async function requestJson(auth: OrgAuth, method: string, resourcePath: string, body?: unknown): Promise<any> {
-  const base = stripTrailingSlash(auth.instanceUrl);
-  const url = `${base}${resourcePath}`;
-  const res = await fetch(url, {
-    method,
-    headers: {
-      Authorization: `Bearer ${auth.accessToken}`,
-      'Content-Type': 'application/json'
-    },
-    body: body === undefined ? undefined : JSON.stringify(body)
-  });
-  const text = await res.text();
-  if (!res.ok) {
-    const detail = text ? ` -> ${text}` : '';
-    throw new Error(`Tooling API request failed (${res.status}) for ${resourcePath}${detail}`);
-  }
-  if (!text) {
-    return undefined;
-  }
-  try {
-    return JSON.parse(text);
-  } catch {
-    return text;
-  }
+  const send = async (allowRefresh: boolean): Promise<any> => {
+    const base = stripTrailingSlash(auth.instanceUrl);
+    const url = `${base}${resourcePath}`;
+    const res = await fetch(url, {
+      method,
+      headers: {
+        Authorization: `Bearer ${auth.accessToken}`,
+        'Content-Type': 'application/json'
+      },
+      body: body === undefined ? undefined : JSON.stringify(body)
+    });
+    const text = await res.text();
+    if (!res.ok) {
+      if (allowRefresh && isAuthFailure(res.status, text) && (await refreshOrgAuth(auth))) {
+        return await send(false);
+      }
+      const detail = text ? ` -> ${text}` : '';
+      throw new Error(`Tooling API request failed (${res.status}) for ${resourcePath}${detail}`);
+    }
+    if (!text) {
+      return undefined;
+    }
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  };
+
+  return await send(true);
 }
 
 function isSfId(value: unknown): value is string {
@@ -644,10 +738,13 @@ export async function deleteDebugLevelByDeveloperName(auth: OrgAuth, developerNa
   await deleteDebugLevelById(auth, record.id);
 }
 
-export async function getOrgAuth(targetOrg: string): Promise<OrgAuth> {
+export async function getOrgAuth(targetOrg: string, options?: { forceRefresh?: boolean }): Promise<OrgAuth> {
   const cacheKey = getOrgAuthCacheKey(targetOrg);
+  if (options?.forceRefresh) {
+    orgAuthCache.delete(cacheKey);
+  }
   return await getOrCreateCached(orgAuthCache, cacheKey, async () => {
-    return await timeE2eStep(`tooling.getOrgAuth:${targetOrg}`, async () => {
+    const resolved = await timeE2eStep(`tooling.getOrgAuth:${targetOrg}`, async () => {
       const envAlias = String(process.env.SF_E2E_TARGET_ORG_ALIAS || process.env.SF_SCRATCH_ALIAS || '').trim();
       const envAccessToken = String(process.env.SF_E2E_ACCESS_TOKEN || '').trim();
       const envInstanceUrl = String(process.env.SF_E2E_INSTANCE_URL || '').trim();
@@ -676,6 +773,8 @@ export async function getOrgAuth(targetOrg: string): Promise<OrgAuth> {
         apiVersion
       };
     });
+    rememberOrgAuthTarget(targetOrg, resolved);
+    return resolved;
   });
 }
 
@@ -684,18 +783,19 @@ export async function executeAnonymousApex(
   anonymousApex: string,
   options?: { allowFailure?: boolean }
 ): Promise<void> {
-  const connection = await getToolingConnection(auth);
-  const encodedBody = encodeURIComponent(anonymousApex);
-  const result = await connection.request<{
-    compiled?: boolean;
-    success?: boolean;
-    compileProblem?: string | null;
-    exceptionMessage?: string | null;
-    exceptionStackTrace?: string | null;
-  }>({
-    method: 'GET',
-    url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/executeAnonymous?anonymousBody=${encodedBody}`,
-    headers: { 'Content-Type': 'application/json' }
+  const result = await withToolingConnection(auth, async connection => {
+    const encodedBody = encodeURIComponent(anonymousApex);
+    return await connection.request<{
+      compiled?: boolean;
+      success?: boolean;
+      compileProblem?: string | null;
+      exceptionMessage?: string | null;
+      exceptionStackTrace?: string | null;
+    }>({
+      method: 'GET',
+      url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/executeAnonymous?anonymousBody=${encodedBody}`,
+      headers: { 'Content-Type': 'application/json' }
+    });
   });
   if (result?.compiled === false) {
     throw new Error(`Anonymous Apex compile failed: ${String(result?.compileProblem || 'unknown problem')}`.trim());
@@ -708,34 +808,35 @@ export async function executeAnonymousApex(
 
 export async function findRecentApexLogId(auth: OrgAuth, startedAtMs: number, marker: string): Promise<string | undefined> {
   const userId = await getCurrentUserId(auth);
-  const connection = await getToolingConnection(auth);
-  const soql = `SELECT Id, StartTime FROM ApexLog WHERE LogUserId = '${userId}' ORDER BY StartTime DESC LIMIT 10`;
-  const response = await connection.tooling.query<{ Id?: string; StartTime?: string }>(soql);
-  const rows = Array.isArray(response?.records) ? response.records : [];
-  const thresholdMs = startedAtMs - 1_000;
+  return await withToolingConnection(auth, async connection => {
+    const soql = `SELECT Id, StartTime FROM ApexLog WHERE LogUserId = '${userId}' ORDER BY StartTime DESC LIMIT 10`;
+    const response = await connection.tooling.query<{ Id?: string; StartTime?: string }>(soql);
+    const rows = Array.isArray(response?.records) ? response.records : [];
+    const thresholdMs = startedAtMs - 1_000;
 
-  for (const row of rows) {
-    if (!isSfId(row?.Id) || typeof row?.StartTime !== 'string') {
-      continue;
-    }
-    const startedAt = Date.parse(String(row.StartTime).replace(/([+-]\d{2})(\d{2})$/, '$1:$2'));
-    if (!Number.isFinite(startedAt) || startedAt < thresholdMs) {
-      continue;
+    for (const row of rows) {
+      if (!isSfId(row?.Id) || typeof row?.StartTime !== 'string') {
+        continue;
+      }
+      const startedAt = Date.parse(String(row.StartTime).replace(/([+-]\d{2})(\d{2})$/, '$1:$2'));
+      if (!Number.isFinite(startedAt) || startedAt < thresholdMs) {
+        continue;
+      }
+
+      const body = await connection.request<string>(
+        {
+          method: 'GET',
+          url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/sobjects/ApexLog/${row.Id}/Body`
+        },
+        { responseType: 'text/plain', encoding: 'utf8' } as any
+      );
+      if (String(body || '').includes(marker)) {
+        return row.Id;
+      }
     }
 
-    const body = await connection.request<string>(
-      {
-        method: 'GET',
-        url: `${auth.instanceUrl}/services/data/v${auth.apiVersion}/tooling/sobjects/ApexLog/${row.Id}/Body`
-      },
-      { responseType: 'text/plain', encoding: 'utf8' } as any
-    );
-    if (String(body || '').includes(marker)) {
-      return row.Id;
-    }
-  }
-
-  return undefined;
+    return undefined;
+  });
 }
 
 export async function ensureE2eTraceFlag(auth: OrgAuth, options?: { debugLevelName?: string; ttlMinutes?: number }) {

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -6,6 +6,7 @@ import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
 import { removePathBestEffort } from './fsCleanup';
 import { dismissAllNotifications } from './notifications';
+import { timeE2eStep } from './timing';
 
 export type VscodeLaunch = {
   app: ElectronApplication;
@@ -24,10 +25,48 @@ function getVsCodeVersion(): string {
   return v || 'stable';
 }
 
+function envFlag(name: string): boolean {
+  const value = String(process.env[name] || '')
+    .trim()
+    .toLowerCase();
+  return value === '1' || value === 'true';
+}
+
 export function resolveSupportExtensionIds(extensionIds: unknown[] = [], extraExtensionIds: string[] = []): string[] {
   return Array.from(
     new Set([...extensionIds, ...extraExtensionIds].map(String).map(value => value.trim()).filter(Boolean))
   );
+}
+
+export function shouldAllowLocalExtensionsDirFallback(): boolean {
+  return envFlag('ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR');
+}
+
+export function resolveExtensionsDirForMissingDependencies(options: {
+  isolatedExtensionsDir: string;
+  missingExtensionIds: string[];
+  localExtensionsRoot?: string;
+}): { extensionsDir: string; warning?: string } {
+  if (!options.missingExtensionIds.length) {
+    return { extensionsDir: options.isolatedExtensionsDir };
+  }
+
+  const missingList = options.missingExtensionIds.join(', ');
+  if (options.localExtensionsRoot && shouldAllowLocalExtensionsDirFallback()) {
+    return {
+      extensionsDir: options.localExtensionsRoot,
+      warning: `[e2e] Falling back to local VS Code extensions dir: ${options.localExtensionsRoot}`
+    };
+  }
+
+  return {
+    extensionsDir: options.isolatedExtensionsDir,
+    warning:
+      `[e2e] Support extensions still missing in isolated profile: ${missingList}.` +
+      (options.localExtensionsRoot
+        ? ' Set ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1 to opt into using the local VS Code extensions dir.'
+        : '')
+  };
 }
 
 async function readExtensionReferences(extensionDevelopmentPath: string, extraExtensionIds: string[] = []): Promise<string[]> {
@@ -146,43 +185,15 @@ async function copyLocalExtensionWithDependencies(
   return true;
 }
 
-function listInstalledExtensions(args: {
-  cliPath: string;
-  cliArgs: string[];
-  userDataDir: string;
-  extensionsDir: string;
-}): Set<string> {
-  try {
-    const res = spawnSync(
-      args.cliPath,
-      [
-        ...args.cliArgs,
-        '--list-extensions',
-        '--show-versions',
-        '--user-data-dir',
-        args.userDataDir,
-        '--extensions-dir',
-        args.extensionsDir
-      ],
-      {
-        stdio: ['pipe', 'pipe', 'pipe'],
-        encoding: 'utf8',
-        input: 'y\n',
-        env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
-      }
-    );
-    const out = [res.stdout, res.stderr].filter(Boolean).join('\n').trim();
-    const installed = new Set<string>();
-    for (const line of out.split(/\r?\n/)) {
-      const trimmed = (line || '').trim();
-      if (!trimmed) continue;
-      const id = trimmed.split('@')[0]?.trim().toLowerCase();
-      if (id) installed.add(id);
+async function findMissingExtensionIdsInRoot(root: string, extensionIds: string[]): Promise<string[]> {
+  const missing: string[] = [];
+  for (const extensionId of extensionIds) {
+    const match = await findExtensionDirectoryInRoot(root, extensionId);
+    if (!match) {
+      missing.push(extensionId);
     }
-    return installed;
-  } catch {
-    return new Set();
   }
+  return missing;
 }
 
 function installExtensions(args: {
@@ -234,31 +245,26 @@ async function ensureExtensionDependenciesInstalled(args: {
   const cli = resolveCliArgsFromVSCodeExecutablePath(args.vscodeExecutablePath, { reuseMachineInstall: true });
   const cliPath = cli[0];
   const cliArgs = cli.slice(1);
-  if (!cliPath) {
-    console.warn('[e2e] Could not resolve VS Code CLI path; skipping dependency install.');
-    return (await findLocalExtensionsRootForDependencies(deps)) || args.extensionsDir;
-  }
-
-  let installed = listInstalledExtensions({
-    cliPath,
-    cliArgs,
-    userDataDir: args.userDataDir,
-    extensionsDir: args.extensionsDir
-  });
-
-  const missingAfterInitialCheck = deps.filter(id => !installed.has(String(id).toLowerCase()));
+  const missingAfterInitialCheck = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
   for (const dep of missingAfterInitialCheck) {
     await copyLocalExtensionWithDependencies(dep, args.extensionsDir);
   }
 
-  installed = listInstalledExtensions({
-    cliPath,
-    cliArgs,
-    userDataDir: args.userDataDir,
-    extensionsDir: args.extensionsDir
-  });
+  let toInstall = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
+  if (!cliPath) {
+    console.warn('[e2e] Could not resolve VS Code CLI path; skipping support extension install into isolated profile.');
+    const localRoot = await findLocalExtensionsRootForDependencies(deps);
+    const decision = resolveExtensionsDirForMissingDependencies({
+      isolatedExtensionsDir: args.extensionsDir,
+      missingExtensionIds: toInstall,
+      localExtensionsRoot: localRoot
+    });
+    if (decision.warning) {
+      console.warn(decision.warning);
+    }
+    return decision.extensionsDir;
+  }
 
-  const toInstall = deps.filter(id => !installed.has(String(id).toLowerCase()));
   if (!toInstall.length) {
     return args.extensionsDir;
   }
@@ -271,25 +277,17 @@ async function ensureExtensionDependenciesInstalled(args: {
     extensionIds: toInstall
   });
 
-  installed = listInstalledExtensions({
-    cliPath,
-    cliArgs,
-    userDataDir: args.userDataDir,
-    extensionsDir: args.extensionsDir
-  });
-
-  const stillMissing = deps.filter(id => !installed.has(String(id).toLowerCase()));
-  if (!stillMissing.length) {
-    return args.extensionsDir;
-  }
-
+  const stillMissing = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
   const localRoot = await findLocalExtensionsRootForDependencies(deps);
-  if (localRoot) {
-    console.warn(`[e2e] Falling back to local VS Code extensions dir: ${localRoot}`);
-    return localRoot;
+  const decision = resolveExtensionsDirForMissingDependencies({
+    isolatedExtensionsDir: args.extensionsDir,
+    missingExtensionIds: stillMissing,
+    localExtensionsRoot: localRoot
+  });
+  if (decision.warning) {
+    console.warn(decision.warning);
   }
-
-  return args.extensionsDir;
+  return decision.extensionsDir;
 }
 
 async function isAuxiliaryBarOpen(page: Page): Promise<boolean> {
@@ -317,7 +315,9 @@ export async function launchVsCode(options: {
   const vscodeCachePath = process.env.VSCODE_TEST_CACHE_PATH
     ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
     : path.join(options.extensionDevelopmentPath, '.vscode-test');
-  const vscodeExecutablePath = await downloadAndUnzipVSCode({ version: getVsCodeVersion(), cachePath: vscodeCachePath });
+  const vscodeExecutablePath = await timeE2eStep('vscode.download', async () =>
+    await downloadAndUnzipVSCode({ version: getVsCodeVersion(), cachePath: vscodeCachePath })
+  );
 
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
   let extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
@@ -327,13 +327,15 @@ export async function launchVsCode(options: {
   // need support extensions in the isolated profile (for example Replay Debugger),
   // so install manifest references plus scenario-specific ids.
   try {
-    const resolvedExtensionsDir = await ensureExtensionDependenciesInstalled({
-      vscodeExecutablePath,
-      extensionDevelopmentPath: options.extensionDevelopmentPath,
-      userDataDir,
-      extensionsDir,
-      extraExtensionIds: options.extensionIds
-    });
+    const resolvedExtensionsDir = await timeE2eStep('vscode.ensureSupportExtensions', async () =>
+      await ensureExtensionDependenciesInstalled({
+        vscodeExecutablePath,
+        extensionDevelopmentPath: options.extensionDevelopmentPath,
+        userDataDir,
+        extensionsDir,
+        extraExtensionIds: options.extensionIds
+      })
+    );
     if (resolvedExtensionsDir !== extensionsDir) {
       await removePathBestEffort(extensionsDir);
       extensionsDir = resolvedExtensionsDir;
@@ -355,20 +357,24 @@ export async function launchVsCode(options: {
     '--no-sandbox'
   ];
 
-  const app = await electron.launch({
-    executablePath: vscodeExecutablePath,
-    args,
-    env: {
-      ...process.env,
-      ELECTRON_DISABLE_GPU: process.env.ELECTRON_DISABLE_GPU || '1',
-      LC_ALL: process.env.LC_ALL || 'C.UTF-8',
-      DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS || '/dev/null',
-      NO_AT_BRIDGE: process.env.NO_AT_BRIDGE || '1'
-    }
-  });
+  const app = await timeE2eStep('vscode.launch', async () =>
+    await electron.launch({
+      executablePath: vscodeExecutablePath,
+      args,
+      env: {
+        ...process.env,
+        ELECTRON_DISABLE_GPU: process.env.ELECTRON_DISABLE_GPU || '1',
+        LC_ALL: process.env.LC_ALL || 'C.UTF-8',
+        DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS || '/dev/null',
+        NO_AT_BRIDGE: process.env.NO_AT_BRIDGE || '1'
+      }
+    })
+  );
 
-  const page = await app.firstWindow();
-  await page.locator('.monaco-workbench').waitFor({ timeout: 120_000 });
+  const page = await timeE2eStep('vscode.firstWindow', async () => await app.firstWindow());
+  await timeE2eStep('vscode.workbenchReady', async () => {
+    await page.locator('.monaco-workbench').waitFor({ timeout: 120_000 });
+  });
 
   // Close the auxiliary (right) sidebar if it opens by default (e.g., Copilot Chat),
   // as it can overlap/push custom panels and introduce E2E flakiness.

--- a/test/e2e/utils/webviews.ts
+++ b/test/e2e/utils/webviews.ts
@@ -1,4 +1,5 @@
 import type { Frame, Page } from '@playwright/test';
+import { timeE2eStep } from './timing';
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -9,75 +10,77 @@ export async function waitForWebviewFrame(
   matcher: (frame: Frame) => Promise<boolean>,
   options?: { timeoutMs?: number }
 ): Promise<Frame> {
-  const timeoutMs = options?.timeoutMs ?? 120_000;
-  const deadline = Date.now() + timeoutMs;
-  let sawWebviews = false;
+  return await timeE2eStep('webview.waitForFrame', async () => {
+    const timeoutMs = options?.timeoutMs ?? 120_000;
+    const deadline = Date.now() + timeoutMs;
+    let sawWebviews = false;
 
-  const tryFind = async (): Promise<Frame | undefined> => {
-    const allFrames = page.frames();
-    const main = page.mainFrame();
-    const webviewFrames = allFrames.filter(f => /vscode-webview|vscode-webview\.net/i.test(f.url()));
-    if (webviewFrames.length > 0) {
-      sawWebviews = true;
-    }
-    // VS Code webviews often have nested iframes where the outer frame URL matches
-    // vscode-webview*, but the actual content is hosted in a child frame (sometimes
-    // with an about:blank URL). Prefer webview frames, but still scan all non-main
-    // frames so we don't miss the content iframe.
-    const nonMainFrames = allFrames.filter(f => f !== main);
-    const frames = [...webviewFrames, ...nonMainFrames.filter(f => !webviewFrames.includes(f))];
-    for (const frame of frames) {
-      try {
-        if (await matcher(frame)) {
-          return frame;
-        }
-      } catch {
-        // ignore and continue polling
+    const tryFind = async (): Promise<Frame | undefined> => {
+      const allFrames = page.frames();
+      const main = page.mainFrame();
+      const webviewFrames = allFrames.filter(f => /vscode-webview|vscode-webview\.net/i.test(f.url()));
+      if (webviewFrames.length > 0) {
+        sawWebviews = true;
       }
-    }
-    return undefined;
-  };
+      // VS Code webviews often have nested iframes where the outer frame URL matches
+      // vscode-webview*, but the actual content is hosted in a child frame (sometimes
+      // with an about:blank URL). Prefer webview frames, but still scan all non-main
+      // frames so we don't miss the content iframe.
+      const nonMainFrames = allFrames.filter(f => f !== main);
+      const frames = [...webviewFrames, ...nonMainFrames.filter(f => !webviewFrames.includes(f))];
+      for (const frame of frames) {
+        try {
+          if (await matcher(frame)) {
+            return frame;
+          }
+        } catch {
+          // ignore and continue polling
+        }
+      }
+      return undefined;
+    };
 
-  while (Date.now() < deadline) {
+    while (Date.now() < deadline) {
+      const found = await tryFind();
+      if (found) {
+        return found;
+      }
+      await sleep(250);
+    }
+
+    // One last attempt right after the timeout window, to avoid flaking when the
+    // webview finishes rendering between the final poll and the deadline check.
     const found = await tryFind();
     if (found) {
       return found;
     }
-    await sleep(250);
-  }
 
-  // One last attempt right after the timeout window, to avoid flaking when the
-  // webview finishes rendering between the final poll and the deadline check.
-  const found = await tryFind();
-  if (found) {
-    return found;
-  }
-
-  // Best-effort diagnostics to make CI failures actionable.
-  try {
-    const main = page.mainFrame();
-    const frames = page.frames().filter(f => f !== main);
-    const lines: string[] = [];
-    for (const frame of frames.slice(0, 25)) {
-      const url = frame.url();
-      const shortUrl = url.length > 180 ? `${url.slice(0, 180)}…` : url;
-      const isWebview = /vscode-webview|vscode-webview\.net/i.test(url);
-      const rowCount = await frame.locator('[role="row"]').count().catch(() => -1);
-      const hasRefresh = await frame.locator('text=Refresh').count().catch(() => -1);
-      if (isWebview || rowCount > 0 || hasRefresh > 0) {
-        lines.push(`- url=${shortUrl} webview=${String(isWebview)} rows=${String(rowCount)} refreshText=${String(hasRefresh)}`);
+    // Best-effort diagnostics to make CI failures actionable.
+    try {
+      const main = page.mainFrame();
+      const frames = page.frames().filter(f => f !== main);
+      const lines: string[] = [];
+      for (const frame of frames.slice(0, 25)) {
+        const url = frame.url();
+        const shortUrl = url.length > 180 ? `${url.slice(0, 180)}…` : url;
+        const isWebview = /vscode-webview|vscode-webview\.net/i.test(url);
+        const rowCount = await frame.locator('[role="row"]').count().catch(() => -1);
+        const hasRefresh = await frame.locator('text=Refresh').count().catch(() => -1);
+        if (isWebview || rowCount > 0 || hasRefresh > 0) {
+          lines.push(`- url=${shortUrl} webview=${String(isWebview)} rows=${String(rowCount)} refreshText=${String(hasRefresh)}`);
+        }
+      }
+      if (lines.length) {
+        throw new Error(
+          `${sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.'}\n` +
+            `Frame diagnostics:\n${lines.join('\n')}`
+        );
+      }
+    } catch (e) {
+      if (e instanceof Error) {
+        throw e;
       }
     }
-    if (lines.length) {
-      throw new Error(
-        `${sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.'}\n` +
-          `Frame diagnostics:\n${lines.join('\n')}`
-      );
-    }
-  } catch (e) {
-    if (e instanceof Error) {
-      throw e;
-    }
-  }
-  throw new Error(sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.');
+    throw new Error(sawWebviews ? 'Timed out waiting for matching webview frame.' : 'Timed out waiting for any webview frame.');
+  });
 }


### PR DESCRIPTION
## Summary
This PR reduces repeated startup cost in the Playwright E2E harness so local and targeted runs spend less time recreating the same setup work.

The main issue was that several specs were paying the same costs multiple times: relaunching VS Code inside the same file, reopening the command palette just to wait for a command before reopening it again to execute, and reusing the Salesforce CLI for steps that are much cheaper through the Tooling API once org auth is already known. That made the cold path noisy and slow, and it also made the bottleneck harder to isolate.

The harness now keeps the highest-cost setup shared where possible, isolates the support-extension environment by default, and adds timing hooks so we can see where the remaining startup time still goes.

## What changed
- Added `runCommandWhenAvailable` and migrated the affected specs so the command palette is opened once per command execution path instead of twice.
- Reworked the `debugFlagsPanel` suite to share the scratch org, temp workspace, and VS Code instance at the file level instead of rebuilding them for each test.
- Hardened the VS Code harness so support extensions are copied or installed into the temp `extensionsDir` by default, with local-extension fallback only via `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`.
- Added optional timing instrumentation via `ALV_E2E_TIMING=1` across scratch setup, VS Code launch, command execution, and webview readiness.
- Cached expensive harness lookups in memory, including the resolved `sf` binary, org auth, current user id, debug level id, and recent trace-flag provisioning.
- Moved the seed-log path off repeated `sf apex run` / `sf apex list log` calls and onto lightweight `jsforce` Tooling API calls.
- Changed recent log discovery to match the seeded marker in the `ApexLog` body instead of relying on Salesforce id ordering.
- Kept scratch-org reuse on stable CLI contracts and did not rely on direct reads from Salesforce CLI auth files.

## Verification
- `npm run test:e2e:utils`
  - Passed: 21 tests
- `ALV_E2E_TIMING=1 node scripts/run-playwright-e2e.js test/e2e/specs/openLogViewer.e2e.spec.ts --reporter=line`
  - Passed in `33.0s`
  - Key timings from the run: `scratch.ensure: 5580ms`, `seed.log: 2002ms`
- `node scripts/run-playwright-e2e.js test/e2e/specs/replayDebugger.e2e.spec.ts --reporter=line`
  - Passed in `50.3s`

## Notes
This PR keeps the validated harness changes only. A temporary experiment that read Salesforce auth directly from `~/.sfdx` was dropped before opening the PR, because that internal filesystem contract is not stable enough for this test harness.
