### PR TITLE
[codex] fix debug flags special-target lookup and telemetry schema resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 ### Bug Fixes
 
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.
+- Debug Flags: resolve special trace-flag targets for `Automated Process` and `Platform Integration` by active Salesforce user type instead of relying on specific user names.
+- Telemetry: make `telemetry.json` resolution resilient to stale extension roots and host working-directory differences so schema-guarded telemetry keeps working across runtime and test environments.
 
 ### Chores
 
@@ -21,6 +23,7 @@
 - Webview: add coverage for platform-specific `Service Worker` cache path resolution and keep activation tests asserting the troubleshooting command stays registered.
 - Telemetry: add contract coverage for schema-declared event names, required `outcome` fields, activation-duration modeling, and wrapper-side filtering of undeclared properties and measurements.
 - Telemetry/E2E: add an explicit `npm run test:e2e:telemetry` path that injects a test-only connection string plus `testRunId` and validates that the current Playwright run reaches the dedicated App Insights resource.
+- Debug Flags: update unit and E2E-helper coverage so special trace-flag targets are discovered by active user type without name-based fallbacks.
 
 ## [0.32.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.30.0...v0.32.0) (2026-03-09)
 

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -24,7 +24,6 @@ const userIdCache = new Map<string, string>();
 const specialTargetIdsCache = new Map<string, string[]>();
 const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
 const AUTOMATED_PROCESS_TARGET_NAME = 'Automated Process';
-const PLATFORM_INTEGRATION_TARGET_NAMES = ['Platform Integration', 'Platform Integration User'] as const;
 const AUTOMATED_PROCESS_USER_TYPE = 'AutomatedProcess';
 const PLATFORM_INTEGRATION_USER_TYPE = 'CloudIntegrationUser';
 
@@ -34,7 +33,6 @@ type QueryResponse<TRecord = any> = {
 
 type SpecialTargetUserQueryRecord = {
   Id?: string;
-  Name?: string;
 };
 
 type TraceFlagQueryRecord = {
@@ -389,44 +387,26 @@ function isTraceFlagActive(startDate: string | undefined, expirationDate: string
   return startMs <= now && now <= expMs;
 }
 
-async function queryUsersByExactNamesAndType(
-  auth: OrgAuth,
-  names: readonly string[],
-  userType: string
-): Promise<Array<{ id: string; name: string }>> {
-  const normalizedNames = names.map(name => String(name || '').trim()).filter(Boolean);
+async function queryActiveUsersByType(auth: OrgAuth, userType: string): Promise<string[]> {
   const normalizedUserType = String(userType || '').trim();
-  if (normalizedNames.length === 0 || !normalizedUserType) {
+  if (!normalizedUserType) {
     return [];
   }
 
-  const escapedNames = normalizedNames.map(name => `'${escapeSoqlLiteral(name)}'`).join(', ');
   const escapedUserType = escapeSoqlLiteral(normalizedUserType);
-  const soql =
-    `SELECT Id, Name FROM User WHERE Name IN (${escapedNames}) AND UserType = '${escapedUserType}' ` +
-    `AND IsActive = true ORDER BY Id LIMIT 200`;
+  const soql = `SELECT Id FROM User WHERE UserType = '${escapedUserType}' AND IsActive = true ORDER BY Id LIMIT 200`;
   const json = await queryStandard<SpecialTargetUserQueryRecord>(auth, soql);
-  const users = (Array.isArray(json.records) ? json.records : [])
-    .map(record => {
-      const id = record?.Id;
-      if (!isSalesforceId(id)) {
-        return undefined;
-      }
-      return {
-        id,
-        name: typeof record?.Name === 'string' ? record.Name : ''
-      };
-    })
-    .filter((value): value is { id: string; name: string } => Boolean(value));
-
   const seen = new Set<string>();
-  return users.filter(user => {
-    if (seen.has(user.id)) {
-      return false;
-    }
-    seen.add(user.id);
-    return true;
-  });
+  return (Array.isArray(json.records) ? json.records : [])
+    .map(record => record?.Id)
+    .filter((id): id is string => isSalesforceId(id))
+    .filter(id => {
+      if (seen.has(id)) {
+        return false;
+      }
+      seen.add(id);
+      return true;
+    });
 }
 
 export async function getCurrentUserId(auth: OrgAuth): Promise<string | undefined> {
@@ -459,12 +439,9 @@ async function getSpecialTraceFlagTargetIds(
     return [...(specialTargetIdsCache.get(cacheKey) || [])];
   }
 
-  const candidateNames =
-    targetType === 'automatedProcess' ? [AUTOMATED_PROCESS_TARGET_NAME] : [...PLATFORM_INTEGRATION_TARGET_NAMES];
   const expectedUserType =
     targetType === 'automatedProcess' ? AUTOMATED_PROCESS_USER_TYPE : PLATFORM_INTEGRATION_USER_TYPE;
-  const users = await queryUsersByExactNamesAndType(auth, candidateNames, expectedUserType);
-  const userIds = users.map(user => user.id);
+  const userIds = await queryActiveUsersByType(auth, expectedUserType);
   specialTargetIdsCache.set(cacheKey, userIds);
   return [...userIds];
 }

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -61,12 +61,26 @@ function getConnectionString(context: vscode.ExtensionContext): string | undefin
   return conn;
 }
 
+function pushUniquePath(paths: string[], value: string | undefined): void {
+  const normalized = String(value || '').trim();
+  if (!normalized) {
+    return;
+  }
+  if (!paths.includes(normalized)) {
+    paths.push(normalized);
+  }
+}
+
 function getTelemetrySchemaPath(context: vscode.ExtensionContext): string {
-  const extensionPath =
-    (context.extension as { extensionPath?: string } | undefined)?.extensionPath ||
-    (context as { extensionPath?: string } | undefined)?.extensionPath ||
-    process.cwd();
-  return path.join(extensionPath, 'telemetry.json');
+  const candidateRoots: string[] = [];
+  pushUniquePath(candidateRoots, (context.extension as { extensionPath?: string } | undefined)?.extensionPath);
+  pushUniquePath(candidateRoots, (context as { extensionPath?: string } | undefined)?.extensionPath);
+  pushUniquePath(candidateRoots, process.cwd());
+  pushUniquePath(candidateRoots, path.resolve(__dirname, '..'));
+  pushUniquePath(candidateRoots, path.resolve(__dirname, '../..'));
+
+  const candidatePaths = candidateRoots.map(root => path.join(root, 'telemetry.json'));
+  return candidatePaths.find(candidate => fs.existsSync(candidate)) || candidatePaths[0] || path.join(process.cwd(), 'telemetry.json');
 }
 
 function loadTelemetryCatalog(context: vscode.ExtensionContext): TelemetryCatalog | undefined {

--- a/src/test/telemetry.test.ts
+++ b/src/test/telemetry.test.ts
@@ -1,7 +1,9 @@
 import assert from 'assert/strict';
+import * as path from 'node:path';
 const proxyquire: any = require('proxyquire').noCallThru().noPreserveCache();
 
 type TelemetryModule = typeof import('../shared/telemetry');
+const REPO_ROOT = path.resolve(__dirname, '../..');
 
 const extensionMode = {
   Production: 1,
@@ -69,7 +71,7 @@ function loadTelemetryModule() {
 function createContext(mode: number) {
   return {
     extension: {
-      extensionPath: process.cwd(),
+      extensionPath: REPO_ROOT,
       packageJSON: { telemetryConnectionString: 'pkg-conn' }
     },
     extensionMode: mode,
@@ -144,6 +146,27 @@ suite('telemetry', () => {
     assert.equal(subscriptions.length, 1);
     subscriptions[0]?.dispose();
     assert.equal(getDisposeCount(), 1);
+    telemetry.disposeTelemetry();
+  });
+
+  test('falls back to a module-relative telemetry schema path when context extensionPath is stale', () => {
+    delete process.env.APPLICATIONINSIGHTS_CONNECTION_STRING;
+    delete process.env.VSCODE_TELEMETRY_CONNECTION_STRING;
+
+    const { telemetry, created, usageEvents } = loadTelemetryModule();
+    const staleRoot = path.join(REPO_ROOT, '.vscode-test', 'stale-host-root');
+
+    telemetry.activateTelemetry({
+      ...createContext(extensionMode.Production),
+      extension: {
+        extensionPath: staleRoot,
+        packageJSON: { telemetryConnectionString: 'pkg-conn' }
+      }
+    });
+    telemetry.safeSendEvent('logs.refresh', { outcome: 'ok' });
+
+    assert.deepEqual(created, ['pkg-conn']);
+    assert.equal(usageEvents.length, 1);
     telemetry.disposeTelemetry();
   });
 

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -94,6 +94,14 @@ function decodeSoql(path: string): string {
   return decodeURIComponent(path.slice(idx + qMarker.length));
 }
 
+function isSpecialTargetUserResolutionQuery(soql: string, userType: string): boolean {
+  return (
+    soql.includes(`FROM User WHERE UserType = '${userType}'`) &&
+    soql.includes('IsActive = true') &&
+    !soql.includes('Name IN (')
+  );
+}
+
 suite('traceflags user management', () => {
   const auth: OrgAuth = {
     accessToken: 'token',
@@ -313,11 +321,7 @@ suite('traceflags user management', () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'AutomatedProcess')) {
           return {
             statusCode: 200,
             body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
@@ -370,25 +374,17 @@ suite('traceflags user management', () => {
     assert.ok(
       calls.some(call => {
         const soql = decodeSoql(call.path);
-        return (
-          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'") &&
-          soql.includes('IsActive = true')
-        );
+        return isSpecialTargetUserResolutionQuery(soql, 'AutomatedProcess');
       }),
-      'expected Automated Process user resolution query with system user type'
+      'expected Automated Process user resolution query by active user type only'
     );
   });
 
-  test('getTraceFlagTargetStatus falls back to Platform Integration User when needed', async () => {
+  test('getTraceFlagTargetStatus resolves Platform Integration by active user type', async () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return {
             statusCode: 200,
             body: { records: [{ Id: '005000000000004AAA' }] }
@@ -414,13 +410,9 @@ suite('traceflags user management', () => {
     assert.ok(
       calls.some(call => {
         const soql = decodeSoql(call.path);
-        return (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        );
+        return isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser');
       }),
-      'expected Platform Integration lookup across accepted names with cloud integration user type'
+      'expected Platform Integration lookup by active user type only'
     );
   });
 
@@ -428,11 +420,7 @@ suite('traceflags user management', () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return {
             statusCode: 200,
             body: {
@@ -480,11 +468,7 @@ suite('traceflags user management', () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return {
             statusCode: 200,
             body: {
@@ -542,11 +526,7 @@ suite('traceflags user management', () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'AutomatedProcess')) {
           return {
             statusCode: 200,
             body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
@@ -602,11 +582,7 @@ suite('traceflags user management', () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return {
             statusCode: 200,
             body: { records: [] }
@@ -1057,11 +1033,7 @@ suite('traceflags user management', () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Automated Process')") &&
-          soql.includes("UserType = 'AutomatedProcess'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'AutomatedProcess')) {
           return {
             statusCode: 200,
             body: { records: [{ Id: '005000000000003AAA' }, { Id: '005000000000004AAA' }] }
@@ -1129,11 +1101,7 @@ suite('traceflags user management', () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'") &&
-          soql.includes('IsActive = true')
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return {
             statusCode: 200,
             body: {
@@ -1167,10 +1135,7 @@ suite('traceflags user management', () => {
     installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {
         const soql = decodeSoql(req.path);
-        if (
-          soql.includes("FROM User WHERE Name IN ('Platform Integration', 'Platform Integration User')") &&
-          soql.includes("UserType = 'CloudIntegrationUser'")
-        ) {
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
           return { statusCode: 200, body: { records: [] } };
         }
       }

--- a/test/e2e/utils/__tests__/tooling.test.ts
+++ b/test/e2e/utils/__tests__/tooling.test.ts
@@ -36,6 +36,14 @@ function responseFrom(spec: MockFetchResponse): Response {
   } as unknown as Response;
 }
 
+function isSpecialTargetUserResolutionQuery(soql: string, userType: string): boolean {
+  return (
+    soql.includes(`FROM User WHERE UserType = '${userType}'`) &&
+    soql.includes('IsActive = true') &&
+    !soql.includes('Name IN (')
+  );
+}
+
 describe('ensureDebugFlagsTestUser', () => {
   const originalFetch = globalThis.fetch;
   const originalUsernameEnv = process.env.SF_E2E_DEBUG_FLAGS_USERNAME;
@@ -597,7 +605,7 @@ describe('ensureDebugFlagsTestUser', () => {
     );
   });
 
-  test('resolves Platform Integration via accepted names and returns all active matches', async () => {
+  test('resolves Platform Integration via active user type and returns all active matches', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -609,10 +617,7 @@ describe('ensureDebugFlagsTestUser', () => {
       const url = String(input);
       const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
 
-      if (
-        soql.includes("Name IN ('Platform Integration', 'Platform Integration User')") &&
-        soql.includes("UserType = 'CloudIntegrationUser'")
-      ) {
+      if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
         return responseFrom({
           status: 200,
           body: { records: [{ Id: '005000000000777AAA', Name: 'Platform Integration User' }] }
@@ -631,7 +636,7 @@ describe('ensureDebugFlagsTestUser', () => {
     });
   });
 
-  test('falls back to the first candidate name when Salesforce omits the special target name', async () => {
+  test('falls back to the special target label when Salesforce omits the user name', async () => {
     const auth: OrgAuth = {
       accessToken: 'token',
       instanceUrl: 'https://example.my.salesforce.com',
@@ -643,10 +648,7 @@ describe('ensureDebugFlagsTestUser', () => {
       const url = String(input);
       const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
 
-      if (
-        soql.includes("Name IN ('Platform Integration', 'Platform Integration User')") &&
-        soql.includes("UserType = 'CloudIntegrationUser'")
-      ) {
+      if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
         return responseFrom({
           status: 200,
           body: { records: [{ Id: '005000000000777AAA' }] }
@@ -676,10 +678,7 @@ describe('ensureDebugFlagsTestUser', () => {
     globalThis.fetch = jest.fn(async (input: RequestInfo | URL) => {
       const url = String(input);
       const soql = decodeURIComponent(url.slice(url.indexOf('?q=') + 3));
-      if (
-        soql.includes("Name IN ('Platform Integration', 'Platform Integration User')") &&
-        soql.includes("UserType = 'CloudIntegrationUser'")
-      ) {
+      if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
         return responseFrom({
           status: 200,
           body: {

--- a/test/e2e/utils/tooling.ts
+++ b/test/e2e/utils/tooling.ts
@@ -43,10 +43,6 @@ export type DebugLevelToolingRecord = {
 const DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION = '63.0';
 const TRACE_FLAG_REMOVAL_TIMEOUT_MS = 30_000;
 const TRACE_FLAG_REMOVAL_POLL_INTERVAL_MS = 1_000;
-const SPECIAL_TRACE_FLAG_TARGET_NAMES: Record<SpecialTraceFlagTargetType, readonly string[]> = {
-  automatedProcess: ['Automated Process'],
-  platformIntegration: ['Platform Integration', 'Platform Integration User']
-};
 const SPECIAL_TRACE_FLAG_TARGET_USER_TYPES: Record<SpecialTraceFlagTargetType, string> = {
   automatedProcess: 'AutomatedProcess',
   platformIntegration: 'CloudIntegrationUser'
@@ -409,20 +405,9 @@ async function findUserByUsername(
   };
 }
 
-async function findUsersByExactNames(
-  auth: OrgAuth,
-  names: readonly string[],
-  userType: string
-): Promise<Array<{ id: string; name: string }>> {
-  const normalizedNames = names.map(name => String(name || '').trim()).filter(Boolean);
-  if (normalizedNames.length === 0) {
-    return [];
-  }
-  const namesEsc = normalizedNames.map(name => `'${escapeSoqlLiteral(name)}'`).join(', ');
+async function findActiveUsersByType(auth: OrgAuth, userType: string): Promise<Array<{ id: string; name: string }>> {
   const userTypeEsc = escapeSoqlLiteral(userType);
-  const soql = encodeURIComponent(
-    `SELECT Id, Name FROM User WHERE Name IN (${namesEsc}) AND UserType = '${userTypeEsc}' AND IsActive = true ORDER BY Id LIMIT 200`
-  );
+  const soql = encodeURIComponent(`SELECT Id, Name FROM User WHERE UserType = '${userTypeEsc}' AND IsActive = true ORDER BY Id LIMIT 200`);
   const response = await requestJson(auth, 'GET', `/services/data/v${auth.apiVersion}/query?q=${soql}`);
   const records = Array.isArray(response?.records) ? response.records : [];
   const seen = new Set<string>();
@@ -430,7 +415,7 @@ async function findUsersByExactNames(
     .filter((record: any) => isSfId(record?.Id))
     .map((record: any) => ({
       id: record.Id,
-      name: typeof record?.Name === 'string' ? record.Name : normalizedNames[0]!
+      name: typeof record?.Name === 'string' ? record.Name : ''
     }))
     .filter(record => {
       if (seen.has(record.id)) {
@@ -661,14 +646,14 @@ export async function resolveSpecialTraceFlagTarget(
   auth: OrgAuth,
   targetType: SpecialTraceFlagTargetType
 ): Promise<ResolvedSpecialTraceFlagTarget | undefined> {
-  const candidateNames = SPECIAL_TRACE_FLAG_TARGET_NAMES[targetType];
+  const label = SPECIAL_TRACE_FLAG_TARGET_LABELS[targetType];
   const userType = SPECIAL_TRACE_FLAG_TARGET_USER_TYPES[targetType];
-  const users = await findUsersByExactNames(auth, candidateNames, userType);
+  const users = await findActiveUsersByType(auth, userType);
   if (users.length > 0) {
     return {
       ids: users.map(user => user.id),
-      label: SPECIAL_TRACE_FLAG_TARGET_LABELS[targetType],
-      matchedNames: users.map(user => user.name)
+      label,
+      matchedNames: users.map(user => user.name || label)
     };
   }
   return undefined;


### PR DESCRIPTION
## Summary
This PR fixes two reliability issues that surfaced while updating the Debug Flags flow.

First, special trace-flag targets for `Automated Process` and `Platform Integration` are now resolved by active Salesforce `UserType` instead of depending on specific `User.Name` values. In practice, orgs can expose those special users with different names or omit the expected name entirely, which made the UI and backend flows brittle even when the underlying target user existed and was active.

Second, telemetry schema loading now resolves `telemetry.json` more defensively across environments. The telemetry wrapper previously trusted the first `extensionPath`/working-directory candidate it received, which worked in the normal extension host but failed in some test and host setups where the path pointed at a stale VS Code install root instead of the repository or packaged extension contents. When that happened, schema loading failed closed and the telemetry suite cascaded into multiple false-negative failures.

## Root Cause
The debug-flags implementation used `Name IN (...) AND UserType = ... AND IsActive = true` when discovering the special targets. That encoded display-name assumptions into backend behavior even though `UserType` plus active state is the real invariant we care about.

The telemetry wrapper used a single derived path for `telemetry.json` and did not verify that the schema file actually existed there before attempting to load it. Under the VS Code unit-test host, `process.cwd()` and some extension-path values can drift away from the repo root, so the loader would read from the wrong place and disable telemetry entirely.

## Fix
For debug flags, the trace-flag service and E2E helper now query special targets only by `UserType` and `IsActive = true`, then aggregate all resolved active matches exactly as before. The UI labels remain unchanged, but name matching no longer influences whether the target is considered available.

For telemetry, the schema loader now walks a small ordered set of candidate roots and uses the first `telemetry.json` that actually exists. The telemetry tests were also updated to pin the repo root explicitly and to cover the stale-extension-path fallback case so the behavior remains stable across shells, hosts, and different working-directory layouts.

## Validation
I validated the change with the focused suites used during development and then with the full unit runner:

- `npm run test:e2e:utils -- --runTestsByPath test/e2e/utils/__tests__/tooling.test.ts`
- `npm run compile-tests`
- `npx mocha out/test/telemetry.test.js out/test/telemetry.contract.test.js --require out/test/mocha.setup.js --ui tdd --timeout 120000 --reporter spec`
- `npm run check-types`
- `npx eslint src/salesforce/traceflags.ts src/shared/telemetry.ts src/test/telemetry.test.ts src/test/traceflags.userFlags.test.ts test/e2e/utils/tooling.ts test/e2e/utils/__tests__/tooling.test.ts`
- `bash scripts/run-tests.sh --scope=unit`
