### PR TITLE
[codex] Fix diagnostic sidebar navigation for duplicate lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### Bug Fixes
 
+- Open Log View: map diagnostics with duplicated Apex line numbers to the matching log event type so sidebar clicks land on the correct row.
 - Open Log View: show an explicit unavailable state in the diagnostics sidebar when async triage fails instead of implying the log is clean.
 - Open Log View: reset the diagnostics severity filter when opening or refreshing a log so hidden sidebar state does not suppress new results.
 - Open Log View: re-scroll the virtualized log list when switching between diagnostics that collapse onto the same rendered row.

--- a/src/webview/__tests__/logViewerApp.test.tsx
+++ b/src/webview/__tests__/logViewerApp.test.tsx
@@ -274,6 +274,51 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('scrolls to the eventType-matched row when diagnostics target a duplicated line number', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'duplicate-line-log',
+      locale: 'en-US',
+      fileName: 'duplicate-line.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[1]|Alpha|A',
+        '12:00:01.000 (2)|VARIABLE_SCOPE_BEGIN|[66]|LoggerConfigurationSelector.mockLogEntryDataMaskRules|List<LogEntryDataMaskRule__mdt>|true|true',
+        '12:00:02.000 (3)|EXCEPTION_THROWN|[66]|System.DmlException: Insert failed. First exception on row 0; first error: DUPLICATE_VALUE'
+      ]
+    });
+
+    send(bus, {
+      type: 'logViewerTriageUpdate',
+      logId: 'duplicate-line-log',
+      triage: {
+        hasErrors: true,
+        reasons: [
+          {
+            code: 'dml_failure',
+            severity: 'error',
+            summary: 'DML failure',
+            line: 66,
+            eventType: 'EXCEPTION_THROWN'
+          }
+        ]
+      }
+    });
+
+    const diagnosticsPanel = screen.getByText('Diagnostics').closest('aside');
+    expect(diagnosticsPanel).not.toBeNull();
+
+    const diagnosticButton = await within(diagnosticsPanel as HTMLElement).findByRole('button', { name: /DML failure/ });
+    fireEvent.click(diagnosticButton);
+
+    await waitFor(() => {
+      expect(listScrollCalls.at(-1)).toBe(2);
+    });
+  });
+
   it('clears a hidden active diagnostic when the sidebar severity filter excludes it', async () => {
     const { vscode } = createVsCodeMock();
     const bus = new EventTarget();

--- a/src/webview/__tests__/logViewerDiagnostics.test.ts
+++ b/src/webview/__tests__/logViewerDiagnostics.test.ts
@@ -177,6 +177,49 @@ describe('logViewerDiagnostics', () => {
     ]);
   });
 
+  it('prefers a duplicate lineNumber row whose event type matches the diagnostic eventType', () => {
+    const entries: ParsedLogEntry[] = [
+      {
+        id: 0,
+        timestamp: '00:00:00.000',
+        type: 'VARIABLE_SCOPE_BEGIN',
+        message: 'prelude',
+        raw: 'raw-0',
+        category: 'other',
+        lineNumber: 66
+      },
+      {
+        id: 1,
+        timestamp: '00:00:01.000',
+        type: 'EXCEPTION_THROWN',
+        message: 'boom',
+        raw: 'raw-1',
+        category: 'error',
+        lineNumber: 66
+      }
+    ];
+
+    const result = mapDiagnosticsToEntries(entries, [
+      {
+        code: 'dml_failure',
+        severity: 'error',
+        summary: 'maps-to-exception',
+        line: 66,
+        eventType: 'EXCEPTION_THROWN'
+      }
+    ]);
+
+    expect(result.mappedEntries[0].diagnostics).toEqual([]);
+    expect(result.mappedEntries[1].diagnostics).toEqual([
+      expect.objectContaining({
+        summary: 'maps-to-exception',
+        mappedEntryId: 1,
+        mappedLineNumber: 66,
+        eventType: 'EXCEPTION_THROWN'
+      })
+    ]);
+  });
+
   it('does not force visibility when active diagnostic is unmapped or lacks mappedEntryId', () => {
     const entries: ParsedLogEntry[] = [
       makeEntry(0, 1, 'other'),

--- a/src/webview/utils/logViewerDiagnostics.ts
+++ b/src/webview/utils/logViewerDiagnostics.ts
@@ -44,6 +44,28 @@ function bySeverityThenOriginalOrder(a: LogViewerMappedDiagnostic, b: LogViewerM
   return a.originalIndex - b.originalIndex;
 }
 
+function pickMatchingEntryForDiagnostic(
+  candidates: readonly LogEntryDiagnosticGroup[],
+  reason: LogDiagnostic
+): LogEntryDiagnosticGroup | undefined {
+  if (candidates.length === 0) {
+    return undefined;
+  }
+  if (candidates.length === 1) {
+    return candidates[0];
+  }
+
+  const targetEventType = reason.eventType?.trim().toUpperCase();
+  if (targetEventType) {
+    const eventTypeMatch = candidates.find(candidate => candidate.entry.type.trim().toUpperCase() === targetEventType);
+    if (eventTypeMatch) {
+      return eventTypeMatch;
+    }
+  }
+
+  return candidates[0];
+}
+
 export function orderDiagnostics(reasons: readonly LogDiagnostic[]): LogViewerMappedDiagnostic[] {
   return reasons
     .map((reason, index) => ({
@@ -80,17 +102,18 @@ export function mapDiagnosticsToEntries(
     diagnostics: []
   }));
 
-  // Policy: when duplicate line numbers exist in ParsedLogEntry list (realistic for some sources),
-  // always keep the first matching row for deterministic, stable mapping.
-  const byLine = new Map<number, LogEntryDiagnosticGroup>();
+  const byLine = new Map<number, LogEntryDiagnosticGroup[]>();
   const byPhysicalLine = new Map<number, LogEntryDiagnosticGroup>();
   const unmappedDiagnostics: LogViewerMappedDiagnostic[] = [];
 
   for (const row of mappedEntries) {
     byPhysicalLine.set(row.entry.id + 1, row);
     if (hasExactLine(row.entry.lineNumber)) {
-      if (!byLine.has(row.entry.lineNumber)) {
-        byLine.set(row.entry.lineNumber, row);
+      const existing = byLine.get(row.entry.lineNumber);
+      if (existing) {
+        existing.push(row);
+      } else {
+        byLine.set(row.entry.lineNumber, [row]);
       }
     }
   }
@@ -101,7 +124,7 @@ export function mapDiagnosticsToEntries(
       continue;
     }
 
-    const target = byLine.get(reason.line);
+    const target = pickMatchingEntryForDiagnostic(byLine.get(reason.line) ?? [], reason);
     if (target) {
       target.diagnostics.push({
         ...reason,


### PR DESCRIPTION
## Summary
- map diagnostics with duplicated Apex line numbers to the matching log event type when triage provides `eventType`
- add regression coverage for duplicate-line mapper behavior and sidebar click-to-scroll navigation
- document the user-visible fix in `CHANGELOG.md`

## Root Cause
The diagnostics mapper collapsed duplicate `lineNumber` entries to the first matching rendered row. In logs like the reported NebulaLogger example, that made `DML failure` on line `66` navigate to an earlier `VARIABLE_SCOPE_BEGIN` entry instead of the matching `EXCEPTION_THROWN` row.

## Validation
- `npm run check-types`
- `npm run test:webview`
