### PR TITLE
chore(deps): bump tree-sitter-sfapex triage fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16986,7 +16986,7 @@
     },
     "node_modules/tree-sitter-sfapex": {
       "version": "2.4.1",
-      "resolved": "git+ssh://git@github.com/manoelcalixto/tree-sitter-sfapex.git#685c57c5461eb247d019b244f2130e198c7cc706",
+      "resolved": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#685c57c5461eb247d019b244f2130e198c7cc706",
       "integrity": "sha512-oF/tDp4i4RSBAVrWyF4uJ1rmV6HmXHkpGSC6tzKaaxZ+c9O8KXk9MjXQ6WrjgMswGGTDEkXyGx97KP6MiiKkWQ==",
       "hasInstallScript": true,
       "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "cross-spawn": "^7.0.6",
         "lucide-react": "^0.577.0",
         "tailwind-merge": "^3.5.0",
-        "tree-sitter-sfapex": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#1995752cbd77fcbf305251f8597a71a23d7a86e0",
+        "tree-sitter-sfapex": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#685c57c5461eb247d019b244f2130e198c7cc706",
         "vscode-nls": "^5.2.0"
       },
       "devDependencies": {
@@ -16986,7 +16986,8 @@
     },
     "node_modules/tree-sitter-sfapex": {
       "version": "2.4.1",
-      "resolved": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#1995752cbd77fcbf305251f8597a71a23d7a86e0",
+      "resolved": "git+ssh://git@github.com/manoelcalixto/tree-sitter-sfapex.git#685c57c5461eb247d019b244f2130e198c7cc706",
+      "integrity": "sha512-oF/tDp4i4RSBAVrWyF4uJ1rmV6HmXHkpGSC6tzKaaxZ+c9O8KXk9MjXQ6WrjgMswGGTDEkXyGx97KP6MiiKkWQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -528,7 +528,7 @@
     "cross-spawn": "^7.0.6",
     "lucide-react": "^0.577.0",
     "tailwind-merge": "^3.5.0",
-    "tree-sitter-sfapex": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#1995752cbd77fcbf305251f8597a71a23d7a86e0",
+    "tree-sitter-sfapex": "git+https://github.com/manoelcalixto/tree-sitter-sfapex.git#685c57c5461eb247d019b244f2130e198c7cc706",
     "vscode-nls": "^5.2.0"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- bump `tree-sitter-sfapex` from `1995752` to `685c57c`, which includes the merged parser-backed log triage fixes
- refresh the lockfile so the extension consumes the same parser helper version in development and CI
- keep the PR scoped to the dependency update only, on top of current `main`

## Test Plan
- [x] `npm run build`
- [x] `npm run test:unit`
