### PR TITLE
ci(e2e): reuse scratch org in GitHub Actions

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -58,6 +58,23 @@ jobs:
       - name: Install Salesforce CLI
         run: npm install -g @salesforce/cli
 
+      - name: Require GitHub secrets rotator token (pull_request)
+        if: ${{ github.event_name == 'pull_request' && env.CAN_ROTATE_SCRATCH_SECRET != '1' }}
+        shell: bash
+        run: |
+          echo "::error::GH_SECRETS_ROTATOR_PAT must be configured for pull_request runs so the workflow can rotate SF_SCRATCH_CI_SFDX_AUTH_URL and avoid exhausting daily scratch org signup limits."
+          exit 1
+
+      - name: Validate GitHub secrets rotator token
+        if: ${{ env.CAN_ROTATE_SCRATCH_SECRET == '1' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/secrets/public-key" >/dev/null
+          echo "GH_SECRETS_ROTATOR_PAT validated for Actions secrets rotation."
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECRETS_ROTATOR_PAT }}
+
       - name: Login to reusable scratch org (best-effort)
         if: ${{ env.HAS_SCRATCH_AUTH_URL == '1' }}
         shell: bash

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -167,7 +167,8 @@ jobs:
           fi
 
           gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app actions --repo "${GITHUB_REPOSITORY}" < "${auth_url}"
-          echo "Updated repository secret SF_SCRATCH_CI_SFDX_AUTH_URL."
+          gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app dependabot --repo "${GITHUB_REPOSITORY}" < "${auth_url}"
+          echo "Updated repository secret SF_SCRATCH_CI_SFDX_AUTH_URL for Actions and Dependabot."
         env:
           GH_TOKEN: ${{ secrets.GH_SECRETS_ROTATOR_PAT }}
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -25,8 +25,8 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: sf-e2e-scratch-global
+  cancel-in-progress: false
 
 permissions:
   contents: read

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -43,6 +43,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
       HAS_SCRATCH_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' && '1' || '' }}
+      CAN_ROTATE_SCRATCH_SECRET: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && '1' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -109,6 +110,34 @@ jobs:
           # - pull_request: keep scratch org for reuse across CI runs
           # - workflow_dispatch: keep unless explicitly disabled
           SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '1' }}
+
+      - name: Rotate scratch auth URL secret (post-run)
+        if: ${{ always() && env.CAN_ROTATE_SCRATCH_SECRET == '1' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          auth_json="$(mktemp)"
+          cleanup() {
+            rm -f "${auth_json}"
+          }
+          trap cleanup EXIT
+
+          if ! sf org display --target-org "${SF_SCRATCH_ALIAS}" --verbose --json > "${auth_json}"; then
+            echo "Scratch org auth export skipped because ${SF_SCRATCH_ALIAS} is unavailable."
+            exit 0
+          fi
+
+          node -e '
+            const fs = require("fs");
+            const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const url = data?.result?.sfdxAuthUrl;
+            if (!url) {
+              process.exit(2);
+            }
+            process.stdout.write(url);
+          ' "${auth_json}" | gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app actions --body - --repo "${GITHUB_REPOSITORY}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECRETS_ROTATOR_PAT }}
 
       - name: Upload Playwright artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -43,7 +43,7 @@ jobs:
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
       HAS_SCRATCH_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' && '1' || '' }}
-      CAN_ROTATE_SCRATCH_SECRET: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && '1' || '' }}
+      CAN_ROTATE_SCRATCH_SECRET: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && (github.event_name != 'workflow_dispatch' || github.event.inputs.keep_scratch_org != 'false') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) && '1' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -110,12 +110,12 @@ jobs:
           SF_DEVHUB_ALIAS: DevHubElectivus
           SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || '1' }}
           # Default behavior:
-          # - pull_request: keep scratch org for reuse across CI runs
+          # - pull_request: keep scratch org only when reuse/rotation is possible
           # - workflow_dispatch: keep unless explicitly disabled
-          SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '1' }}
+          SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || github.event_name != 'workflow_dispatch' && (env.HAS_SCRATCH_AUTH_URL == '1' || env.CAN_ROTATE_SCRATCH_SECRET == '1') && '1' || '' }}
 
       - name: Rotate scratch auth URL secret (post-run)
-        if: ${{ always() && env.CAN_ROTATE_SCRATCH_SECRET == '1' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        if: ${{ always() && env.CAN_ROTATE_SCRATCH_SECRET == '1' }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -85,12 +85,12 @@ jobs:
           VSCODE_TEST_VERSION: ${{ github.event.inputs.vscode_version || 'stable' }}
           SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
           SF_DEVHUB_ALIAS: DevHubElectivus
-          SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}
+          SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
           SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || '1' }}
           # Default behavior:
-          # - pull_request: delete scratch org (avoid leaking scratch orgs on every PR update)
+          # - pull_request: keep scratch org for reuse across CI runs
           # - workflow_dispatch: keep unless explicitly disabled
-          SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '' }}
+          SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '1' }}
 
       - name: Upload Playwright artifacts
         if: ${{ !cancelled() }}

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Login to reusable scratch org (best-effort)
         if: ${{ env.HAS_SCRATCH_AUTH_URL == '1' }}
-        continue-on-error: true
         shell: bash
         run: |
           set -euo pipefail
@@ -71,7 +70,11 @@ jobs:
           trap cleanup EXIT
 
           printf '%s' "${SF_SCRATCH_CI_SFDX_AUTH_URL}" > "${tmp}"
-          sf org login sfdx-url --sfdx-url-file "${tmp}" --alias "${SF_SCRATCH_ALIAS}"
+          if sf org login sfdx-url --sfdx-url-file "${tmp}" --alias "${SF_SCRATCH_ALIAS}"; then
+            echo "Scratch org auth restored for alias '${SF_SCRATCH_ALIAS}'."
+          else
+            echo "::warning::Scratch org login failed; tests will attempt to create a new scratch org."
+          fi
         env:
           SF_SCRATCH_CI_SFDX_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL }}
 
@@ -117,8 +120,9 @@ jobs:
         run: |
           set -euo pipefail
           auth_json="$(mktemp)"
+          auth_url="$(mktemp)"
           cleanup() {
-            rm -f "${auth_json}"
+            rm -f "${auth_json}" "${auth_url}"
           }
           trap cleanup EXIT
 
@@ -127,7 +131,7 @@ jobs:
             exit 0
           fi
 
-          node -e '
+          if ! node -e '
             const fs = require("fs");
             const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
             const url = data?.result?.sfdxAuthUrl;
@@ -135,7 +139,18 @@ jobs:
               process.exit(2);
             }
             process.stdout.write(url);
-          ' "${auth_json}" | gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app actions --body - --repo "${GITHUB_REPOSITORY}"
+          ' "${auth_json}" > "${auth_url}"; then
+            echo "::warning::Scratch org auth export skipped because no sfdxAuthUrl was returned."
+            exit 0
+          fi
+
+          if [[ ! -s "${auth_url}" ]]; then
+            echo "::warning::Scratch org auth export skipped because the extracted sfdxAuthUrl was empty."
+            exit 0
+          fi
+
+          gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app actions --repo "${GITHUB_REPOSITORY}" < "${auth_url}"
+          echo "Updated repository secret SF_SCRATCH_CI_SFDX_AUTH_URL."
         env:
           GH_TOKEN: ${{ secrets.GH_SECRETS_ROTATOR_PAT }}
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -41,6 +41,8 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
+      HAS_SCRATCH_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' && '1' || '' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -54,6 +56,23 @@ jobs:
 
       - name: Install Salesforce CLI
         run: npm install -g @salesforce/cli
+
+      - name: Login to reusable scratch org (best-effort)
+        if: ${{ env.HAS_SCRATCH_AUTH_URL == '1' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          cleanup() {
+            rm -f "${tmp}"
+          }
+          trap cleanup EXIT
+
+          printf '%s' "${SF_SCRATCH_CI_SFDX_AUTH_URL}" > "${tmp}"
+          sf org login sfdx-url --sfdx-url-file "${tmp}" --alias "${SF_SCRATCH_ALIAS}"
+        env:
+          SF_SCRATCH_CI_SFDX_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL }}
 
       - name: Install extension dependencies
         run: npm ci
@@ -85,7 +104,6 @@ jobs:
           VSCODE_TEST_VERSION: ${{ github.event.inputs.vscode_version || 'stable' }}
           SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
           SF_DEVHUB_ALIAS: DevHubElectivus
-          SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
           SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || '1' }}
           # Default behavior:
           # - pull_request: keep scratch org for reuse across CI runs

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -14,9 +14,31 @@ Build & Test basics:
 
 Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref.
 
+## E2E Scratch Org Reuse
+
+The Playwright workflow in `.github/workflows/e2e-playwright.yml` reuses a single CI scratch org to avoid exhausting the Salesforce daily scratch-org quota.
+
+Required repository secrets:
+
+- `SF_DEVHUB_AUTH_URL`: authenticates the workflow to the Dev Hub so it can create or recreate the scratch org when reuse is not possible.
+- `SF_SCRATCH_CI_SFDX_AUTH_URL`: stores the current `sfdxAuthUrl` for the reusable CI scratch org so GitHub-hosted runners can log back into it.
+- `GH_SECRETS_ROTATOR_PAT`: fine-grained PAT with permission to update repository Actions secrets; used to rotate `SF_SCRATCH_CI_SFDX_AUTH_URL` after the scratch org is recreated.
+
+Key behavior:
+
+- The workflow uses a fixed alias, `ALV_E2E_SCRATCH_CI`, so the E2E scratch-org helpers can find and reuse the same org across runs.
+- `SF_TEST_KEEP_ORG` stays enabled for `pull_request` runs and is only disabled manually through `workflow_dispatch`, so the scratch org is preserved for reuse.
+- A best-effort login step restores the reusable scratch org from `SF_SCRATCH_CI_SFDX_AUTH_URL` before the tests start. If that auth URL is missing or stale, the E2E helpers fall back to creating a new scratch org through the Dev Hub.
+- A post-run rotation step refreshes `SF_SCRATCH_CI_SFDX_AUTH_URL` with the current org credentials when the job has access to `GH_SECRETS_ROTATOR_PAT`.
+- The workflow is serialized with `concurrency.group: sf-e2e-scratch-global`, which prevents simultaneous E2E runs from sharing the same org. GitHub Actions still allows one pending run and may replace older pending runs with newer ones, so this protects the org from concurrent access but is not a strict FIFO queue.
+
+Operational note:
+
+- The scratch org is expected to be cleaned and reseeded by the E2E suite itself before each run. Reuse reduces daily org creation but does not replace test-level cleanup.
+
 ## Setup Azure OIDC for E2E Telemetry Validation
 
-The telemetry-aware Playwright workflow uses `azure/login@v2` with GitHub OIDC. Configure these repository secrets:
+The telemetry-aware Playwright workflow uses `azure/login@v3` with GitHub OIDC. Configure these repository secrets:
 
 - `AZURE_CLIENT_ID`
 - `AZURE_TENANT_ID`

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -27,9 +27,10 @@ Required repository secrets:
 Key behavior:
 
 - The workflow uses a fixed alias, `ALV_E2E_SCRATCH_CI`, so the E2E scratch-org helpers can find and reuse the same org across runs.
-- `SF_TEST_KEEP_ORG` stays enabled for `pull_request` runs and is only disabled manually through `workflow_dispatch`, so the scratch org is preserved for reuse.
+- `SF_TEST_KEEP_ORG` is enabled for `pull_request` runs only when reuse is possible (`SF_SCRATCH_CI_SFDX_AUTH_URL` is available) or when the workflow can rotate the auth secret (`GH_SECRETS_ROTATOR_PAT` is configured). This avoids keeping throwaway scratch orgs when reuse bootstrap is unavailable.
+- On `workflow_dispatch`, setting `keep_scratch_org=false` forces the scratch org to be deleted after the run even if it was reused, providing a manual reset path for corrupted state.
 - A best-effort login step restores the reusable scratch org from `SF_SCRATCH_CI_SFDX_AUTH_URL` before the tests start. If that auth URL is missing or stale, the E2E helpers fall back to creating a new scratch org through the Dev Hub.
-- A post-run rotation step refreshes `SF_SCRATCH_CI_SFDX_AUTH_URL` with the current org credentials when the job has access to `GH_SECRETS_ROTATOR_PAT`.
+- A post-run rotation step refreshes `SF_SCRATCH_CI_SFDX_AUTH_URL` with the current org credentials when the job has access to `GH_SECRETS_ROTATOR_PAT` and the scratch org is intended to be kept.
 - The workflow is serialized with `concurrency.group: sf-e2e-scratch-global`, which prevents simultaneous E2E runs from sharing the same org. GitHub Actions still allows one pending run and may replace older pending runs with newer ones, so this protects the org from concurrent access but is not a strict FIFO queue.
 
 Operational note:

--- a/docs/superpowers/plans/2026-03-22-scratch-org-reuse-github-actions.md
+++ b/docs/superpowers/plans/2026-03-22-scratch-org-reuse-github-actions.md
@@ -1,0 +1,254 @@
+# Scratch Org Reuse (GitHub Actions E2E) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Reutilizar uma única scratch org entre execuções do workflow E2E no GitHub Actions, evitando conflitos via fila global e reautenticando por `sfdxAuthUrl` com rotação automática do secret quando a org for recriada.
+
+**Architecture:** O workflow E2E passa a usar `concurrency` global (1 execução por vez), um alias fixo para scratch, login no começo via `sf org login sfdx-url` (secret com `sfdxAuthUrl`) e um passo no fim que extrai `sfdxAuthUrl` via `sf org display --verbose --json` e atualiza o secret via `gh secret set` usando um PAT.
+
+**Tech Stack:** GitHub Actions (YAML), Salesforce CLI (`sf`), GitHub CLI (`gh`), Node.js (para parse seguro de JSON).
+
+---
+
+## File Structure (what changes where)
+
+**Modify**
+- `.github/workflows/e2e-playwright.yml:27` (concurrency global), `:74` (env e passos de login/rotação)
+- `docs/CI.md:15` (documentar reuso de scratch e secrets)
+
+**No changes expected**
+- `test/e2e/utils/scratchOrg.ts` (já suporta reuso por alias; vamos controlar via env no workflow)
+
+---
+
+### Task 1: Serializar E2E globalmente (evitar conflito)
+
+**Files:**
+- Modify: `.github/workflows/e2e-playwright.yml:27-30`
+
+- [ ] **Step 1: Ajustar `concurrency` para um grupo global**
+
+Atualizar:
+
+```yaml
+concurrency:
+  group: sf-e2e-scratch-global
+  cancel-in-progress: false
+```
+
+Notas:
+- `cancel-in-progress: false` garante fila (não cancela runs antigas).  
+- Se vocês preferirem “sempre o último PR”, isso vira `true`, mas não faz parte deste spec.
+
+- [ ] **Step 2: Verificar sintaxe YAML localmente**
+
+Run (sanity only):
+```bash
+node -e "require('fs').readFileSync('.github/workflows/e2e-playwright.yml','utf8'); console.log('ok')"
+```
+
+Expected: imprime `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-playwright.yml
+git commit -m "ci(e2e): serialize scratch org usage" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 2: Fixar alias da scratch e manter org entre runs
+
+**Files:**
+- Modify: `.github/workflows/e2e-playwright.yml:84-94`
+
+- [ ] **Step 1: Fixar `SF_SCRATCH_ALIAS` do CI**
+
+Trocar:
+
+```yaml
+SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}
+```
+
+Para:
+
+```yaml
+SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
+```
+
+- [ ] **Step 2: Garantir `SF_TEST_KEEP_ORG=1` em `pull_request`**
+
+Substituir a lógica atual por algo explícito:
+
+```yaml
+SF_TEST_KEEP_ORG: ${{ github.event_name == 'workflow_dispatch' && (github.event.inputs.keep_scratch_org == 'false' && '' || '1') || '1' }}
+```
+
+Objetivo:
+- `pull_request`: sempre keep (`'1'`)
+- `workflow_dispatch`: respeitar input (default keep)
+
+- [ ] **Step 3: (Opcional) Aumentar default de `scratch_duration_days`**
+
+Se o DevHub permitir, considerar trocar default `1` para `7` (ou outro máximo permitido).  
+Se não tiver certeza, manter como está e deixar operador escolher em `workflow_dispatch`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/e2e-playwright.yml
+git commit -m "ci(e2e): reuse scratch org alias in CI" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 3: Login best-effort na scratch via `sfdxAuthUrl` (runner efêmero)
+
+**Files:**
+- Modify: `.github/workflows/e2e-playwright.yml:55-74` (inserir step após instalar `@salesforce/cli`)
+
+**Secrets (repo settings):**
+- Add: `SF_SCRATCH_CI_SFDX_AUTH_URL` (conteúdo: `force://...` / `sfdxAuthUrl`)
+
+- [ ] **Step 1: Inserir step de login antes de rodar Playwright**
+
+Inserir após “Install Salesforce CLI”:
+
+```yaml
+      - name: Login to reusable scratch org (best-effort)
+        if: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' }}
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -euo pipefail
+          tmp="$(mktemp)"
+          printf '%s' "${SF_SCRATCH_CI_SFDX_AUTH_URL}" > "${tmp}"
+          sf org login sfdx-url --sfdx-url-file "${tmp}" --alias "${SF_SCRATCH_ALIAS}"
+          rm -f "${tmp}"
+        env:
+          SF_SCRATCH_CI_SFDX_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL }}
+          SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
+```
+
+Racional:
+- Login falha quando o secret está desatualizado/expirado; `continue-on-error` permite que o `ensureScratchOrg()` crie uma scratch nova.
+
+- [ ] **Step 2: Validar que o workflow continua funcionando sem o secret**
+
+Teste mental/checklist (não envolve rodar CI):
+- Sem `SF_SCRATCH_CI_SFDX_AUTH_URL`, o step é pulado.
+- `ensureScratchOrg()` tenta `sf org display` e, sem auth, vai criar a scratch (desde que `SF_DEVHUB_AUTH_URL` exista).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-playwright.yml
+git commit -m "ci(e2e): login to reusable scratch org via sfdxAuthUrl" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 4: Rotação automática do secret no mesmo run (self-healing)
+
+**Files:**
+- Modify: `.github/workflows/e2e-playwright.yml:95` (inserir step após “Run Playwright E2E” e antes de upload artifacts)
+
+**Secrets (repo settings):**
+- Add: `GH_SECRETS_ROTATOR_PAT` (fine-grained PAT com permissão mínima para editar Actions secrets)
+
+**Important security boundary:**
+- Este step deve rodar somente quando `GH_SECRETS_ROTATOR_PAT` estiver disponível (PR interno / workflow_dispatch).  
+  Em forks, secrets não existem; o step deve ficar automaticamente desabilitado.
+
+- [ ] **Step 1: Inserir step “Rotate scratch auth URL secret”**
+
+Adicionar após “Run Playwright E2E”:
+
+```yaml
+      - name: Rotate scratch auth URL secret (post-run)
+        if: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          auth_json="$(mktemp)"
+
+          # IMPORTANT: do NOT print this JSON; it includes access tokens.
+          sf org display --target-org "${SF_SCRATCH_ALIAS}" --verbose --json > "${auth_json}"
+
+          # Extract sfdxAuthUrl without echoing it to logs; pass via stdin to gh.
+          node -e '
+            const fs = require("fs");
+            const data = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
+            const url = data && data.result && data.result.sfdxAuthUrl;
+            if (!url) process.exit(2);
+            process.stdout.write(url);
+          ' "${auth_json}" | gh secret set SF_SCRATCH_CI_SFDX_AUTH_URL --app actions --body - --repo "${GITHUB_REPOSITORY}"
+
+          rm -f "${auth_json}"
+        env:
+          GH_TOKEN: ${{ secrets.GH_SECRETS_ROTATOR_PAT }}
+          SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI
+```
+
+Expected:
+- Step termina com sucesso e log do `gh` indicando secret atualizado (sem imprimir o valor).
+
+- [ ] **Step 2: Tornar a condição ainda mais explícita para forks (opcional, mas recomendado)**
+
+Para reduzir ambiguidades, reforçar o `if`:
+
+```yaml
+if: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/e2e-playwright.yml
+git commit -m "ci(e2e): rotate scratch sfdxAuthUrl secret after run" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 5: Documentar o novo modelo de reuso no `docs/CI.md`
+
+**Files:**
+- Modify: `docs/CI.md:15`
+
+- [ ] **Step 1: Atualizar a seção de CI para explicar reuso de scratch**
+
+Adicionar uma subseção (sugestão de conteúdo):
+
+```md
+## E2E scratch org reuse (GitHub Actions)
+
+O workflow `.github/workflows/e2e-playwright.yml` reutiliza uma scratch org única no CI para evitar esgotar a quota diária de criação.
+
+Secrets necessários:
+- `SF_DEVHUB_AUTH_URL`: login no Dev Hub (criar/recriar scratch quando necessário)
+- `SF_SCRATCH_CI_SFDX_AUTH_URL`: `sfdxAuthUrl` para login não-interativo na scratch reutilizável
+- `GH_SECRETS_ROTATOR_PAT`: (internal PR / workflow_dispatch) atualiza `SF_SCRATCH_CI_SFDX_AUTH_URL` quando a scratch é recriada
+```
+
+E mencionar:
+- existe fila global (`concurrency`) para impedir conflito
+- a scratch é mantida (`SF_TEST_KEEP_ORG=1`) e limpa/seed nos testes
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/CI.md
+git commit -m "docs(ci): document scratch org reuse and required secrets" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+## End-to-end verification (post-merge / in CI)
+
+- [ ] **Step: Trigger `workflow_dispatch` once**
+  - Expected: primeira execução cria scratch (se needed) e atualiza o secret no final.
+- [ ] **Step: Trigger novamente**
+  - Expected: login via secret funciona e `ensureScratchOrg()` reusa (sem criar).
+- [ ] **Step: Confirmar não-concorrência**
+  - Disparar 2 runs e confirmar que o segundo fica “Queued” até o primeiro finalizar.

--- a/docs/superpowers/plans/2026-03-22-scratch-org-reuse-github-actions.md
+++ b/docs/superpowers/plans/2026-03-22-scratch-org-reuse-github-actions.md
@@ -16,8 +16,9 @@
 - `.github/workflows/e2e-playwright.yml:27` (concurrency global), `:74` (env e passos de login/rotação)
 - `docs/CI.md:15` (documentar reuso de scratch e secrets)
 
-**No changes expected**
-- `test/e2e/utils/scratchOrg.ts` (já suporta reuso por alias; vamos controlar via env no workflow)
+**Optional (observability)**
+- `test/e2e/utils/scratchOrg.ts:281` (log seguro: reused vs created)
+- `test/e2e/utils/__tests__/scratchOrg.test.ts:84` (assert do log, se aplicável)
 
 ---
 
@@ -91,8 +92,8 @@ Objetivo:
 
 - [ ] **Step 3: (Opcional) Aumentar default de `scratch_duration_days`**
 
-Se o DevHub permitir, considerar trocar default `1` para `7` (ou outro máximo permitido).  
-Se não tiver certeza, manter como está e deixar operador escolher em `workflow_dispatch`.
+Fora do caminho crítico do spec. Só fazer se vocês explicitamente quiserem aumentar a duração padrão.  
+Se o DevHub permitir, considerar trocar default `1` para `7` (ou outro máximo permitido); caso contrário manter como está.
 
 - [ ] **Step 4: Commit**
 
@@ -113,11 +114,19 @@ git commit -m "ci(e2e): reuse scratch org alias in CI" -m "Co-authored-by: Codex
 
 - [ ] **Step 1: Inserir step de login antes de rodar Playwright**
 
+Primeiro, adicionar no `jobs.playwright_e2e.env` um sinal booleano (GitHub não permite usar `secrets.*` diretamente em `if:`; gatear por `env.*`):
+
+```yaml
+    env:
+      # ...existing env...
+      HAS_SCRATCH_AUTH_URL: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' && '1' || '' }}
+```
+
 Inserir após “Install Salesforce CLI”:
 
 ```yaml
       - name: Login to reusable scratch org (best-effort)
-        if: ${{ secrets.SF_SCRATCH_CI_SFDX_AUTH_URL != '' }}
+        if: ${{ env.HAS_SCRATCH_AUTH_URL == '1' }}
         continue-on-error: true
         shell: bash
         run: |
@@ -163,11 +172,19 @@ git commit -m "ci(e2e): login to reusable scratch org via sfdxAuthUrl" -m "Co-au
 
 - [ ] **Step 1: Inserir step “Rotate scratch auth URL secret”**
 
+Primeiro, adicionar no `jobs.playwright_e2e.env` um sinal booleano para liberar rotação:
+
+```yaml
+    env:
+      # ...existing env...
+      CAN_ROTATE_SCRATCH_SECRET: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && '1' || '' }}
+```
+
 Adicionar após “Run Playwright E2E”:
 
 ```yaml
       - name: Rotate scratch auth URL secret (post-run)
-        if: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' }}
+        if: ${{ always() && env.CAN_ROTATE_SCRATCH_SECRET == '1' }}
         shell: bash
         run: |
           set -euo pipefail
@@ -199,7 +216,7 @@ Expected:
 Para reduzir ambiguidades, reforçar o `if`:
 
 ```yaml
-if: ${{ secrets.GH_SECRETS_ROTATOR_PAT != '' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+if: ${{ always() && env.CAN_ROTATE_SCRATCH_SECRET == '1' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
 ```
 
 - [ ] **Step 3: Commit**
@@ -240,6 +257,53 @@ E mencionar:
 ```bash
 git add docs/CI.md
 git commit -m "docs(ci): document scratch org reuse and required secrets" -m "Co-authored-by: Codex <noreply@openai.com>"
+```
+
+---
+
+### Task 6 (Recommended): Emitir sinal “reused vs created” sem vazar credenciais
+
+**Why:** Ajuda a confirmar rollout e facilita triagem quando o CI parar de reusar e voltar a criar orgs.
+
+**Files:**
+- Modify: `test/e2e/utils/scratchOrg.ts:288`
+- Test: `test/e2e/utils/__tests__/scratchOrg.test.ts:84`
+
+- [ ] **Step 1: Escrever teste falhando para o log**
+
+No teste “reuses an active scratch org…”, capturar `console.info` e esperar um log do tipo:
+
+```ts
+const infoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+// ... run ensureScratchOrg()
+expect(infoSpy).toHaveBeenCalledWith(expect.stringContaining("[e2e] scratch org reused"));
+infoSpy.mockRestore();
+```
+
+- [ ] **Step 2: Implementar log seguro em `ensureScratchOrg()`**
+
+Em `test/e2e/utils/scratchOrg.ts`, adicionar:
+- no caminho de reuse (antes do return `created: false`): `console.info("[e2e] scratch org reused: ...")`
+- no caminho de create (antes do return `created: true`): `console.info("[e2e] scratch org created: ...")`
+
+Regras:
+- NÃO imprimir accessToken/instanceUrl/sfdxAuthUrl
+- Pode imprimir apenas `scratchAlias` e o `devHubAlias` escolhido
+
+- [ ] **Step 3: Rodar testes unitários**
+
+Run:
+```bash
+npm run test:unit -- test/e2e/utils/__tests__/scratchOrg.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add test/e2e/utils/scratchOrg.ts test/e2e/utils/__tests__/scratchOrg.test.ts
+git commit -m "test(e2e): log scratch org reuse vs creation" -m "Co-authored-by: Codex <noreply@openai.com>"
 ```
 
 ---

--- a/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
+++ b/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
@@ -118,20 +118,16 @@ Quando `ensureScratchOrg()` precisar criar uma scratch nova (org inválida), o s
 - Extrair o campo `sfdxAuthUrl`
 - Atualizar o GitHub Secret que guarda o `sfdxAuthUrl`
 
-#### Recomendação de segurança: rotacionar o secret fora do workflow de PR
+#### Modelo adotado (explícito): rotação no mesmo run que recriar
 
-Para reduzir risco, preferir um workflow separado de maintenance (por exemplo: `.github/workflows/scratch-maintenance.yml`), com:
+Para garantir que o reuso funcione em runners efêmeros (GitHub-hosted), **a rotação precisa acontecer imediatamente no mesmo run** em que a scratch foi recriada. Caso contrário, a execução seguinte não tem como “descobrir” e autenticar automaticamente na scratch recém-criada.
 
-- `on: workflow_dispatch` (e opcionalmente `schedule`)
-- Permissões/segredos (PAT) apenas nesse workflow
-- Responsabilidade: “garantir scratch viva e atualizar secrets”
+Portanto, este design assume:
 
-O workflow de PR/E2E consome somente:
-- `SF_DEVHUB_AUTH_URL` (para recriar se necessário)
-- `SF_SCRATCH_CI_SFDX_AUTH_URL` (para login na scratch atual)
+- Se a scratch foi recriada, o próprio workflow E2E atualiza `SF_SCRATCH_CI_SFDX_AUTH_URL` no final do job (ou imediatamente após criar).
+- Isso requer um token (PAT fine-grained) com permissão mínima para atualizar secrets do repositório.
 
-> Alternativa (mais simples, mais risco): fazer a rotação dentro do próprio workflow E2E.  
-> Isso só é recomendado se o repositório e contribuições forem considerados confiáveis o suficiente para expor um token de rotação ao job.
+> Nota de segurança (trade-off assumido): esse modelo expõe o token de rotação ao job E2E em execuções `pull_request` internas (não-fork). Se isso for considerado arriscado para o seu contexto, um modelo alternativo é mover a criação/rotação para um workflow de maintenance (`workflow_dispatch`/`schedule`) e fazer o E2E falhar com instruções claras quando a org estiver inválida — mas isso deixa de ser “self-healing” no PR.
 
 ## Configuração de Secrets (proposta)
 
@@ -178,4 +174,3 @@ Recomendações:
 2. Implementar step de login por `sfdxAuthUrl` no CI.
 3. Implementar workflow de maintenance para rotação automática do secret quando recriar.
 4. Executar 2–3 runs seguidas em PRs para validar reuso (sem criação diária).
-

--- a/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
+++ b/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
@@ -135,7 +135,7 @@ Obrigatórios:
 - `SF_DEVHUB_AUTH_URL` (já existe): login no Dev Hub em CI
 - `SF_SCRATCH_CI_SFDX_AUTH_URL` **ou** `SF_SCRATCH_CI_AUTH_FILE_JSON`: credencial para login na scratch reutilizável
 
-Para auto-rotação (modo 2):
+Para auto-rotação (modelo adotado):
 - `GH_SECRETS_ROTATOR_PAT`: token (PAT fine-grained) com permissão mínima para **atualizar secrets do repositório**
 
 ## Fluxo de execução (end-to-end)
@@ -151,12 +151,12 @@ Para auto-rotação (modo 2):
 7. Cleanup:
    - Mantém scratch (reuso).
 8. Se scratch foi recriada:
-   - Workflow de maintenance (ou step controlado) atualiza secret do `sfdxAuthUrl`.
+   - O próprio workflow E2E atualiza `SF_SCRATCH_CI_SFDX_AUTH_URL` no mesmo run.
 
 ## Falhas esperadas e comportamento
 
 - **Secret do `sfdxAuthUrl` inválido/expirado**:
-  - Login na scratch falha; `ensureScratchOrg()` recria usando DevHub auth; maintenance rota secret.
+  - Login na scratch falha; `ensureScratchOrg()` recria usando DevHub auth; o workflow E2E rota o secret no mesmo run.
 - **Quota diária estourada**:
   - Criação falha; pipeline falha com erro explícito (sem workaround automático).
 - **Scratch “meio pronta” / interstitial**:
@@ -172,5 +172,6 @@ Recomendações:
 
 1. Implementar fila global + alias fixo + keep org no workflow E2E.
 2. Implementar step de login por `sfdxAuthUrl` no CI.
-3. Implementar workflow de maintenance para rotação automática do secret quando recriar.
+3. Implementar step de rotação do secret (PAT) quando a scratch for recriada.
 4. Executar 2–3 runs seguidas em PRs para validar reuso (sem criação diária).
+5. (Opcional) Adicionar um workflow de maintenance apenas para “force reset”/recovery manual (não faz parte do caminho primário).

--- a/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
+++ b/docs/superpowers/specs/2026-03-22-scratch-org-reuse-github-actions-design.md
@@ -1,0 +1,181 @@
+# Scratch org reutilizável no GitHub Actions (E2E Playwright)
+
+**Data:** 2026-03-22  
+**Status:** Aprovado para planejamento (pré-implementação)  
+**Contexto do repo:** `Apex-Log-Viewer` (workflow E2E real org via scratch)
+
+## Problema
+
+No ecossistema Salesforce, **a criação diária de Scratch Orgs é limitada** (quota do Dev Hub). O workflow de E2E no GitHub Actions precisa validar os testes Playwright contra uma org real, mas:
+
+- Criar uma scratch org nova a cada execução evita conflito, porém **consome quota** e pode parar o pipeline quando a quota diária acaba.
+- Reutilizar a mesma scratch org reduz consumo de quota, porém precisa evitar **conflito/concor­rên­cia** (duas execuções usando a mesma org ao mesmo tempo) e precisa funcionar em runners **efêmeros** (GitHub-hosted), que não guardam estado entre runs.
+
+## Situação atual (baseline)
+
+Arquivos relevantes no repo:
+
+- Workflow E2E: `.github/workflows/e2e-playwright.yml`
+  - Hoje usa alias único por run: `SF_SCRATCH_ALIAS: ALV_E2E_Scratch_${{ github.run_id }}_${{ github.run_attempt }}`
+  - Hoje tende a deletar a scratch no fim para `pull_request` (via `SF_TEST_KEEP_ORG` vazio).
+- Provisionamento/reuso de scratch na suíte E2E: `test/e2e/utils/scratchOrg.ts`
+  - Já existe lógica de reuso quando o alias aponta para uma scratch válida (`isReusableScratchOrg(...)`).
+  - Em CI, esse reuso só acontece se a execução conseguir **autenticar no mesmo alias** em todo run.
+
+## Objetivos
+
+1. **Reutilizar scratch org entre execuções do GitHub Actions** para reduzir consumo de quota diária.
+2. **Evitar conflitos** ao garantir que apenas uma execução E2E use a scratch por vez.
+3. **Auto-healing**: recriar scratch quando estiver inválida (expirada/deletada/quebrada) e voltar a funcionar sem intervenção frequente.
+4. Manter o fluxo compatível com o utilitário existente (`ensureScratchOrg()`), mudando o mínimo necessário.
+
+## Não-objetivos (por enquanto)
+
+- Pool com N scratch orgs e alocação paralela (leasing/locks por org).
+- Paralelismo de E2E (várias execuções simultâneas no repo).
+- Persistir segredos em caches/artifacts (não recomendado para credenciais).
+
+## Restrições / Premissas
+
+- **Apenas 1 execução de E2E por vez no repositório inteiro** (aceito como requisito).
+- Runner GitHub-hosted é **stateless**: não dá pra depender de `~/.sf` / `~/.sfdx` persistindo.
+- Credenciais precisam ser não-interativas:
+  - A forma suportada/recomendada pela Salesforce para CI é via **SFDX Authorization URL (`sfdxAuthUrl`)**.
+  - Doc oficial: “Authorize an Org Using Its SFDX Authorization URL”.  
+    Exemplo: `sf org display --verbose --json > authFile.json` (inclui `sfdxAuthUrl`) e depois `sf org login sfdx-url --sfdx-url-file authFile.json`.
+
+## Abordagens consideradas
+
+### A) Singleton scratch + fila global (GitHub Actions concurrency) + `sfdxAuthUrl` persistido (RECOMENDADA)
+
+- Uma scratch “oficial do CI”, com alias fixo (ex.: `ALV_E2E_SCRATCH_CI`)
+- Workflows E2E enfileirados globalmente (uma execução por vez)
+- Antes dos testes: reautentica na scratch via `sf org login sfdx-url` usando `sfdxAuthUrl` persistido (secret)
+- Durante os testes: suíte faz limpeza/seed conforme já faz hoje
+- Se a org estiver inválida: `ensureScratchOrg()` recria (usando DevHub auth já existente)
+- Após recriar: sistema atualiza o secret do `sfdxAuthUrl` (auto-rotação) para os próximos runs
+
+Prós:
+- Reduz drasticamente consumo de quota diária.
+- Elimina conflito por design (fila global).
+- Mantém comportamento previsível e depuração simples.
+
+Contras:
+- Precisa de estratégia de rotação segura do `sfdxAuthUrl` (ver abaixo).
+
+### B) Self-hosted runner fixo
+
+Prós:
+- Estado local do CLI persiste; reuso fica trivial.
+
+Contras:
+- Infra para manter, atualizar e proteger.
+
+### C) Pool real (N scratch orgs) + lease/lock
+
+Contras:
+- Complexidade não necessária dado requisito de serialização (1 execução por vez).
+
+## Design aprovado (Abordagem A)
+
+### 1) Fila global no GitHub Actions (evita conflito)
+
+No workflow `.github/workflows/e2e-playwright.yml`, configurar `concurrency` para:
+
+- `group`: valor constante (ex.: `sf-e2e-scratch-global`)
+- `cancel-in-progress: false` (enfileirar em vez de cancelar)
+
+Resultado: nenhuma run E2E concorrente usa a mesma org simultaneamente.
+
+### 2) Alias fixo para a scratch do CI
+
+No step “Run Playwright E2E”, usar:
+
+- `SF_SCRATCH_ALIAS: ALV_E2E_SCRATCH_CI`
+
+Isso permite que o código existente (`ensureScratchOrg()`) reconheça e reutilize a org quando ela estiver ativa.
+
+### 3) Não deletar a scratch no fim do job (reuso)
+
+Garantir `SF_TEST_KEEP_ORG=1` no CI para que `ensureScratchOrg()` não execute `sf org delete scratch` no cleanup.
+
+Observação: deleção continua possível via um modo manual/maintenance (ex.: `workflow_dispatch` “force reset”).
+
+### 4) Reautenticação no início do job (runner efêmero)
+
+Adicionar um step no job para autenticar na scratch com `sfdxAuthUrl`:
+
+1. Materializar um arquivo `authFile.json` (ou `sfdxAuthUrl.txt`) a partir de um GitHub Secret
+2. Rodar `sf org login sfdx-url --sfdx-url-file <arquivo> --alias ALV_E2E_SCRATCH_CI`
+
+Depois disso, `sf org display -o ALV_E2E_SCRATCH_CI` funciona no runner, habilitando o reuso no `ensureScratchOrg()`.
+
+### 5) Auto-rotação do `sfdxAuthUrl` quando recriar a scratch (modo “self-healing”)
+
+Quando `ensureScratchOrg()` precisar criar uma scratch nova (org inválida), o sistema deve:
+
+- Executar `sf org display --target-org ALV_E2E_SCRATCH_CI --verbose --json`
+- Extrair o campo `sfdxAuthUrl`
+- Atualizar o GitHub Secret que guarda o `sfdxAuthUrl`
+
+#### Recomendação de segurança: rotacionar o secret fora do workflow de PR
+
+Para reduzir risco, preferir um workflow separado de maintenance (por exemplo: `.github/workflows/scratch-maintenance.yml`), com:
+
+- `on: workflow_dispatch` (e opcionalmente `schedule`)
+- Permissões/segredos (PAT) apenas nesse workflow
+- Responsabilidade: “garantir scratch viva e atualizar secrets”
+
+O workflow de PR/E2E consome somente:
+- `SF_DEVHUB_AUTH_URL` (para recriar se necessário)
+- `SF_SCRATCH_CI_SFDX_AUTH_URL` (para login na scratch atual)
+
+> Alternativa (mais simples, mais risco): fazer a rotação dentro do próprio workflow E2E.  
+> Isso só é recomendado se o repositório e contribuições forem considerados confiáveis o suficiente para expor um token de rotação ao job.
+
+## Configuração de Secrets (proposta)
+
+Obrigatórios:
+- `SF_DEVHUB_AUTH_URL` (já existe): login no Dev Hub em CI
+- `SF_SCRATCH_CI_SFDX_AUTH_URL` **ou** `SF_SCRATCH_CI_AUTH_FILE_JSON`: credencial para login na scratch reutilizável
+
+Para auto-rotação (modo 2):
+- `GH_SECRETS_ROTATOR_PAT`: token (PAT fine-grained) com permissão mínima para **atualizar secrets do repositório**
+
+## Fluxo de execução (end-to-end)
+
+1. Job E2E inicia (fila global garante exclusividade).
+2. `sf` CLI instalado.
+3. Login no DevHub via `SF_DEVHUB_AUTH_URL` (já suportado por `ensureScratchOrg()`).
+4. Login na scratch via `sfdxAuthUrl` (secret) para reuso.
+5. `ensureScratchOrg()`:
+   - Se scratch válida: reusa.
+   - Se stale/ausente: recria.
+6. Suíte E2E faz limpeza/seed/validação.
+7. Cleanup:
+   - Mantém scratch (reuso).
+8. Se scratch foi recriada:
+   - Workflow de maintenance (ou step controlado) atualiza secret do `sfdxAuthUrl`.
+
+## Falhas esperadas e comportamento
+
+- **Secret do `sfdxAuthUrl` inválido/expirado**:
+  - Login na scratch falha; `ensureScratchOrg()` recria usando DevHub auth; maintenance rota secret.
+- **Quota diária estourada**:
+  - Criação falha; pipeline falha com erro explícito (sem workaround automático).
+- **Scratch “meio pronta” / interstitial**:
+  - `ensureScratchOrg()` já faz polling de readiness (Tooling API) antes de prosseguir.
+
+## Observabilidade / Debug
+
+Recomendações:
+- Emitir logs “de alto nível” (sem tokens) no workflow: “reused vs created”.
+- Nunca imprimir `sfdxAuthUrl` em logs (treat as secret).
+
+## Plano de rollout (alto nível)
+
+1. Implementar fila global + alias fixo + keep org no workflow E2E.
+2. Implementar step de login por `sfdxAuthUrl` no CI.
+3. Implementar workflow de maintenance para rotação automática do secret quando recriar.
+4. Executar 2–3 runs seguidas em PRs para validar reuso (sem criação diária).
+

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -9,6 +9,7 @@ const runSfJsonMock = jest.mocked(runSfJson);
 
 describe('ensureScratchOrg', () => {
   const originalEnv = { ...process.env };
+  let consoleInfoSpy: jest.SpiedFunction<typeof console.info>;
 
   beforeEach(() => {
     process.env = {
@@ -18,6 +19,11 @@ describe('ensureScratchOrg', () => {
       SF_TEST_KEEP_ORG: '1'
     };
     runSfJsonMock.mockReset();
+    consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleInfoSpy.mockRestore();
   });
 
   afterAll(() => {
@@ -78,6 +84,7 @@ describe('ensureScratchOrg', () => {
       expect.arrayContaining(['org', 'create', 'scratch', '--alias', 'ALV_E2E_Scratch']),
       expect.any(Object)
     );
+    expect(consoleInfoSpy).toHaveBeenCalledWith("[e2e] scratch org created for alias 'ALV_E2E_Scratch'.");
     await scratch.cleanup();
   });
 
@@ -117,6 +124,7 @@ describe('ensureScratchOrg', () => {
       expect.arrayContaining(['org', 'create', 'scratch']),
       expect.anything()
     );
+    expect(consoleInfoSpy).toHaveBeenCalledWith("[e2e] scratch org reused for alias 'ALV_E2E_Scratch'.");
     await scratch.cleanup();
   });
 

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -298,7 +298,16 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
         devHubAlias,
         scratchAlias,
         created: false,
-        cleanup: async () => {}
+        cleanup: async () => {
+          if (keep) {
+            return;
+          }
+          try {
+            await runSfJson(['org', 'delete', 'scratch', '-o', scratchAlias, '--no-prompt']);
+          } catch {
+            // Best-effort cleanup.
+          }
+        }
       };
     }
     if (existingScratch) {

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -293,6 +293,7 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
         primeOrgAuthCache(scratchAlias, auth);
       }
       await waitForScratchOrgReady(scratchAlias, auth);
+      console.info(`[e2e] scratch org reused for alias '${scratchAlias}'.`);
       return {
         devHubAlias,
         scratchAlias,
@@ -386,6 +387,7 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
       }
     }
 
+    console.info(`[e2e] scratch org created for alias '${scratchAlias}'.`);
     return {
       devHubAlias,
       scratchAlias,


### PR DESCRIPTION
## What

This PR changes the Playwright E2E workflow to reuse a single CI scratch org (instead of creating a new one every run), while preventing concurrent runs from clobbering each other.

## Key changes

- Serialize E2E runs repo-wide using `concurrency.group: sf-e2e-scratch-global` (not a strict FIFO queue, but prevents concurrent access).
- Use a fixed scratch alias: `ALV_E2E_SCRATCH_CI`.
- Best-effort login into the reusable scratch org via `SF_SCRATCH_CI_SFDX_AUTH_URL` before tests start.
- Rotate `SF_SCRATCH_CI_SFDX_AUTH_URL` post-run using `GH_SECRETS_ROTATOR_PAT` (guarded for forks).
- Add logs + unit test coverage for `ensureScratchOrg()` reuse vs create decisions.
- Document the required secrets and behavior in `docs/CI.md`.

## Required secrets

- `SF_DEVHUB_AUTH_URL`
- `SF_SCRATCH_CI_SFDX_AUTH_URL`
- `GH_SECRETS_ROTATOR_PAT`

## Testing

- `npm run test:e2e:utils` (local)
