### PR TITLE
feat(log-viewer): add diagnostics sidebar to Open Log View

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+- Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.
 - Debug Flags: resolve special trace-flag targets for `Automated Process` and `Platform Integration` by active Salesforce user type instead of relying on specific user names.
 - Telemetry: make `telemetry.json` resolution resilient to stale extension roots and host working-directory differences so schema-guarded telemetry keeps working across runtime and test environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
 - Open Log View: reset the diagnostics severity filter when opening or refreshing a log so hidden sidebar state does not suppress new results.
 - Open Log View: re-scroll the virtualized log list when switching between diagnostics that collapse onto the same rendered row.
+- Open Log View: keep severity filters honest by showing the empty sidebar state when no diagnostics match the selected filter instead of falling back to the primary summary card.
 - Open Log View: preserve parser `primaryReason` summaries in the diagnostics sidebar even when triage produces no mapped reasons.
 - Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Open Log View: reset the diagnostics severity filter when opening or refreshing a log so hidden sidebar state does not suppress new results.
 - Open Log View: re-scroll the virtualized log list when switching between diagnostics that collapse onto the same rendered row.
 - Open Log View: keep severity filters honest by showing the empty sidebar state when no diagnostics match the selected filter instead of falling back to the primary summary card.
+- Open Log View: preserve parser-reported line numbers in sidebar diagnostics even when the mapping step cannot resolve a rendered row.
 - Open Log View: preserve parser `primaryReason` summaries in the diagnostics sidebar even when triage produces no mapped reasons.
 - Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
 - Open Log View: reset the diagnostics severity filter when opening or refreshing a log so hidden sidebar state does not suppress new results.
+- Open Log View: re-scroll the virtualized log list when switching between diagnostics that collapse onto the same rendered row.
 - Open Log View: preserve parser `primaryReason` summaries in the diagnostics sidebar even when triage produces no mapped reasons.
 - Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
+- Open Log View: reset the diagnostics severity filter when opening or refreshing a log so hidden sidebar state does not suppress new results.
 - Open Log View: preserve parser `primaryReason` summaries in the diagnostics sidebar even when triage produces no mapped reasons.
 - Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
+- Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.
 - Debug Flags: resolve special trace-flag targets for `Automated Process` and `Platform Integration` by active Salesforce user type instead of relying on specific user names.
 - Telemetry: make `telemetry.json` resolution resilient to stale extension roots and host working-directory differences so schema-guarded telemetry keeps working across runtime and test environments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Debug Flags: add special-target facilitators for `Automated Process` and `Platform Integration` directly in the panel, including aggregated status plus apply/remove flows across all matching active `USER_DEBUG` trace-flag targets.
 - Logs: surface a compact triage reason badge beside the existing error badge when the parser provides a primary reason for an error row.
+- Open Log View: add an async diagnostics sidebar with parser-backed triage results, clickable error navigation, and row highlighting that keeps the active diagnostic visible through filters and search.
 - Telemetry: enforce a public telemetry schema via `telemetry.json`, standardize `outcome` handling across events, and fold activation timing into `extension.activate` instead of emitting a separate duration event.
 
 ### Bug Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 ### Bug Fixes
 
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
+- Open Log View: preserve parser `primaryReason` summaries in the diagnostics sidebar even when triage produces no mapped reasons.
 - Open Log View: preserve the rendered bracketed line number in diagnostics when fallback mapping has to jump by physical row position.
 - Webview: add a built-in troubleshooting command for the recurring VS Code webview service-worker failure, including direct guidance to the correct `Service Worker` cache folder for `Code` vs `Code - Insiders`.
 - Debug Flags: resolve special trace-flag targets for `Automated Process` and `Platform Integration` by active Salesforce user type instead of relying on specific user names.

--- a/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
+++ b/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
@@ -1,0 +1,205 @@
+# Open Log View Triage Sidebar Design
+
+## Goal
+
+Expand the `Open Log View` experience so developers can find parser-detected log errors faster by combining:
+
+- a dedicated diagnostics sidebar for parser-backed triage results
+- inline highlighting on affected log rows
+- click-to-navigate behavior from the sidebar into the virtualized log list
+
+The view must still open at the top of the log. Navigation to the first issue only happens after the user explicitly clicks a sidebar item.
+
+## Context
+
+The repository already uses `tree-sitter-sfapex` / `sflog-triage` on the extension side to classify saved logs and produce `LogTriageSummary` data such as `hasErrors`, `primaryReason`, and `reasons[]`. That parser-backed triage currently improves the main logs list, but the `Open Log View` webview still loads only the raw log text and local file metadata. Inside the webview, `parseLogLines()` creates `ParsedLogEntry[]` from the file content for rendering, filtering, and search.
+
+This means the developer can identify that a log is suspicious before opening it, but once the detailed log viewer opens, the parser-backed diagnostics are lost. The current experience forces manual scrolling or searching through long logs even when structured diagnostics already exist.
+
+## Approved UX Decisions
+
+- Use a dedicated diagnostics sidebar in the `Open Log View`.
+- Also highlight affected rows inline in the main log list.
+- The view opens at the top of the log, not at the first diagnostic.
+- Clicking a sidebar item scrolls the list to the related row and marks that diagnostic as active.
+- Existing line-category filters in the view remain available and are not replaced by the diagnostics sidebar.
+
+## Architecture
+
+The detailed log viewer keeps its current split responsibilities:
+
+- The extension host remains responsible for parser-backed triage.
+- The webview remains responsible for loading the raw file and parsing rows for presentation.
+
+The new data flow is:
+
+1. `LogViewerPanel` opens a saved log as it does today.
+2. Before posting `logViewerInit`, the panel also resolves the `LogTriageSummary` for that file.
+3. The `logViewerInit` message sends:
+   - `logUri`
+   - existing file metadata
+   - parser-backed triage payload for the file
+4. The webview fetches the raw log text as it does today and parses it into `ParsedLogEntry[]`.
+5. A lightweight adapter maps `LogTriageSummary.reasons[]` to rendered rows using `diagnostic.line` as the primary key.
+6. The diagnostics sidebar renders from the triage payload.
+7. The log list renders inline markers from the same mapped diagnostics data.
+
+The webview does not run `tree-sitter-sfapex` itself. Parser-backed diagnostics stay on the extension side and are treated as input data for the UI.
+
+## Data Contract Changes
+
+`LogViewerToWebviewMessage` should grow a triage payload on `logViewerInit`. The payload should include:
+
+- `hasErrors`
+- `primaryReason`
+- `reasons[]`
+
+Each diagnostic entry should preserve the existing normalized fields:
+
+- `code`
+- `severity`
+- `summary`
+- `line`
+- `eventType`
+
+The webview should treat the payload as optional. If triage data is missing or empty, the `Open Log View` must still load and behave like the current implementation.
+
+## UI Layout
+
+Below the existing header and filters row, the page should become a two-pane layout:
+
+- Left pane: diagnostics sidebar
+- Right pane: virtualized log entries list
+
+The diagnostics sidebar should include:
+
+- A compact title such as `Diagnostics`
+- Counts for `Errors` and `Warnings`
+- Local sidebar filter chips or tabs for `All`, `Errors`, and `Warnings`
+- A vertically scrollable list of diagnostics ordered by line number when available
+
+Each sidebar item should show:
+
+- `summary`
+- `line` when known
+- `eventType` when useful
+- severity styling
+
+The active sidebar item should have a stronger selected state than the non-active items.
+
+The main log list should keep the current row layout and add:
+
+- a row-level visual highlight for rows referenced by diagnostics
+- a stronger active-state highlight for the row selected through the sidebar
+- a compact diagnostic badge or summary fragment on the row when one or more diagnostics map to it
+
+If multiple diagnostics map to the same row, the row should present the most severe reason first and still preserve the rest in the row metadata for tooltip or secondary rendering.
+
+## Interaction Model
+
+Initial load:
+
+- The log view opens at the top.
+- No diagnostic is auto-selected.
+- The sidebar shows available diagnostics immediately after the init payload arrives.
+- Inline row highlighting appears once rows are parsed and line mappings are resolved.
+
+Sidebar interaction:
+
+- Clicking a sidebar item makes it active.
+- The list scrolls to the mapped row with centered alignment.
+- The matching row receives the active diagnostic highlight.
+
+Filtering:
+
+- Existing `Debug Only`, `Errors`, `SOQL`, and `DML` filters keep their current semantics based on parsed row categories.
+- Sidebar filters apply only to diagnostics shown in the sidebar.
+- Sidebar filtering must not mutate the underlying log rows or replace the main filters.
+
+Search:
+
+- Existing text search remains unchanged.
+- Search highlighting and diagnostic highlighting can coexist on the same row.
+- The active diagnostic state must remain visible even when search matches are present.
+
+## Mapping Rules
+
+The adapter between `LogTriageSummary.reasons[]` and `ParsedLogEntry[]` should be deterministic and conservative.
+
+Primary mapping:
+
+- Use `diagnostic.line` to map a diagnostic to the parsed row whose `lineNumber` matches that value.
+
+Fallback behavior:
+
+- If a diagnostic has no `line`, keep it in the sidebar with a `No exact line` style and do not force a row highlight.
+- If a diagnostic has a line but no parsed row matches it, keep the sidebar item available and treat it as unmapped instead of guessing aggressively.
+
+The first implementation should not attempt fuzzy full-text matching or parser re-analysis inside the browser. Planning can add a narrow fallback later if implementation reveals a recurring mismatch pattern, but the approved design assumes exact line matching only.
+
+## Failure and Degradation Behavior
+
+The diagnostics experience is additive. It must never block the log viewer.
+
+- If parser-backed triage is unavailable, the log opens normally and the sidebar shows a simple unavailable state.
+- If diagnostics exist but some rows cannot be mapped, mapped rows still highlight correctly and unmapped diagnostics remain visible in the sidebar.
+- If the file refreshes and previous mappings become stale, the UI should clear invalid active-row state rather than crashing or pointing to the wrong row.
+- The raw log content always remains readable even when diagnostics data is incomplete.
+
+## Testing Strategy
+
+Implementation planning should cover at least these test areas.
+
+Extension-side messaging:
+
+- `LogViewerPanel` sends triage data together with `logUri` and metadata.
+- Missing triage data still produces a valid `logViewerInit` payload.
+
+Webview app state:
+
+- The diagnostics sidebar renders from init payload data.
+- Sidebar severity filters switch between `All`, `Errors`, and `Warnings`.
+- Clicking a sidebar diagnostic activates it and requests scroll to the mapped row.
+- The app remains stable when diagnostics are absent.
+
+Mapping logic:
+
+- A diagnostic with a valid line maps to the expected parsed row.
+- Diagnostics without `line` remain sidebar-only.
+- Multiple diagnostics on one row collapse to one row decoration while preserving individual sidebar entries.
+
+Row rendering:
+
+- Diagnostic badges render on affected rows.
+- Active diagnostic styling is stronger than passive highlighted styling.
+- Search highlighting remains visible without masking active diagnostic state.
+
+## Scope Boundaries
+
+In scope:
+
+- passing parser-backed diagnostics into `Open Log View`
+- dedicated diagnostics sidebar
+- inline row highlighting and active selection state
+- click-to-scroll navigation from sidebar to list
+- tests for message flow, mapping, and UI rendering
+
+Out of scope for this design:
+
+- automatically opening the log at the first error
+- running `tree-sitter-sfapex` inside the webview
+- replacing existing row-category filters with diagnostics-only controls
+- adding fuzzy diagnosis-to-row matching heuristics
+- redesigning the entire log viewer layout beyond what is needed for the sidebar
+
+## Risks
+
+- Some diagnostics may not include a line that matches the row parser output exactly.
+- A two-pane layout may reduce readable width for long messages if the sidebar is too wide.
+- Active diagnostic styling can conflict visually with search highlighting if not layered carefully.
+
+## Mitigations
+
+- Treat unmapped diagnostics as valid sidebar items instead of forcing unreliable row guesses.
+- Keep the sidebar compact and fixed-width so the log list remains the primary reading surface.
+- Use separate visual treatments for passive diagnostic rows, active diagnostic rows, and search matches.

--- a/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
+++ b/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
@@ -62,6 +62,8 @@ Each diagnostic entry should preserve the existing normalized fields:
 - `line`
 - `eventType`
 
+`severity` is constrained to the existing normalized enum used by shared triage types: `error | warning`. Unknown severities should already be filtered out by extension-side normalization and must not reach the webview contract.
+
 The webview should treat the payload as optional. If triage data is missing or empty, the `Open Log View` must still load and behave like the current implementation.
 
 ## UI Layout
@@ -85,6 +87,11 @@ Each sidebar item should show:
 - `eventType` when useful
 - severity styling
 
+Sidebar counts and filters are based on the two normalized severity buckets only:
+
+- `Errors` = diagnostics with `severity: "error"`
+- `Warnings` = diagnostics with `severity: "warning"`
+
 The active sidebar item should have a stronger selected state than the non-active items.
 
 The main log list should keep the current row layout and add:
@@ -94,6 +101,13 @@ The main log list should keep the current row layout and add:
 - a compact diagnostic badge or summary fragment on the row when one or more diagnostics map to it
 
 If multiple diagnostics map to the same row, the row should present the most severe reason first and still preserve the rest in the row metadata for tooltip or secondary rendering.
+
+Row-level collapse order must be deterministic:
+
+- sort mapped diagnostics for the row by severity, with `error` before `warning`
+- preserve original `reasons[]` order for ties within the same severity
+- show the first sorted diagnostic as the primary row badge or summary
+- keep the remaining diagnostics available as secondary row metadata for tooltip or expanded rendering
 
 ## Interaction Model
 
@@ -107,8 +121,9 @@ Initial load:
 Sidebar interaction:
 
 - Clicking a sidebar item makes it active.
-- The list scrolls to the mapped row with centered alignment.
-- The matching row receives the active diagnostic highlight.
+- If the item is mapped, the list scrolls to the mapped row with centered alignment.
+- If the item is unmapped, the sidebar item still becomes active but the list does not scroll and no toast is shown.
+- The matching row receives the active diagnostic highlight only for mapped items.
 
 Filtering:
 
@@ -128,7 +143,9 @@ The adapter between `LogTriageSummary.reasons[]` and `ParsedLogEntry[]` should b
 
 Primary mapping:
 
-- Use `diagnostic.line` to map a diagnostic to the parsed row whose `lineNumber` matches that value.
+- Treat `diagnostic.line` as a 1-based log line number.
+- Use `diagnostic.line` to map a diagnostic to the parsed row whose `lineNumber` matches that same 1-based value exactly.
+- Do not translate `diagnostic.line` to a zero-based row index.
 
 Fallback behavior:
 
@@ -166,7 +183,9 @@ Mapping logic:
 
 - A diagnostic with a valid line maps to the expected parsed row.
 - Diagnostics without `line` remain sidebar-only.
+- Clicking an unmapped sidebar item activates it without attempting row scroll.
 - Multiple diagnostics on one row collapse to one row decoration while preserving individual sidebar entries.
+- Row-level collapse order is deterministic: `error` before `warning`, then original diagnostic order for ties.
 
 Row rendering:
 

--- a/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
+++ b/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
@@ -34,25 +34,33 @@ The detailed log viewer keeps its current split responsibilities:
 The new data flow is:
 
 1. `LogViewerPanel` opens a saved log as it does today.
-2. Before posting `logViewerInit`, the panel also resolves the `LogTriageSummary` for that file.
+2. `LogViewerPanel` posts `logViewerInit` immediately with the base payload needed to render the view.
 3. The `logViewerInit` message sends:
    - `logUri`
    - existing file metadata
-   - parser-backed triage payload for the file
-4. The webview fetches the raw log text as it does today and parses it into `ParsedLogEntry[]`.
-5. A lightweight adapter maps `LogTriageSummary.reasons[]` to rendered rows using `diagnostic.line` as the primary key.
-6. The diagnostics sidebar renders from the triage payload.
-7. The log list renders inline markers from the same mapped diagnostics data.
+   - optional `triage` when it is already available cheaply
+4. `LogViewerPanel` resolves parser-backed triage asynchronously after the view is already opening.
+5. When triage becomes available, the extension posts a follow-up `logViewerTriageUpdate` message carrying the normalized triage payload for the same log.
+6. The webview fetches the raw log text as it does today and parses it into `ParsedLogEntry[]`.
+7. A lightweight adapter maps `LogTriageSummary.reasons[]` to rendered rows using `diagnostic.line` as the primary key.
+8. The diagnostics sidebar renders from the latest triage payload available.
+9. The log list renders inline markers from the same mapped diagnostics data.
 
 The webview does not run `tree-sitter-sfapex` itself. Parser-backed diagnostics stay on the extension side and are treated as input data for the UI.
 
 ## Data Contract Changes
 
-`LogViewerToWebviewMessage` should grow a triage payload on `logViewerInit`. The payload should include:
+`LogViewerToWebviewMessage` should grow a triage payload on `logViewerInit` and add a follow-up update message. The payload should include:
 
 - `triage?: { hasErrors: boolean; primaryReason?: string; reasons: LogDiagnostic[] }`
 
 `logViewerInit` keeps its existing top-level fields and adds a new optional `triage` object rather than spreading triage fields across the top level. This keeps the message backward-compatible for callers and tests that already depend on the current payload shape.
+
+Add a second optional message for async delivery:
+
+- `logViewerTriageUpdate: { logId: string; triage?: { hasErrors: boolean; primaryReason?: string; reasons: LogDiagnostic[] } }`
+
+`triage` should be omitted, not `null`, when triage is unavailable or not yet resolved.
 
 Each diagnostic entry should preserve the existing normalized fields:
 
@@ -61,6 +69,8 @@ Each diagnostic entry should preserve the existing normalized fields:
 - `summary`
 - `line`
 - `eventType`
+
+`line` remains optional on each `LogDiagnostic`.
 
 `severity` is constrained to the existing normalized enum used by shared triage types: `error | warning`. Unknown severities should already be filtered out by extension-side normalization and must not reach the webview contract.
 
@@ -121,7 +131,7 @@ Initial load:
 
 - The log view opens at the top.
 - No diagnostic is auto-selected.
-- The sidebar shows available diagnostics immediately after the init payload arrives.
+- The sidebar can render in a loading, empty, or ready state depending on whether triage has arrived yet.
 - Inline row highlighting appears once rows are parsed and line mappings are resolved.
 
 Sidebar interaction:
@@ -144,6 +154,7 @@ Search:
 - Existing text search remains unchanged.
 - Search highlighting and diagnostic highlighting can coexist on the same row.
 - The active diagnostic state must remain visible even when search matches are present.
+- If the active mapped row would otherwise be hidden by category filters or text search, that one active row remains temporarily visible until the active diagnostic selection is cleared or changed.
 
 ## Mapping Rules
 
@@ -167,6 +178,7 @@ The first implementation should not attempt fuzzy full-text matching or parser r
 The diagnostics experience is additive. It must never block the log viewer.
 
 - If parser-backed triage is unavailable, the log opens normally and the sidebar shows a simple unavailable state.
+- If parser-backed triage is slow, the log still opens immediately and the sidebar can remain in a loading state until `logViewerTriageUpdate` arrives or the load is abandoned.
 - If diagnostics exist but some rows cannot be mapped, mapped rows still highlight correctly and unmapped diagnostics remain visible in the sidebar.
 - If the file refreshes and previous mappings become stale, the UI should clear invalid active-row state rather than crashing or pointing to the wrong row.
 - The raw log content always remains readable even when diagnostics data is incomplete.

--- a/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
+++ b/docs/superpowers/specs/2026-03-18-open-log-view-triage-sidebar-design.md
@@ -50,9 +50,9 @@ The webview does not run `tree-sitter-sfapex` itself. Parser-backed diagnostics 
 
 `LogViewerToWebviewMessage` should grow a triage payload on `logViewerInit`. The payload should include:
 
-- `hasErrors`
-- `primaryReason`
-- `reasons[]`
+- `triage?: { hasErrors: boolean; primaryReason?: string; reasons: LogDiagnostic[] }`
+
+`logViewerInit` keeps its existing top-level fields and adds a new optional `triage` object rather than spreading triage fields across the top level. This keeps the message backward-compatible for callers and tests that already depend on the current payload shape.
 
 Each diagnostic entry should preserve the existing normalized fields:
 
@@ -92,6 +92,12 @@ Sidebar counts and filters are based on the two normalized severity buckets only
 - `Errors` = diagnostics with `severity: "error"`
 - `Warnings` = diagnostics with `severity: "warning"`
 
+Sidebar ordering must be deterministic:
+
+- diagnostics with `line` are sorted first by ascending line number
+- diagnostics without `line` are listed after the mapped diagnostics
+- diagnostics without `line` preserve their original `reasons[]` order
+
 The active sidebar item should have a stronger selected state than the non-active items.
 
 The main log list should keep the current row layout and add:
@@ -124,12 +130,14 @@ Sidebar interaction:
 - If the item is mapped, the list scrolls to the mapped row with centered alignment.
 - If the item is unmapped, the sidebar item still becomes active but the list does not scroll and no toast is shown.
 - The matching row receives the active diagnostic highlight only for mapped items.
+- If the mapped row is currently hidden by the active row-category filter, the active diagnostic selection temporarily forces that one mapped row into the rendered list without changing the visible filter state.
 
 Filtering:
 
 - Existing `Debug Only`, `Errors`, `SOQL`, and `DML` filters keep their current semantics based on parsed row categories.
 - Sidebar filters apply only to diagnostics shown in the sidebar.
 - Sidebar filtering must not mutate the underlying log rows or replace the main filters.
+- Diagnostic selection can temporarily override row visibility for the active mapped row only; it does not rewrite the current category filter selection.
 
 Search:
 

--- a/src/panel/LogViewerPanel.ts
+++ b/src/panel/LogViewerPanel.ts
@@ -210,6 +210,13 @@ export class LogViewerPanel {
   }
 
   private async loadTriage(requestId: number): Promise<void> {
+    const postUnavailableMessage = (): void => {
+      void this.panel.webview.postMessage({
+        type: 'logViewerTriageUpdate',
+        logId: this.logId
+      } as LogViewerToWebviewMessage);
+    };
+
     try {
       const triage = await summarizeLogFile(this.filePath);
       if (!this.shouldPublishTriage(requestId)) {
@@ -218,6 +225,7 @@ export class LogViewerPanel {
 
       const normalizedTriage = this.normalizeTriage(triage);
       if (!normalizedTriage) {
+        postUnavailableMessage();
         return;
       }
 
@@ -229,6 +237,10 @@ export class LogViewerPanel {
       void this.panel.webview.postMessage(message);
     } catch (err) {
       logWarn('LogViewerPanel: summarizeLogFile failed ->', getErrorMessage(err));
+      if (!this.shouldPublishTriage(requestId)) {
+        return;
+      }
+      postUnavailableMessage();
     } finally {
       if (this.triageRequest === requestId) {
         this.triageRequested = false;

--- a/src/panel/LogViewerPanel.ts
+++ b/src/panel/LogViewerPanel.ts
@@ -195,13 +195,17 @@ export class LogViewerPanel {
     void this.panel.webview.postMessage(message);
   }
 
-  private requestTriageUpdate(): void {
-    if (this.triageRequested || !this.ready || this.disposed) {
+  private requestTriageUpdate(force = false): void {
+    if (!this.ready || this.disposed) {
       return;
     }
 
-    this.triageRequested = true;
+    if (this.triageRequested && !force) {
+      return;
+    }
+
     const requestId = ++this.triageRequest;
+    this.triageRequested = true;
     void this.loadTriage(requestId);
   }
 
@@ -225,6 +229,10 @@ export class LogViewerPanel {
       void this.panel.webview.postMessage(message);
     } catch (err) {
       logWarn('LogViewerPanel: summarizeLogFile failed ->', getErrorMessage(err));
+    } finally {
+      if (this.triageRequest === requestId) {
+        this.triageRequested = false;
+      }
     }
   }
 
@@ -261,6 +269,7 @@ export class LogViewerPanel {
     this.cacheBust = Date.now();
     if (this.ready) {
       this.postInit();
+      this.requestTriageUpdate(true);
     }
   }
 

--- a/src/panel/LogViewerPanel.ts
+++ b/src/panel/LogViewerPanel.ts
@@ -4,7 +4,13 @@ import * as path from 'path';
 import { buildWebviewHtml } from '../utils/webviewHtml';
 import { logInfo, logWarn } from '../utils/logger';
 import { getErrorMessage } from '../utils/error';
-import type { LogViewerFromWebviewMessage, LogViewerToWebviewMessage } from '../shared/logViewerMessages';
+import { summarizeLogFile } from '../services/logTriage';
+import { normalizeLogTriageSummary, type LogDiagnostic } from '../shared/logTriage';
+import type {
+  LogViewerFromWebviewMessage,
+  LogViewerToWebviewMessage,
+  LogViewerTriagePayload
+} from '../shared/logViewerMessages';
 
 interface ShowOptions {
   logId: string;
@@ -82,6 +88,8 @@ export class LogViewerPanel {
   private ready = false;
   private disposed = false;
   private cacheBust = Date.now();
+  private triageRequest = 0;
+  private triageRequested = false;
 
   private constructor(
     extensionUri: vscode.Uri,
@@ -136,6 +144,7 @@ export class LogViewerPanel {
       case 'logViewerReady':
         this.ready = true;
         this.postInit();
+        this.requestTriageUpdate();
         break;
       case 'logViewerViewRaw':
         await this.viewRaw();
@@ -184,6 +193,67 @@ export class LogViewerPanel {
         : undefined
     };
     void this.panel.webview.postMessage(message);
+  }
+
+  private requestTriageUpdate(): void {
+    if (this.triageRequested || !this.ready || this.disposed) {
+      return;
+    }
+
+    this.triageRequested = true;
+    const requestId = ++this.triageRequest;
+    void this.loadTriage(requestId);
+  }
+
+  private async loadTriage(requestId: number): Promise<void> {
+    try {
+      const triage = await summarizeLogFile(this.filePath);
+      if (!this.shouldPublishTriage(requestId)) {
+        return;
+      }
+
+      const normalizedTriage = this.normalizeTriage(triage);
+      if (!normalizedTriage) {
+        return;
+      }
+
+      const message: LogViewerToWebviewMessage = {
+        type: 'logViewerTriageUpdate',
+        logId: this.logId,
+        triage: normalizedTriage
+      };
+      void this.panel.webview.postMessage(message);
+    } catch (err) {
+      logWarn('LogViewerPanel: summarizeLogFile failed ->', getErrorMessage(err));
+    }
+  }
+
+  private shouldPublishTriage(requestId: number): boolean {
+    return !this.disposed && this.ready && this.triageRequest === requestId && LogViewerPanel.panels.get(this.filePath) === this;
+  }
+
+  private normalizeTriage(rawTriage: unknown): LogViewerTriagePayload | undefined {
+    if (!rawTriage || typeof rawTriage !== 'object') {
+      return undefined;
+    }
+
+    const summary = normalizeLogTriageSummary(rawTriage);
+    const reasons = summary.reasons.map(reason => {
+      const typed = reason as Pick<LogDiagnostic, 'code' | 'severity' | 'summary' | 'line' | 'eventType'>;
+      return {
+        code: typed.code,
+        severity: typed.severity,
+        summary: typed.summary,
+        ...(typed.line !== undefined ? { line: typed.line } : {}),
+        ...(typed.eventType !== undefined ? { eventType: typed.eventType } : {})
+      };
+    });
+
+    return {
+      hasErrors: summary.hasErrors,
+      primaryReason: summary.primaryReason,
+      reasons
+    };
   }
 
   private update(stats: Stats | undefined): void {

--- a/src/shared/logViewerMessages.ts
+++ b/src/shared/logViewerMessages.ts
@@ -1,4 +1,11 @@
 import type * as vscode from 'vscode';
+import type { LogDiagnostic } from './logTriage';
+
+export type LogViewerTriagePayload = {
+  hasErrors: boolean;
+  primaryReason?: string;
+  reasons: LogDiagnostic[];
+};
 
 export type LogViewerToWebviewMessage =
   | {
@@ -12,7 +19,9 @@ export type LogViewerToWebviewMessage =
         sizeBytes?: number;
         modifiedAt?: string;
       };
+      triage?: LogViewerTriagePayload;
     }
+  | { type: 'logViewerTriageUpdate'; logId: string; triage?: LogViewerTriagePayload }
   | { type: 'logViewerError'; message: string };
 
 export type LogViewerFromWebviewMessage =

--- a/src/test/logViewerPanel.test.ts
+++ b/src/test/logViewerPanel.test.ts
@@ -1,0 +1,242 @@
+import assert from 'assert/strict';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+import * as vscode from 'vscode';
+import type { LogViewerToWebviewMessage } from '../shared/logViewerMessages';
+
+type InitMessage = Extract<LogViewerToWebviewMessage, { type: 'logViewerInit' }>;
+type TriageUpdateMessage = Extract<LogViewerToWebviewMessage, { type: 'logViewerTriageUpdate' }>;
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+class MockDisposable implements vscode.Disposable {
+  dispose(): void {
+    /* noop */
+  }
+}
+
+class MockWebview implements vscode.Webview {
+  html = '';
+  options: vscode.WebviewOptions = {};
+  cspSource = 'vscode-resource://test';
+  private messageListener: ((message: any) => void) | undefined;
+  postedMessages: LogViewerToWebviewMessage[] = [];
+
+  asWebviewUri(uri: vscode.Uri): vscode.Uri {
+    return uri;
+  }
+
+  postMessage(message: unknown): Thenable<boolean> {
+    this.postedMessages.push(message as LogViewerToWebviewMessage);
+    return Promise.resolve(true);
+  }
+
+  onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+    this.messageListener = listener;
+    return new MockDisposable();
+  }
+
+  emitMessage(message: unknown): void {
+    this.messageListener?.(message);
+  }
+}
+
+class MockWebviewPanel implements vscode.WebviewPanel {
+  readonly active = true;
+  readonly visible = true;
+  readonly options: vscode.WebviewPanelOptions = {};
+  public viewType: string;
+  public title = 'Apex Log Viewer';
+  public viewColumn: vscode.ViewColumn = vscode.ViewColumn.Active;
+  public webview: MockWebview;
+  private onDispose: (() => void) | undefined;
+  private onChangeViewState:
+    | ((e: vscode.WebviewPanelOnDidChangeViewStateEvent) => void)
+    | undefined;
+
+  constructor(viewType: string, webview: MockWebview) {
+    this.viewType = viewType;
+    this.webview = webview;
+  }
+
+  onDidDispose(_listener: () => void, _thisArg?: unknown, _disposables?: unknown): vscode.Disposable {
+    this.onDispose = _listener;
+    return new MockDisposable();
+  }
+
+  onDidChangeViewState(
+    listener: (e: vscode.WebviewPanelOnDidChangeViewStateEvent) => void,
+    _thisArg?: unknown,
+    _disposables?: unknown
+  ): vscode.Disposable {
+    this.onChangeViewState = listener;
+    return new MockDisposable();
+  }
+
+  reveal(_viewColumn?: vscode.ViewColumn, _preserveFocus?: boolean): void {
+    this.onChangeViewState?.({ webviewPanel: this });
+  }
+
+  dispose(): void {
+    this.onDispose?.();
+  }
+}
+
+function createDeferred<T>() {
+  let resolve: (value: T) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function createPanelHarness(stubs: { summarizeLogFile: () => Promise<unknown> }) {
+  const webview = new MockWebview();
+  const panel = new MockWebviewPanel('sfLogViewer.logPanel', webview);
+  const ExtensionContext = {
+    extensionUri: vscode.Uri.file(process.cwd()),
+    subscriptions: [] as vscode.Disposable[]
+  } as vscode.ExtensionContext;
+
+  const vscodeMock = {
+    ...vscode,
+    Uri: vscode.Uri,
+    window: {
+      activeTextEditor: undefined,
+      createWebviewPanel: () => panel
+    },
+    workspace: {
+      openTextDocument: async () => ({})
+    },
+    env: {
+      language: 'en-US'
+    }
+  };
+
+  const { LogViewerPanel } = proxyquireStrict('../panel/LogViewerPanel', {
+    vscode: vscodeMock,
+    '../services/logTriage': {
+      summarizeLogFile: stubs.summarizeLogFile
+    },
+    '../utils/webviewHtml': { buildWebviewHtml: () => '<html />' },
+    '../utils/logger': {
+      logInfo: () => undefined,
+      logWarn: () => undefined,
+      logError: () => undefined,
+      showOutput: () => undefined,
+      setTraceEnabled: () => undefined,
+      disposeLogger: () => undefined
+    }
+  });
+  (LogViewerPanel as any).initialize(ExtensionContext);
+
+  return { LogViewerPanel, panel, webview, context: ExtensionContext };
+}
+
+async function createLogFile(): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'logViewerPanel-'));
+  const filePath = path.join(dir, 'sample.log');
+  await fs.writeFile(filePath, 'INFO start');
+  return {
+    filePath,
+    cleanup: () => fs.rm(dir, { recursive: true, force: true })
+  };
+}
+
+suite('LogViewerPanel', () => {
+  test('posts logViewerInit immediately after logViewerReady with no triage payload', async () => {
+    const summary = createDeferred<unknown>();
+    const { LogViewerPanel, webview } = createPanelHarness({
+      summarizeLogFile: () => summary.promise
+    });
+    const { filePath, cleanup } = await createLogFile();
+
+    try {
+      await LogViewerPanel.show({ logId: 'LOG-001', filePath });
+      webview.emitMessage({ type: 'logViewerReady' });
+
+      assert.equal(webview.postedMessages.length, 1, 'expected exactly one message from initial init');
+      const initMessage = webview.postedMessages[0] as InitMessage;
+      assert.equal(initMessage.type, 'logViewerInit');
+      assert.equal(initMessage.logId, 'LOG-001');
+      assert.equal(initMessage.fileName, 'sample.log');
+      assert.equal(initMessage.locale, 'en-US');
+      assert.ok(!('triage' in initMessage), 'triage should remain optional on logViewerInit');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('posts logViewerTriageUpdate after async summarizeLogFile resolves', async () => {
+    const summary = createDeferred<unknown>();
+    const { LogViewerPanel, webview } = createPanelHarness({
+      summarizeLogFile: () => summary.promise
+    });
+    const { filePath, cleanup } = await createLogFile();
+
+    try {
+      await LogViewerPanel.show({ logId: 'LOG-002', filePath });
+      webview.emitMessage({ type: 'logViewerReady' });
+
+      summary.resolve({
+        hasErrors: true,
+        primaryReason: 'Fatal exception',
+        reasons: [
+          {
+            code: 'fatal_exception',
+            severity: 'error',
+            summary: 'Fatal exception',
+            line: 2,
+            eventType: 'EXCEPTION_THROWN'
+          },
+          {
+            code: 'invalid_code',
+            severity: 'other',
+            summary: 'Invalid entry should be removed by normalization',
+            line: 3
+          } as unknown
+        ]
+      } as unknown);
+
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      const updateMessage = webview.postedMessages.find(
+        (msg): msg is TriageUpdateMessage => msg.type === 'logViewerTriageUpdate'
+      );
+      assert.ok(updateMessage);
+      assert.equal(updateMessage.logId, 'LOG-002');
+      assert.equal(updateMessage.triage?.hasErrors, true);
+      assert.equal(updateMessage.triage?.primaryReason, 'Fatal exception');
+      assert.equal(updateMessage.triage?.reasons.length, 1, 'invalid reasons should be normalized away');
+    } finally {
+      await cleanup();
+    }
+  });
+
+  test('still posts initial init payload when triage is unavailable or slow', async () => {
+    const { LogViewerPanel, webview } = createPanelHarness({
+      summarizeLogFile: () => Promise.reject(new Error('triage unavailable'))
+    });
+    const { filePath, cleanup } = await createLogFile();
+
+    try {
+      await LogViewerPanel.show({ logId: 'LOG-003', filePath });
+      webview.emitMessage({ type: 'logViewerReady' });
+
+      assert.equal(webview.postedMessages.length >= 1, true);
+      const initMessage = webview.postedMessages[0] as InitMessage;
+      assert.equal(initMessage.type, 'logViewerInit');
+      assert.equal(initMessage.logId, 'LOG-003');
+      assert.ok(!('triage' in initMessage), 'triage should be optional until async resolution');
+
+      await new Promise(resolve => setTimeout(resolve, 10));
+      assert.ok(!webview.postedMessages.some(msg => msg.type === 'logViewerTriageUpdate'), 'triage updates should not block initial payload');
+    } finally {
+      await cleanup();
+    }
+  });
+});

--- a/src/test/logViewerPanel.test.ts
+++ b/src/test/logViewerPanel.test.ts
@@ -137,6 +137,10 @@ function createPanelHarness(stubs: { summarizeLogFile: () => Promise<unknown> })
   return { LogViewerPanel, panel, webview, context: ExtensionContext };
 }
 
+function nextTick(): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, 0));
+}
+
 async function createLogFile(): Promise<{ filePath: string; cleanup: () => Promise<void> }> {
   const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'logViewerPanel-'));
   const filePath = path.join(dir, 'sample.log');
@@ -150,7 +154,7 @@ async function createLogFile(): Promise<{ filePath: string; cleanup: () => Promi
 suite('LogViewerPanel', () => {
   test('posts logViewerInit immediately after logViewerReady with no triage payload', async () => {
     const summary = createDeferred<unknown>();
-    const { LogViewerPanel, webview } = createPanelHarness({
+    const { LogViewerPanel, panel, webview } = createPanelHarness({
       summarizeLogFile: () => summary.promise
     });
     const { filePath, cleanup } = await createLogFile();
@@ -167,13 +171,14 @@ suite('LogViewerPanel', () => {
       assert.equal(initMessage.locale, 'en-US');
       assert.ok(!('triage' in initMessage), 'triage should remain optional on logViewerInit');
     } finally {
+      panel.dispose();
       await cleanup();
     }
   });
 
   test('posts logViewerTriageUpdate after async summarizeLogFile resolves', async () => {
     const summary = createDeferred<unknown>();
-    const { LogViewerPanel, webview } = createPanelHarness({
+    const { LogViewerPanel, panel, webview } = createPanelHarness({
       summarizeLogFile: () => summary.promise
     });
     const { filePath, cleanup } = await createLogFile();
@@ -203,6 +208,7 @@ suite('LogViewerPanel', () => {
       } as unknown);
 
       await new Promise(resolve => setTimeout(resolve, 0));
+      await nextTick();
 
       const updateMessage = webview.postedMessages.find(
         (msg): msg is TriageUpdateMessage => msg.type === 'logViewerTriageUpdate'
@@ -213,12 +219,73 @@ suite('LogViewerPanel', () => {
       assert.equal(updateMessage.triage?.primaryReason, 'Fatal exception');
       assert.equal(updateMessage.triage?.reasons.length, 1, 'invalid reasons should be normalized away');
     } finally {
+      panel.dispose();
+      await cleanup();
+    }
+  });
+
+  test('recomputes triage when refreshing an existing panel', async () => {
+    const firstSummary = createDeferred<unknown>();
+    const secondSummary = createDeferred<unknown>();
+    const summarizeQueue: Array<() => Promise<unknown>> = [
+      () => firstSummary.promise,
+      () => secondSummary.promise
+    ];
+    const { LogViewerPanel, panel, webview } = createPanelHarness({
+      summarizeLogFile: () => summarizeQueue.shift()!()
+    });
+    const { filePath, cleanup } = await createLogFile();
+
+    try {
+      await LogViewerPanel.show({ logId: 'LOG-004', filePath });
+      webview.emitMessage({ type: 'logViewerReady' });
+
+      firstSummary.resolve({
+        hasErrors: true,
+        primaryReason: 'Initial issue',
+        reasons: [
+          {
+            code: 'initial',
+            severity: 'error',
+            summary: 'Initial issue'
+          }
+        ]
+      });
+
+      await nextTick();
+
+      const firstUpdateMessages = webview.postedMessages.filter(
+        (msg): msg is TriageUpdateMessage => msg.type === 'logViewerTriageUpdate'
+      );
+      assert.equal(firstUpdateMessages.length, 1);
+
+      await LogViewerPanel.show({ logId: 'LOG-004', filePath });
+      assert.equal(webview.postedMessages[0]?.type, 'logViewerInit', 'existing panel should still send init payloads');
+
+      secondSummary.resolve({
+        hasErrors: false,
+        primaryReason: undefined,
+        reasons: []
+      });
+
+      await nextTick();
+
+      const updateMessages = webview.postedMessages.filter(
+        (msg): msg is TriageUpdateMessage => msg.type === 'logViewerTriageUpdate'
+      );
+      assert.equal(updateMessages.length, 2);
+      const refreshTriageUpdate = updateMessages[1];
+      assert.ok(refreshTriageUpdate);
+      assert.equal(refreshTriageUpdate.triage?.hasErrors, false);
+      assert.equal(refreshTriageUpdate.triage?.primaryReason, undefined);
+    } finally {
+      panel.dispose();
       await cleanup();
     }
   });
 
   test('still posts initial init payload when triage is unavailable or slow', async () => {
-    const { LogViewerPanel, webview } = createPanelHarness({
+    const { LogViewerPanel, panel, webview } = createPanelHarness({
       summarizeLogFile: () => Promise.reject(new Error('triage unavailable'))
     });
     const { filePath, cleanup } = await createLogFile();
@@ -234,8 +301,40 @@ suite('LogViewerPanel', () => {
       assert.ok(!('triage' in initMessage), 'triage should be optional until async resolution');
 
       await new Promise(resolve => setTimeout(resolve, 10));
+      await nextTick();
       assert.ok(!webview.postedMessages.some(msg => msg.type === 'logViewerTriageUpdate'), 'triage updates should not block initial payload');
     } finally {
+      panel.dispose();
+      await cleanup();
+    }
+  });
+
+  test('does not post triage updates after dispose', async () => {
+    const summary = createDeferred<unknown>();
+    const { LogViewerPanel, webview, panel } = createPanelHarness({
+      summarizeLogFile: () => summary.promise
+    });
+    const { filePath, cleanup } = await createLogFile();
+
+    try {
+      await LogViewerPanel.show({ logId: 'LOG-005', filePath });
+      webview.emitMessage({ type: 'logViewerReady' });
+
+      panel.dispose();
+      summary.resolve({
+        hasErrors: true,
+        primaryReason: 'Should not post',
+        reasons: []
+      });
+
+      await nextTick();
+      assert.equal(
+        webview.postedMessages.filter(msg => msg.type === 'logViewerTriageUpdate').length,
+        0,
+        'disposed panel should ignore resolved triage'
+      );
+    } finally {
+      panel.dispose();
       await cleanup();
     }
   });

--- a/src/test/logViewerPanel.test.ts
+++ b/src/test/logViewerPanel.test.ts
@@ -284,7 +284,7 @@ suite('LogViewerPanel', () => {
     }
   });
 
-  test('still posts initial init payload when triage is unavailable or slow', async () => {
+  test('still posts initial init payload and terminal triage update when triage is unavailable or slow', async () => {
     const { LogViewerPanel, panel, webview } = createPanelHarness({
       summarizeLogFile: () => Promise.reject(new Error('triage unavailable'))
     });
@@ -302,7 +302,12 @@ suite('LogViewerPanel', () => {
 
       await new Promise(resolve => setTimeout(resolve, 10));
       await nextTick();
-      assert.ok(!webview.postedMessages.some(msg => msg.type === 'logViewerTriageUpdate'), 'triage updates should not block initial payload');
+      const triageMessage = webview.postedMessages.find(
+        (msg): msg is TriageUpdateMessage => msg.type === 'logViewerTriageUpdate'
+      );
+      assert.ok(triageMessage, 'triage update should still be posted as a terminal signal');
+      assert.equal(triageMessage.logId, 'LOG-003');
+      assert.ok(!('triage' in triageMessage), 'triage payload should be omitted for terminal failure signaling');
     } finally {
       panel.dispose();
       await cleanup();

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -274,6 +274,59 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('clears a hidden active diagnostic when the sidebar severity filter excludes it', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'severity-filter-log',
+      locale: 'en-US',
+      fileName: 'severity-filter.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A',
+        '12:00:01.000 (2)|EXCEPTION|[2]|Error row|B'
+      ]
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'severity-filter-log',
+      triage: {
+        hasErrors: true,
+        reasons: [
+          { code: 'validation_failure', severity: 'warning', summary: 'Debug row warning', line: 1 },
+          { code: 'fatal_exception', severity: 'error', summary: 'Error row issue', line: 2 }
+        ]
+      }
+    });
+
+    fireEvent.click(screen.getAllByRole('button', { name: 'Errors' })[0]!);
+    await waitFor(() => {
+      expect(screen.queryByText(/Alpha \| A/)).toBeNull();
+      expect(screen.getByText(/Error row \| B/)).toBeInTheDocument();
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+
+    const warningDiagnostic = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Debug row warning/ });
+    fireEvent.click(warningDiagnostic);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Alpha \| A/)).toBeInTheDocument();
+    });
+
+    fireEvent.click(within(diagnosticsPanel as HTMLElement).getByRole('button', { name: 'Errors' }));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/Alpha \| A/)).toBeNull();
+      expect(screen.getByText(/Error row \| B/)).toBeInTheDocument();
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Debug row warning/ })).not.toBeInTheDocument();
+    });
+  });
+
   it('falls back to terminal diagnostics state when triage never arrives', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();
@@ -293,6 +346,44 @@ describe('Log Viewer App', () => {
       logId: 'triage-missing-log'
     });
     await waitFor(() => expect(screen.getByText('No diagnostics found.')).toBeInTheDocument());
+  });
+
+  it('clears stale diagnostics when logViewerError is received after a successful open', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'error-reset-log',
+      locale: 'en-US',
+      fileName: 'error-reset.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A',
+        '12:00:01.000 (2)|EXCEPTION|[2]|Error row|B'
+      ]
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'error-reset-log',
+      triage: {
+        hasErrors: true,
+        reasons: [{ code: 'fatal_exception', severity: 'error', summary: 'Active issue', line: 2 }]
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+    await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Active issue/ });
+
+    send(bus, { type: 'logViewerError', message: 'Falha específica' });
+
+    await screen.findByText('Falha específica');
+    await waitFor(() => {
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Active issue/ })).not.toBeInTheDocument();
+      expect(within(diagnosticsPanel as HTMLElement).getByText('No diagnostics found.')).toBeInTheDocument();
+    });
   });
 
   it('ignores stale triage updates that do not match the active log id', async () => {

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -124,7 +124,7 @@ describe('Log Viewer App', () => {
 
     const searchInput = screen.getByPlaceholderText('Search entries…');
     fireEvent.change(searchInput, { target: { value: 'sem resultado' } });
-    await screen.findByText('No entries match the current filters.');
+    await screen.findByText(/Olá Mundo/);
     screen.getByText('0/0');
     expect(screen.getByLabelText('Next match')).toBeDisabled();
     fireEvent.change(searchInput, { target: { value: '' } });
@@ -288,12 +288,11 @@ describe('Log Viewer App', () => {
     });
 
     await screen.findByText('Loading diagnostics…');
-    await waitFor(
-      () => {
-        expect(screen.getByText('No diagnostics found.')).toBeInTheDocument();
-      },
-      { timeout: 1500 }
-    );
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'triage-missing-log'
+    });
+    await waitFor(() => expect(screen.getByText('No diagnostics found.')).toBeInTheDocument());
   });
 
   it('ignores stale triage updates that do not match the active log id', async () => {
@@ -379,7 +378,10 @@ describe('Log Viewer App', () => {
 
     const searchInput = screen.getByPlaceholderText('Search entries…');
     fireEvent.change(searchInput, { target: { value: 'no-match-at-all' } });
-    await screen.findByText('No entries match the current filters.');
+    expect(screen.getByText(/Unmapped issue/)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(within(diagnosticsPanel as HTMLElement).getByRole('button', { name: /Unmapped issue/ })).toBeInTheDocument();
+    });
     const unmappedButton = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Unmapped issue/ });
     expect(unmappedButton.className).toContain('bg-amber-500/20');
     expect(listScrollCalls).toHaveLength(0);

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -327,6 +327,58 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('resets the diagnostics severity filter when a new log is loaded', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'warnings-log',
+      locale: 'en-US',
+      fileName: 'warnings.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'warnings-log',
+      triage: {
+        hasErrors: false,
+        reasons: [{ code: 'validation_failure', severity: 'warning', summary: 'Initial warning', line: 1 }]
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+    await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Initial warning/ });
+
+    fireEvent.click(within(diagnosticsPanel as HTMLElement).getByRole('button', { name: 'Warnings' }));
+    expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Initial warning/ })).toBeInTheDocument();
+
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'errors-log',
+      locale: 'en-US',
+      fileName: 'errors.log',
+      lines: ['12:00:01.000 (2)|EXCEPTION|[2]|Beta|B']
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'errors-log',
+      triage: {
+        hasErrors: true,
+        reasons: [{ code: 'fatal_exception', severity: 'error', summary: 'Fresh error', line: 1 }]
+      }
+    });
+
+    await waitFor(() => {
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Initial warning/ })).not.toBeInTheDocument();
+      expect(within(diagnosticsPanel as HTMLElement).getByRole('button', { name: /Fresh error/ })).toBeInTheDocument();
+    });
+  });
+
   it('shows triage unavailable when the terminal update omits diagnostics', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -348,6 +348,36 @@ describe('Log Viewer App', () => {
     await waitFor(() => expect(screen.getByText('Diagnostics unavailable.')).toBeInTheDocument());
   });
 
+  it('preserves primaryReason-only triage summaries when no diagnostics are returned', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'triage-summary-only-log',
+      locale: 'en-US',
+      fileName: 'summary-only.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    await screen.findByText('Loading diagnostics…');
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'triage-summary-only-log',
+      triage: {
+        hasErrors: true,
+        primaryReason: 'Fatal exception',
+        reasons: []
+      }
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Fatal exception')).toBeInTheDocument();
+      expect(screen.queryByText('No diagnostics found.')).toBeNull();
+    });
+  });
+
   it('clears stale diagnostics when logViewerError is received after a successful open', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -362,7 +362,7 @@ describe('Log Viewer App', () => {
       logId: 'unmapped-log',
       triage: {
         hasErrors: true,
-        reasons: [{ code: 'mystery', severity: 'warning', summary: 'Unmapped issue', line: 99 }]
+        reasons: [{ code: 'suspicious_error_payload', severity: 'warning', summary: 'Unmapped issue', line: 99 }]
       }
     });
 

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -274,6 +274,117 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('falls back to terminal diagnostics state when triage never arrives', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'triage-missing-log',
+      locale: 'en-US',
+      fileName: 'missing-triage.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    await screen.findByText('Loading diagnostics…');
+    await waitFor(
+      () => {
+        expect(screen.getByText('No diagnostics found.')).toBeInTheDocument();
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('ignores stale triage updates that do not match the active log id', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'active-log',
+      locale: 'en-US',
+      fileName: 'active.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+
+    await screen.findByText('Loading diagnostics…');
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'other-log',
+      triage: {
+        hasErrors: true,
+        reasons: [{ code: 'fatal_exception', severity: 'error', summary: 'Ignored issue', line: 1 }]
+      }
+    });
+
+    await waitFor(
+      () => {
+        expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Ignored issue/ })).not.toBeInTheDocument();
+      },
+      { timeout: 1200 }
+    );
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'active-log',
+      triage: {
+        hasErrors: true,
+        reasons: [{ code: 'fatal_exception', severity: 'error', summary: 'Active issue', line: 1 }]
+      }
+    });
+
+    await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Active issue/ });
+  });
+
+  it('keeps unmapped diagnostics selectable as sidebar state without forcing row visibility', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'unmapped-log',
+      locale: 'en-US',
+      fileName: 'unmapped.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'unmapped-log',
+      triage: {
+        hasErrors: true,
+        reasons: [{ code: 'mystery', severity: 'warning', summary: 'Unmapped issue', line: 99 }]
+      }
+    });
+
+    const diagnosticsButton = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Unmapped issue/ });
+    expect(diagnosticsButton).toBeInTheDocument();
+    resetListScrollCalls();
+
+    fireEvent.click(diagnosticsButton);
+    await waitFor(() => {
+      expect(diagnosticsButton.className).toContain('bg-amber-500/20');
+    });
+    expect(screen.getByText(/Unmapped issue/)).toBeInTheDocument();
+    expect(listScrollCalls).toHaveLength(0);
+
+    const searchInput = screen.getByPlaceholderText('Search entries…');
+    fireEvent.change(searchInput, { target: { value: 'no-match-at-all' } });
+    await screen.findByText('No entries match the current filters.');
+    const unmappedButton = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Unmapped issue/ });
+    expect(unmappedButton.className).toContain('bg-amber-500/20');
+    expect(listScrollCalls).toHaveLength(0);
+  });
+
   it('keeps the active mapped row visible across overrides and clears stale selection on remap', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -1,9 +1,55 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 
 import type { LogViewerFromWebviewMessage, LogViewerToWebviewMessage } from '../shared/logViewerMessages';
+import type { LogDiagnostic } from '../shared/logTriage';
 import type { VsCodeWebviewApi } from '../vscodeApi';
 import { LogViewerApp } from '../logViewer';
+
+const listScrollCalls: number[] = [];
+
+const resetListScrollCalls = () => {
+  listScrollCalls.length = 0;
+};
+
+jest.mock('react-window', () => {
+  const React = require('react');
+  return {
+    List: ({ listRef, rowCount, rowHeight, rowComponent, rowProps, style, className }: any) => {
+      const rows = Array.from({ length: rowCount }).map((_: unknown, index: number) =>
+        React.createElement(
+          React.Fragment,
+          { key: index },
+          rowComponent({
+            ...rowProps,
+            index,
+            style: {
+              height: rowHeight(index)
+            }
+          })
+        )
+      );
+      const api = {
+        element: null,
+        scrollToRow: (opts: { index: number }) => {
+          if (typeof opts === 'number') {
+            listScrollCalls.push(opts);
+            return;
+          }
+          if (typeof opts?.index === 'number') {
+            listScrollCalls.push(opts.index);
+          }
+        }
+      };
+      if (typeof listRef === 'function') {
+        listRef(api);
+      } else if (listRef && 'current' in listRef) {
+        (listRef as { current: unknown }).current = api;
+      }
+      return React.createElement('div', { 'data-testid': 'virtual-list', style, className }, rows);
+    }
+  };
+});
 
 type PendingFetch = {
   url: string;
@@ -12,6 +58,10 @@ type PendingFetch = {
 };
 
 describe('Log Viewer App', () => {
+  beforeEach(() => {
+    resetListScrollCalls();
+  });
+
   function createVsCodeMock() {
     const posted: LogViewerFromWebviewMessage[] = [];
     const vscode: VsCodeWebviewApi<LogViewerFromWebviewMessage> = {
@@ -67,14 +117,14 @@ describe('Log Viewer App', () => {
       metadata: { sizeBytes: 1024 },
       lines: ['12:00:00.000 (0)|USER_DEBUG|[1]|Olá Mundo|Detalhe']
     });
-    await screen.findByText('Olá Mundo | Detalhe');
+    await screen.findByText(/Olá Mundo/);
 
     fireEvent.click(screen.getByText('Debug Only'));
     fireEvent.click(screen.getByText('Debug Only'));
 
     const searchInput = screen.getByPlaceholderText('Search entries…');
     fireEvent.change(searchInput, { target: { value: 'sem resultado' } });
-    await screen.findByText('Olá Mundo | Detalhe');
+    await screen.findByText('No entries match the current filters.');
     screen.getByText('0/0');
     expect(screen.getByLabelText('Next match')).toBeDisabled();
     fireEvent.change(searchInput, { target: { value: '' } });
@@ -150,6 +200,134 @@ describe('Log Viewer App', () => {
       const types = posted.map(m => m.type);
       expect(types[0]).toBe('logViewerReady');
       expect(types).toContain('logViewerViewRaw');
+    });
+  });
+
+  it('opens logs immediately, hydrates async triage, and scrolls only when a diagnostic is clicked', async () => {
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    expect(posted[0]?.type).toBe('logViewerReady');
+
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'triage-log',
+      locale: 'en-US',
+      fileName: 'triage.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A',
+        '12:00:01.000 (2)|DML_EXECUTE_BEGIN|[2]|Database update|B',
+        '12:00:02.000 (3)|EXCEPTION|[3]|Error row|C'
+      ],
+      metadata: { sizeBytes: 2048 }
+    });
+
+    await screen.findByText(/Alpha/);
+    expect(screen.getByText('Loading diagnostics…')).toBeInTheDocument();
+    expect(document.querySelector('.ring-2')).toBeNull();
+    expect(listScrollCalls).toHaveLength(0);
+
+    const diagnostics: LogDiagnostic[] = [
+      { code: 'fatal_exception', severity: 'error', summary: 'Debug row has issue', line: 1 },
+      { code: 'validation_failure', severity: 'warning', summary: 'Error row warning', line: 3 }
+    ];
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'triage-log',
+      triage: {
+        hasErrors: true,
+        reasons: diagnostics
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+    const firstDiagnostic = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Debug row has issue/ });
+    const secondDiagnostic = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Error row warning/ });
+    expect(firstDiagnostic).toBeInTheDocument();
+    expect(secondDiagnostic).toBeInTheDocument();
+    expect(listScrollCalls).toHaveLength(0);
+    fireEvent.click(firstDiagnostic);
+
+    await waitFor(() => {
+      expect(listScrollCalls.at(-1)).toBe(0);
+    });
+
+    resetListScrollCalls();
+    fireEvent.click(secondDiagnostic);
+    await waitFor(() => {
+      expect(listScrollCalls.length).toBeGreaterThan(0);
+    });
+    expect(listScrollCalls.at(-1)).toBe(2);
+
+    const diagnosticsErrorFilter = within(diagnosticsPanel as HTMLElement).getByRole('button', { name: 'Errors' });
+    fireEvent.click(diagnosticsErrorFilter);
+    expect(screen.getByText(/Error row \| C/)).toBeInTheDocument();
+
+    const searchInput = screen.getByPlaceholderText('Search entries…');
+    fireEvent.change(searchInput, { target: { value: '' } });
+    fireEvent.change(searchInput, { target: { value: 'no-match-at-all' } });
+    await waitFor(() => {
+      expect(screen.getByText(/Error row \| C/)).toBeInTheDocument();
+    });
+  });
+
+  it('keeps the active mapped row visible across overrides and clears stale selection on remap', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'remap-log',
+      locale: 'en-US',
+      fileName: 'remap.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A',
+        '12:00:01.000 (2)|DML_EXECUTE_BEGIN|[2]|Database update|B',
+        '12:00:02.000 (3)|EXCEPTION|[3]|Error row|C'
+      ]
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'remap-log',
+      triage: {
+        hasErrors: true,
+        reasons: [
+          { code: 'fatal_exception', severity: 'error', summary: 'Debug row has issue', line: 1 },
+          { code: 'validation_failure', severity: 'warning', summary: 'Error row warning', line: 3 }
+        ]
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+    const firstDiagnostic = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Debug row has issue/ });
+    const secondDiagnostic = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Error row warning/ });
+
+    fireEvent.click(firstDiagnostic);
+    expect(screen.getByText(/Alpha/)).toBeInTheDocument();
+
+    const diagnosticsErrorFilter = within(diagnosticsPanel as HTMLElement).getByRole('button', { name: 'Errors' });
+    fireEvent.click(diagnosticsErrorFilter);
+    expect(screen.getByText(/Alpha/)).toBeInTheDocument();
+
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'remap-refresh',
+      locale: 'en-US',
+      fileName: 'remap.log',
+      lines: ['12:00:03.000 (4)|EXCEPTION|[4]|Refreshed row|D']
+    });
+    await screen.findByText(/Refreshed row/);
+
+    expect(screen.queryByText(/Alpha/)).toBeNull();
+    await waitFor(() => {
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Debug row has issue/ })).not.toBeInTheDocument();
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Error row warning/ })).not.toBeInTheDocument();
     });
   });
 });

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -327,7 +327,7 @@ describe('Log Viewer App', () => {
     });
   });
 
-  it('falls back to terminal diagnostics state when triage never arrives', async () => {
+  it('shows triage unavailable when the terminal update omits diagnostics', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();
 
@@ -345,7 +345,7 @@ describe('Log Viewer App', () => {
       type: 'logViewerTriageUpdate',
       logId: 'triage-missing-log'
     });
-    await waitFor(() => expect(screen.getByText('No diagnostics found.')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Diagnostics unavailable.')).toBeInTheDocument());
   });
 
   it('clears stale diagnostics when logViewerError is received after a successful open', async () => {

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -379,6 +379,42 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('shows an empty filtered state instead of the summary card when a severity has no matches', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'warning-only-log',
+      locale: 'en-US',
+      fileName: 'warning-only.log',
+      lines: ['12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A']
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'warning-only-log',
+      triage: {
+        hasErrors: false,
+        primaryReason: 'Validation warning',
+        reasons: [{ code: 'validation_failure', severity: 'warning', summary: 'Validation warning', line: 1 }]
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+    await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /Validation warning/ });
+
+    fireEvent.click(within(diagnosticsPanel as HTMLElement).getByRole('button', { name: 'Errors' }));
+
+    await waitFor(() => {
+      expect(within(diagnosticsPanel as HTMLElement).getByText('No diagnostics found.')).toBeInTheDocument();
+      expect(within(diagnosticsPanel as HTMLElement).queryByText('Summary')).toBeNull();
+      expect(within(diagnosticsPanel as HTMLElement).queryByRole('button', { name: /Validation warning/ })).toBeNull();
+    });
+  });
+
   it('shows triage unavailable when the terminal update omits diagnostics', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -319,6 +319,18 @@ describe('Log viewer components', () => {
 
       rerender(
         <LogDiagnosticsSidebar
+          diagnostics={[]}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="ready"
+          primaryReason="Fatal exception"
+        />
+      );
+      screen.getByText('Fatal exception');
+
+      rerender(
+        <LogDiagnosticsSidebar
           diagnostics={diagnostics}
           filter="all"
           onFilterChange={() => {}}

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -380,6 +380,30 @@ describe('Log viewer components', () => {
       fireEvent.click(warningItem);
       expect(selectCalls).toEqual([2]);
     });
+
+    it('shows an empty filtered state when the current severity has no matches', () => {
+      render(
+        <LogDiagnosticsSidebar
+          diagnostics={[
+            {
+              code: 'validation_failure',
+              severity: 'warning',
+              summary: 'Validation warning',
+              originalIndex: 2,
+              mappedLineNumber: undefined
+            }
+          ]}
+          filter="error"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="ready"
+          primaryReason="Validation warning"
+        />
+      );
+
+      screen.getByText('No diagnostics found.');
+      expect(screen.queryByText('Validation warning')).toBeNull();
+    });
   });
 
   describe('LogEntryList', () => {

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -381,6 +381,29 @@ describe('Log viewer components', () => {
       expect(selectCalls).toEqual([2]);
     });
 
+    it('preserves the parser line number when a diagnostic cannot map to a rendered row', () => {
+      render(
+        <LogDiagnosticsSidebar
+          diagnostics={[
+            {
+              code: 'suspicious_error_payload',
+              severity: 'warning',
+              summary: 'Original parser line',
+              originalIndex: 3,
+              line: 99
+            }
+          ]}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="ready"
+        />
+      );
+
+      screen.getByText('Line 99');
+      expect(screen.queryByText('Unmapped')).toBeNull();
+    });
+
     it('shows an empty filtered state when the current severity has no matches', () => {
       render(
         <LogDiagnosticsSidebar

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -2,9 +2,11 @@ import React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
 import type { LogCategory, ParsedLogEntry } from '../utils/logViewerParser';
+import type { LogViewerMappedDiagnostic } from '../utils/logViewerDiagnostics';
 import { LogViewerFilters } from '../components/log-viewer/LogViewerFilters';
 import { LogViewerHeader } from '../components/log-viewer/LogViewerHeader';
 import { LogViewerStatusBar } from '../components/log-viewer/LogViewerStatusBar';
+import { LogDiagnosticsSidebar } from '../components/log-viewer/LogDiagnosticsSidebar';
 import { LogEntryRow } from '../components/log-viewer/LogEntryRow';
 import { LogEntryList } from '../components/log-viewer/LogEntryList';
 
@@ -215,6 +217,146 @@ describe('Log viewer components', () => {
       const highlightedRow = document.querySelector('.ring-1');
       expect(highlightedRow).not.toBeNull();
     });
+
+    it('renders passive diagnostic badges', () => {
+      const diagnostics: LogViewerMappedDiagnostic[] = [
+        {
+          code: 'dml_failure',
+          severity: 'warning',
+          summary: 'Mapped warning',
+          originalIndex: 1,
+          mappedEntryId: 1,
+          mappedLineNumber: 12
+        }
+      ];
+      render(
+        <LogEntryRow entry={baseEntry} highlighted={false} diagnostics={diagnostics} onMeasured={() => {}} />
+      );
+      const passiveBadge = screen.getByText('Mapped warning');
+      expect(passiveBadge.className).toContain('bg-muted/20');
+      expect(passiveBadge.className).toContain('text-[11px]');
+    });
+
+    it('renders stronger active diagnostic badge style and active row highlight', () => {
+      const diagnostics: LogViewerMappedDiagnostic[] = [
+        {
+          code: 'fatal_exception',
+          severity: 'error',
+          summary: 'Mapped error',
+          originalIndex: 3,
+          mappedEntryId: 1,
+          mappedLineNumber: 12
+        }
+      ];
+      const { container } = render(
+        <LogEntryRow
+          entry={baseEntry}
+          highlighted={false}
+          diagnostics={diagnostics}
+          activeDiagnosticId={3}
+          isActiveDiagnostic
+          onMeasured={() => {}}
+        />
+      );
+      const rowElement = container.firstElementChild as HTMLDivElement | null;
+      expect(rowElement?.className).toContain('ring-2');
+      const activeBadge = screen.getByText('Mapped error');
+      expect(activeBadge.className).toContain('bg-amber-500/30');
+    });
+  });
+
+  describe('LogDiagnosticsSidebar', () => {
+    const diagnostics: LogViewerMappedDiagnostic[] = [
+      {
+        code: 'fatal_exception',
+        severity: 'error',
+        summary: 'Fatal exception',
+        originalIndex: 1,
+        mappedLineNumber: 11
+      },
+      {
+        code: 'validation_failure',
+        severity: 'warning',
+        summary: 'Validation warning',
+        originalIndex: 2,
+        mappedLineNumber: undefined
+      }
+    ];
+
+    it('renders loading, empty, and ready states', () => {
+      const { rerender } = render(
+        <LogDiagnosticsSidebar
+          diagnostics={diagnostics}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="loading"
+        />
+      );
+      screen.getByText('Loading diagnostics…');
+
+      rerender(
+        <LogDiagnosticsSidebar
+          diagnostics={[]}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="empty"
+        />
+      );
+      screen.getByText('No diagnostics found.');
+
+      rerender(
+        <LogDiagnosticsSidebar
+          diagnostics={diagnostics}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="ready"
+        />
+      );
+      screen.getByText('Fatal exception');
+      screen.getByText('Validation warning');
+    });
+
+    it('switches severity filters with All/Errors/Warnings controls', () => {
+      const calls: string[] = [];
+      render(
+        <LogDiagnosticsSidebar
+          diagnostics={diagnostics}
+          filter="all"
+          onFilterChange={next => calls.push(next)}
+          onSelectDiagnostic={() => {}}
+          triageState="ready"
+        />
+      );
+
+      fireEvent.click(screen.getByRole('button', { name: 'Errors' }));
+      expect(calls[0]).toBe('error');
+
+      fireEvent.click(screen.getByRole('button', { name: 'Warnings' }));
+      expect(calls[1]).toBe('warning');
+
+      fireEvent.click(screen.getByRole('button', { name: 'All' }));
+      expect(calls[2]).toBe('all');
+    });
+
+    it('keeps unmapped diagnostics clickable without requiring list scroll state', () => {
+      const selectCalls: number[] = [];
+      render(
+        <LogDiagnosticsSidebar
+          diagnostics={diagnostics}
+          filter="all"
+          activeId={2}
+          onFilterChange={() => {}}
+          onSelectDiagnostic={id => selectCalls.push(id)}
+          triageState="ready"
+        />
+      );
+      const warningItem = screen.getByText('Validation warning');
+      fireEvent.click(warningItem);
+      expect(selectCalls).toEqual([2]);
+    });
   });
 
   describe('LogEntryList', () => {
@@ -270,7 +412,7 @@ describe('Log viewer components', () => {
         );
       };
 
-      const StubRow = ({ entry, highlighted, onMeasured, isMatch, isActiveMatch }: any) => {
+      const StubRow = ({ entry, highlighted, onMeasured, isMatch, isActiveMatch, diagnostics, activeDiagnosticId, isActiveDiagnostic }: any) => {
         React.useEffect(() => {
           const value = 72 + entry.id;
           captured.measured.push(value);
@@ -279,6 +421,9 @@ describe('Log viewer components', () => {
         captured.highlighted[entry.id] = highlighted;
         captured.highlighted[`${entry.id}-match`] = isMatch;
         captured.highlighted[`${entry.id}-active`] = isActiveMatch;
+        captured.highlighted[`${entry.id}-diag-count`] = diagnostics?.length ?? 0;
+        captured.highlighted[`${entry.id}-active-diag`] = !!isActiveDiagnostic;
+        captured.highlighted[`${entry.id}-active-diag-id`] = activeDiagnosticId;
         return <div data-testid={`row-${entry.id}`}>{entry.message}</div>;
       };
 
@@ -291,6 +436,9 @@ describe('Log viewer components', () => {
           matchIndices={[0]}
           activeMatchIndex={0}
           searchTerm="debug"
+          activeDiagnosticEntryIndex={0}
+          activeDiagnosticId={1}
+          entryDiagnosticSummaries={[{ entryId: 0, diagnostics: [{ code: 'fatal_exception', severity: 'error', summary: 'row-0', originalIndex: 1 }] }]}
         />
       );
 
@@ -299,11 +447,65 @@ describe('Log viewer components', () => {
         expect(captured.highlighted[1]).toBe(false);
         expect(captured.highlighted['0-match']).toBe(true);
         expect(captured.highlighted['0-active']).toBe(true);
+        expect(captured.highlighted['0-diag-count']).toBe(1);
+        expect(captured.highlighted['0-active-diag']).toBe(true);
+        expect(captured.highlighted['0-active-diag-id']).toBe(1);
       });
 
       await waitFor(() => {
         expect(captured.measured.length).toBeGreaterThan(0);
       });
+    });
+
+    it('scrolls only with active diagnostic entry index, not unmapped id alone', async () => {
+      const scrollCalls: number[] = [];
+      const entries: ParsedLogEntry[] = [
+        { id: 0, timestamp: '00:00', type: 'USER_DEBUG', message: 'A', raw: 'raw', category: 'debug' },
+        { id: 1, timestamp: '00:01', type: 'SOQL', message: 'B', raw: 'raw', category: 'soql' }
+      ];
+
+      const VirtualList = ({ rowCount, rowHeight, rowComponent, rowProps, listRef }: any) => {
+        return (
+          <div
+            ref={el => {
+              const api = { element: el, scrollToRow: (opts: { index: number }) => scrollCalls.push(opts.index) };
+              if (typeof listRef === 'function') {
+                listRef(api);
+              } else if (listRef && 'current' in listRef) {
+                (listRef as { current: unknown }).current = api;
+              }
+            }}
+          >
+            {Array.from({ length: rowCount }).map((_, index) => (
+              <React.Fragment key={index}>{rowComponent({ ...rowProps, index, style: { height: rowHeight(index) } })}</React.Fragment>
+            ))}
+          </div>
+        );
+      };
+
+      const { rerender } = render(
+        <LogEntryList
+          entries={entries}
+          virtualListComponent={VirtualList}
+          activeDiagnosticEntryIndex={1}
+          RowComponent={() => <div />}
+        />
+      );
+
+      await waitFor(() => {
+        expect(scrollCalls).toEqual([1]);
+      });
+
+      rerender(
+        <LogEntryList
+          entries={entries}
+          virtualListComponent={VirtualList}
+          activeDiagnosticId={9}
+          activeDiagnosticEntryIndex={undefined}
+          RowComponent={() => <div />}
+        />
+      );
+      expect(scrollCalls).toEqual([1]);
     });
   });
 });

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -530,5 +530,61 @@ describe('Log viewer components', () => {
       );
       expect(scrollCalls).toEqual([1]);
     });
+
+    it('re-scrolls when a different diagnostic becomes active on the same row', async () => {
+      const scrollCalls: number[] = [];
+      const entries: ParsedLogEntry[] = [
+        { id: 0, timestamp: '00:00', type: 'USER_DEBUG', message: 'A', raw: 'raw', category: 'debug' },
+        { id: 1, timestamp: '00:01', type: 'SOQL', message: 'B', raw: 'raw', category: 'soql' }
+      ];
+
+      const VirtualList = ({ rowCount, rowHeight, rowComponent, rowProps, listRef }: any) => {
+        return (
+          <div
+            ref={el => {
+              const api = { element: el, scrollToRow: (opts: { index: number }) => scrollCalls.push(opts.index) };
+              if (typeof listRef === 'function') {
+                listRef(api);
+              } else if (listRef && 'current' in listRef) {
+                (listRef as { current: unknown }).current = api;
+              }
+            }}
+          >
+            {Array.from({ length: rowCount }).map((_, index) => (
+              <React.Fragment key={index}>{rowComponent({ ...rowProps, index, style: { height: rowHeight(index) } })}</React.Fragment>
+            ))}
+          </div>
+        );
+      };
+
+      const { rerender } = render(
+        <LogEntryList
+          entries={entries}
+          virtualListComponent={VirtualList}
+          activeDiagnosticId={1}
+          activeDiagnosticEntryIndex={1}
+          RowComponent={() => <div />}
+        />
+      );
+
+      await waitFor(() => {
+        expect(scrollCalls).toEqual([1]);
+      });
+
+      scrollCalls.length = 0;
+      rerender(
+        <LogEntryList
+          entries={entries}
+          virtualListComponent={VirtualList}
+          activeDiagnosticId={2}
+          activeDiagnosticEntryIndex={1}
+          RowComponent={() => <div />}
+        />
+      );
+
+      await waitFor(() => {
+        expect(scrollCalls).toEqual([1]);
+      });
+    });
   });
 });

--- a/src/webview/__tests__/logViewerComponents.test.tsx
+++ b/src/webview/__tests__/logViewerComponents.test.tsx
@@ -283,7 +283,7 @@ describe('Log viewer components', () => {
       }
     ];
 
-    it('renders loading, empty, and ready states', () => {
+    it('renders loading, unavailable, empty, and ready states', () => {
       const { rerender } = render(
         <LogDiagnosticsSidebar
           diagnostics={diagnostics}
@@ -294,6 +294,17 @@ describe('Log viewer components', () => {
         />
       );
       screen.getByText('Loading diagnostics…');
+
+      rerender(
+        <LogDiagnosticsSidebar
+          diagnostics={[]}
+          filter="all"
+          onFilterChange={() => {}}
+          onSelectDiagnostic={() => {}}
+          triageState="unavailable"
+        />
+      );
+      screen.getByText('Diagnostics unavailable.');
 
       rerender(
         <LogDiagnosticsSidebar

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -39,7 +39,7 @@ describe('logViewerDiagnostics', () => {
     const result = mapDiagnosticsToEntries(entries, [
       { code: 'dml_failure', severity: 'warning', summary: 'mapped-10', line: 10 },
       { code: 'dml_failure', severity: 'warning', summary: 'mapped-1', line: 1 },
-      { code: 'dml_failure', severity: 'warning', summary: 'unmapped', line: 3 },
+      { code: 'dml_failure', severity: 'warning', summary: 'unmapped', line: 30 },
       { code: 'dml_failure', severity: 'warning', summary: 'no-line' }
     ]);
 
@@ -88,6 +88,33 @@ describe('logViewerDiagnostics', () => {
       })
     ]);
     expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['unmapped']);
+  });
+
+  it('falls back to rendered row mapping when lineNumber mismatches and all rows have bracketed line numbers', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, 12, 'other'),
+      makeEntry(1, 13, 'other'),
+      makeEntry(2, 14, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'dml_failure', severity: 'warning', summary: 'exact-line', line: 13 },
+      { code: 'dml_failure', severity: 'warning', summary: 'fallback-line', line: 2 },
+      { code: 'dml_failure', severity: 'warning', summary: 'still-unmapped', line: 99 }
+    ]);
+
+    expect(result.mappedEntries[1].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'exact-line',
+        mappedEntryId: 1,
+        mappedLineNumber: 13
+      }),
+      expect.objectContaining({
+        summary: 'fallback-line',
+        mappedEntryId: 1,
+        mappedLineNumber: 2
+      })
+    ]);
+    expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['still-unmapped']);
   });
 
   it('collapses diagnostics for a row by severity then original order for ties', () => {

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -98,4 +98,46 @@ describe('logViewerDiagnostics', () => {
 
     expect(visible.map(v => v.entry.id)).toEqual([0, 1]);
   });
+
+  it('maps multiple diagnostics with duplicate lineNumber to the first matching row only', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, 11, 'error'),
+      makeEntry(1, 11, 'other'),
+      makeEntry(2, 12, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'fatal_exception', severity: 'error', summary: 'for-11-primary', line: 11 },
+      { code: 'dml_failure', severity: 'warning', summary: 'for-11-secondary', line: 11 },
+      { code: 'rollback_detected', severity: 'warning', summary: 'for-12', line: 12 }
+    ]);
+
+    expect(result.mappedEntries[0].diagnostics.map(d => d.summary)).toEqual([
+      'for-11-primary',
+      'for-11-secondary'
+    ]);
+    expect(result.mappedEntries[1].diagnostics).toEqual([]);
+    expect(result.mappedEntries[2].diagnostics).toEqual([
+      expect.objectContaining({ summary: 'for-12', mappedEntryId: 2 })
+    ]);
+  });
+
+  it('does not force visibility when active diagnostic is unmapped or lacks mappedEntryId', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, 1, 'other'),
+      makeEntry(1, 2, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'fatal_exception', severity: 'error', summary: 'unmapped-line', line: 99 },
+      { code: 'dml_failure', severity: 'warning', summary: 'unmapped-no-line' }
+    ]);
+    const activeDiagnostic = result.unmappedDiagnostics[0]!;
+
+    const visible = buildVisibleEntries({
+      entries: result.mappedEntries,
+      activeDiagnostic,
+      shouldIncludeEntry: () => false
+    });
+
+    expect(visible).toEqual([]);
+  });
 });

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -111,7 +111,7 @@ describe('logViewerDiagnostics', () => {
       expect.objectContaining({
         summary: 'fallback-line',
         mappedEntryId: 1,
-        mappedLineNumber: 2
+        mappedLineNumber: 13
       })
     ]);
     expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['still-unmapped']);

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -61,6 +61,35 @@ describe('logViewerDiagnostics', () => {
     expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['unmapped', 'no-line']);
   });
 
+  it('falls back to rendered row mapping using entry.id + 1 when no ParsedLogEntry.lineNumber matches', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, undefined, 'other'),
+      makeEntry(1, undefined, 'other'),
+      makeEntry(2, undefined, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'dml_failure', severity: 'warning', summary: 'mapped-2', line: 2 },
+      { code: 'dml_failure', severity: 'warning', summary: 'mapped-3', line: 3 },
+      { code: 'dml_failure', severity: 'warning', summary: 'unmapped', line: 99 }
+    ]);
+
+    expect(result.mappedEntries[1].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'mapped-2',
+        mappedEntryId: 1,
+        mappedLineNumber: 2
+      })
+    ]);
+    expect(result.mappedEntries[2].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'mapped-3',
+        mappedEntryId: 2,
+        mappedLineNumber: 3
+      })
+    ]);
+    expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['unmapped']);
+  });
+
   it('collapses diagnostics for a row by severity then original order for ties', () => {
     const entries: ParsedLogEntry[] = [makeEntry(0, 4, 'error'), makeEntry(1, 5, 'other')];
     const result = mapDiagnosticsToEntries(entries, [

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -1,0 +1,101 @@
+import type { ParsedLogEntry } from '../utils/logViewerParser';
+import { buildVisibleEntries, mapDiagnosticsToEntries, orderDiagnostics } from '../utils/logViewerDiagnostics';
+
+const makeEntry = (id: number, lineNumber: number | undefined, category: ParsedLogEntry['category']): ParsedLogEntry => ({
+  id,
+  timestamp: '00:00:00.000',
+  type: 'INFO',
+  message: `line-${id}`,
+  raw: `raw-${id}`,
+  category,
+  lineNumber
+});
+
+describe('logViewerDiagnostics', () => {
+  it('orders diagnostics by ascending line number and keeps no-line diagnostics after mapped diagnostics', () => {
+    const ordered = orderDiagnostics([
+      { code: 'validation_failure', severity: 'warning', summary: 'third', line: 12 },
+      { code: 'fatal_exception', severity: 'error', summary: 'unmapped-2' },
+      { code: 'dml_failure', severity: 'warning', summary: 'first', line: 2 },
+      { code: 'assertion_failure', severity: 'error', summary: 'unmapped-1' },
+      { code: 'suspicious_error_payload', severity: 'warning', summary: 'second', line: 8 }
+    ]);
+
+    expect(ordered.map(d => d.summary)).toEqual([
+      'first',
+      'second',
+      'third',
+      'unmapped-2',
+      'unmapped-1'
+    ]);
+  });
+
+  it('maps diagnostic.line to ParsedLogEntry.lineNumber exactly (1-based) and keeps unmapped diagnostics', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, 1, 'other'),
+      makeEntry(1, 9, 'other'),
+      makeEntry(2, 10, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'dml_failure', severity: 'warning', summary: 'mapped-10', line: 10 },
+      { code: 'dml_failure', severity: 'warning', summary: 'mapped-1', line: 1 },
+      { code: 'dml_failure', severity: 'warning', summary: 'unmapped', line: 3 },
+      { code: 'dml_failure', severity: 'warning', summary: 'no-line' }
+    ]);
+
+    expect(result.orderedDiagnostics).toHaveLength(4);
+    expect(result.mappedEntries[0].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'mapped-1',
+        mappedEntryId: 0,
+        mappedLineNumber: 1
+      })
+    ]);
+    expect(result.mappedEntries[2].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'mapped-10',
+        mappedEntryId: 2,
+        mappedLineNumber: 10
+      })
+    ]);
+    expect(result.unmappedDiagnostics.map(d => d.summary)).toEqual(['unmapped', 'no-line']);
+  });
+
+  it('collapses diagnostics for a row by severity then original order for ties', () => {
+    const entries: ParsedLogEntry[] = [makeEntry(0, 4, 'error'), makeEntry(1, 5, 'other')];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'validation_failure', severity: 'warning', summary: 'warning-first', line: 4 },
+      { code: 'fatal_exception', severity: 'error', summary: 'error-one', line: 4 },
+      { code: 'rollback_detected', severity: 'warning', summary: 'warning-second', line: 4 },
+      { code: 'suspicious_error_payload', severity: 'warning', summary: 'warning-third', line: 4 }
+    ]);
+
+    expect(result.mappedEntries[0].diagnostics.map(d => d.summary)).toEqual([
+      'error-one',
+      'warning-first',
+      'warning-second',
+      'warning-third'
+    ]);
+  });
+
+  it('keeps active mapped row visible when row filter would hide it', () => {
+    const entries: ParsedLogEntry[] = [
+      makeEntry(0, 1, 'other'),
+      makeEntry(1, 2, 'error'),
+      makeEntry(2, 3, 'other')
+    ];
+    const result = mapDiagnosticsToEntries(entries, [
+      { code: 'fatal_exception', severity: 'error', summary: 'goes-to-row-1', line: 1 },
+      { code: 'dml_failure', severity: 'warning', summary: 'goes-to-row-2', line: 2 }
+    ]);
+    const activeDiagnostic = result.mappedEntries[0]!.diagnostics.find(d => d.summary === 'goes-to-row-1');
+
+    const visible = buildVisibleEntries({
+      entries: result.mappedEntries,
+      activeDiagnostic,
+      shouldIncludeEntry: entry => entry.category === 'error'
+    });
+
+    expect(visible.map(v => v.entry.id)).toEqual([0, 1]);
+  });
+});

--- a/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
+++ b/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
@@ -77,7 +77,7 @@ export function LogDiagnosticsSidebar({
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Diagnostics unavailable.</div>
         ) : triageState === 'empty' ? (
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">No diagnostics found.</div>
-        ) : visibleDiagnostics.length === 0 && summaryText ? (
+        ) : diagnostics.length === 0 && summaryText ? (
           <div className="space-y-3 p-4">
             <div className="flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-muted-foreground">
               <AlertCircle className="h-3.5 w-3.5" />

--- a/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
+++ b/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
@@ -14,6 +14,7 @@ interface Props {
   filter: SeverityFilter;
   onFilterChange: (filter: SeverityFilter) => void;
   onSelectDiagnostic: (id: number) => void;
+  primaryReason?: string;
   triageState: TriageState;
 }
 
@@ -23,6 +24,7 @@ export function LogDiagnosticsSidebar({
   filter,
   onFilterChange,
   onSelectDiagnostic,
+  primaryReason,
   triageState
 }: Props) {
   const visibleDiagnostics = diagnostics.filter(diagnostic => {
@@ -31,6 +33,7 @@ export function LogDiagnosticsSidebar({
     }
     return diagnostic.severity === filter;
   });
+  const summaryText = primaryReason?.trim() ? primaryReason : undefined;
 
   return (
     <aside className="flex h-full w-80 flex-col gap-2 border-l border-border/60 bg-muted/20 px-4 py-4">
@@ -72,7 +75,17 @@ export function LogDiagnosticsSidebar({
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Loading diagnostics…</div>
         ) : triageState === 'unavailable' ? (
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Diagnostics unavailable.</div>
-        ) : triageState === 'empty' || visibleDiagnostics.length === 0 ? (
+        ) : triageState === 'empty' ? (
+          <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">No diagnostics found.</div>
+        ) : visibleDiagnostics.length === 0 && summaryText ? (
+          <div className="space-y-3 p-4">
+            <div className="flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+              <AlertCircle className="h-3.5 w-3.5" />
+              <span>Summary</span>
+            </div>
+            <div className="rounded-md border border-border/60 bg-muted/30 px-3 py-2 text-sm text-foreground">{summaryText}</div>
+          </div>
+        ) : visibleDiagnostics.length === 0 ? (
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">No diagnostics found.</div>
         ) : (
           <ul className="max-h-[calc(100vh-220px)] overflow-y-auto p-2 text-sm">

--- a/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
+++ b/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
@@ -6,7 +6,7 @@ import { cn } from '../../lib/utils';
 import type { LogViewerMappedDiagnostic } from '../../utils/logViewerDiagnostics';
 
 type SeverityFilter = 'all' | 'error' | 'warning';
-type TriageState = 'loading' | 'empty' | 'ready';
+type TriageState = 'loading' | 'unavailable' | 'empty' | 'ready';
 
 interface Props {
   diagnostics: readonly LogViewerMappedDiagnostic[];
@@ -70,6 +70,8 @@ export function LogDiagnosticsSidebar({
       <div className="rounded-md border border-border/60 bg-background/80">
         {triageState === 'loading' ? (
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Loading diagnostics…</div>
+        ) : triageState === 'unavailable' ? (
+          <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Diagnostics unavailable.</div>
         ) : triageState === 'empty' || visibleDiagnostics.length === 0 ? (
           <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">No diagnostics found.</div>
         ) : (

--- a/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
+++ b/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
@@ -92,7 +92,7 @@ export function LogDiagnosticsSidebar({
             {visibleDiagnostics.map(diagnostic => {
               const isActive = diagnostic.originalIndex === activeId;
               const isError = diagnostic.severity === 'error';
-              const canJumpToLine = diagnostic.mappedLineNumber !== undefined;
+              const displayLineNumber = diagnostic.mappedLineNumber ?? diagnostic.line;
               return (
                 <li key={diagnostic.originalIndex}>
                   <button
@@ -117,7 +117,7 @@ export function LogDiagnosticsSidebar({
                     </div>
                     <div className="break-words text-foreground">{diagnostic.summary}</div>
                     <div className="mt-1 text-xs text-muted-foreground">
-                      {canJumpToLine ? `Line ${diagnostic.mappedLineNumber}` : 'Unmapped'}
+                      {displayLineNumber !== undefined ? `Line ${displayLineNumber}` : 'Unmapped'}
                     </div>
                   </button>
                 </li>

--- a/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
+++ b/src/webview/components/log-viewer/LogDiagnosticsSidebar.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { AlertCircle, AlertTriangle, Filter, ScanSearch } from 'lucide-react';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { cn } from '../../lib/utils';
+import type { LogViewerMappedDiagnostic } from '../../utils/logViewerDiagnostics';
+
+type SeverityFilter = 'all' | 'error' | 'warning';
+type TriageState = 'loading' | 'empty' | 'ready';
+
+interface Props {
+  diagnostics: readonly LogViewerMappedDiagnostic[];
+  activeId?: number;
+  filter: SeverityFilter;
+  onFilterChange: (filter: SeverityFilter) => void;
+  onSelectDiagnostic: (id: number) => void;
+  triageState: TriageState;
+}
+
+export function LogDiagnosticsSidebar({
+  diagnostics,
+  activeId,
+  filter,
+  onFilterChange,
+  onSelectDiagnostic,
+  triageState
+}: Props) {
+  const visibleDiagnostics = diagnostics.filter(diagnostic => {
+    if (filter === 'all') {
+      return true;
+    }
+    return diagnostic.severity === filter;
+  });
+
+  return (
+    <aside className="flex h-full w-80 flex-col gap-2 border-l border-border/60 bg-muted/20 px-4 py-4">
+      <div className="mb-1 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 text-xs uppercase tracking-[0.14em] text-muted-foreground">
+          <ScanSearch className="h-3.5 w-3.5" />
+          <span>Diagnostics</span>
+        </div>
+        <span className="text-[11px] text-muted-foreground">{diagnostics.length} total</span>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button
+          size="sm"
+          variant={filter === 'all' ? 'default' : 'ghost'}
+          onClick={() => onFilterChange('all')}
+          className={cn('h-7 px-2 text-[11px]', filter === 'all' ? 'bg-slate-600 text-white' : 'text-muted-foreground')}
+        >
+          All
+        </Button>
+        <Button
+          size="sm"
+          variant={filter === 'error' ? 'default' : 'ghost'}
+          onClick={() => onFilterChange('error')}
+          className={cn('h-7 px-2 text-[11px]', filter === 'error' ? 'bg-rose-600 text-white' : 'text-muted-foreground')}
+        >
+          Errors
+        </Button>
+        <Button
+          size="sm"
+          variant={filter === 'warning' ? 'default' : 'ghost'}
+          onClick={() => onFilterChange('warning')}
+          className={cn('h-7 px-2 text-[11px]', filter === 'warning' ? 'bg-amber-600 text-white' : 'text-muted-foreground')}
+        >
+          Warnings
+        </Button>
+      </div>
+      <div className="rounded-md border border-border/60 bg-background/80">
+        {triageState === 'loading' ? (
+          <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">Loading diagnostics…</div>
+        ) : triageState === 'empty' || visibleDiagnostics.length === 0 ? (
+          <div className="flex h-32 items-center justify-center p-4 text-sm text-muted-foreground">No diagnostics found.</div>
+        ) : (
+          <ul className="max-h-[calc(100vh-220px)] overflow-y-auto p-2 text-sm">
+            {visibleDiagnostics.map(diagnostic => {
+              const isActive = diagnostic.originalIndex === activeId;
+              const isError = diagnostic.severity === 'error';
+              const canJumpToLine = diagnostic.mappedLineNumber !== undefined;
+              return (
+                <li key={diagnostic.originalIndex}>
+                  <button
+                    type="button"
+                    onClick={() => onSelectDiagnostic(diagnostic.originalIndex)}
+                    className={cn(
+                      'mb-2 block w-full rounded-md border border-transparent p-2 text-left transition-colors',
+                      isActive
+                        ? 'bg-amber-500/20 border-amber-500/40 text-amber-100'
+                        : 'text-muted-foreground hover:bg-background/50 hover:text-foreground'
+                    )}
+                  >
+                    <div className="mb-1 flex items-center gap-2">
+                      {isError ? <AlertCircle className="h-3.5 w-3.5 text-red-300" /> : <AlertTriangle className="h-3.5 w-3.5 text-amber-300" />}
+                      <span className="text-[11px] uppercase tracking-wide text-muted-foreground">{diagnostic.code.replace(/_/g, ' ')}</span>
+                      <span className="ml-auto flex items-center gap-1">
+                        <Filter className="h-3 w-3 text-muted-foreground" />
+                        <Badge variant="outline" className={cn('text-[10px]', isError ? 'border-red-500/40 text-red-200' : 'border-amber-500/40 text-amber-200')}>
+                          {diagnostic.severity}
+                        </Badge>
+                      </span>
+                    </div>
+                    <div className="break-words text-foreground">{diagnostic.summary}</div>
+                    <div className="mt-1 text-xs text-muted-foreground">
+                      {canJumpToLine ? `Line ${diagnostic.mappedLineNumber}` : 'Unmapped'}
+                    </div>
+                  </button>
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+    </aside>
+  );
+}

--- a/src/webview/components/log-viewer/LogEntryList.tsx
+++ b/src/webview/components/log-viewer/LogEntryList.tsx
@@ -1,13 +1,22 @@
 import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { List, type ListImperativeAPI } from 'react-window';
 import type { ParsedLogEntry, LogCategory } from '../../utils/logViewerParser';
+import type { LogViewerMappedDiagnostic } from '../../utils/logViewerDiagnostics';
 import { LogEntryRow } from './LogEntryRow';
+
+export type LogEntryDiagnosticSummary = {
+  entryId: number;
+  diagnostics: readonly LogViewerMappedDiagnostic[];
+};
 
 interface Props {
   entries: ParsedLogEntry[];
   highlightCategory?: LogCategory;
   matchIndices?: number[];
   activeMatchIndex?: number;
+  entryDiagnosticSummaries?: readonly LogEntryDiagnosticSummary[];
+  activeDiagnosticId?: number;
+  activeDiagnosticEntryIndex?: number;
   searchTerm?: string;
   listRef?: React.RefObject<ListImperativeAPI | null>;
   virtualListComponent?: typeof List;
@@ -19,6 +28,9 @@ export function LogEntryList({
   highlightCategory,
   matchIndices,
   activeMatchIndex,
+  entryDiagnosticSummaries,
+  activeDiagnosticId,
+  activeDiagnosticEntryIndex,
   searchTerm,
   listRef,
   virtualListComponent,
@@ -86,6 +98,17 @@ export function LogEntryList({
     return new Set(matchIndices);
   }, [matchIndices]);
 
+  const diagnosticsByEntryId = useMemo(() => {
+    const map = new Map<number, readonly LogViewerMappedDiagnostic[]>();
+    for (const summary of entryDiagnosticSummaries ?? []) {
+      if (summary?.entryId === undefined || summary.entryId === null) {
+        continue;
+      }
+      map.set(summary.entryId, summary.diagnostics ?? []);
+    }
+    return map;
+  }, [entryDiagnosticSummaries]);
+
   const activeMatchEntryIndex = useMemo(() => {
     if (activeMatchIndex === undefined || activeMatchIndex === null || activeMatchIndex < 0) {
       return undefined;
@@ -93,9 +116,34 @@ export function LogEntryList({
     return matchIndices?.[activeMatchIndex];
   }, [activeMatchIndex, matchIndices]);
 
+  useLayoutEffect(() => {
+    if (
+      activeDiagnosticEntryIndex === undefined ||
+      activeDiagnosticEntryIndex === null ||
+      activeDiagnosticEntryIndex < 0 ||
+      activeDiagnosticEntryIndex >= entries.length
+    ) {
+      return;
+    }
+    resolvedListRef.current?.scrollToRow({
+      index: activeDiagnosticEntryIndex,
+      align: 'center',
+      behavior: 'auto'
+    });
+  }, [activeDiagnosticEntryIndex, entries.length, resolvedListRef]);
+
   const data = useMemo(
-    () => ({ entries, highlightCategory, setRowHeight, matchSet, activeMatchEntryIndex, searchTerm }),
-    [entries, highlightCategory, setRowHeight, matchSet, activeMatchEntryIndex, searchTerm]
+    () => ({
+      entries,
+      highlightCategory,
+      setRowHeight,
+      matchSet,
+      activeMatchEntryIndex,
+      activeDiagnosticId,
+      diagnosticsByEntryId,
+      searchTerm
+    }),
+    [diagnosticsByEntryId, entries, highlightCategory, setRowHeight, matchSet, activeMatchEntryIndex, activeDiagnosticId, searchTerm]
   );
 
   const renderRow = useCallback(
@@ -107,6 +155,8 @@ export function LogEntryList({
       setRowHeight: measure,
       matchSet: matchLookup,
       activeMatchEntryIndex: activeIndex,
+      activeDiagnosticId: diagnosticId,
+      diagnosticsByEntryId: diagnosticsById,
       searchTerm: term
     }: any) => {
       const entry = listEntries[index] as ParsedLogEntry | undefined;
@@ -114,6 +164,8 @@ export function LogEntryList({
       const highlighted = target ? entry.category === target : false;
       const isMatch = matchLookup ? matchLookup.has(index) : false;
       const isActiveMatch = isMatch && activeIndex === index;
+      const isActiveDiagnostic = index === activeDiagnosticEntryIndex;
+      const rowDiagnostics = diagnosticsById.get(entry.id) ?? [];
       return (
         <div style={style}>
           <Row
@@ -121,13 +173,16 @@ export function LogEntryList({
             highlighted={highlighted}
             isMatch={isMatch}
             isActiveMatch={isActiveMatch}
+            isActiveDiagnostic={isActiveDiagnostic}
+            diagnostics={rowDiagnostics}
+            activeDiagnosticId={diagnosticId}
             searchTerm={term}
             onMeasured={h => measure(index, h)}
           />
         </div>
       );
     },
-    []
+    [activeDiagnosticEntryIndex]
   );
 
   return (

--- a/src/webview/components/log-viewer/LogEntryList.tsx
+++ b/src/webview/components/log-viewer/LogEntryList.tsx
@@ -130,7 +130,7 @@ export function LogEntryList({
       align: 'center',
       behavior: 'auto'
     });
-  }, [activeDiagnosticEntryIndex, entries.length, resolvedListRef]);
+  }, [activeDiagnosticEntryIndex, activeDiagnosticId, entries.length, resolvedListRef]);
 
   const data = useMemo(
     () => ({

--- a/src/webview/components/log-viewer/LogEntryRow.tsx
+++ b/src/webview/components/log-viewer/LogEntryRow.tsx
@@ -2,18 +2,32 @@ import React, { useLayoutEffect, useRef } from 'react';
 import { Badge } from '../ui/badge';
 import { cn } from '../../lib/utils';
 import type { LogCategory, ParsedLogEntry } from '../../utils/logViewerParser';
+import type { LogViewerMappedDiagnostic } from '../../utils/logViewerDiagnostics';
 import { Bug, Database, Edit3, Settings, Info, AlertTriangle, AlertOctagon, Cpu } from 'lucide-react';
 
 interface Props {
   entry: ParsedLogEntry;
   highlighted: boolean;
+  isActiveDiagnostic?: boolean;
   isMatch?: boolean;
   isActiveMatch?: boolean;
+  diagnostics?: readonly LogViewerMappedDiagnostic[];
+  activeDiagnosticId?: number;
   searchTerm?: string;
   onMeasured: (height: number) => void;
 }
 
-export function LogEntryRow({ entry, highlighted, isMatch, isActiveMatch, searchTerm, onMeasured }: Props) {
+export function LogEntryRow({
+  entry,
+  highlighted,
+  isActiveDiagnostic,
+  isMatch,
+  isActiveMatch,
+  diagnostics,
+  activeDiagnosticId,
+  searchTerm,
+  onMeasured
+}: Props) {
   const ref = useRef<HTMLDivElement | null>(null);
   useLayoutEffect(() => {
     const el = ref.current;
@@ -34,6 +48,8 @@ export function LogEntryRow({ entry, highlighted, isMatch, isActiveMatch, search
   const { badgeClass, icon: Icon, iconClass } = getCategoryVisuals(entry.category);
   const normalizedTerm = (searchTerm ?? '').trim();
   const showMatchHighlight = normalizedTerm.length > 0 && isMatch;
+  const rowDiagnostics = diagnostics ?? [];
+  const hasActiveDiagnostic = typeof activeDiagnosticId === 'number';
 
   return (
     <div
@@ -42,8 +58,9 @@ export function LogEntryRow({ entry, highlighted, isMatch, isActiveMatch, search
         'flex items-start gap-3 border-b border-border/40 px-4 py-2 text-xs transition-colors',
         !(highlighted || showMatchHighlight || isActiveMatch) && 'hover:bg-muted/20',
         highlighted && 'bg-sky-500/10',
+        isActiveDiagnostic && 'bg-amber-500/20 ring-2 ring-amber-400/60',
         showMatchHighlight && 'bg-amber-500/10',
-        isActiveMatch && 'bg-amber-500/20 ring-1 ring-amber-400'
+        isActiveMatch && !isActiveDiagnostic && 'bg-amber-500/20 ring-1 ring-amber-400'
       )}
     >
       <div className="mt-0.5 min-w-[84px] font-mono text-[11px] text-muted-foreground">
@@ -63,6 +80,26 @@ export function LogEntryRow({ entry, highlighted, isMatch, isActiveMatch, search
         {entry.details && (
           <div className="rounded-md bg-muted/15 px-3 py-1 font-mono text-[11px] text-muted-foreground shadow-inner">
             {highlightText(entry.details, normalizedTerm)}
+          </div>
+        )}
+        {rowDiagnostics.length > 0 && (
+          <div className="mt-1 flex flex-wrap gap-2" role="list">
+            {rowDiagnostics.map(diagnostic => {
+              const isActive = hasActiveDiagnostic && diagnostic.originalIndex === activeDiagnosticId;
+              return (
+                <Badge
+                  key={diagnostic.originalIndex}
+                  variant="outline"
+                  className={cn(
+                    'text-[11px]',
+                    isActive ? 'border-amber-300 bg-amber-500/30 text-amber-100' : 'border-muted-foreground/30 bg-muted/20',
+                    diagnostic.severity === 'error' ? 'text-red-200' : 'text-amber-200'
+                  )}
+                >
+                  {diagnostic.summary}
+                </Badge>
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -98,6 +98,7 @@ export function LogViewerApp({
           setTriageState('loading');
         }
         setActiveDiagnosticId(undefined);
+        setActiveDiagnosticSeverityFilter('all');
         if (typeof msg.logUri === 'string' && msg.logUri.length > 0) {
           if (resolvedFetch) {
             const requestId = ++latestRequestId.current;

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -17,7 +17,7 @@ import type { ListImperativeAPI } from 'react-window';
 import type { LogViewerMappedDiagnostic } from './utils/logViewerDiagnostics';
 import { buildVisibleEntries, mapDiagnosticsToEntries } from './utils/logViewerDiagnostics';
 
-type TriageState = 'loading' | 'empty' | 'ready';
+type TriageState = 'loading' | 'unavailable' | 'empty' | 'ready';
 type DiagnosticSeverityFilter = 'all' | 'error' | 'warning';
 
 type Metadata = {
@@ -38,6 +38,10 @@ function mapFilterToCategory(filter: LogFilter): LogCategory | undefined {
     default:
       return undefined;
   }
+}
+
+function getResolvedTriageState(triage: LogViewerTriagePayload): Exclude<TriageState, 'loading' | 'unavailable'> {
+  return triage.reasons?.length ? 'ready' : 'empty';
 }
 
 export interface LogViewerAppProps {
@@ -89,7 +93,7 @@ export function LogViewerApp({
         setMetadata(msg.metadata);
         setTriage(msg.triage);
         if (msg.triage) {
-          setTriageState(msg.triage.reasons?.length ? 'ready' : 'empty');
+          setTriageState(getResolvedTriageState(msg.triage));
         } else {
           setTriageState('loading');
         }
@@ -150,7 +154,7 @@ export function LogViewerApp({
           return;
         }
         setTriage(msg.triage);
-        setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'empty');
+        setTriageState(msg.triage ? getResolvedTriageState(msg.triage) : 'unavailable');
       }
     };
     messageBus.addEventListener('message', handler as EventListener);

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -64,7 +64,7 @@ export function LogViewerApp({
   const [activeDiagnosticId, setActiveDiagnosticId] = useState<number | undefined>(undefined);
   const [activeDiagnosticSeverityFilter, setActiveDiagnosticSeverityFilter] = useState<DiagnosticSeverityFilter>('all');
   const latestRequestId = useRef(0);
-  const triageFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const triageFallbackTimerRef = useRef<number | null>(null);
   const TRIAGE_LOADING_TIMEOUT_MS = 1000;
   const listRef = useRef<ListImperativeAPI | null>(null);
   const [activeMatchIndex, setActiveMatchIndex] = useState<number>(-1);

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -64,6 +64,8 @@ export function LogViewerApp({
   const [activeDiagnosticId, setActiveDiagnosticId] = useState<number | undefined>(undefined);
   const [activeDiagnosticSeverityFilter, setActiveDiagnosticSeverityFilter] = useState<DiagnosticSeverityFilter>('all');
   const latestRequestId = useRef(0);
+  const triageFallbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const TRIAGE_LOADING_TIMEOUT_MS = 1000;
   const listRef = useRef<ListImperativeAPI | null>(null);
   const [activeMatchIndex, setActiveMatchIndex] = useState<number>(-1);
   const activeLogId = useRef<string>('');
@@ -75,20 +77,37 @@ export function LogViewerApp({
       vscode.postMessage({ type: 'logViewerReady' });
       return;
     }
+
+    const clearTriageFallbackTimer = () => {
+      if (triageFallbackTimerRef.current !== null) {
+        window.clearTimeout(triageFallbackTimerRef.current);
+        triageFallbackTimerRef.current = null;
+      }
+    };
+
     const handler = (event: MessageEvent<LogViewerToWebviewMessage>) => {
       const msg = event.data;
       if (!msg || typeof msg !== 'object') {
         return;
       }
       if (msg.type === 'logViewerInit') {
-        if (msg.logId) {
-          activeLogId.current = msg.logId;
-        }
+        const nextLogId = typeof msg.logId === 'string' ? msg.logId : '';
+        activeLogId.current = nextLogId;
         setLocale(msg.locale || 'en');
         setFileName(msg.fileName);
         setMetadata(msg.metadata);
+        clearTriageFallbackTimer();
         setTriage(msg.triage);
-        setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'loading');
+        if (msg.triage) {
+          setTriageState(msg.triage.reasons?.length ? 'ready' : 'empty');
+        } else {
+          setTriageState('loading');
+          triageFallbackTimerRef.current = window.setTimeout(() => {
+            if (activeLogId.current === nextLogId) {
+              setTriageState('empty');
+            }
+          }, TRIAGE_LOADING_TIMEOUT_MS);
+        }
         setActiveDiagnosticId(undefined);
         if (typeof msg.logUri === 'string' && msg.logUri.length > 0) {
           if (resolvedFetch) {
@@ -141,13 +160,17 @@ export function LogViewerApp({
         if (msg.logId !== activeLogId.current) {
           return;
         }
+        clearTriageFallbackTimer();
         setTriage(msg.triage);
         setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'empty');
       }
     };
     messageBus.addEventListener('message', handler as EventListener);
     vscode.postMessage({ type: 'logViewerReady' });
-    return () => messageBus.removeEventListener('message', handler as EventListener);
+    return () => {
+      clearTriageFallbackTimer();
+      messageBus.removeEventListener('message', handler as EventListener);
+    };
   }, [messageBus, resolvedFetch, vscode]);
 
   const counts = useMemo(() => {
@@ -257,9 +280,6 @@ export function LogViewerApp({
     if (activeDiagnosticSummary === undefined) {
       setActiveDiagnosticId(undefined);
       return;
-    }
-    if (activeDiagnosticSummary.mappedEntryId === undefined) {
-      setActiveDiagnosticId(undefined);
     }
   }, [activeDiagnosticId, activeDiagnosticSummary]);
 

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -41,7 +41,7 @@ function mapFilterToCategory(filter: LogFilter): LogCategory | undefined {
 }
 
 function getResolvedTriageState(triage: LogViewerTriagePayload): Exclude<TriageState, 'loading' | 'unavailable'> {
-  return triage.reasons?.length ? 'ready' : 'empty';
+  return triage.reasons?.length || triage.primaryReason?.trim() ? 'ready' : 'empty';
 }
 
 export interface LogViewerAppProps {
@@ -195,6 +195,10 @@ export function LogViewerApp({
   }, [entries]);
 
   const mappedDiagnostics = useMemo(() => mapDiagnosticsToEntries(entries, triage?.reasons ?? []), [entries, triage?.reasons]);
+  const primaryReason = useMemo(() => {
+    const summary = triage?.primaryReason?.trim();
+    return summary ? summary : undefined;
+  }, [triage?.primaryReason]);
 
   const mappedDiagnosticById = useMemo(() => {
     const map = new Map<number, LogViewerMappedDiagnostic>();
@@ -419,6 +423,7 @@ export function LogViewerApp({
             onSelectDiagnostic={nextActiveDiagnosticId =>
               setActiveDiagnosticId(current => (current === nextActiveDiagnosticId ? undefined : nextActiveDiagnosticId))
             }
+            primaryReason={primaryReason}
             triageState={triageState}
           />
         </div>

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -139,6 +139,10 @@ export function LogViewerApp({
           setError(undefined);
         }
       } else if (msg.type === 'logViewerError') {
+        activeLogId.current = '';
+        setTriage(undefined);
+        setTriageState('empty');
+        setActiveDiagnosticId(undefined);
         setError(msg.message);
         setLoading(false);
       } else if (msg.type === 'logViewerTriageUpdate') {
@@ -256,7 +260,13 @@ export function LogViewerApp({
       setActiveDiagnosticId(undefined);
       return;
     }
-  }, [activeDiagnosticId, activeDiagnosticSummary]);
+    if (
+      activeDiagnosticSeverityFilter !== 'all' &&
+      activeDiagnosticSummary.severity !== activeDiagnosticSeverityFilter
+    ) {
+      setActiveDiagnosticId(undefined);
+    }
+  }, [activeDiagnosticId, activeDiagnosticSeverityFilter, activeDiagnosticSummary]);
 
   const entryDiagnosticSummaries = useMemo(
     () =>

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -64,8 +64,6 @@ export function LogViewerApp({
   const [activeDiagnosticId, setActiveDiagnosticId] = useState<number | undefined>(undefined);
   const [activeDiagnosticSeverityFilter, setActiveDiagnosticSeverityFilter] = useState<DiagnosticSeverityFilter>('all');
   const latestRequestId = useRef(0);
-  const triageFallbackTimerRef = useRef<number | null>(null);
-  const TRIAGE_LOADING_TIMEOUT_MS = 1000;
   const listRef = useRef<ListImperativeAPI | null>(null);
   const [activeMatchIndex, setActiveMatchIndex] = useState<number>(-1);
   const activeLogId = useRef<string>('');
@@ -78,13 +76,6 @@ export function LogViewerApp({
       return;
     }
 
-    const clearTriageFallbackTimer = () => {
-      if (triageFallbackTimerRef.current !== null) {
-        window.clearTimeout(triageFallbackTimerRef.current);
-        triageFallbackTimerRef.current = null;
-      }
-    };
-
     const handler = (event: MessageEvent<LogViewerToWebviewMessage>) => {
       const msg = event.data;
       if (!msg || typeof msg !== 'object') {
@@ -96,17 +87,11 @@ export function LogViewerApp({
         setLocale(msg.locale || 'en');
         setFileName(msg.fileName);
         setMetadata(msg.metadata);
-        clearTriageFallbackTimer();
         setTriage(msg.triage);
         if (msg.triage) {
           setTriageState(msg.triage.reasons?.length ? 'ready' : 'empty');
         } else {
           setTriageState('loading');
-          triageFallbackTimerRef.current = window.setTimeout(() => {
-            if (activeLogId.current === nextLogId) {
-              setTriageState('empty');
-            }
-          }, TRIAGE_LOADING_TIMEOUT_MS);
         }
         setActiveDiagnosticId(undefined);
         if (typeof msg.logUri === 'string' && msg.logUri.length > 0) {
@@ -160,7 +145,6 @@ export function LogViewerApp({
         if (msg.logId !== activeLogId.current) {
           return;
         }
-        clearTriageFallbackTimer();
         setTriage(msg.triage);
         setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'empty');
       }
@@ -168,7 +152,6 @@ export function LogViewerApp({
     messageBus.addEventListener('message', handler as EventListener);
     vscode.postMessage({ type: 'logViewerReady' });
     return () => {
-      clearTriageFallbackTimer();
       messageBus.removeEventListener('message', handler as EventListener);
     };
   }, [messageBus, resolvedFetch, vscode]);
@@ -227,7 +210,7 @@ export function LogViewerApp({
     return orderedDiagnosticsWithMapping.find(diagnostic => diagnostic.originalIndex === activeDiagnosticId);
   }, [activeDiagnosticId, orderedDiagnosticsWithMapping]);
 
-  const shouldIncludeByFilterAndSearch = useCallback(
+  const shouldIncludeByFilter = useCallback(
     (entry: ParsedLogEntry) => {
       switch (filter) {
         case 'debug':
@@ -243,17 +226,9 @@ export function LogViewerApp({
           if (entry.category !== 'dml') return false;
           break;
       }
-      const normalizedSearch = search.trim().toLowerCase();
-      if (!normalizedSearch) {
-        return true;
-      }
-      const haystack = [entry.timestamp, entry.type, entry.message, entry.details, entry.raw]
-        .filter(Boolean)
-        .join(' ')
-        .toLowerCase();
-      return haystack.includes(normalizedSearch);
+      return true;
     },
-    [search, filter]
+    [filter]
   );
 
   const orderedDiagnostics = useMemo(
@@ -262,13 +237,13 @@ export function LogViewerApp({
   );
 
   const visibleDiagnosticRows = useMemo(
-    () =>
-      buildVisibleEntries({
-        entries: mappedDiagnostics.mappedEntries,
-        shouldIncludeEntry: shouldIncludeByFilterAndSearch,
-        activeDiagnostic: activeDiagnosticSummary
-      }),
-    [mappedDiagnostics.mappedEntries, shouldIncludeByFilterAndSearch, activeDiagnosticSummary]
+      () =>
+        buildVisibleEntries({
+          entries: mappedDiagnostics.mappedEntries,
+          shouldIncludeEntry: shouldIncludeByFilter,
+          activeDiagnostic: activeDiagnosticSummary
+        }),
+    [mappedDiagnostics.mappedEntries, shouldIncludeByFilter, activeDiagnosticSummary]
   );
 
   const visibleEntries = useMemo(() => visibleDiagnosticRows.map(entry => entry.entry), [visibleDiagnosticRows]);

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -244,11 +244,6 @@ export function LogViewerApp({
     [filter]
   );
 
-  const orderedDiagnostics = useMemo(
-    () => orderedDiagnosticsWithMapping.filter(diagnostic => activeDiagnosticSeverityFilter === 'all' || diagnostic.severity === activeDiagnosticSeverityFilter),
-    [activeDiagnosticSeverityFilter, orderedDiagnosticsWithMapping]
-  );
-
   const visibleDiagnosticRows = useMemo(
       () =>
         buildVisibleEntries({
@@ -417,7 +412,7 @@ export function LogViewerApp({
             )}
           </section>
           <LogDiagnosticsSidebar
-            diagnostics={orderedDiagnostics}
+            diagnostics={orderedDiagnosticsWithMapping}
             activeId={activeDiagnosticId}
             filter={activeDiagnosticSeverityFilter}
             onFilterChange={setActiveDiagnosticSeverityFilter}

--- a/src/webview/logViewer.tsx
+++ b/src/webview/logViewer.tsx
@@ -1,14 +1,24 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { createRoot } from 'react-dom/client';
-import type { LogViewerFromWebviewMessage, LogViewerToWebviewMessage } from '../shared/logViewerMessages';
+import type {
+  LogViewerFromWebviewMessage,
+  LogViewerToWebviewMessage,
+  LogViewerTriagePayload
+} from '../shared/logViewerMessages';
 import { parseLogLines, type ParsedLogEntry, type LogCategory } from './utils/logViewerParser';
 import { LogViewerHeader } from './components/log-viewer/LogViewerHeader';
 import { LogViewerFilters, type LogFilter } from './components/log-viewer/LogViewerFilters';
 import { LogEntryList } from './components/log-viewer/LogEntryList';
+import { LogDiagnosticsSidebar } from './components/log-viewer/LogDiagnosticsSidebar';
 import { LogViewerStatusBar } from './components/log-viewer/LogViewerStatusBar';
 import type { VsCodeWebviewApi, MessageBus } from './vscodeApi';
 import { getDefaultMessageBus, getDefaultVsCodeApi } from './vscodeApi';
 import type { ListImperativeAPI } from 'react-window';
+import type { LogViewerMappedDiagnostic } from './utils/logViewerDiagnostics';
+import { buildVisibleEntries, mapDiagnosticsToEntries } from './utils/logViewerDiagnostics';
+
+type TriageState = 'loading' | 'empty' | 'ready';
+type DiagnosticSeverityFilter = 'all' | 'error' | 'warning';
 
 type Metadata = {
   sizeBytes?: number;
@@ -45,13 +55,18 @@ export function LogViewerApp({
   const [locale, setLocale] = useState('en');
   const [metadata, setMetadata] = useState<Metadata | undefined>(undefined);
   const [entries, setEntries] = useState<ParsedLogEntry[]>([]);
+  const [triage, setTriage] = useState<LogViewerTriagePayload | undefined>(undefined);
   const [search, setSearch] = useState('');
   const [filter, setFilter] = useState<LogFilter>('all');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | undefined>(undefined);
+  const [triageState, setTriageState] = useState<TriageState>('loading');
+  const [activeDiagnosticId, setActiveDiagnosticId] = useState<number | undefined>(undefined);
+  const [activeDiagnosticSeverityFilter, setActiveDiagnosticSeverityFilter] = useState<DiagnosticSeverityFilter>('all');
   const latestRequestId = useRef(0);
   const listRef = useRef<ListImperativeAPI | null>(null);
   const [activeMatchIndex, setActiveMatchIndex] = useState<number>(-1);
+  const activeLogId = useRef<string>('');
 
   const resolvedFetch = fetchImpl ?? (typeof fetch === 'function' ? fetch : undefined);
 
@@ -66,14 +81,21 @@ export function LogViewerApp({
         return;
       }
       if (msg.type === 'logViewerInit') {
+        if (msg.logId) {
+          activeLogId.current = msg.logId;
+        }
         setLocale(msg.locale || 'en');
         setFileName(msg.fileName);
         setMetadata(msg.metadata);
+        setTriage(msg.triage);
+        setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'loading');
+        setActiveDiagnosticId(undefined);
         if (typeof msg.logUri === 'string' && msg.logUri.length > 0) {
           if (resolvedFetch) {
             const requestId = ++latestRequestId.current;
             setLoading(true);
             setError(undefined);
+            setEntries([]);
             void resolvedFetch(msg.logUri)
               .then(response => {
                 if (!response.ok) {
@@ -115,6 +137,12 @@ export function LogViewerApp({
       } else if (msg.type === 'logViewerError') {
         setError(msg.message);
         setLoading(false);
+      } else if (msg.type === 'logViewerTriageUpdate') {
+        if (msg.logId !== activeLogId.current) {
+          return;
+        }
+        setTriage(msg.triage);
+        setTriageState(msg.triage ? (msg.triage.reasons?.length ? 'ready' : 'empty') : 'empty');
       }
     };
     messageBus.addEventListener('message', handler as EventListener);
@@ -152,8 +180,32 @@ export function LogViewerApp({
     };
   }, [entries]);
 
-  const filteredEntries = useMemo(() => {
-    return entries.filter(entry => {
+  const mappedDiagnostics = useMemo(() => mapDiagnosticsToEntries(entries, triage?.reasons ?? []), [entries, triage?.reasons]);
+
+  const mappedDiagnosticById = useMemo(() => {
+    const map = new Map<number, LogViewerMappedDiagnostic>();
+    for (const group of mappedDiagnostics.mappedEntries) {
+      for (const diagnostic of group.diagnostics) {
+        map.set(diagnostic.originalIndex, diagnostic);
+      }
+    }
+    return map;
+  }, [mappedDiagnostics.mappedEntries]);
+
+  const orderedDiagnosticsWithMapping = useMemo(
+    () => mappedDiagnostics.orderedDiagnostics.map(diagnostic => mappedDiagnosticById.get(diagnostic.originalIndex) ?? diagnostic),
+    [mappedDiagnostics.orderedDiagnostics, mappedDiagnosticById]
+  );
+
+  const activeDiagnosticSummary = useMemo(() => {
+    if (typeof activeDiagnosticId !== 'number') {
+      return undefined;
+    }
+    return orderedDiagnosticsWithMapping.find(diagnostic => diagnostic.originalIndex === activeDiagnosticId);
+  }, [activeDiagnosticId, orderedDiagnosticsWithMapping]);
+
+  const shouldIncludeByFilterAndSearch = useCallback(
+    (entry: ParsedLogEntry) => {
       switch (filter) {
         case 'debug':
           if (entry.category !== 'debug') return false;
@@ -168,9 +220,68 @@ export function LogViewerApp({
           if (entry.category !== 'dml') return false;
           break;
       }
-      return true;
-    });
-  }, [entries, filter]);
+      const normalizedSearch = search.trim().toLowerCase();
+      if (!normalizedSearch) {
+        return true;
+      }
+      const haystack = [entry.timestamp, entry.type, entry.message, entry.details, entry.raw]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase();
+      return haystack.includes(normalizedSearch);
+    },
+    [search, filter]
+  );
+
+  const orderedDiagnostics = useMemo(
+    () => orderedDiagnosticsWithMapping.filter(diagnostic => activeDiagnosticSeverityFilter === 'all' || diagnostic.severity === activeDiagnosticSeverityFilter),
+    [activeDiagnosticSeverityFilter, orderedDiagnosticsWithMapping]
+  );
+
+  const visibleDiagnosticRows = useMemo(
+    () =>
+      buildVisibleEntries({
+        entries: mappedDiagnostics.mappedEntries,
+        shouldIncludeEntry: shouldIncludeByFilterAndSearch,
+        activeDiagnostic: activeDiagnosticSummary
+      }),
+    [mappedDiagnostics.mappedEntries, shouldIncludeByFilterAndSearch, activeDiagnosticSummary]
+  );
+
+  const visibleEntries = useMemo(() => visibleDiagnosticRows.map(entry => entry.entry), [visibleDiagnosticRows]);
+
+  useEffect(() => {
+    if (activeDiagnosticId === undefined) {
+      return;
+    }
+    if (activeDiagnosticSummary === undefined) {
+      setActiveDiagnosticId(undefined);
+      return;
+    }
+    if (activeDiagnosticSummary.mappedEntryId === undefined) {
+      setActiveDiagnosticId(undefined);
+    }
+  }, [activeDiagnosticId, activeDiagnosticSummary]);
+
+  const entryDiagnosticSummaries = useMemo(
+    () =>
+      visibleDiagnosticRows.map(({ entry, diagnostics }) => ({
+        entryId: entry.id,
+        diagnostics
+      })),
+    [visibleDiagnosticRows]
+  );
+
+  const activeDiagnosticEntryIndex = useMemo(() => {
+    if (activeDiagnosticSummary?.mappedEntryId === undefined) {
+      return undefined;
+    }
+    const index = visibleEntries.findIndex(entry => entry.id === activeDiagnosticSummary.mappedEntryId);
+    if (index < 0) {
+      return undefined;
+    }
+    return index;
+  }, [activeDiagnosticSummary, visibleEntries]);
 
   const trimmedSearch = useMemo(() => search.trim(), [search]);
 
@@ -180,7 +291,7 @@ export function LogViewerApp({
       return [] as number[];
     }
     const matches: number[] = [];
-    filteredEntries.forEach((entry, index) => {
+    visibleEntries.forEach((entry, index) => {
       const haystack = [entry.timestamp, entry.type, entry.message, entry.details, entry.raw]
         .filter(Boolean)
         .join(' ')
@@ -190,7 +301,7 @@ export function LogViewerApp({
       }
     });
     return matches;
-  }, [filteredEntries, trimmedSearch]);
+  }, [visibleEntries, trimmedSearch]);
 
   useEffect(() => {
     setActiveMatchIndex(prev => {
@@ -267,24 +378,41 @@ export function LogViewerApp({
       />
       <LogViewerFilters active={filter} onChange={setFilter} counts={counts} locale={locale} />
       <main className="flex min-h-0 flex-1 flex-col bg-background/40">
-        {error ? (
-          <div className="m-6 rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
-            {error}
-          </div>
-        ) : loading ? (
-          <div className="m-6 rounded-md border border-border/40 bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
-            Loading log entries…
-          </div>
-        ) : (
-          <LogEntryList
-            entries={filteredEntries}
-            highlightCategory={highlightCategory}
-            matchIndices={matchIndices}
-            activeMatchIndex={activeMatchIndex >= 0 ? activeMatchIndex : undefined}
-            searchTerm={trimmedSearch}
-            listRef={listRef}
+        <div className="grid min-h-0 flex-1 gap-3 px-4 pb-3 lg:grid-cols-[1fr_22rem]">
+          <section className="min-h-0">
+            {error ? (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+                {error}
+              </div>
+            ) : loading ? (
+              <div className="rounded-md border border-border/40 bg-muted/20 px-4 py-3 text-sm text-muted-foreground">
+                Loading log entries…
+              </div>
+              ) : (
+              <LogEntryList
+                entries={visibleEntries}
+                entryDiagnosticSummaries={entryDiagnosticSummaries}
+                highlightCategory={highlightCategory}
+                matchIndices={matchIndices}
+                activeMatchIndex={activeMatchIndex >= 0 ? activeMatchIndex : undefined}
+                searchTerm={trimmedSearch}
+                listRef={listRef}
+                activeDiagnosticId={activeDiagnosticId}
+                activeDiagnosticEntryIndex={activeDiagnosticEntryIndex}
+              />
+            )}
+          </section>
+          <LogDiagnosticsSidebar
+            diagnostics={orderedDiagnostics}
+            activeId={activeDiagnosticId}
+            filter={activeDiagnosticSeverityFilter}
+            onFilterChange={setActiveDiagnosticSeverityFilter}
+            onSelectDiagnostic={nextActiveDiagnosticId =>
+              setActiveDiagnosticId(current => (current === nextActiveDiagnosticId ? undefined : nextActiveDiagnosticId))
+            }
+            triageState={triageState}
           />
-        )}
+        </div>
       </main>
       <LogViewerStatusBar counts={counts} locale={locale} metadata={metadata} />
     </div>

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -59,8 +59,12 @@ export function orderDiagnostics(reasons: readonly LogDiagnostic[]): LogViewerMa
       if (!aHasLine && bHasLine) {
         return 1;
       }
-      if (aHasLine && bHasLine && a.line !== b.line) {
-        return a.line - b.line;
+      if (aHasLine && bHasLine) {
+        const aLine = a.line as number;
+        const bLine = b.line as number;
+        if (aLine !== bLine) {
+          return aLine - bLine;
+        }
       }
       return a.originalIndex - b.originalIndex;
     });

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -87,13 +87,12 @@ export function mapDiagnosticsToEntries(
   const unmappedDiagnostics: LogViewerMappedDiagnostic[] = [];
 
   for (const row of mappedEntries) {
+    byPhysicalLine.set(row.entry.id + 1, row);
     if (hasExactLine(row.entry.lineNumber)) {
       if (!byLine.has(row.entry.lineNumber)) {
         byLine.set(row.entry.lineNumber, row);
       }
-      continue;
     }
-    byPhysicalLine.set(row.entry.id + 1, row);
   }
 
   for (const reason of orderedDiagnostics) {

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -75,12 +75,17 @@ export function mapDiagnosticsToEntries(
     entry,
     diagnostics: []
   }));
+
+  // Policy: when duplicate line numbers exist in ParsedLogEntry list (realistic for some sources),
+  // always keep the first matching row for deterministic, stable mapping.
   const byLine = new Map<number, LogEntryDiagnosticGroup>();
   const unmappedDiagnostics: LogViewerMappedDiagnostic[] = [];
 
   for (const row of mappedEntries) {
     if (hasExactLine(row.entry.lineNumber)) {
-      byLine.set(row.entry.lineNumber, row);
+      if (!byLine.has(row.entry.lineNumber)) {
+        byLine.set(row.entry.lineNumber, row);
+      }
     }
   }
 

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -116,7 +116,7 @@ export function mapDiagnosticsToEntries(
       fallbackTarget.diagnostics.push({
         ...reason,
         mappedEntryId: fallbackTarget.entry.id,
-        mappedLineNumber: reason.line
+        mappedLineNumber: fallbackTarget.entry.lineNumber ?? reason.line
       });
       continue;
     }

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -83,6 +83,7 @@ export function mapDiagnosticsToEntries(
   // Policy: when duplicate line numbers exist in ParsedLogEntry list (realistic for some sources),
   // always keep the first matching row for deterministic, stable mapping.
   const byLine = new Map<number, LogEntryDiagnosticGroup>();
+  const byPhysicalLine = new Map<number, LogEntryDiagnosticGroup>();
   const unmappedDiagnostics: LogViewerMappedDiagnostic[] = [];
 
   for (const row of mappedEntries) {
@@ -90,7 +91,9 @@ export function mapDiagnosticsToEntries(
       if (!byLine.has(row.entry.lineNumber)) {
         byLine.set(row.entry.lineNumber, row);
       }
+      continue;
     }
+    byPhysicalLine.set(row.entry.id + 1, row);
   }
 
   for (const reason of orderedDiagnostics) {
@@ -106,9 +109,20 @@ export function mapDiagnosticsToEntries(
         mappedEntryId: target.entry.id,
         mappedLineNumber: reason.line
       });
-    } else {
-      unmappedDiagnostics.push(reason);
+      continue;
     }
+
+    const fallbackTarget = byPhysicalLine.get(reason.line);
+    if (fallbackTarget) {
+      fallbackTarget.diagnostics.push({
+        ...reason,
+        mappedEntryId: fallbackTarget.entry.id,
+        mappedLineNumber: reason.line
+      });
+      continue;
+    }
+
+    unmappedDiagnostics.push(reason);
   }
 
   const collapsedEntries = mappedEntries.map(group => ({

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -1,0 +1,133 @@
+import type { ParsedLogEntry } from './logViewerParser';
+import type { LogDiagnostic } from '../../shared/logTriage';
+
+type LogDiagnosticSeverity = LogDiagnostic['severity'];
+
+export interface LogViewerMappedDiagnostic extends LogDiagnostic {
+  originalIndex: number;
+  mappedEntryId?: number;
+  mappedLineNumber?: number;
+}
+
+export interface LogEntryDiagnosticGroup {
+  entry: ParsedLogEntry;
+  diagnostics: LogViewerMappedDiagnostic[];
+}
+
+export interface MappedDiagnosticsResult {
+  orderedDiagnostics: LogViewerMappedDiagnostic[];
+  mappedEntries: LogEntryDiagnosticGroup[];
+  unmappedDiagnostics: LogViewerMappedDiagnostic[];
+}
+
+export interface BuildVisibleEntriesArgs {
+  entries: ReadonlyArray<LogEntryDiagnosticGroup>;
+  shouldIncludeEntry: (entry: ParsedLogEntry) => boolean;
+  activeDiagnostic?: LogViewerMappedDiagnostic;
+}
+
+const hasExactLine = (line: number | undefined): line is number => {
+  return typeof line === 'number' && Number.isInteger(line) && Number.isFinite(line);
+};
+
+const SEVERITY_ORDER: Record<LogDiagnosticSeverity, number> = {
+  error: 0,
+  warning: 1
+};
+
+function bySeverityThenOriginalOrder(a: LogViewerMappedDiagnostic, b: LogViewerMappedDiagnostic): number {
+  const aSeverity = SEVERITY_ORDER[a.severity] ?? 1;
+  const bSeverity = SEVERITY_ORDER[b.severity] ?? 1;
+  if (aSeverity !== bSeverity) {
+    return aSeverity - bSeverity;
+  }
+  return a.originalIndex - b.originalIndex;
+}
+
+export function orderDiagnostics(reasons: readonly LogDiagnostic[]): LogViewerMappedDiagnostic[] {
+  return reasons
+    .map((reason, index) => ({
+      ...reason,
+      originalIndex: index
+    }))
+    .sort((a, b) => {
+      const aHasLine = hasExactLine(a.line);
+      const bHasLine = hasExactLine(b.line);
+      if (aHasLine && !bHasLine) {
+        return -1;
+      }
+      if (!aHasLine && bHasLine) {
+        return 1;
+      }
+      if (aHasLine && bHasLine && a.line !== b.line) {
+        return a.line - b.line;
+      }
+      return a.originalIndex - b.originalIndex;
+    });
+}
+
+export function mapDiagnosticsToEntries(
+  entries: readonly ParsedLogEntry[],
+  reasons: readonly LogDiagnostic[]
+): MappedDiagnosticsResult {
+  const orderedDiagnostics = orderDiagnostics(reasons);
+  const mappedEntries: LogEntryDiagnosticGroup[] = entries.map(entry => ({
+    entry,
+    diagnostics: []
+  }));
+  const byLine = new Map<number, LogEntryDiagnosticGroup>();
+  const unmappedDiagnostics: LogViewerMappedDiagnostic[] = [];
+
+  for (const row of mappedEntries) {
+    if (hasExactLine(row.entry.lineNumber)) {
+      byLine.set(row.entry.lineNumber, row);
+    }
+  }
+
+  for (const reason of orderedDiagnostics) {
+    if (!hasExactLine(reason.line)) {
+      unmappedDiagnostics.push(reason);
+      continue;
+    }
+
+    const target = byLine.get(reason.line);
+    if (target) {
+      target.diagnostics.push({
+        ...reason,
+        mappedEntryId: target.entry.id,
+        mappedLineNumber: reason.line
+      });
+    } else {
+      unmappedDiagnostics.push(reason);
+    }
+  }
+
+  const collapsedEntries = mappedEntries.map(group => ({
+    ...group,
+    diagnostics: [...group.diagnostics].sort(bySeverityThenOriginalOrder)
+  }));
+
+  return {
+    orderedDiagnostics,
+    mappedEntries: collapsedEntries,
+    unmappedDiagnostics
+  };
+}
+
+export function buildVisibleEntries({
+  entries,
+  shouldIncludeEntry,
+  activeDiagnostic
+}: BuildVisibleEntriesArgs): LogEntryDiagnosticGroup[] {
+  const activeMappedEntryId = activeDiagnostic?.mappedEntryId;
+
+  return entries.filter(({ entry }) => {
+    if (shouldIncludeEntry(entry)) {
+      return true;
+    }
+    if (activeMappedEntryId === undefined) {
+      return false;
+    }
+    return entry.id === activeMappedEntryId;
+  });
+}


### PR DESCRIPTION
## Summary
- add async parser-backed diagnostics to Open Log View with a dedicated sidebar, severity filters, and click-to-highlight navigation
- keep the active mapped row visible through category filters and search while preserving sidebar-only selection for unmapped diagnostics
- add panel, helper, component, and app coverage for async triage delivery, deterministic mapping, and stale-update handling

## Test Plan
- [x] `npm run test:webview`
- [x] `npm run pretest`
- [x] `node scripts/run-tests-cli.js --scope=unit`
- [x] `npm run build`

## Notes
- UI change in Open Log View.
- Visual asset not attached in this automated CLI flow.
