### PR TITLE
[codex] Add babysit-pr skill to repo

### DIFF
--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: babysit-pr
+description: Babysit a GitHub pull request after creation by continuously polling CI checks/workflow runs, new review comments, and mergeability state until the PR is ready to merge (or merged/closed). Diagnose failures, retry likely flaky failures up to 3 times, auto-fix/push branch-related issues when appropriate, and stop only when user help is required (for example CI infrastructure issues, exhausted flaky retries, or ambiguous/blocking situations). Use when the user asks Codex to monitor a PR, watch CI, handle review comments, or keep an eye on failures and feedback on an open PR.
+---
+
+# PR Babysitter
+
+## Objective
+Babysit a PR persistently until one of these terminal outcomes occurs:
+
+- The PR is merged or closed.
+- CI is successful, there are no unaddressed review comments surfaced by the watcher, required review approval is not blocking merge, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk).
+- A situation requires user help (for example CI infrastructure issues, repeated flaky failures after retry budget is exhausted, permission problems, or ambiguity that cannot be resolved safely).
+
+Do not stop merely because a single snapshot returns `idle` while checks are still pending.
+
+## Inputs
+Accept any of the following:
+
+- No PR argument: infer the PR from the current branch (`--pr auto`)
+- PR number
+- PR URL
+
+## Core Workflow
+
+1. When the user asks to "monitor"/"watch"/"babysit" a PR, start with the watcher's continuous mode (`--watch`) unless you are intentionally doing a one-shot diagnostic snapshot.
+2. Run the watcher script to snapshot PR/CI/review state (or consume each streamed snapshot from `--watch`).
+3. Inspect the `actions` list in the JSON response.
+4. If `diagnose_ci_failure` is present, inspect failed run logs and classify the failure.
+5. If the failure is likely caused by the current branch, patch code locally, commit, and push.
+6. If `process_review_comment` is present, inspect surfaced review items and decide whether to address them.
+7. If a review item is actionable and correct, patch code locally, commit, and push.
+8. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
+9. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
+10. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state.
+11. After any push or rerun action, immediately return to step 1 and continue polling on the updated SHA/state.
+12. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
+13. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
+14. Maintain terminal/session ownership: while babysitting is active, keep consuming watcher output in the same turn; do not leave a detached `--watch` process running and then end the turn as if monitoring were complete.
+
+## Commands
+
+### One-shot snapshot
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --once
+```
+
+### Continuous watch (JSONL)
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --watch
+```
+
+### Trigger flaky retry cycle (only when watcher indicates)
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --retry-failed-now
+```
+
+### Explicit PR target
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr <number-or-url> --once
+```
+
+## CI Failure Classification
+Use `gh` commands to inspect failed runs before deciding to rerun.
+
+- `gh run view <run-id> --json jobs,name,workflowName,conclusion,status,url,headSha`
+- `gh run view <run-id> --log-failed`
+
+Prefer treating failures as branch-related when logs point to changed code (compile/test/lint/typecheck/snapshots/static analysis in touched areas).
+
+Prefer treating failures as flaky/unrelated when logs show transient infra/external issues (timeouts, runner provisioning failures, registry/network outages, GitHub Actions infra errors).
+
+If classification is ambiguous, perform one manual diagnosis attempt before choosing rerun.
+
+Read `.codex/skills/babysit-pr/references/heuristics.md` for a concise checklist.
+
+## Review Comment Handling
+The watcher surfaces review items from:
+
+- PR issue comments
+- Inline review comments
+- Review submissions (COMMENT / APPROVED / CHANGES_REQUESTED)
+
+It intentionally surfaces Codex reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
+For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex.
+On a fresh watcher state file, existing pending review feedback may be surfaced immediately (not only comments that arrive after monitoring starts). This is intentional so already-open review comments are not missed.
+
+When you agree with a comment and it is actionable:
+
+1. Patch code locally.
+2. Commit with `codex: address PR review feedback (#<n>)`.
+3. Push to the PR head branch.
+4. Resume watching on the new SHA immediately (do not stop after reporting the push).
+5. If monitoring was running in `--watch` mode, restart `--watch` immediately after the push in the same turn; do not wait for the user to ask again.
+
+If you disagree or the comment is non-actionable/already addressed, record it as handled by continuing the watcher loop (the script de-duplicates surfaced items via state after surfacing them).
+If a code review comment/thread is already marked as resolved in GitHub, treat it as non-actionable and safely ignore it unless new unresolved follow-up feedback appears.
+
+## Git Safety Rules
+
+- Work only on the PR head branch.
+- Avoid destructive git commands.
+- Do not switch branches unless necessary to recover context.
+- Before editing, check for unrelated uncommitted changes. If present, stop and ask the user.
+- After each successful fix, commit and `git push`, then re-run the watcher.
+- If you interrupted a live `--watch` session to make the fix, restart `--watch` immediately after the push in the same turn.
+- Do not run multiple concurrent `--watch` processes for the same PR/state file; keep one watcher session active and reuse it until it stops or you intentionally restart it.
+- A push is not a terminal outcome; continue the monitoring loop unless a strict stop condition is met.
+
+Commit message defaults:
+
+- `codex: fix CI failure on PR #<n>`
+- `codex: address PR review feedback (#<n>)`
+
+## Monitoring Loop Pattern
+Use this loop in a live Codex session:
+
+1. Run `--once`.
+2. Read `actions`.
+3. First check whether the PR is now merged or otherwise closed; if so, report that terminal state and stop polling immediately.
+4. Check CI summary, new review items, and mergeability/conflict status.
+5. Diagnose CI failures and classify branch-related vs flaky/unrelated.
+6. Process actionable review comments before flaky reruns when both are present; if a review fix requires a commit, push it and skip rerunning failed checks on the old SHA.
+7. Retry failed checks only when `retry_failed_checks` is present and you are not about to replace the current SHA with a review/CI fix commit.
+8. If you pushed a commit or triggered a rerun, report the action briefly and continue polling (do not stop).
+9. After a review-fix push, proactively restart continuous monitoring (`--watch`) in the same turn unless a strict stop condition has already been reached.
+10. If everything is passing, mergeable, not blocked on required review approval, and there are no unaddressed review items, report success and stop.
+11. If blocked on a user-help-required issue (infra outage, exhausted flaky retries, unclear reviewer request, permissions), report the blocker and stop.
+12. Otherwise sleep according to the polling cadence below and repeat.
+
+When the user explicitly asks to monitor/watch/babysit a PR, prefer `--watch` so polling continues autonomously in one command. Use repeated `--once` snapshots only for debugging, local testing, or when the user explicitly asks for a one-shot check.
+Do not stop to ask the user whether to continue polling; continue autonomously until a strict stop condition is met or the user explicitly interrupts.
+Do not hand control back to the user after a review-fix push just because a new SHA was created; restarting the watcher and re-entering the poll loop is part of the same babysitting task.
+If a `--watch` process is still running and no strict stop condition has been reached, the babysitting task is still in progress; keep streaming/consuming watcher output instead of ending the turn.
+
+## Polling Cadence
+Use adaptive polling and continue monitoring even after CI turns green:
+
+- While CI is not green (pending/running/queued or failing): poll every 1 minute.
+- After CI turns green: start at every 1 minute, then back off exponentially when there is no change (for example 1m, 2m, 4m, 8m, 16m, 32m), capping at every 1 hour.
+- Reset the green-state polling interval back to 1 minute whenever anything changes (new commit/SHA, check status changes, new review comments, mergeability changes, review decision changes).
+- If CI stops being green again (new commit, rerun, or regression): return to 1-minute polling.
+- If any poll shows the PR is merged or otherwise closed: stop polling immediately and report the terminal state.
+
+## Stop Conditions (Strict)
+Stop only when one of the following is true:
+
+- PR merged or closed (stop as soon as a poll/snapshot confirms this).
+- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, not blocked on required review approval, and no merge conflict risk.
+- User intervention is required and Codex cannot safely proceed alone.
+
+Keep polling when:
+
+- `actions` contains only `idle` but checks are still pending.
+- CI is still running/queued.
+- Review state is quiet but CI is not terminal.
+- CI is green but mergeability is unknown/pending.
+- CI is green and mergeable, but the PR is still open and you are waiting for possible new review comments or merge-conflict changes per the green-state cadence.
+- The PR is green but blocked on review approval (`REVIEW_REQUIRED` / similar); continue polling on the green-state cadence and surface any new review comments without asking for confirmation to keep watching.
+
+## Output Expectations
+Provide concise progress updates while monitoring and a final summary that includes:
+
+- During long unchanged monitoring periods, avoid emitting a full update on every poll; summarize only status changes plus occasional heartbeat updates.
+- Treat push confirmations, intermediate CI snapshots, and review-action updates as progress updates only; do not emit the final summary or end the babysitting session unless a strict stop condition is met.
+- A user request to "monitor" is not satisfied by a couple of sample polls; remain in the loop until a strict stop condition or an explicit user interruption.
+- A review-fix commit + push is not a completion event; immediately resume live monitoring (`--watch`) in the same turn and continue reporting progress updates.
+- When CI first transitions to all green for the current SHA, emit a one-time celebratory progress update (do not repeat it on every green poll). Preferred style: `🚀 CI is all green! 33/33 passed. Still on watch for review approval.`
+- Do not send the final summary while a watcher terminal is still running unless the watcher has emitted/confirmed a strict stop condition; otherwise continue with progress updates.
+
+- Final PR SHA
+- CI status summary
+- Mergeability / conflict status
+- Fixes pushed
+- Flaky retry cycles used
+- Remaining unresolved failures or review comments
+
+## References
+
+- Heuristics and decision tree: `.codex/skills/babysit-pr/references/heuristics.md`
+- GitHub CLI/API details used by the watcher: `.codex/skills/babysit-pr/references/github-api-notes.md`

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -9,7 +9,7 @@ description: Babysit a GitHub pull request after creation by continuously pollin
 Babysit a PR persistently until one of these terminal outcomes occurs:
 
 - The PR is merged or closed.
-- CI is successful, there are no unaddressed review comments surfaced by the watcher, required review approval is not blocking merge, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk).
+- CI is successful, there are no unaddressed review comments surfaced by the watcher, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk). A `👍` reaction on the PR itself also counts as a ready signal and can satisfy the review gate.
 - A situation requires user help (for example CI infrastructure issues, repeated flaky failures after retry budget is exhausted, permission problems, or ambiguity that cannot be resolved safely).
 
 Do not stop merely because a single snapshot returns `idle` while checks are still pending.
@@ -32,7 +32,7 @@ Accept any of the following:
 7. If a review item is actionable and correct, patch code locally, commit, and push.
 8. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
 9. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
-10. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state.
+10. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state, and check whether the PR itself has received a `👍` reaction.
 11. After any push or rerun action, immediately return to step 1 and continue polling on the updated SHA/state.
 12. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
 13. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
@@ -128,7 +128,7 @@ Use this loop in a live Codex session:
 7. Retry failed checks only when `retry_failed_checks` is present and you are not about to replace the current SHA with a review/CI fix commit.
 8. If you pushed a commit or triggered a rerun, report the action briefly and continue polling (do not stop).
 9. After a review-fix push, proactively restart continuous monitoring (`--watch`) in the same turn unless a strict stop condition has already been reached.
-10. If everything is passing, mergeable, not blocked on required review approval, and there are no unaddressed review items, report success and stop.
+10. If everything is passing, mergeable, not blocked on required review approval, and there are no unaddressed review items or unresolved review threads, report success and stop. If the PR itself has a `👍` reaction, treat that as an approval signal for readiness even if GitHub still reports `REVIEW_REQUIRED`.
 11. If blocked on a user-help-required issue (infra outage, exhausted flaky retries, unclear reviewer request, permissions), report the blocker and stop.
 12. Otherwise sleep according to the polling cadence below and repeat.
 
@@ -150,7 +150,7 @@ Use adaptive polling and continue monitoring even after CI turns green:
 Stop only when one of the following is true:
 
 - PR merged or closed (stop as soon as a poll/snapshot confirms this).
-- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, not blocked on required review approval, and no merge conflict risk.
+- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, no unresolved review threads, and no merge conflict risk. A `👍` reaction on the PR itself counts as satisfying the review gate for this readiness check.
 - User intervention is required and Codex cannot safely proceed alone.
 
 Keep polling when:

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -28,15 +28,17 @@ Accept any of the following:
 3. Inspect the `actions` list in the JSON response.
 4. If `diagnose_ci_failure` is present, inspect failed run logs and classify the failure.
 5. If the failure is likely caused by the current branch, patch code locally, commit, and push.
-6. If `process_review_comment` is present, inspect surfaced review items and decide whether to address them.
-7. If a review item is actionable and correct, patch code locally, commit, and push.
-8. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
-9. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
-10. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state, and check whether the PR itself has received a `👍` reaction.
-11. After any push or rerun action, immediately return to step 1 and continue polling on the updated SHA/state.
-12. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
-13. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
-14. Maintain terminal/session ownership: while babysitting is active, keep consuming watcher output in the same turn; do not leave a detached `--watch` process running and then end the turn as if monitoring were complete.
+6. If `process_review_comment` is present, inspect surfaced review items and triage them before changing code.
+7. If a review item is actionable, correct, and in scope for the PR, patch code locally, commit, and push.
+8. If a review item is important but not actually part of the PR's scope, record it as a follow-up issue instead of expanding the PR.
+9. If a review item is incorrect, already handled, or otherwise non-actionable, mark it as intentionally rejected/ignored and continue watching.
+10. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
+11. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
+12. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state, and check whether the PR itself has received a `👍` reaction.
+13. After any push, rerun, or follow-up issue capture, immediately return to step 1 and continue polling on the updated SHA/state.
+14. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
+15. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
+16. Maintain terminal/session ownership: while babysitting is active, keep consuming watcher output in the same turn; do not leave a detached `--watch` process running and then end the turn as if monitoring were complete.
 
 ## Commands
 
@@ -62,6 +64,42 @@ python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --retry-failed
 
 ```bash
 python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr <number-or-url> --once
+```
+
+### List current Codex feedback items
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --list
+```
+
+### Acknowledge all currently listed Codex feedback with `👍` and resolve open Codex threads
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all
+```
+
+### Dry-run an acknowledgement pass before mutating GitHub state
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all --dry-run
+```
+
+### Create a follow-up issue for out-of-scope Codex feedback, then mark it captured with `👍`
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --follow-up <item-id> --issue-label follow-up
+```
+
+### Dry-run follow-up issue creation before mutating GitHub state
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --follow-up <item-id> --issue-label follow-up --dry-run
+```
+
+### Reply on a review thread before resolving it
+
+```bash
+python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack <item-id> --reply-body "Handled in the latest PR update."
 ```
 
 ## CI Failure Classification
@@ -94,11 +132,27 @@ When you agree with a comment and it is actionable:
 1. Patch code locally.
 2. Commit with `codex: address PR review feedback (#<n>)`.
 3. Push to the PR head branch.
-4. Resume watching on the new SHA immediately (do not stop after reporting the push).
-5. If monitoring was running in `--watch` mode, restart `--watch` immediately after the push in the same turn; do not wait for the user to ask again.
+4. Prefer replying in the GitHub review thread with a short status update before resolving it (for example what changed, or that it was captured as follow-up). Then react with `👍` to the relevant Codex feedback and resolve Codex-authored review threads you handled. Prefer `python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all --dry-run` first, then rerun without `--dry-run` once you are satisfied.
+5. Resume watching on the new SHA immediately (do not stop after reporting the push).
+6. If monitoring was running in `--watch` mode, restart `--watch` immediately after the push in the same turn; do not wait for the user to ask again.
+
+Triage review feedback explicitly before touching code:
+
+1. In scope for the PR and correct: fix it in the PR.
+2. Important but out of scope for the PR: do not silently widen the PR. First look for an existing issue covering the same problem; if none exists, create a follow-up issue and keep the PR focused.
+3. Incorrect, already addressed, or not worth acting on: reject it explicitly and continue watching.
+
+When a comment is important but out of scope for the current PR:
+
+1. Search for an existing issue that already tracks the same problem.
+2. If none exists, create a follow-up issue from the feedback item with `gh_pr_codex_feedback.py --follow-up ...`.
+3. If the item is a review thread, reply in-thread with the tracking issue link so future readers can see where the work moved.
+4. React with `👍` on the source feedback once it has been captured as follow-up; if the item is a Codex review thread, resolve the thread after the issue is created unless the thread should stay open.
+5. Resume watching immediately. Do not implement the out-of-scope change in the current PR unless the user explicitly broadens scope.
 
 If you disagree or the comment is non-actionable/already addressed, record it as handled by continuing the watcher loop (the script de-duplicates surfaced items via state after surfacing them).
 If a code review comment/thread is already marked as resolved in GitHub, treat it as non-actionable and safely ignore it unless new unresolved follow-up feedback appears.
+If you intentionally reject Codex feedback, react with `👎` using `gh_pr_codex_feedback.py --reject ...`. Leave the thread open unless you are intentionally closing the loop after documenting why the suggestion should not be applied.
 
 ## Git Safety Rules
 

--- a/.codex/skills/babysit-pr/agents/openai.yaml
+++ b/.codex/skills/babysit-pr/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PR Babysitter"
+  short_description: "Watch PR CI, reviews, and merge conflicts"
+  default_prompt: "Babysit the current PR: monitor CI, reviewer comments, and merge-conflict status (prefer the watcher’s --watch mode for live monitoring); fix valid issues, push updates, and rerun flaky failures up to 3 times. Keep exactly one watcher session active for the PR (do not leave duplicate --watch terminals running). If you pause monitoring to patch review/CI feedback, restart --watch yourself immediately after the push in the same turn. If a watcher is still running and no strict stop condition has been reached, the task is still in progress: keep consuming watcher output and sending progress updates instead of ending the turn. Continue polling autonomously after any push/rerun until a strict terminal stop condition is reached or the user interrupts."

--- a/.codex/skills/babysit-pr/references/github-api-notes.md
+++ b/.codex/skills/babysit-pr/references/github-api-notes.md
@@ -1,0 +1,72 @@
+# GitHub CLI / API Notes For `babysit-pr`
+
+## Primary commands used
+
+### PR metadata
+
+- `gh pr view --json number,url,state,mergedAt,closedAt,headRefName,headRefOid,headRepository,headRepositoryOwner`
+
+Used to resolve PR number, URL, branch, head SHA, and closed/merged state.
+
+### PR checks summary
+
+- `gh pr checks --json name,state,bucket,link,workflow,event,startedAt,completedAt`
+
+Used to compute pending/failed/passed counts and whether the current CI round is terminal.
+
+### Workflow runs for head SHA
+
+- `gh api repos/{owner}/{repo}/actions/runs -X GET -f head_sha=<sha> -f per_page=100`
+
+Used to discover failed workflow runs and rerunnable run IDs.
+
+### Failed log inspection
+
+- `gh run view <run-id> --json jobs,name,workflowName,conclusion,status,url,headSha`
+- `gh run view <run-id> --log-failed`
+
+Used by Codex to classify branch-related vs flaky/unrelated failures.
+
+### Retry failed jobs only
+
+- `gh run rerun <run-id> --failed`
+
+Reruns only failed jobs (and dependencies) for a workflow run.
+
+## Review-related endpoints
+
+- Issue comments on PR:
+  - `gh api repos/{owner}/{repo}/issues/<pr_number>/comments?per_page=100`
+- Inline PR review comments:
+  - `gh api repos/{owner}/{repo}/pulls/<pr_number>/comments?per_page=100`
+- Review submissions:
+  - `gh api repos/{owner}/{repo}/pulls/<pr_number>/reviews?per_page=100`
+
+## JSON fields consumed by the watcher
+
+### `gh pr view`
+
+- `number`
+- `url`
+- `state`
+- `mergedAt`
+- `closedAt`
+- `headRefName`
+- `headRefOid`
+
+### `gh pr checks`
+
+- `bucket` (`pass`, `fail`, `pending`, `skipping`)
+- `state`
+- `name`
+- `workflow`
+- `link`
+
+### Actions runs API (`workflow_runs[]`)
+
+- `id`
+- `name`
+- `status`
+- `conclusion`
+- `html_url`
+- `head_sha`

--- a/.codex/skills/babysit-pr/references/heuristics.md
+++ b/.codex/skills/babysit-pr/references/heuristics.md
@@ -1,0 +1,58 @@
+# CI / Review Heuristics
+
+## CI classification checklist
+
+Treat as **branch-related** when logs clearly indicate a regression caused by the PR branch:
+
+- Compile/typecheck/lint failures in files or modules touched by the branch
+- Deterministic unit/integration test failures in changed areas
+- Snapshot output changes caused by UI/text changes in the branch
+- Static analysis violations introduced by the latest push
+- Build script/config changes in the PR causing a deterministic failure
+
+Treat as **likely flaky or unrelated** when evidence points to transient or external issues:
+
+- DNS/network/registry timeout errors while fetching dependencies
+- Runner image provisioning or startup failures
+- GitHub Actions infrastructure/service outages
+- Cloud/service rate limits or transient API outages
+- Non-deterministic failures in unrelated integration tests with known flake patterns
+
+If uncertain, inspect failed logs once before choosing rerun.
+
+## Decision tree (fix vs rerun vs stop)
+
+1. If PR is merged/closed: stop.
+2. If there are failed checks:
+   - Diagnose first.
+   - If branch-related: fix locally, commit, push.
+   - If likely flaky/unrelated and all checks for the current SHA are terminal: rerun failed jobs.
+   - If checks are still pending: wait.
+3. If flaky reruns for the same SHA reach the configured limit (default 3): stop and report persistent failure.
+4. Independently, process any new human review comments.
+
+## Review comment agreement criteria
+
+Address the comment when:
+
+- The comment is technically correct.
+- The change is actionable in the current branch.
+- The requested change does not conflict with the user’s intent or recent guidance.
+- The change can be made safely without unrelated refactors.
+
+Do not auto-fix when:
+
+- The comment is ambiguous and needs clarification.
+- The request conflicts with explicit user instructions.
+- The proposed change requires product/design decisions the user has not made.
+- The codebase is in a dirty/unrelated state that makes safe editing uncertain.
+
+## Stop-and-ask conditions
+
+Stop and ask the user instead of continuing automatically when:
+
+- The local worktree has unrelated uncommitted changes.
+- `gh` auth/permissions fail.
+- The PR branch cannot be pushed.
+- CI failures persist after the flaky retry budget.
+- Reviewer feedback requires a product decision or cross-team coordination.

--- a/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
@@ -1,0 +1,661 @@
+#!/usr/bin/env python3
+"""List, acknowledge, reject, or capture Codex review feedback on a GitHub PR."""
+
+import argparse
+import json
+import re
+import sys
+
+from gh_pr_watch import GhCommandError, gh_api_list_paginated, gh_json, graphql_json, resolve_pr
+
+CODEX_LOGIN_KEYWORD = "codex"
+REACTION_CONTENTS = {
+    "ack": "THUMBS_UP",
+    "reject": "THUMBS_DOWN",
+}
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description="List Codex review feedback and optionally react/resolve it."
+    )
+    parser.add_argument("--pr", default="auto", help="auto, PR number, or PR URL")
+    parser.add_argument("--repo", help="Optional OWNER/REPO override")
+    parser.add_argument(
+        "--include-older-reviews",
+        action="store_true",
+        help="Include top-level Codex reviews from older SHAs on the same PR",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show intended mutations without applying them",
+    )
+    parser.add_argument(
+        "--no-resolve",
+        action="store_true",
+        help="Do not resolve threads when reacting to thread items",
+    )
+    parser.add_argument(
+        "--no-react",
+        action="store_true",
+        help="Do not react to source feedback when creating follow-up issues",
+    )
+    parser.add_argument(
+        "--issue-label",
+        action="append",
+        default=[],
+        help="Label to apply to follow-up issues; may be repeated",
+    )
+    parser.add_argument(
+        "--issue-title-prefix",
+        default="Follow-up",
+        help="Prefix to use when creating follow-up issue titles",
+    )
+    parser.add_argument(
+        "--reply-body",
+        help=(
+            "Optional reply to post on thread items before resolving them. Supports "
+            "placeholders such as {issue_url}, {issue_number}, {pr_url}, {pr_number}, "
+            "{item_id}, {path}, and {line}."
+        ),
+    )
+    parser.add_argument(
+        "--no-reply",
+        action="store_true",
+        help="Do not post a reply on review threads before resolving them",
+    )
+
+    action_group = parser.add_mutually_exclusive_group(required=True)
+    action_group.add_argument("--list", action="store_true", help="List Codex feedback items")
+    action_group.add_argument(
+        "--ack-all",
+        action="store_true",
+        help="React with 👍 to all listed items and resolve thread items",
+    )
+    action_group.add_argument(
+        "--reject-all",
+        action="store_true",
+        help="React with 👎 to all listed items and leave thread state unchanged unless --no-resolve is omitted",
+    )
+    action_group.add_argument(
+        "--ack",
+        nargs="+",
+        metavar="ITEM_ID",
+        help="React with 👍 to specific listed item IDs",
+    )
+    action_group.add_argument(
+        "--reject",
+        nargs="+",
+        metavar="ITEM_ID",
+        help="React with 👎 to specific listed item IDs",
+    )
+    action_group.add_argument(
+        "--follow-up-all",
+        action="store_true",
+        help=(
+            "Create follow-up GitHub issues for all listed items, then react with 👍 "
+            "and resolve thread items unless disabled"
+        ),
+    )
+    action_group.add_argument(
+        "--follow-up",
+        nargs="+",
+        metavar="ITEM_ID",
+        help=(
+            "Create follow-up GitHub issues for specific listed item IDs, then react "
+            "with 👍 and resolve thread items unless disabled"
+        ),
+    )
+    return parser.parse_args()
+
+
+def print_json(payload):
+    sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
+
+
+def is_codex_login(login):
+    return CODEX_LOGIN_KEYWORD in str(login or "").lower()
+
+
+def summarize_body(body, limit=160):
+    text = " ".join(str(body or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 3] + "..."
+
+
+def quote_markdown(text):
+    lines = str(text or "").splitlines() or [""]
+    return "\n".join(f"> {line}" if line else ">" for line in lines)
+
+
+def plain_text_excerpt(text, limit=90):
+    cleaned = str(text or "")
+    cleaned = re.sub(r"!\[[^\]]*\]\([^)]*\)", "", cleaned)
+    cleaned = re.sub(r"<[^>]+>", " ", cleaned)
+    cleaned = cleaned.replace("`", "")
+    cleaned = cleaned.replace("*", "")
+    cleaned = re.sub(r"Useful\?\s*React with.*$", "", cleaned, flags=re.IGNORECASE | re.DOTALL)
+    cleaned = " ".join(cleaned.split())
+    if not cleaned:
+        return "Investigate Codex review feedback"
+    if len(cleaned) <= limit:
+        return cleaned
+    return cleaned[: limit - 3] + "..."
+
+
+def format_reply_body(template, pr, item, follow_up_issue=None):
+    values = {
+        "pr_number": pr["number"],
+        "pr_url": pr["url"],
+        "item_id": item["item_id"],
+        "path": item.get("path") or "",
+        "line": item.get("line") if item.get("line") is not None else "",
+        "issue_number": "",
+        "issue_url": "",
+    }
+    if isinstance(follow_up_issue, dict):
+        values["issue_number"] = follow_up_issue.get("issue_number") or ""
+        values["issue_url"] = follow_up_issue.get("issue_url") or ""
+        if not values["issue_number"] and follow_up_issue.get("status") == "dry_run":
+            values["issue_number"] = "new"
+        if not values["issue_url"] and follow_up_issue.get("status") == "dry_run":
+            values["issue_url"] = "(issue URL available on live run)"
+    try:
+        return str(template).format(**values).strip()
+    except KeyError as err:
+        raise GhCommandError(f"Unknown placeholder in --reply-body: {err}") from err
+
+
+def fetch_codex_reviews(pr, include_older_reviews=False):
+    endpoint = f"repos/{pr['repo']}/pulls/{pr['number']}/reviews"
+    payload = gh_api_list_paginated(endpoint, repo=pr["repo"])
+    items = []
+    for review in payload:
+        if not isinstance(review, dict):
+            continue
+        login = ((review.get("user") or {}).get("login")) or ""
+        if not is_codex_login(login):
+            continue
+        commit_id = str(review.get("commit_id") or "")
+        if not include_older_reviews and commit_id and commit_id != pr["head_sha"]:
+            continue
+        node_id = str(review.get("node_id") or "")
+        if not node_id:
+            continue
+        item_id = f"review:{node_id}"
+        body = str(review.get("body") or "")
+        items.append(
+            {
+                "item_id": item_id,
+                "kind": "review",
+                "subject_id": node_id,
+                "thread_id": None,
+                "author": login,
+                "body": body,
+                "summary": summarize_body(body),
+                "commit_id": commit_id,
+                "created_at": str(review.get("submitted_at") or review.get("created_at") or ""),
+                "html_url": str(review.get("html_url") or ""),
+                "review_state": str(review.get("state") or ""),
+                "path": None,
+                "line": None,
+            }
+        )
+    items.sort(key=lambda item: (item["created_at"], item["item_id"]))
+    return items
+
+
+def fetch_codex_threads(pr):
+    owner, repo_name = pr["repo"].split("/", 1)
+    query = """
+query($owner:String!, $repo:String!, $number:Int!, $after:String) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100, after:$after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+        nodes {
+          id
+          isResolved
+          isOutdated
+          comments(first:100) {
+            nodes {
+              id
+              databaseId
+              body
+              path
+              line
+              url
+              createdAt
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+    items = []
+    after_cursor = None
+    while True:
+        variables = {
+            "owner": owner,
+            "repo": repo_name,
+            "number": pr["number"],
+        }
+        if after_cursor:
+            variables["after"] = after_cursor
+        payload = graphql_json(query, variables=variables)
+        review_threads = (
+            payload.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
+        )
+        nodes = review_threads.get("nodes", [])
+        if not isinstance(nodes, list):
+            raise GhCommandError("Expected reviewThreads.nodes to be a list")
+        for thread in nodes:
+            if not isinstance(thread, dict):
+                continue
+            if thread.get("isResolved") or thread.get("isOutdated"):
+                continue
+            thread_id = str(thread.get("id") or "")
+            comments = thread.get("comments", {}).get("nodes", [])
+            if not thread_id or not isinstance(comments, list) or not comments:
+                continue
+            latest_comment = comments[-1]
+            if not isinstance(latest_comment, dict):
+                continue
+            login = ((latest_comment.get("author") or {}).get("login")) or ""
+            if not is_codex_login(login):
+                continue
+            subject_id = str(latest_comment.get("id") or "")
+            body = str(latest_comment.get("body") or "")
+            items.append(
+                {
+                    "item_id": f"thread:{thread_id}",
+                    "kind": "thread",
+                    "subject_id": subject_id,
+                    "thread_id": thread_id,
+                    "author": login,
+                    "body": body,
+                    "summary": summarize_body(body),
+                    "commit_id": pr["head_sha"],
+                    "created_at": str(latest_comment.get("createdAt") or ""),
+                    "html_url": str(latest_comment.get("url") or pr["url"]),
+                    "review_state": None,
+                    "path": latest_comment.get("path"),
+                    "line": latest_comment.get("line"),
+                    "database_id": str(latest_comment.get("databaseId") or ""),
+                }
+            )
+        page_info = review_threads.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        after_cursor = page_info.get("endCursor")
+        if not after_cursor:
+            break
+    items.sort(key=lambda item: (item["created_at"], item["item_id"]))
+    return items
+
+
+def list_feedback_items(pr, include_older_reviews=False):
+    items = fetch_codex_threads(pr)
+    items.extend(fetch_codex_reviews(pr, include_older_reviews=include_older_reviews))
+    items.sort(key=lambda item: (item["created_at"], item["kind"], item["item_id"]))
+    return items
+
+
+def add_reaction(subject_id, reaction_content, dry_run=False):
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "subject_id": subject_id,
+            "reaction": reaction_content,
+        }
+    mutation = """
+mutation($subjectId:ID!, $content:ReactionContent!) {
+  addReaction(input:{subjectId:$subjectId, content:$content}) {
+    reaction {
+      content
+    }
+    subject {
+      id
+    }
+  }
+}
+""".strip()
+    payload = graphql_json(
+        mutation,
+        variables={
+            "subjectId": subject_id,
+            "content": reaction_content,
+        },
+    )
+    reaction = (
+        payload.get("data", {})
+        .get("addReaction", {})
+        .get("reaction", {})
+        .get("content")
+    )
+    return {
+        "status": "reacted",
+        "subject_id": subject_id,
+        "reaction": reaction,
+    }
+
+
+def build_issue_title(item, title_prefix):
+    summary = plain_text_excerpt(item.get("body") or item.get("summary"), limit=90)
+    title = f"{title_prefix}: {summary}"
+    return title[:120]
+
+
+def build_issue_body(pr, item):
+    details = [
+        "This follow-up was captured from Codex review feedback that looks important but out of scope for the current PR.",
+        "",
+        f"- PR: #{pr['number']} ({pr['url']})",
+        f"- Review item: {item['html_url']}",
+        f"- Reviewer: `{item['author']}`",
+        f"- Kind: `{item['kind']}`",
+    ]
+    if item.get("review_state"):
+        details.append(f"- Review state: `{item['review_state']}`")
+    if item.get("commit_id"):
+        details.append(f"- Commit SHA: `{item['commit_id']}`")
+    if item.get("path"):
+        details.append(f"- File: `{item['path']}`")
+    if item.get("line") is not None:
+        details.append(f"- Line: `{item['line']}`")
+    details.extend(
+        [
+            "",
+            "Summary",
+            "",
+            item.get("summary") or "_No summary provided._",
+            "",
+            "Original feedback",
+            "",
+            quote_markdown(item.get("body") or "_No body provided._"),
+        ]
+    )
+    return "\n".join(details)
+
+
+def create_follow_up_issue(pr, item, title_prefix="Follow-up", labels=None, dry_run=False):
+    title = build_issue_title(item, title_prefix)
+    body = build_issue_body(pr, item)
+    labels = [label for label in labels or [] if label]
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "title": title,
+            "body": body,
+            "labels": labels,
+        }
+
+    args = [
+        "api",
+        "--method",
+        "POST",
+        f"repos/{pr['repo']}/issues",
+        "-f",
+        f"title={title}",
+        "-f",
+        f"body={body}",
+    ]
+    for label in labels:
+        args.extend(["-f", f"labels[]={label}"])
+    payload = gh_json(args)
+    if not isinstance(payload, dict):
+        raise GhCommandError("Unexpected issue payload from `gh api repos/.../issues`")
+    return {
+        "status": "created",
+        "issue_number": payload.get("number"),
+        "issue_url": str(payload.get("html_url") or ""),
+        "title": str(payload.get("title") or title),
+        "labels": labels,
+    }
+
+
+def resolve_thread(thread_id, dry_run=False):
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "thread_id": thread_id,
+            "resolved": True,
+        }
+    mutation = """
+mutation($threadId:ID!) {
+  resolveReviewThread(input:{threadId:$threadId}) {
+    thread {
+      id
+      isResolved
+    }
+  }
+}
+""".strip()
+    payload = graphql_json(mutation, variables={"threadId": thread_id})
+    thread = payload.get("data", {}).get("resolveReviewThread", {}).get("thread", {})
+    return {
+        "status": "resolved",
+        "thread_id": str(thread.get("id") or thread_id),
+        "resolved": bool(thread.get("isResolved")),
+    }
+
+
+def reply_to_thread(pr, item, body, dry_run=False):
+    if item.get("kind") != "thread":
+        return {
+            "status": "skipped",
+            "reason": "item is not a thread",
+        }
+    comment_database_id = str(item.get("database_id") or "")
+    if not comment_database_id:
+        return {
+            "status": "skipped",
+            "reason": "thread comment database id is unavailable",
+        }
+    if dry_run:
+        return {
+            "status": "dry_run",
+            "comment_database_id": comment_database_id,
+            "body": body,
+        }
+    payload = gh_json(
+        [
+            "api",
+            "--method",
+            "POST",
+            f"repos/{pr['repo']}/pulls/{pr['number']}/comments/{comment_database_id}/replies",
+            "-f",
+            f"body={body}",
+        ]
+    )
+    if not isinstance(payload, dict):
+        raise GhCommandError("Unexpected reply payload from `gh api pulls/.../comments/.../replies`")
+    return {
+        "status": "replied",
+        "comment_database_id": comment_database_id,
+        "reply_url": str(payload.get("html_url") or ""),
+        "reply_id": payload.get("id"),
+    }
+
+
+def select_items(items, selected_ids=None, all_items=False):
+    if all_items:
+        return items
+    item_by_id = {item["item_id"]: item for item in items}
+    selected = []
+    missing = []
+    for item_id in selected_ids or []:
+        item = item_by_id.get(item_id)
+        if item is None:
+            missing.append(item_id)
+            continue
+        selected.append(item)
+    if missing:
+        raise GhCommandError(f"Unknown item IDs: {', '.join(missing)}")
+    return selected
+
+
+def act_on_items(
+    pr,
+    items,
+    reaction_key,
+    dry_run=False,
+    resolve_threads_enabled=True,
+    reply_body_template=None,
+    reply_enabled=True,
+):
+    reaction_content = REACTION_CONTENTS[reaction_key]
+    results = []
+    for item in items:
+        item_result = {
+            "item_id": item["item_id"],
+            "kind": item["kind"],
+            "html_url": item["html_url"],
+        }
+        if reply_enabled and reply_body_template and item["kind"] == "thread":
+            reply_body = format_reply_body(reply_body_template, pr, item)
+            if reply_body:
+                item_result["reply"] = reply_to_thread(pr, item, reply_body, dry_run=dry_run)
+        item_result["reaction"] = add_reaction(item["subject_id"], reaction_content, dry_run=dry_run)
+        if item["kind"] == "thread" and resolve_threads_enabled:
+            item_result["thread_resolution"] = resolve_thread(item["thread_id"], dry_run=dry_run)
+        results.append(item_result)
+    return results
+
+
+def create_follow_up_results(
+    pr,
+    items,
+    dry_run=False,
+    resolve_threads_enabled=True,
+    react_to_source=True,
+    issue_labels=None,
+    issue_title_prefix="Follow-up",
+    reply_enabled=True,
+    reply_body_template=None,
+):
+    results = []
+    for item in items:
+        follow_up_issue = create_follow_up_issue(
+            pr,
+            item,
+            title_prefix=issue_title_prefix,
+            labels=issue_labels,
+            dry_run=dry_run,
+        )
+        item_result = {
+            "item_id": item["item_id"],
+            "kind": item["kind"],
+            "html_url": item["html_url"],
+            "follow_up_issue": follow_up_issue,
+        }
+        if reply_enabled and item["kind"] == "thread":
+            template = reply_body_template or (
+                "Captured for follow-up in #{issue_number}: {issue_url}\n\n"
+                "Keeping this PR focused on its current scope."
+            )
+            reply_body = format_reply_body(template, pr, item, follow_up_issue=follow_up_issue)
+            if reply_body:
+                item_result["reply"] = reply_to_thread(pr, item, reply_body, dry_run=dry_run)
+        if react_to_source:
+            item_result["reaction"] = add_reaction(
+                item["subject_id"],
+                REACTION_CONTENTS["ack"],
+                dry_run=dry_run,
+            )
+        if item["kind"] == "thread" and resolve_threads_enabled:
+            item_result["thread_resolution"] = resolve_thread(item["thread_id"], dry_run=dry_run)
+        results.append(item_result)
+    return results
+
+
+def main():
+    args = parse_args()
+    try:
+        pr = resolve_pr(args.pr, repo_override=args.repo)
+        items = list_feedback_items(
+            pr,
+            include_older_reviews=args.include_older_reviews,
+        )
+
+        if args.list:
+            print_json(
+                {
+                    "items": items,
+                    "pr": pr,
+                }
+            )
+            return 0
+
+        if args.ack_all:
+            selected_items = select_items(items, all_items=True)
+            reaction_key = "ack"
+        elif args.reject_all:
+            selected_items = select_items(items, all_items=True)
+            reaction_key = "reject"
+        elif args.ack:
+            selected_items = select_items(items, selected_ids=args.ack)
+            reaction_key = "ack"
+        elif args.follow_up_all:
+            selected_items = select_items(items, all_items=True)
+            reaction_key = None
+        elif args.follow_up:
+            selected_items = select_items(items, selected_ids=args.follow_up)
+            reaction_key = None
+        else:
+            selected_items = select_items(items, selected_ids=args.reject)
+            reaction_key = "reject"
+
+        if reaction_key is None:
+            results = create_follow_up_results(
+                pr,
+                selected_items,
+                dry_run=args.dry_run,
+                resolve_threads_enabled=not args.no_resolve,
+                react_to_source=not args.no_react,
+                issue_labels=args.issue_label,
+                issue_title_prefix=args.issue_title_prefix,
+                reply_enabled=not args.no_reply,
+                reply_body_template=args.reply_body,
+            )
+        else:
+            results = act_on_items(
+                pr,
+                selected_items,
+                reaction_key,
+                dry_run=args.dry_run,
+                resolve_threads_enabled=not args.no_resolve,
+                reply_body_template=args.reply_body,
+                reply_enabled=not args.no_reply,
+            )
+        print_json(
+            {
+                "pr": pr,
+                "results": results,
+                "selected_items": selected_items,
+            }
+        )
+        return 0
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"gh_pr_codex_feedback.py error: {err}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stderr.write("gh_pr_codex_feedback.py interrupted\n")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
@@ -271,14 +271,18 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
             comments = thread.get("comments", {}).get("nodes", [])
             if not thread_id or not isinstance(comments, list) or not comments:
                 continue
-            latest_comment = comments[-1]
-            if not isinstance(latest_comment, dict):
+            latest_codex_comment = None
+            for comment in comments:
+                if not isinstance(comment, dict):
+                    continue
+                login = ((comment.get("author") or {}).get("login")) or ""
+                if is_codex_login(login):
+                    latest_codex_comment = comment
+            if not isinstance(latest_codex_comment, dict):
                 continue
-            login = ((latest_comment.get("author") or {}).get("login")) or ""
-            if not is_codex_login(login):
-                continue
-            subject_id = str(latest_comment.get("id") or "")
-            body = str(latest_comment.get("body") or "")
+            login = ((latest_codex_comment.get("author") or {}).get("login")) or ""
+            subject_id = str(latest_codex_comment.get("id") or "")
+            body = str(latest_codex_comment.get("body") or "")
             items.append(
                 {
                     "item_id": f"thread:{thread_id}",
@@ -289,12 +293,12 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
                     "body": body,
                     "summary": summarize_body(body),
                     "commit_id": pr["head_sha"],
-                    "created_at": str(latest_comment.get("createdAt") or ""),
-                    "html_url": str(latest_comment.get("url") or pr["url"]),
+                    "created_at": str(latest_codex_comment.get("createdAt") or ""),
+                    "html_url": str(latest_codex_comment.get("url") or pr["url"]),
                     "review_state": None,
-                    "path": latest_comment.get("path"),
-                    "line": latest_comment.get("line"),
-                    "database_id": str(latest_comment.get("databaseId") or ""),
+                    "path": latest_codex_comment.get("path"),
+                    "line": latest_codex_comment.get("line"),
+                    "database_id": str(latest_codex_comment.get("databaseId") or ""),
                 }
             )
         page_info = review_threads.get("pageInfo", {})

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""Watch GitHub PR CI and review activity for Codex PR babysitting workflows."""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from urllib.parse import urlparse
+
+FAILED_RUN_CONCLUSIONS = {
+    "failure",
+    "timed_out",
+    "cancelled",
+    "action_required",
+    "startup_failure",
+    "stale",
+}
+PENDING_CHECK_STATES = {
+    "QUEUED",
+    "IN_PROGRESS",
+    "PENDING",
+    "WAITING",
+    "REQUESTED",
+}
+REVIEW_BOT_LOGIN_KEYWORDS = {
+    "codex",
+}
+TRUSTED_AUTHOR_ASSOCIATIONS = {
+    "OWNER",
+    "MEMBER",
+    "COLLABORATOR",
+}
+MERGE_BLOCKING_REVIEW_DECISIONS = {
+    "REVIEW_REQUIRED",
+    "CHANGES_REQUESTED",
+}
+MERGE_CONFLICT_OR_BLOCKING_STATES = {
+    "BLOCKED",
+    "DIRTY",
+    "DRAFT",
+    "UNKNOWN",
+}
+GREEN_STATE_MAX_POLL_SECONDS = 60 * 60
+
+
+class GhCommandError(RuntimeError):
+    pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize PR/CI/review state for Codex PR babysitting and optionally "
+            "trigger flaky reruns."
+        )
+    )
+    parser.add_argument("--pr", default="auto", help="auto, PR number, or PR URL")
+    parser.add_argument("--repo", help="Optional OWNER/REPO override")
+    parser.add_argument("--poll-seconds", type=int, default=30, help="Watch poll interval")
+    parser.add_argument(
+        "--max-flaky-retries",
+        type=int,
+        default=3,
+        help="Max rerun cycles per head SHA before stop recommendation",
+    )
+    parser.add_argument("--state-file", help="Path to state JSON file")
+    parser.add_argument("--once", action="store_true", help="Emit one snapshot and exit")
+    parser.add_argument("--watch", action="store_true", help="Continuously emit JSONL snapshots")
+    parser.add_argument(
+        "--retry-failed-now",
+        action="store_true",
+        help="Rerun failed jobs for current failed workflow runs when policy allows",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable output (default behavior for --once and --retry-failed-now)",
+    )
+    args = parser.parse_args()
+
+    if args.poll_seconds <= 0:
+        parser.error("--poll-seconds must be > 0")
+    if args.max_flaky_retries < 0:
+        parser.error("--max-flaky-retries must be >= 0")
+    if args.watch and args.retry_failed_now:
+        parser.error("--watch cannot be combined with --retry-failed-now")
+    if not args.once and not args.watch and not args.retry_failed_now:
+        args.once = True
+    return args
+
+
+def _format_gh_error(cmd, err):
+    stdout = (err.stdout or "").strip()
+    stderr = (err.stderr or "").strip()
+    parts = [f"GitHub CLI command failed: {' '.join(cmd)}"]
+    if stdout:
+        parts.append(f"stdout: {stdout}")
+    if stderr:
+        parts.append(f"stderr: {stderr}")
+    return "\n".join(parts)
+
+
+def gh_text(args, repo=None):
+    cmd = ["gh"]
+    # `gh api` does not accept `-R/--repo` on all gh versions. The watcher's
+    # API calls use explicit endpoints (e.g. repos/{owner}/{repo}/...), so the
+    # repo flag is unnecessary there.
+    if repo and (not args or args[0] != "api"):
+        cmd.extend(["-R", repo])
+    cmd.extend(args)
+    try:
+        proc = subprocess.run(cmd, check=True, capture_output=True, text=True)
+    except FileNotFoundError as err:
+        raise GhCommandError("`gh` command not found") from err
+    except subprocess.CalledProcessError as err:
+        raise GhCommandError(_format_gh_error(cmd, err)) from err
+    return proc.stdout
+
+
+def gh_json(args, repo=None):
+    raw = gh_text(args, repo=repo).strip()
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as err:
+        raise GhCommandError(f"Failed to parse JSON from gh output for {' '.join(args)}") from err
+
+
+def parse_pr_spec(pr_spec):
+    if pr_spec == "auto":
+        return {"mode": "auto", "value": None}
+    if re.fullmatch(r"\d+", pr_spec):
+        return {"mode": "number", "value": pr_spec}
+    parsed = urlparse(pr_spec)
+    if parsed.scheme and parsed.netloc and "/pull/" in parsed.path:
+        return {"mode": "url", "value": pr_spec}
+    raise ValueError("--pr must be 'auto', a PR number, or a PR URL")
+
+
+def pr_view_fields():
+    return (
+        "number,url,state,mergedAt,closedAt,headRefName,headRefOid,"
+        "headRepository,headRepositoryOwner,mergeable,mergeStateStatus,reviewDecision"
+    )
+
+
+def checks_fields():
+    return "name,state,bucket,link,workflow,event,startedAt,completedAt"
+
+
+def resolve_pr(pr_spec, repo_override=None):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "view"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", pr_view_fields()])
+    data = gh_json(cmd, repo=repo_override)
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected PR payload from `gh pr view`")
+
+    pr_url = str(data.get("url") or "")
+    repo = (
+        repo_override
+        or extract_repo_from_pr_url(pr_url)
+        or extract_repo_from_pr_view(data)
+    )
+    if not repo:
+        raise GhCommandError("Unable to determine OWNER/REPO for the PR")
+
+    state = str(data.get("state") or "")
+    merged = bool(data.get("mergedAt"))
+    closed = bool(data.get("closedAt")) or state.upper() == "CLOSED"
+
+    return {
+        "number": int(data["number"]),
+        "url": pr_url,
+        "repo": repo,
+        "head_sha": str(data.get("headRefOid") or ""),
+        "head_branch": str(data.get("headRefName") or ""),
+        "state": state,
+        "merged": merged,
+        "closed": closed,
+        "mergeable": str(data.get("mergeable") or ""),
+        "merge_state_status": str(data.get("mergeStateStatus") or ""),
+        "review_decision": str(data.get("reviewDecision") or ""),
+    }
+
+
+def extract_repo_from_pr_view(data):
+    head_repo = data.get("headRepository")
+    head_owner = data.get("headRepositoryOwner")
+    owner = None
+    name = None
+    if isinstance(head_owner, dict):
+        owner = head_owner.get("login") or head_owner.get("name")
+    elif isinstance(head_owner, str):
+        owner = head_owner
+    if isinstance(head_repo, dict):
+        name = head_repo.get("name")
+        repo_owner = head_repo.get("owner")
+        if not owner and isinstance(repo_owner, dict):
+            owner = repo_owner.get("login") or repo_owner.get("name")
+    elif isinstance(head_repo, str):
+        name = head_repo
+    if owner and name:
+        return f"{owner}/{name}"
+    return None
+def extract_repo_from_pr_url(pr_url):
+    parsed = urlparse(pr_url)
+    parts = [p for p in parsed.path.split("/") if p]
+    if len(parts) >= 4 and parts[2] == "pull":
+        return f"{parts[0]}/{parts[1]}"
+    return None
+
+
+def load_state(path):
+    if path.exists():
+        try:
+            data = json.loads(path.read_text())
+        except json.JSONDecodeError as err:
+            raise RuntimeError(f"State file is not valid JSON: {path}") from err
+        if not isinstance(data, dict):
+            raise RuntimeError(f"State file must contain an object: {path}")
+        return data, False
+    return {
+        "pr": {},
+        "started_at": None,
+        "last_seen_head_sha": None,
+        "retries_by_sha": {},
+        "seen_issue_comment_ids": [],
+        "seen_review_comment_ids": [],
+        "seen_review_ids": [],
+        "last_snapshot_at": None,
+    }, True
+
+
+def save_state(path, state):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(state, indent=2, sort_keys=True) + "\n"
+    fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", suffix=".tmp", dir=path.parent)
+    tmp_path = Path(tmp_name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+            tmp_file.write(payload)
+        os.replace(tmp_path, path)
+    except Exception:
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+
+def default_state_file_for(pr):
+    repo_slug = pr["repo"].replace("/", "-")
+    return Path(f"/tmp/codex-babysit-pr-{repo_slug}-pr{pr['number']}.json")
+
+
+def get_pr_checks(pr_spec, repo):
+    parsed = parse_pr_spec(pr_spec)
+    cmd = ["pr", "checks"]
+    if parsed["value"] is not None:
+        cmd.append(parsed["value"])
+    cmd.extend(["--json", checks_fields()])
+    data = gh_json(cmd, repo=repo)
+    if data is None:
+        return []
+    if not isinstance(data, list):
+        raise GhCommandError("Unexpected payload from `gh pr checks`")
+    return data
+
+
+def is_pending_check(check):
+    bucket = str(check.get("bucket") or "").lower()
+    state = str(check.get("state") or "").upper()
+    return bucket == "pending" or state in PENDING_CHECK_STATES
+
+
+def summarize_checks(checks):
+    pending_count = 0
+    failed_count = 0
+    passed_count = 0
+    for check in checks:
+        bucket = str(check.get("bucket") or "").lower()
+        if is_pending_check(check):
+            pending_count += 1
+        if bucket == "fail":
+            failed_count += 1
+        if bucket == "pass":
+            passed_count += 1
+    return {
+        "pending_count": pending_count,
+        "failed_count": failed_count,
+        "passed_count": passed_count,
+        "all_terminal": pending_count == 0,
+    }
+
+
+def get_workflow_runs_for_sha(repo, head_sha):
+    endpoint = f"repos/{repo}/actions/runs"
+    data = gh_json(
+        ["api", endpoint, "-X", "GET", "-f", f"head_sha={head_sha}", "-f", "per_page=100"],
+        repo=repo,
+    )
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected payload from actions runs API")
+    runs = data.get("workflow_runs") or []
+    if not isinstance(runs, list):
+        raise GhCommandError("Expected `workflow_runs` to be a list")
+    return runs
+
+
+def failed_runs_from_workflow_runs(runs, head_sha):
+    failed_runs = []
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("head_sha") or "") != head_sha:
+            continue
+        conclusion = str(run.get("conclusion") or "")
+        if conclusion not in FAILED_RUN_CONCLUSIONS:
+            continue
+        failed_runs.append(
+            {
+                "run_id": run.get("id"),
+                "workflow_name": run.get("name") or run.get("display_title") or "",
+                "status": str(run.get("status") or ""),
+                "conclusion": conclusion,
+                "html_url": str(run.get("html_url") or ""),
+            }
+        )
+    failed_runs.sort(key=lambda item: (str(item.get("workflow_name") or ""), str(item.get("run_id") or "")))
+    return failed_runs
+
+
+def get_authenticated_login():
+    data = gh_json(["api", "user"])
+    if not isinstance(data, dict) or not data.get("login"):
+        raise GhCommandError("Unable to determine authenticated GitHub login from `gh api user`")
+    return str(data["login"])
+
+
+def comment_endpoints(repo, pr_number):
+    return {
+        "issue_comment": f"repos/{repo}/issues/{pr_number}/comments",
+        "review_comment": f"repos/{repo}/pulls/{pr_number}/comments",
+        "review": f"repos/{repo}/pulls/{pr_number}/reviews",
+    }
+
+
+def gh_api_list_paginated(endpoint, repo=None, per_page=100):
+    items = []
+    page = 1
+    while True:
+        sep = "&" if "?" in endpoint else "?"
+        page_endpoint = f"{endpoint}{sep}per_page={per_page}&page={page}"
+        payload = gh_json(["api", page_endpoint], repo=repo)
+        if payload is None:
+            break
+        if not isinstance(payload, list):
+            raise GhCommandError(f"Unexpected paginated payload from gh api {endpoint}")
+        items.extend(payload)
+        if len(payload) < per_page:
+            break
+        page += 1
+    return items
+
+
+def normalize_issue_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "issue_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_review_comments(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        line = item.get("line")
+        if line is None:
+            line = item.get("original_line")
+        out.append(
+            {
+                "kind": "review_comment",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": item.get("path"),
+                "line": line,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_reviews(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "kind": "review",
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "author_association": str(item.get("author_association") or ""),
+                "created_at": str(item.get("submitted_at") or item.get("created_at") or ""),
+                "body": str(item.get("body") or ""),
+                "path": None,
+                "line": None,
+                "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def extract_login(user_obj):
+    if isinstance(user_obj, dict):
+        return str(user_obj.get("login") or "")
+    return ""
+
+
+def is_bot_login(login):
+    return bool(login) and login.endswith("[bot]")
+
+
+def is_actionable_review_bot_login(login):
+    if not is_bot_login(login):
+        return False
+    lower_login = login.lower()
+    return any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
+
+
+def is_trusted_human_review_author(item, authenticated_login):
+    author = str(item.get("author") or "")
+    if not author:
+        return False
+    if authenticated_login and author == authenticated_login:
+        return True
+    association = str(item.get("author_association") or "").upper()
+    return association in TRUSTED_AUTHOR_ASSOCIATIONS
+
+
+def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
+    repo = pr["repo"]
+    pr_number = pr["number"]
+    endpoints = comment_endpoints(repo, pr_number)
+
+    issue_payload = gh_api_list_paginated(endpoints["issue_comment"], repo=repo)
+    review_comment_payload = gh_api_list_paginated(endpoints["review_comment"], repo=repo)
+    review_payload = gh_api_list_paginated(endpoints["review"], repo=repo)
+
+    issue_items = normalize_issue_comments(issue_payload)
+    review_comment_items = normalize_review_comments(review_comment_payload)
+    review_items = normalize_reviews(review_payload)
+    all_items = issue_items + review_comment_items + review_items
+
+    seen_issue = {str(x) for x in state.get("seen_issue_comment_ids") or []}
+    seen_review_comment = {str(x) for x in state.get("seen_review_comment_ids") or []}
+    seen_review = {str(x) for x in state.get("seen_review_ids") or []}
+
+    # On a brand-new state file, surface existing review activity instead of
+    # silently treating it as seen. This avoids missing already-pending review
+    # feedback when monitoring starts after comments were posted.
+
+    new_items = []
+    for item in all_items:
+        item_id = item.get("id")
+        if not item_id:
+            continue
+        author = item.get("author") or ""
+        if not author:
+            continue
+        if is_bot_login(author):
+            if not is_actionable_review_bot_login(author):
+                continue
+        elif not is_trusted_human_review_author(item, authenticated_login):
+            continue
+
+        kind = item["kind"]
+        if kind == "issue_comment" and item_id in seen_issue:
+            continue
+        if kind == "review_comment" and item_id in seen_review_comment:
+            continue
+        if kind == "review" and item_id in seen_review:
+            continue
+
+        new_items.append(item)
+        if kind == "issue_comment":
+            seen_issue.add(item_id)
+        elif kind == "review_comment":
+            seen_review_comment.add(item_id)
+        elif kind == "review":
+            seen_review.add(item_id)
+
+    new_items.sort(key=lambda item: (item.get("created_at") or "", item.get("kind") or "", item.get("id") or ""))
+    state["seen_issue_comment_ids"] = sorted(seen_issue)
+    state["seen_review_comment_ids"] = sorted(seen_review_comment)
+    state["seen_review_ids"] = sorted(seen_review)
+    return new_items
+
+
+def current_retry_count(state, head_sha):
+    retries = state.get("retries_by_sha") or {}
+    value = retries.get(head_sha, 0)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def set_retry_count(state, head_sha, count):
+    retries = state.get("retries_by_sha")
+    if not isinstance(retries, dict):
+        retries = {}
+    retries[head_sha] = int(count)
+    state["retries_by_sha"] = retries
+
+
+def unique_actions(actions):
+    out = []
+    seen = set()
+    for action in actions:
+        if action not in seen:
+            out.append(action)
+            seen.add(action)
+    return out
+
+
+def is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+    if pr["closed"] or pr["merged"]:
+        return False
+    if not checks_summary["all_terminal"]:
+        return False
+    if checks_summary["failed_count"] > 0 or checks_summary["pending_count"] > 0:
+        return False
+    if new_review_items:
+        return False
+    if str(pr.get("mergeable") or "") != "MERGEABLE":
+        return False
+    if str(pr.get("merge_state_status") or "") in MERGE_CONFLICT_OR_BLOCKING_STATES:
+        return False
+    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS:
+        return False
+    return True
+
+
+def recommend_actions(pr, checks_summary, failed_runs, new_review_items, retries_used, max_retries):
+    actions = []
+    if pr["closed"] or pr["merged"]:
+        if new_review_items:
+            actions.append("process_review_comment")
+        actions.append("stop_pr_closed")
+        return unique_actions(actions)
+
+    if is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+        actions.append("stop_ready_to_merge")
+        return unique_actions(actions)
+
+    if new_review_items:
+        actions.append("process_review_comment")
+
+    has_failed_pr_checks = checks_summary["failed_count"] > 0
+    if has_failed_pr_checks:
+        if checks_summary["all_terminal"] and retries_used >= max_retries:
+            actions.append("stop_exhausted_retries")
+        else:
+            actions.append("diagnose_ci_failure")
+            if checks_summary["all_terminal"] and failed_runs and retries_used < max_retries:
+                actions.append("retry_failed_checks")
+
+    if not actions:
+        actions.append("idle")
+    return unique_actions(actions)
+
+
+def collect_snapshot(args):
+    pr = resolve_pr(args.pr, repo_override=args.repo)
+    state_path = Path(args.state_file) if args.state_file else default_state_file_for(pr)
+    state, fresh_state = load_state(state_path)
+
+    if not state.get("started_at"):
+        state["started_at"] = int(time.time())
+
+    # `gh pr checks -R <repo>` requires an explicit PR/branch/url argument.
+    # After resolving `--pr auto`, reuse the concrete PR number.
+    checks = get_pr_checks(str(pr["number"]), repo=pr["repo"])
+    checks_summary = summarize_checks(checks)
+    workflow_runs = get_workflow_runs_for_sha(pr["repo"], pr["head_sha"])
+    failed_runs = failed_runs_from_workflow_runs(workflow_runs, pr["head_sha"])
+    authenticated_login = get_authenticated_login()
+    new_review_items = fetch_new_review_items(
+        pr,
+        state,
+        fresh_state=fresh_state,
+        authenticated_login=authenticated_login,
+    )
+
+    retries_used = current_retry_count(state, pr["head_sha"])
+    actions = recommend_actions(
+        pr,
+        checks_summary,
+        failed_runs,
+        new_review_items,
+        retries_used,
+        args.max_flaky_retries,
+    )
+
+    state["pr"] = {"repo": pr["repo"], "number": pr["number"]}
+    state["last_seen_head_sha"] = pr["head_sha"]
+    state["last_snapshot_at"] = int(time.time())
+    save_state(state_path, state)
+
+    snapshot = {
+        "pr": pr,
+        "checks": checks_summary,
+        "failed_runs": failed_runs,
+        "new_review_items": new_review_items,
+        "actions": actions,
+        "retry_state": {
+            "current_sha_retries_used": retries_used,
+            "max_flaky_retries": args.max_flaky_retries,
+        },
+    }
+    return snapshot, state_path
+
+
+def retry_failed_now(args):
+    snapshot, state_path = collect_snapshot(args)
+    pr = snapshot["pr"]
+    checks_summary = snapshot["checks"]
+    failed_runs = snapshot["failed_runs"]
+    retries_used = snapshot["retry_state"]["current_sha_retries_used"]
+    max_retries = snapshot["retry_state"]["max_flaky_retries"]
+
+    result = {
+        "snapshot": snapshot,
+        "state_file": str(state_path),
+        "rerun_attempted": False,
+        "rerun_count": 0,
+        "rerun_run_ids": [],
+        "reason": None,
+    }
+
+    if pr["closed"] or pr["merged"]:
+        result["reason"] = "pr_closed"
+        return result
+    if checks_summary["failed_count"] <= 0:
+        result["reason"] = "no_failed_pr_checks"
+        return result
+    if not failed_runs:
+        result["reason"] = "no_failed_runs"
+        return result
+    if not checks_summary["all_terminal"]:
+        result["reason"] = "checks_still_pending"
+        return result
+    if retries_used >= max_retries:
+        result["reason"] = "retry_budget_exhausted"
+        return result
+
+    for run in failed_runs:
+        run_id = run.get("run_id")
+        if run_id in (None, ""):
+            continue
+        gh_text(["run", "rerun", str(run_id), "--failed"], repo=pr["repo"])
+        result["rerun_run_ids"].append(run_id)
+
+    if result["rerun_run_ids"]:
+        state, _ = load_state(state_path)
+        new_count = current_retry_count(state, pr["head_sha"]) + 1
+        set_retry_count(state, pr["head_sha"], new_count)
+        state["last_snapshot_at"] = int(time.time())
+        save_state(state_path, state)
+        result["rerun_attempted"] = True
+        result["rerun_count"] = len(result["rerun_run_ids"])
+        result["reason"] = "rerun_triggered"
+    else:
+        result["reason"] = "failed_runs_missing_ids"
+
+    return result
+
+
+def print_json(obj):
+    sys.stdout.write(json.dumps(obj, sort_keys=True) + "\n")
+    sys.stdout.flush()
+
+
+def print_event(event, payload):
+    print_json({"event": event, "payload": payload})
+
+
+def is_ci_green(snapshot):
+    checks = snapshot.get("checks") or {}
+    return (
+        bool(checks.get("all_terminal"))
+        and int(checks.get("failed_count") or 0) == 0
+        and int(checks.get("pending_count") or 0) == 0
+    )
+
+
+def snapshot_change_key(snapshot):
+    pr = snapshot.get("pr") or {}
+    checks = snapshot.get("checks") or {}
+    review_items = snapshot.get("new_review_items") or []
+    return (
+        str(pr.get("head_sha") or ""),
+        str(pr.get("state") or ""),
+        str(pr.get("mergeable") or ""),
+        str(pr.get("merge_state_status") or ""),
+        str(pr.get("review_decision") or ""),
+        int(checks.get("passed_count") or 0),
+        int(checks.get("failed_count") or 0),
+        int(checks.get("pending_count") or 0),
+        tuple(
+            (str(item.get("kind") or ""), str(item.get("id") or ""))
+            for item in review_items
+            if isinstance(item, dict)
+        ),
+        tuple(snapshot.get("actions") or []),
+    )
+
+
+def run_watch(args):
+    poll_seconds = args.poll_seconds
+    last_change_key = None
+    while True:
+        snapshot, state_path = collect_snapshot(args)
+        print_event(
+            "snapshot",
+            {
+                "snapshot": snapshot,
+                "state_file": str(state_path),
+                "next_poll_seconds": poll_seconds,
+            },
+        )
+        actions = set(snapshot.get("actions") or [])
+        if (
+            "stop_pr_closed" in actions
+            or "stop_exhausted_retries" in actions
+            or "stop_ready_to_merge" in actions
+        ):
+            print_event("stop", {"actions": snapshot.get("actions"), "pr": snapshot.get("pr")})
+            return 0
+
+        current_change_key = snapshot_change_key(snapshot)
+        changed = current_change_key != last_change_key
+        green = is_ci_green(snapshot)
+
+        if not green:
+            poll_seconds = args.poll_seconds
+        elif changed or last_change_key is None:
+            poll_seconds = args.poll_seconds
+        else:
+            poll_seconds = min(poll_seconds * 2, GREEN_STATE_MAX_POLL_SECONDS)
+
+        last_change_key = current_change_key
+        time.sleep(poll_seconds)
+
+
+def main():
+    args = parse_args()
+    try:
+        if args.retry_failed_now:
+            print_json(retry_failed_now(args))
+            return 0
+        if args.watch:
+            return run_watch(args)
+        snapshot, state_path = collect_snapshot(args)
+        snapshot["state_file"] = str(state_path)
+        print_json(snapshot)
+        return 0
+    except (GhCommandError, RuntimeError, ValueError) as err:
+        sys.stderr.write(f"gh_pr_watch.py error: {err}\n")
+        return 1
+    except KeyboardInterrupt:
+        sys.stderr.write("gh_pr_watch.py interrupted\n")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -308,6 +308,20 @@ def summarize_checks(checks):
     }
 
 
+def failed_pr_check_keys(checks):
+    keys = set()
+    for check in checks:
+        if not isinstance(check, dict):
+            continue
+        bucket = str(check.get("bucket") or "").lower()
+        if bucket != "fail":
+            continue
+        workflow_name = str(check.get("workflow") or check.get("name") or "")
+        event = str(check.get("event") or "")
+        keys.add((workflow_name, event))
+    return keys
+
+
 def get_workflow_runs_for_sha(repo, head_sha):
     endpoint = f"repos/{repo}/actions/runs"
     data = gh_json(
@@ -351,7 +365,7 @@ def workflow_run_sort_key(run):
     )
 
 
-def failed_runs_from_workflow_runs(runs, head_sha):
+def failed_runs_from_workflow_runs(runs, head_sha, failed_check_keys=None):
     latest_runs_by_key = {}
     failed_runs = []
     for run in runs:
@@ -368,10 +382,15 @@ def failed_runs_from_workflow_runs(runs, head_sha):
         conclusion = str(run.get("conclusion") or "")
         if conclusion not in FAILED_RUN_CONCLUSIONS:
             continue
+        workflow_name = str(run.get("name") or run.get("display_title") or "")
+        event = str(run.get("event") or "")
+        if failed_check_keys and (workflow_name, event) not in failed_check_keys:
+            continue
         failed_runs.append(
             {
                 "run_id": run.get("id"),
-                "workflow_name": run.get("name") or run.get("display_title") or "",
+                "workflow_name": workflow_name,
+                "event": event,
                 "run_attempt": run.get("run_attempt"),
                 "status": str(run.get("status") or ""),
                 "conclusion": conclusion,
@@ -967,7 +986,11 @@ def collect_snapshot(args):
     checks = get_pr_checks(str(pr["number"]), repo=pr["repo"])
     checks_summary = summarize_checks(checks)
     workflow_runs = get_workflow_runs_for_sha(pr["repo"], pr["head_sha"])
-    failed_runs = failed_runs_from_workflow_runs(workflow_runs, pr["head_sha"])
+    failed_runs = failed_runs_from_workflow_runs(
+        workflow_runs,
+        pr["head_sha"],
+        failed_check_keys=failed_pr_check_keys(checks),
+    )
     authenticated_login = get_authenticated_login()
     new_review_items = fetch_new_review_items(
         pr,

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -30,6 +30,7 @@ PENDING_CHECK_STATES = {
 REVIEW_BOT_LOGIN_KEYWORDS = {
     "codex",
 }
+READY_REACTION_CONTENT = "+1"
 TRUSTED_AUTHOR_ASSOCIATIONS = {
     "OWNER",
     "MEMBER",
@@ -316,13 +317,51 @@ def get_workflow_runs_for_sha(repo, head_sha):
     return runs
 
 
+def workflow_run_key(run):
+    workflow_id = run.get("workflow_id")
+    if workflow_id not in (None, ""):
+        return f"workflow:{workflow_id}"
+    return "|".join(
+        [
+            f"name:{str(run.get('name') or run.get('display_title') or '')}",
+            f"event:{str(run.get('event') or '')}",
+        ]
+    )
+
+
+def workflow_run_sort_key(run):
+    run_attempt = run.get("run_attempt")
+    run_id = run.get("id")
+    try:
+        run_attempt = int(run_attempt)
+    except (TypeError, ValueError):
+        run_attempt = 0
+    try:
+        run_id = int(run_id)
+    except (TypeError, ValueError):
+        run_id = 0
+    return (
+        run_attempt,
+        str(run.get("created_at") or ""),
+        str(run.get("updated_at") or ""),
+        run_id,
+    )
+
+
 def failed_runs_from_workflow_runs(runs, head_sha):
+    latest_runs_by_key = {}
     failed_runs = []
     for run in runs:
         if not isinstance(run, dict):
             continue
         if str(run.get("head_sha") or "") != head_sha:
             continue
+        run_key = workflow_run_key(run)
+        existing = latest_runs_by_key.get(run_key)
+        if existing is None or workflow_run_sort_key(run) > workflow_run_sort_key(existing):
+            latest_runs_by_key[run_key] = run
+
+    for run in latest_runs_by_key.values():
         conclusion = str(run.get("conclusion") or "")
         if conclusion not in FAILED_RUN_CONCLUSIONS:
             continue
@@ -330,6 +369,7 @@ def failed_runs_from_workflow_runs(runs, head_sha):
             {
                 "run_id": run.get("id"),
                 "workflow_name": run.get("name") or run.get("display_title") or "",
+                "run_attempt": run.get("run_attempt"),
                 "status": str(run.get("status") or ""),
                 "conclusion": conclusion,
                 "html_url": str(run.get("html_url") or ""),
@@ -354,6 +394,10 @@ def comment_endpoints(repo, pr_number):
     }
 
 
+def reaction_endpoint(repo, pr_number):
+    return f"repos/{repo}/issues/{pr_number}/reactions"
+
+
 def gh_api_list_paginated(endpoint, repo=None, per_page=100):
     items = []
     page = 1
@@ -370,6 +414,16 @@ def gh_api_list_paginated(endpoint, repo=None, per_page=100):
             break
         page += 1
     return items
+
+
+def graphql_json(query, variables=None):
+    cmd = ["api", "graphql", "-f", f"query={query}"]
+    for key, value in (variables or {}).items():
+        cmd.extend(["-F", f"{key}={value}"])
+    data = gh_json(cmd)
+    if not isinstance(data, dict):
+        raise GhCommandError("Unexpected payload from `gh api graphql`")
+    return data
 
 
 def normalize_issue_comments(items):
@@ -433,6 +487,21 @@ def normalize_reviews(items):
                 "path": None,
                 "line": None,
                 "url": str(item.get("html_url") or ""),
+            }
+        )
+    return out
+
+
+def normalize_reactions(items):
+    out = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        out.append(
+            {
+                "id": str(item.get("id") or ""),
+                "author": extract_login(item.get("user")),
+                "content": str(item.get("content") or ""),
             }
         )
     return out
@@ -524,6 +593,101 @@ def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
     return new_items
 
 
+def fetch_pr_ready_reactions(pr):
+    payload = gh_api_list_paginated(reaction_endpoint(pr["repo"], pr["number"]), repo=pr["repo"])
+    reactions = normalize_reactions(payload)
+    ready_reactions = []
+    for reaction in reactions:
+        if reaction.get("content") != READY_REACTION_CONTENT:
+            continue
+        ready_reactions.append(
+            {
+                "id": reaction.get("id") or "",
+                "author": reaction.get("author") or "",
+                "content": READY_REACTION_CONTENT,
+            }
+        )
+    ready_reactions.sort(key=lambda item: (str(item.get("author") or ""), str(item.get("id") or "")))
+    return ready_reactions
+
+
+def fetch_unresolved_review_threads(pr):
+    owner, repo_name = pr["repo"].split("/", 1)
+    query = """
+query($owner:String!, $repo:String!, $number:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100) {
+        nodes {
+          isResolved
+          isOutdated
+          comments(first:100) {
+            nodes {
+              databaseId
+              body
+              path
+              line
+              createdAt
+              author {
+                login
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+""".strip()
+    payload = graphql_json(
+        query,
+        variables={
+            "owner": owner,
+            "repo": repo_name,
+            "number": pr["number"],
+        },
+    )
+    nodes = (
+        payload.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+        .get("nodes", [])
+    )
+    if not isinstance(nodes, list):
+        raise GhCommandError("Expected reviewThreads.nodes to be a list")
+
+    unresolved_threads = []
+    for thread in nodes:
+        if not isinstance(thread, dict):
+            continue
+        if thread.get("isResolved") or thread.get("isOutdated"):
+            continue
+        comments = thread.get("comments", {}).get("nodes", [])
+        if not isinstance(comments, list) or not comments:
+            continue
+        latest_comment = comments[-1]
+        if not isinstance(latest_comment, dict):
+            continue
+        author = (latest_comment.get("author") or {}).get("login") or ""
+        unresolved_threads.append(
+            {
+                "author": str(author),
+                "body": str(latest_comment.get("body") or ""),
+                "created_at": str(latest_comment.get("createdAt") or ""),
+                "id": str(latest_comment.get("databaseId") or ""),
+                "kind": "unresolved_review_thread",
+                "line": latest_comment.get("line"),
+                "path": latest_comment.get("path"),
+                "url": pr["url"],
+            }
+        )
+    unresolved_threads.sort(
+        key=lambda item: (str(item.get("created_at") or ""), str(item.get("path") or ""), str(item.get("id") or ""))
+    )
+    return unresolved_threads
+
+
 def current_retry_count(state, head_sha):
     retries = state.get("retries_by_sha") or {}
     value = retries.get(head_sha, 0)
@@ -551,7 +715,7 @@ def unique_actions(actions):
     return out
 
 
-def is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+def is_pr_ready_to_merge(pr, checks_summary, new_review_items, unresolved_review_threads, ready_reactions):
     if pr["closed"] or pr["merged"]:
         return False
     if not checks_summary["all_terminal"]:
@@ -560,28 +724,43 @@ def is_pr_ready_to_merge(pr, checks_summary, new_review_items):
         return False
     if new_review_items:
         return False
+    if unresolved_review_threads:
+        return False
     if str(pr.get("mergeable") or "") != "MERGEABLE":
         return False
-    if str(pr.get("merge_state_status") or "") in MERGE_CONFLICT_OR_BLOCKING_STATES:
+    has_ready_reaction = bool(ready_reactions)
+    merge_state_status = str(pr.get("merge_state_status") or "")
+    if merge_state_status in {"DIRTY", "DRAFT", "UNKNOWN"}:
         return False
-    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS:
+    if merge_state_status == "BLOCKED" and not has_ready_reaction:
+        return False
+    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS and not has_ready_reaction:
         return False
     return True
 
 
-def recommend_actions(pr, checks_summary, failed_runs, new_review_items, retries_used, max_retries):
+def recommend_actions(
+    pr,
+    checks_summary,
+    failed_runs,
+    new_review_items,
+    unresolved_review_threads,
+    ready_reactions,
+    retries_used,
+    max_retries,
+):
     actions = []
     if pr["closed"] or pr["merged"]:
-        if new_review_items:
+        if new_review_items or unresolved_review_threads:
             actions.append("process_review_comment")
         actions.append("stop_pr_closed")
         return unique_actions(actions)
 
-    if is_pr_ready_to_merge(pr, checks_summary, new_review_items):
+    if is_pr_ready_to_merge(pr, checks_summary, new_review_items, unresolved_review_threads, ready_reactions):
         actions.append("stop_ready_to_merge")
         return unique_actions(actions)
 
-    if new_review_items:
+    if new_review_items or unresolved_review_threads:
         actions.append("process_review_comment")
 
     has_failed_pr_checks = checks_summary["failed_count"] > 0
@@ -619,6 +798,8 @@ def collect_snapshot(args):
         fresh_state=fresh_state,
         authenticated_login=authenticated_login,
     )
+    unresolved_review_threads = fetch_unresolved_review_threads(pr)
+    ready_reactions = fetch_pr_ready_reactions(pr)
 
     retries_used = current_retry_count(state, pr["head_sha"])
     actions = recommend_actions(
@@ -626,6 +807,8 @@ def collect_snapshot(args):
         checks_summary,
         failed_runs,
         new_review_items,
+        unresolved_review_threads,
+        ready_reactions,
         retries_used,
         args.max_flaky_retries,
     )
@@ -640,6 +823,11 @@ def collect_snapshot(args):
         "checks": checks_summary,
         "failed_runs": failed_runs,
         "new_review_items": new_review_items,
+        "unresolved_review_threads": unresolved_review_threads,
+        "approval_signal": {
+            "has_pr_thumbs_up": bool(ready_reactions),
+            "pr_thumbs_up_reactions": ready_reactions,
+        },
         "actions": actions,
         "retry_state": {
             "current_sha_retries_used": retries_used,
@@ -726,6 +914,9 @@ def snapshot_change_key(snapshot):
     pr = snapshot.get("pr") or {}
     checks = snapshot.get("checks") or {}
     review_items = snapshot.get("new_review_items") or []
+    unresolved_review_threads = snapshot.get("unresolved_review_threads") or []
+    approval_signal = snapshot.get("approval_signal") or {}
+    ready_reactions = approval_signal.get("pr_thumbs_up_reactions") or []
     return (
         str(pr.get("head_sha") or ""),
         str(pr.get("state") or ""),
@@ -738,6 +929,16 @@ def snapshot_change_key(snapshot):
         tuple(
             (str(item.get("kind") or ""), str(item.get("id") or ""))
             for item in review_items
+            if isinstance(item, dict)
+        ),
+        tuple(
+            (str(item.get("path") or ""), str(item.get("id") or ""))
+            for item in unresolved_review_threads
+            if isinstance(item, dict)
+        ),
+        tuple(
+            (str(item.get("author") or ""), str(item.get("id") or ""))
+            for item in ready_reactions
             if isinstance(item, dict)
         ),
         tuple(snapshot.get("actions") or []),

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -650,7 +650,16 @@ def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
         if kind != "review":
             continue
         review_state = str(item.get("review_state") or "").upper()
+        author = str(item.get("author") or "")
         if review_state in NON_BLOCKING_REVIEW_STATES:
+            tracked_items = {
+                tracked_id: tracked_item
+                for tracked_id, tracked_item in tracked_items.items()
+                if not (
+                    str(tracked_item.get("kind") or "") == "review"
+                    and str(tracked_item.get("author") or "") == author
+                )
+            }
             continue
         tracked_items[item_id] = item
 
@@ -665,10 +674,14 @@ def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
 def fetch_unresolved_review_threads(pr):
     owner, repo_name = pr["repo"].split("/", 1)
     query = """
-query($owner:String!, $repo:String!, $number:Int!) {
+query($owner:String!, $repo:String!, $number:Int!, $after:String) {
   repository(owner:$owner, name:$repo) {
     pullRequest(number:$number) {
-      reviewThreads(first:100) {
+      reviewThreads(first:100, after:$after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           isResolved
           isOutdated
@@ -690,49 +703,58 @@ query($owner:String!, $repo:String!, $number:Int!) {
   }
 }
 """.strip()
-    payload = graphql_json(
-        query,
-        variables={
+    unresolved_threads = []
+    after_cursor = None
+    while True:
+        variables = {
             "owner": owner,
             "repo": repo_name,
             "number": pr["number"],
-        },
-    )
-    nodes = (
-        payload.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-        .get("nodes", [])
-    )
-    if not isinstance(nodes, list):
-        raise GhCommandError("Expected reviewThreads.nodes to be a list")
-
-    unresolved_threads = []
-    for thread in nodes:
-        if not isinstance(thread, dict):
-            continue
-        if thread.get("isResolved") or thread.get("isOutdated"):
-            continue
-        comments = thread.get("comments", {}).get("nodes", [])
-        if not isinstance(comments, list) or not comments:
-            continue
-        latest_comment = comments[-1]
-        if not isinstance(latest_comment, dict):
-            continue
-        author = (latest_comment.get("author") or {}).get("login") or ""
-        unresolved_threads.append(
-            {
-                "author": str(author),
-                "body": str(latest_comment.get("body") or ""),
-                "created_at": str(latest_comment.get("createdAt") or ""),
-                "id": str(latest_comment.get("databaseId") or ""),
-                "kind": "unresolved_review_thread",
-                "line": latest_comment.get("line"),
-                "path": latest_comment.get("path"),
-                "url": pr["url"],
-            }
+        }
+        if after_cursor:
+            variables["after"] = after_cursor
+        payload = graphql_json(query, variables=variables)
+        review_threads = (
+            payload.get("data", {})
+            .get("repository", {})
+            .get("pullRequest", {})
+            .get("reviewThreads", {})
         )
+        nodes = review_threads.get("nodes", [])
+        if not isinstance(nodes, list):
+            raise GhCommandError("Expected reviewThreads.nodes to be a list")
+
+        for thread in nodes:
+            if not isinstance(thread, dict):
+                continue
+            if thread.get("isResolved") or thread.get("isOutdated"):
+                continue
+            comments = thread.get("comments", {}).get("nodes", [])
+            if not isinstance(comments, list) or not comments:
+                continue
+            latest_comment = comments[-1]
+            if not isinstance(latest_comment, dict):
+                continue
+            author = (latest_comment.get("author") or {}).get("login") or ""
+            unresolved_threads.append(
+                {
+                    "author": str(author),
+                    "body": str(latest_comment.get("body") or ""),
+                    "created_at": str(latest_comment.get("createdAt") or ""),
+                    "id": str(latest_comment.get("databaseId") or ""),
+                    "kind": "unresolved_review_thread",
+                    "line": latest_comment.get("line"),
+                    "path": latest_comment.get("path"),
+                    "url": pr["url"],
+                }
+            )
+
+        page_info = review_threads.get("pageInfo", {})
+        if not page_info.get("hasNextPage"):
+            break
+        after_cursor = page_info.get("endCursor")
+        if not after_cursor:
+            break
     unresolved_threads.sort(
         key=lambda item: (str(item.get("created_at") or ""), str(item.get("path") or ""), str(item.get("id") or ""))
     )

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -538,6 +538,12 @@ def is_trusted_human_review_author(item, authenticated_login):
     return association in TRUSTED_AUTHOR_ASSOCIATIONS
 
 
+def is_authenticated_operator_item(item, authenticated_login):
+    if not authenticated_login or not isinstance(item, dict):
+        return False
+    return str(item.get("author") or "") == authenticated_login
+
+
 def is_generic_codex_summary_review(item):
     if not isinstance(item, dict):
         return False
@@ -623,6 +629,8 @@ def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
         author = item.get("author") or ""
         if not author:
             continue
+        if authenticated_login and author == authenticated_login:
+            continue
         if is_bot_login(author):
             if not is_actionable_review_bot_login(author):
                 continue
@@ -695,17 +703,25 @@ def set_blocking_non_thread_feedback_for_sha(state, head_sha, items):
     state["pending_non_thread_feedback_by_sha"] = pending_by_sha
 
 
-def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
+def update_blocking_non_thread_feedback(state, head_sha, new_review_items, authenticated_login=None):
     tracked_items = {
         str(item.get("id") or ""): item
         for item in blocking_non_thread_feedback_for_sha(state, head_sha)
-        if isinstance(item, dict) and item.get("id") and not is_non_blocking_review_item(item)
+        if (
+            isinstance(item, dict)
+            and item.get("id")
+            and not is_non_blocking_review_item(item)
+            and not is_authenticated_operator_item(item, authenticated_login)
+        )
     }
     for item in new_review_items:
         if not isinstance(item, dict):
             continue
         item_id = str(item.get("id") or "")
         if not item_id:
+            continue
+        if is_authenticated_operator_item(item, authenticated_login):
+            tracked_items.pop(item_id, None)
             continue
         kind = str(item.get("kind") or "")
         if kind == "issue_comment":
@@ -960,7 +976,12 @@ def collect_snapshot(args):
         authenticated_login=authenticated_login,
     )
     unresolved_review_threads = fetch_unresolved_review_threads(pr)
-    blocking_non_thread_feedback = update_blocking_non_thread_feedback(state, pr["head_sha"], new_review_items)
+    blocking_non_thread_feedback = update_blocking_non_thread_feedback(
+        state,
+        pr["head_sha"],
+        new_review_items,
+        authenticated_login=authenticated_login,
+    )
     ready_reactions = fetch_pr_ready_reactions(pr, authenticated_login=authenticated_login)
 
     retries_used = current_retry_count(state, pr["head_sha"])

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -40,6 +40,10 @@ MERGE_BLOCKING_REVIEW_DECISIONS = {
     "REVIEW_REQUIRED",
     "CHANGES_REQUESTED",
 }
+NON_BLOCKING_REVIEW_STATES = {
+    "APPROVED",
+    "DISMISSED",
+}
 MERGE_CONFLICT_OR_BLOCKING_STATES = {
     "BLOCKED",
     "DIRTY",
@@ -233,6 +237,7 @@ def load_state(path):
         "pr": {},
         "started_at": None,
         "last_seen_head_sha": None,
+        "pending_non_thread_feedback_by_sha": {},
         "retries_by_sha": {},
         "seen_issue_comment_ids": [],
         "seen_review_comment_ids": [],
@@ -319,14 +324,12 @@ def get_workflow_runs_for_sha(repo, head_sha):
 
 def workflow_run_key(run):
     workflow_id = run.get("workflow_id")
+    key_parts = [f"event:{str(run.get('event') or '')}"]
     if workflow_id not in (None, ""):
-        return f"workflow:{workflow_id}"
-    return "|".join(
-        [
-            f"name:{str(run.get('name') or run.get('display_title') or '')}",
-            f"event:{str(run.get('event') or '')}",
-        ]
-    )
+        key_parts.insert(0, f"workflow:{workflow_id}")
+        return "|".join(key_parts)
+    key_parts.insert(0, f"name:{str(run.get('name') or run.get('display_title') or '')}")
+    return "|".join(key_parts)
 
 
 def workflow_run_sort_key(run):
@@ -484,6 +487,7 @@ def normalize_reviews(items):
                 "author_association": str(item.get("author_association") or ""),
                 "created_at": str(item.get("submitted_at") or item.get("created_at") or ""),
                 "body": str(item.get("body") or ""),
+                "review_state": str(item.get("state") or ""),
                 "path": None,
                 "line": None,
                 "url": str(item.get("html_url") or ""),
@@ -611,6 +615,53 @@ def fetch_pr_ready_reactions(pr):
     return ready_reactions
 
 
+def blocking_non_thread_feedback_for_sha(state, head_sha):
+    pending_by_sha = state.get("pending_non_thread_feedback_by_sha") or {}
+    items = pending_by_sha.get(head_sha) or []
+    if isinstance(items, list):
+        return items
+    return []
+
+
+def set_blocking_non_thread_feedback_for_sha(state, head_sha, items):
+    pending_by_sha = state.get("pending_non_thread_feedback_by_sha")
+    if not isinstance(pending_by_sha, dict):
+        pending_by_sha = {}
+    pending_by_sha[head_sha] = items
+    state["pending_non_thread_feedback_by_sha"] = pending_by_sha
+
+
+def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
+    tracked_items = {
+        str(item.get("id") or ""): item
+        for item in blocking_non_thread_feedback_for_sha(state, head_sha)
+        if isinstance(item, dict) and item.get("id")
+    }
+    for item in new_review_items:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get("id") or "")
+        if not item_id:
+            continue
+        kind = str(item.get("kind") or "")
+        if kind == "issue_comment":
+            tracked_items[item_id] = item
+            continue
+        if kind != "review":
+            continue
+        review_state = str(item.get("review_state") or "").upper()
+        if review_state in NON_BLOCKING_REVIEW_STATES:
+            continue
+        tracked_items[item_id] = item
+
+    tracked_list = sorted(
+        tracked_items.values(),
+        key=lambda item: (str(item.get("created_at") or ""), str(item.get("kind") or ""), str(item.get("id") or "")),
+    )
+    set_blocking_non_thread_feedback_for_sha(state, head_sha, tracked_list)
+    return tracked_list
+
+
 def fetch_unresolved_review_threads(pr):
     owner, repo_name = pr["repo"].split("/", 1)
     query = """
@@ -715,7 +766,14 @@ def unique_actions(actions):
     return out
 
 
-def is_pr_ready_to_merge(pr, checks_summary, new_review_items, unresolved_review_threads, ready_reactions):
+def is_pr_ready_to_merge(
+    pr,
+    checks_summary,
+    new_review_items,
+    unresolved_review_threads,
+    blocking_non_thread_feedback,
+    ready_reactions,
+):
     if pr["closed"] or pr["merged"]:
         return False
     if not checks_summary["all_terminal"]:
@@ -726,15 +784,19 @@ def is_pr_ready_to_merge(pr, checks_summary, new_review_items, unresolved_review
         return False
     if unresolved_review_threads:
         return False
+    if blocking_non_thread_feedback:
+        return False
     if str(pr.get("mergeable") or "") != "MERGEABLE":
         return False
     has_ready_reaction = bool(ready_reactions)
     merge_state_status = str(pr.get("merge_state_status") or "")
+    review_decision = str(pr.get("review_decision") or "")
+    review_gate_blocked = review_decision in MERGE_BLOCKING_REVIEW_DECISIONS
     if merge_state_status in {"DIRTY", "DRAFT", "UNKNOWN"}:
         return False
-    if merge_state_status == "BLOCKED" and not has_ready_reaction:
+    if merge_state_status == "BLOCKED" and not (has_ready_reaction and review_gate_blocked):
         return False
-    if str(pr.get("review_decision") or "") in MERGE_BLOCKING_REVIEW_DECISIONS and not has_ready_reaction:
+    if review_gate_blocked and not has_ready_reaction:
         return False
     return True
 
@@ -745,22 +807,30 @@ def recommend_actions(
     failed_runs,
     new_review_items,
     unresolved_review_threads,
+    blocking_non_thread_feedback,
     ready_reactions,
     retries_used,
     max_retries,
 ):
     actions = []
     if pr["closed"] or pr["merged"]:
-        if new_review_items or unresolved_review_threads:
+        if new_review_items or unresolved_review_threads or blocking_non_thread_feedback:
             actions.append("process_review_comment")
         actions.append("stop_pr_closed")
         return unique_actions(actions)
 
-    if is_pr_ready_to_merge(pr, checks_summary, new_review_items, unresolved_review_threads, ready_reactions):
+    if is_pr_ready_to_merge(
+        pr,
+        checks_summary,
+        new_review_items,
+        unresolved_review_threads,
+        blocking_non_thread_feedback,
+        ready_reactions,
+    ):
         actions.append("stop_ready_to_merge")
         return unique_actions(actions)
 
-    if new_review_items or unresolved_review_threads:
+    if new_review_items or unresolved_review_threads or blocking_non_thread_feedback:
         actions.append("process_review_comment")
 
     has_failed_pr_checks = checks_summary["failed_count"] > 0
@@ -799,6 +869,7 @@ def collect_snapshot(args):
         authenticated_login=authenticated_login,
     )
     unresolved_review_threads = fetch_unresolved_review_threads(pr)
+    blocking_non_thread_feedback = update_blocking_non_thread_feedback(state, pr["head_sha"], new_review_items)
     ready_reactions = fetch_pr_ready_reactions(pr)
 
     retries_used = current_retry_count(state, pr["head_sha"])
@@ -808,6 +879,7 @@ def collect_snapshot(args):
         failed_runs,
         new_review_items,
         unresolved_review_threads,
+        blocking_non_thread_feedback,
         ready_reactions,
         retries_used,
         args.max_flaky_retries,
@@ -824,6 +896,7 @@ def collect_snapshot(args):
         "failed_runs": failed_runs,
         "new_review_items": new_review_items,
         "unresolved_review_threads": unresolved_review_threads,
+        "blocking_non_thread_feedback": blocking_non_thread_feedback,
         "approval_signal": {
             "has_pr_thumbs_up": bool(ready_reactions),
             "pr_thumbs_up_reactions": ready_reactions,
@@ -915,6 +988,7 @@ def snapshot_change_key(snapshot):
     checks = snapshot.get("checks") or {}
     review_items = snapshot.get("new_review_items") or []
     unresolved_review_threads = snapshot.get("unresolved_review_threads") or []
+    blocking_non_thread_feedback = snapshot.get("blocking_non_thread_feedback") or []
     approval_signal = snapshot.get("approval_signal") or {}
     ready_reactions = approval_signal.get("pr_thumbs_up_reactions") or []
     return (
@@ -934,6 +1008,11 @@ def snapshot_change_key(snapshot):
         tuple(
             (str(item.get("path") or ""), str(item.get("id") or ""))
             for item in unresolved_review_threads
+            if isinstance(item, dict)
+        ),
+        tuple(
+            (str(item.get("kind") or ""), str(item.get("id") or ""))
+            for item in blocking_non_thread_feedback
             if isinstance(item, dict)
         ),
         tuple(

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -265,7 +265,7 @@ def save_state(path, state):
 
 def default_state_file_for(pr):
     repo_slug = pr["repo"].replace("/", "-")
-    return Path(f"/tmp/codex-babysit-pr-{repo_slug}-pr{pr['number']}.json")
+    return Path(tempfile.gettempdir()) / f"codex-babysit-pr-{repo_slug}-pr{pr['number']}.json"
 
 
 def get_pr_checks(pr_spec, repo):
@@ -538,6 +538,61 @@ def is_trusted_human_review_author(item, authenticated_login):
     return association in TRUSTED_AUTHOR_ASSOCIATIONS
 
 
+def is_generic_codex_summary_review(item):
+    if not isinstance(item, dict):
+        return False
+    if str(item.get("kind") or "") != "review":
+        return False
+    author = str(item.get("author") or "")
+    if not is_actionable_review_bot_login(author):
+        return False
+    body = str(item.get("body") or "").lower()
+    return (
+        "here are some automated review suggestions for this pull request" in body
+        or "about codex in github" in body
+    )
+
+
+def is_non_blocking_review_item(item):
+    if not isinstance(item, dict):
+        return False
+    if str(item.get("kind") or "") != "review":
+        return False
+    if is_generic_codex_summary_review(item):
+        return True
+    review_state = str(item.get("review_state") or "").upper()
+    return review_state in NON_BLOCKING_REVIEW_STATES
+
+
+def actionable_new_review_items(items):
+    actionable_items = []
+    for item in items or []:
+        if is_non_blocking_review_item(item):
+            continue
+        actionable_items.append(item)
+    return actionable_items
+
+
+def is_trusted_ready_reaction_author(author, repo, authenticated_login, trust_cache=None):
+    author = str(author or "")
+    if not author:
+        return False
+    if authenticated_login and author == authenticated_login:
+        return True
+    cache = trust_cache if isinstance(trust_cache, dict) else {}
+    cached = cache.get(author)
+    if cached is not None:
+        return cached
+    try:
+        payload = gh_json(["api", f"repos/{repo}/collaborators/{author}/permission"])
+    except GhCommandError:
+        cache[author] = False
+        return False
+    trusted = isinstance(payload, dict) and bool(payload.get("permission") or payload.get("role_name"))
+    cache[author] = trusted
+    return trusted
+
+
 def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
     repo = pr["repo"]
     pr_number = pr["number"]
@@ -597,17 +652,26 @@ def fetch_new_review_items(pr, state, fresh_state, authenticated_login=None):
     return new_items
 
 
-def fetch_pr_ready_reactions(pr):
+def fetch_pr_ready_reactions(pr, authenticated_login=None):
     payload = gh_api_list_paginated(reaction_endpoint(pr["repo"], pr["number"]), repo=pr["repo"])
     reactions = normalize_reactions(payload)
     ready_reactions = []
+    trust_cache = {}
     for reaction in reactions:
         if reaction.get("content") != READY_REACTION_CONTENT:
+            continue
+        author = reaction.get("author") or ""
+        if not is_trusted_ready_reaction_author(
+            author,
+            pr["repo"],
+            authenticated_login=authenticated_login,
+            trust_cache=trust_cache,
+        ):
             continue
         ready_reactions.append(
             {
                 "id": reaction.get("id") or "",
-                "author": reaction.get("author") or "",
+                "author": author,
                 "content": READY_REACTION_CONTENT,
             }
         )
@@ -635,7 +699,7 @@ def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
     tracked_items = {
         str(item.get("id") or ""): item
         for item in blocking_non_thread_feedback_for_sha(state, head_sha)
-        if isinstance(item, dict) and item.get("id")
+        if isinstance(item, dict) and item.get("id") and not is_non_blocking_review_item(item)
     }
     for item in new_review_items:
         if not isinstance(item, dict):
@@ -649,9 +713,12 @@ def update_blocking_non_thread_feedback(state, head_sha, new_review_items):
             continue
         if kind != "review":
             continue
-        review_state = str(item.get("review_state") or "").upper()
         author = str(item.get("author") or "")
-        if review_state in NON_BLOCKING_REVIEW_STATES:
+        if is_non_blocking_review_item(item):
+            tracked_items.pop(item_id, None)
+            review_state = str(item.get("review_state") or "").upper()
+            if review_state not in NON_BLOCKING_REVIEW_STATES:
+                continue
             tracked_items = {
                 tracked_id: tracked_item
                 for tracked_id, tracked_item in tracked_items.items()
@@ -796,13 +863,14 @@ def is_pr_ready_to_merge(
     blocking_non_thread_feedback,
     ready_reactions,
 ):
+    actionable_reviews = actionable_new_review_items(new_review_items)
     if pr["closed"] or pr["merged"]:
         return False
     if not checks_summary["all_terminal"]:
         return False
     if checks_summary["failed_count"] > 0 or checks_summary["pending_count"] > 0:
         return False
-    if new_review_items:
+    if actionable_reviews:
         return False
     if unresolved_review_threads:
         return False
@@ -835,8 +903,9 @@ def recommend_actions(
     max_retries,
 ):
     actions = []
+    actionable_reviews = actionable_new_review_items(new_review_items)
     if pr["closed"] or pr["merged"]:
-        if new_review_items or unresolved_review_threads or blocking_non_thread_feedback:
+        if actionable_reviews or unresolved_review_threads or blocking_non_thread_feedback:
             actions.append("process_review_comment")
         actions.append("stop_pr_closed")
         return unique_actions(actions)
@@ -852,7 +921,7 @@ def recommend_actions(
         actions.append("stop_ready_to_merge")
         return unique_actions(actions)
 
-    if new_review_items or unresolved_review_threads or blocking_non_thread_feedback:
+    if actionable_reviews or unresolved_review_threads or blocking_non_thread_feedback:
         actions.append("process_review_comment")
 
     has_failed_pr_checks = checks_summary["failed_count"] > 0
@@ -892,7 +961,7 @@ def collect_snapshot(args):
     )
     unresolved_review_threads = fetch_unresolved_review_threads(pr)
     blocking_non_thread_feedback = update_blocking_non_thread_feedback(state, pr["head_sha"], new_review_items)
-    ready_reactions = fetch_pr_ready_reactions(pr)
+    ready_reactions = fetch_pr_ready_reactions(pr, authenticated_login=authenticated_login)
 
     retries_used = current_retry_count(state, pr["head_sha"])
     actions = recommend_actions(

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ media/webview-dev.css
 *.zip
 coverage/
 output/playwright/
+__pycache__/
+*.py[cod]
 
 # allow tracking webview entrypoints
 *.log


### PR DESCRIPTION
This PR vendors the `babysit-pr` Codex skill into the repository so the watcher can be run directly from this checkout.

Before this change, the skill only existed in a separate `codex` checkout. The commands documented by the skill referenced `.codex/skills/babysit-pr/...`, but this repository did not contain that directory. In practice, that meant the skill was not portable to `Apex-Log-Viewer`: running the documented local watcher command from this repo failed immediately because the script path did not exist.

The root cause was simple path coupling. The repository had `.codex/environments/environment.toml`, but none of the `babysit-pr` skill assets that its own commands expect to find locally.

This change copies the full skill payload into `.codex/skills/babysit-pr`, including the watcher script, reference material, and agent metadata. After the copy, the repository contains the files required for the skill to resolve its local paths without depending on another clone on the same machine.

Validation for this change focused on the real workflow. I verified that the copied files are present under `.codex/skills/babysit-pr`, that the watcher script can now be invoked from this repository path, and I will re-run `python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --once` against the PR branch after opening this draft PR so the branch-local `--pr auto` flow is covered end to end.
