### PR TITLE
test(ci): ignore false coverage env

### DIFF
--- a/scripts/run-tests-cli.js
+++ b/scripts/run-tests-cli.js
@@ -7,7 +7,7 @@ const { spawn } = require("node:child_process");
 const WEBVIEW_EXCLUDE = "src/webview/**";
 
 function isCoverageEnabled(argv, env) {
-  return argv.includes("--coverage") || (env.ENABLE_COVERAGE && env.ENABLE_COVERAGE !== "0");
+  return argv.includes("--coverage") || /^(1|true)$/i.test(String(env.ENABLE_COVERAGE || ""));
 }
 
 function createRunnerPlan({

--- a/scripts/run-tests-cli.test.js
+++ b/scripts/run-tests-cli.test.js
@@ -63,3 +63,22 @@ test("createRunnerPlan wraps the VS Code host runner with c8 when coverage is en
   ]);
   assert.equal(plan.env.NODE_OPTIONS, "--trace-warnings");
 });
+
+test("createRunnerPlan ignores ENABLE_COVERAGE=false", () => {
+  const repoRoot = path.join("C:", "repo");
+  const execPath = path.join("C:", "Program Files", "nodejs", "node.exe");
+
+  const plan = createRunnerPlan({
+    argv: ["--scope=unit"],
+    env: { ENABLE_COVERAGE: "false" },
+    execPath,
+    repoRoot,
+  });
+
+  assert.equal(plan.command, execPath);
+  assert.deepEqual(plan.args, [
+    path.join(repoRoot, "scripts", "run-tests.js"),
+    "--scope=unit",
+  ]);
+  assert.equal(plan.reportDir, undefined);
+});


### PR DESCRIPTION
## Summary
- add a regression test covering ENABLE_COVERAGE=false in the new run-tests CLI wrapper
- tighten coverage env parsing so only explicit true/1 values opt into c8 wrapping
- keep the patch scoped to the recent test-runner changes from #611

## Verification
- node --test scripts/run-tests-cli.test.js
- npm run test:scripts
- node --test --experimental-test-coverage scripts/run-tests-cli.test.js
