### PR TITLE
fix(babysit-pr): support copilot reviewer feedback

### DIFF
--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -123,8 +123,8 @@ The watcher surfaces review items from:
 - Inline review comments
 - Review submissions (COMMENT / APPROVED / CHANGES_REQUESTED)
 
-It intentionally surfaces trusted reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]` and `copilot-pull-request-reviewer`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
-For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex plus the exact `copilot-pull-request-reviewer` login.
+It intentionally surfaces trusted reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]` and the Copilot reviewer login, which GitHub may emit as `copilot-pull-request-reviewer` or `copilot-pull-request-reviewer[bot]`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
+For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex plus the Copilot reviewer login.
 On a fresh watcher state file, existing pending review feedback may be surfaced immediately (not only comments that arrive after monitoring starts). This is intentional so already-open review comments are not missed.
 
 When you agree with a comment and it is actionable:

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -72,7 +72,7 @@ python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr <number-or-url> --o
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --list
 ```
 
-### Acknowledge all currently listed actionable review bot feedback with `👍` and resolve open handled threads
+### Acknowledge all currently listed actionable review bot feedback with `👍` and resolve open actionable review bot threads you've handled
 
 ```bash
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -123,7 +123,7 @@ The watcher surfaces review items from:
 - Inline review comments
 - Review submissions (COMMENT / APPROVED / CHANGES_REQUESTED)
 
-It intentionally surfaces trusted reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]` and the Copilot reviewer login, which GitHub may emit as `copilot-pull-request-reviewer` or `copilot-pull-request-reviewer[bot]`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
+It intentionally surfaces trusted reviewer bot feedback (for example comments/reviews from the Codex reviewer login, which GitHub may emit as `chatgpt-codex-connector` or `chatgpt-codex-connector[bot]`, and the Copilot reviewer login, which GitHub may emit as `copilot-pull-request-reviewer` or `copilot-pull-request-reviewer[bot]`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
 For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex plus the Copilot reviewer login.
 On a fresh watcher state file, existing pending review feedback may be surfaced immediately (not only comments that arrive after monitoring starts). This is intentional so already-open review comments are not missed.
 

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -66,13 +66,13 @@ python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr auto --retry-failed
 python3 .codex/skills/babysit-pr/scripts/gh_pr_watch.py --pr <number-or-url> --once
 ```
 
-### List current Codex feedback items
+### List current actionable review bot feedback items
 
 ```bash
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --list
 ```
 
-### Acknowledge all currently listed Codex feedback with `👍` and resolve open Codex threads
+### Acknowledge all currently listed actionable review bot feedback with `👍` and resolve open handled threads
 
 ```bash
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all
@@ -84,7 +84,7 @@ python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all --dry-run
 ```
 
-### Create a follow-up issue for out-of-scope Codex feedback, then mark it captured with `👍`
+### Create a follow-up issue for out-of-scope actionable review bot feedback, then mark it captured with `👍`
 
 ```bash
 python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --follow-up <item-id> --issue-label follow-up
@@ -123,8 +123,8 @@ The watcher surfaces review items from:
 - Inline review comments
 - Review submissions (COMMENT / APPROVED / CHANGES_REQUESTED)
 
-It intentionally surfaces Codex reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
-For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex.
+It intentionally surfaces trusted reviewer bot feedback (for example comments/reviews from `chatgpt-codex-connector[bot]` and `copilot-pull-request-reviewer`) in addition to human reviewer feedback. Most unrelated bot noise should still be ignored.
+For safety, the watcher only auto-surfaces trusted human review authors (for example repo OWNER/MEMBER/COLLABORATOR, plus the authenticated operator) and approved review bots such as Codex plus the exact `copilot-pull-request-reviewer` login.
 On a fresh watcher state file, existing pending review feedback may be surfaced immediately (not only comments that arrive after monitoring starts). This is intentional so already-open review comments are not missed.
 
 When you agree with a comment and it is actionable:
@@ -132,7 +132,7 @@ When you agree with a comment and it is actionable:
 1. Patch code locally.
 2. Commit with `codex: address PR review feedback (#<n>)`.
 3. Push to the PR head branch.
-4. Prefer replying in the GitHub review thread with a short status update before resolving it (for example what changed, or that it was captured as follow-up). Then react with `👍` to the relevant Codex feedback and resolve Codex-authored review threads you handled. Prefer `python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all --dry-run` first, then rerun without `--dry-run` once you are satisfied.
+4. Prefer replying in the GitHub review thread with a short status update before resolving it (for example what changed, or that it was captured as follow-up). Then react with `👍` to the relevant actionable review bot feedback and resolve the handled review threads. Prefer `python3 .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py --pr auto --ack-all --dry-run` first, then rerun without `--dry-run` once you are satisfied.
 5. Resume watching on the new SHA immediately (do not stop after reporting the push).
 6. If monitoring was running in `--watch` mode, restart `--watch` immediately after the push in the same turn; do not wait for the user to ask again.
 
@@ -147,12 +147,12 @@ When a comment is important but out of scope for the current PR:
 1. Search for an existing issue that already tracks the same problem.
 2. If none exists, create a follow-up issue from the feedback item with `gh_pr_codex_feedback.py --follow-up ...`.
 3. If the item is a review thread, reply in-thread with the tracking issue link so future readers can see where the work moved.
-4. React with `👍` on the source feedback once it has been captured as follow-up; if the item is a Codex review thread, resolve the thread after the issue is created unless the thread should stay open.
+4. React with `👍` on the source feedback once it has been captured as follow-up; if the item is an actionable review bot thread, resolve the thread after the issue is created unless the thread should stay open.
 5. Resume watching immediately. Do not implement the out-of-scope change in the current PR unless the user explicitly broadens scope.
 
 If you disagree or the comment is non-actionable/already addressed, record it as handled by continuing the watcher loop (the script de-duplicates surfaced items via state after surfacing them).
 If a code review comment/thread is already marked as resolved in GitHub, treat it as non-actionable and safely ignore it unless new unresolved follow-up feedback appears.
-If you intentionally reject Codex feedback, react with `👎` using `gh_pr_codex_feedback.py --reject ...`. Leave the thread open unless you are intentionally closing the loop after documenting why the suggestion should not be applied.
+If you intentionally reject actionable review bot feedback, react with `👎` using `gh_pr_codex_feedback.py --reject ...`. Leave the thread open unless you are intentionally closing the loop after documenting why the suggestion should not be applied.
 
 ## Git Safety Rules
 

--- a/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""List, acknowledge, reject, or capture Codex review feedback on a GitHub PR."""
+"""List, acknowledge, reject, or capture actionable review bot feedback on a GitHub PR."""
 
 import argparse
 import json
@@ -8,7 +8,12 @@ import sys
 
 from gh_pr_watch import GhCommandError, gh_api_list_paginated, gh_json, graphql_json, resolve_pr
 
-CODEX_LOGIN_KEYWORD = "codex"
+ACTIONABLE_REVIEW_BOT_LOGINS = {
+    "copilot-pull-request-reviewer",
+}
+ACTIONABLE_REVIEW_BOT_LOGIN_KEYWORDS = {
+    "codex",
+}
 REACTION_CONTENTS = {
     "ack": "THUMBS_UP",
     "reject": "THUMBS_DOWN",
@@ -17,14 +22,14 @@ REACTION_CONTENTS = {
 
 def parse_args():
     parser = argparse.ArgumentParser(
-        description="List Codex review feedback and optionally react/resolve it."
+        description="List actionable review bot feedback and optionally react/resolve it."
     )
     parser.add_argument("--pr", default="auto", help="auto, PR number, or PR URL")
     parser.add_argument("--repo", help="Optional OWNER/REPO override")
     parser.add_argument(
         "--include-older-reviews",
         action="store_true",
-        help="Include top-level Codex reviews from older SHAs on the same PR",
+        help="Include top-level actionable review bot reviews from older SHAs on the same PR",
     )
     parser.add_argument(
         "--dry-run",
@@ -67,7 +72,11 @@ def parse_args():
     )
 
     action_group = parser.add_mutually_exclusive_group(required=True)
-    action_group.add_argument("--list", action="store_true", help="List Codex feedback items")
+    action_group.add_argument(
+        "--list",
+        action="store_true",
+        help="List actionable review bot feedback items",
+    )
     action_group.add_argument(
         "--ack-all",
         action="store_true",
@@ -114,8 +123,12 @@ def print_json(payload):
     sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
 
 
-def is_codex_login(login):
-    return CODEX_LOGIN_KEYWORD in str(login or "").lower()
+def is_actionable_review_bot_login(login):
+    lower_login = str(login or "").lower()
+    return (
+        lower_login in ACTIONABLE_REVIEW_BOT_LOGINS
+        or any(keyword in lower_login for keyword in ACTIONABLE_REVIEW_BOT_LOGIN_KEYWORDS)
+    )
 
 
 def summarize_body(body, limit=160):
@@ -139,7 +152,7 @@ def plain_text_excerpt(text, limit=90):
     cleaned = re.sub(r"Useful\?\s*React with.*$", "", cleaned, flags=re.IGNORECASE | re.DOTALL)
     cleaned = " ".join(cleaned.split())
     if not cleaned:
-        return "Investigate Codex review feedback"
+        return "Investigate actionable review bot feedback"
     if len(cleaned) <= limit:
         return cleaned
     return cleaned[: limit - 3] + "..."
@@ -168,7 +181,7 @@ def format_reply_body(template, pr, item, follow_up_issue=None):
         raise GhCommandError(f"Unknown placeholder in --reply-body: {err}") from err
 
 
-def fetch_codex_reviews(pr, include_older_reviews=False):
+def fetch_actionable_reviews(pr, include_older_reviews=False):
     endpoint = f"repos/{pr['repo']}/pulls/{pr['number']}/reviews"
     payload = gh_api_list_paginated(endpoint, repo=pr["repo"])
     items = []
@@ -176,7 +189,7 @@ def fetch_codex_reviews(pr, include_older_reviews=False):
         if not isinstance(review, dict):
             continue
         login = ((review.get("user") or {}).get("login")) or ""
-        if not is_codex_login(login):
+        if not is_actionable_review_bot_login(login):
             continue
         commit_id = str(review.get("commit_id") or "")
         if not include_older_reviews and commit_id and commit_id != pr["head_sha"]:
@@ -207,7 +220,7 @@ def fetch_codex_reviews(pr, include_older_reviews=False):
     return items
 
 
-def fetch_codex_threads(pr):
+def fetch_actionable_threads(pr):
     owner, repo_name = pr["repo"].split("/", 1)
     query = """
 query($owner:String!, $repo:String!, $number:Int!, $after:String) {
@@ -271,18 +284,18 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
             comments = thread.get("comments", {}).get("nodes", [])
             if not thread_id or not isinstance(comments, list) or not comments:
                 continue
-            latest_codex_comment = None
+            latest_actionable_comment = None
             for comment in comments:
                 if not isinstance(comment, dict):
                     continue
                 login = ((comment.get("author") or {}).get("login")) or ""
-                if is_codex_login(login):
-                    latest_codex_comment = comment
-            if not isinstance(latest_codex_comment, dict):
+                if is_actionable_review_bot_login(login):
+                    latest_actionable_comment = comment
+            if not isinstance(latest_actionable_comment, dict):
                 continue
-            login = ((latest_codex_comment.get("author") or {}).get("login")) or ""
-            subject_id = str(latest_codex_comment.get("id") or "")
-            body = str(latest_codex_comment.get("body") or "")
+            login = ((latest_actionable_comment.get("author") or {}).get("login")) or ""
+            subject_id = str(latest_actionable_comment.get("id") or "")
+            body = str(latest_actionable_comment.get("body") or "")
             items.append(
                 {
                     "item_id": f"thread:{thread_id}",
@@ -293,12 +306,12 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
                     "body": body,
                     "summary": summarize_body(body),
                     "commit_id": pr["head_sha"],
-                    "created_at": str(latest_codex_comment.get("createdAt") or ""),
-                    "html_url": str(latest_codex_comment.get("url") or pr["url"]),
+                    "created_at": str(latest_actionable_comment.get("createdAt") or ""),
+                    "html_url": str(latest_actionable_comment.get("url") or pr["url"]),
                     "review_state": None,
-                    "path": latest_codex_comment.get("path"),
-                    "line": latest_codex_comment.get("line"),
-                    "database_id": str(latest_codex_comment.get("databaseId") or ""),
+                    "path": latest_actionable_comment.get("path"),
+                    "line": latest_actionable_comment.get("line"),
+                    "database_id": str(latest_actionable_comment.get("databaseId") or ""),
                 }
             )
         page_info = review_threads.get("pageInfo", {})
@@ -312,8 +325,8 @@ query($owner:String!, $repo:String!, $number:Int!, $after:String) {
 
 
 def list_feedback_items(pr, include_older_reviews=False):
-    items = fetch_codex_threads(pr)
-    items.extend(fetch_codex_reviews(pr, include_older_reviews=include_older_reviews))
+    items = fetch_actionable_threads(pr)
+    items.extend(fetch_actionable_reviews(pr, include_older_reviews=include_older_reviews))
     items.sort(key=lambda item: (item["created_at"], item["kind"], item["item_id"]))
     return items
 
@@ -365,7 +378,7 @@ def build_issue_title(item, title_prefix):
 
 def build_issue_body(pr, item):
     details = [
-        "This follow-up was captured from Codex review feedback that looks important but out of scope for the current PR.",
+        "This follow-up was captured from actionable review bot feedback that looks important but out of scope for the current PR.",
         "",
         f"- PR: #{pr['number']} ({pr['url']})",
         f"- Review item: {item['html_url']}",

--- a/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py
@@ -6,14 +6,14 @@ import json
 import re
 import sys
 
-from gh_pr_watch import GhCommandError, gh_api_list_paginated, gh_json, graphql_json, resolve_pr
-
-ACTIONABLE_REVIEW_BOT_LOGINS = {
-    "copilot-pull-request-reviewer",
-}
-ACTIONABLE_REVIEW_BOT_LOGIN_KEYWORDS = {
-    "codex",
-}
+from gh_pr_watch import (
+    GhCommandError,
+    gh_api_list_paginated,
+    gh_json,
+    graphql_json,
+    is_actionable_review_bot_login,
+    resolve_pr,
+)
 REACTION_CONTENTS = {
     "ack": "THUMBS_UP",
     "reject": "THUMBS_DOWN",
@@ -80,7 +80,7 @@ def parse_args():
     action_group.add_argument(
         "--ack-all",
         action="store_true",
-        help="React with 👍 to all listed items and resolve thread items",
+        help="React with 👍 to all listed items and resolve actionable review bot thread items",
     )
     action_group.add_argument(
         "--reject-all",
@@ -121,14 +121,6 @@ def parse_args():
 
 def print_json(payload):
     sys.stdout.write(json.dumps(payload, sort_keys=True) + "\n")
-
-
-def is_actionable_review_bot_login(login):
-    lower_login = str(login or "").lower()
-    return (
-        lower_login in ACTIONABLE_REVIEW_BOT_LOGINS
-        or any(keyword in lower_login for keyword in ACTIONABLE_REVIEW_BOT_LOGIN_KEYWORDS)
-    )
 
 
 def summarize_body(body, limit=160):

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Watch GitHub PR CI and review activity for Codex PR babysitting workflows."""
+"""Watch GitHub PR CI and review activity for PR babysitting workflows."""
 
 import argparse
 import json
@@ -26,6 +26,9 @@ PENDING_CHECK_STATES = {
     "PENDING",
     "WAITING",
     "REQUESTED",
+}
+REVIEW_BOT_LOGINS = {
+    "copilot-pull-request-reviewer",
 }
 REVIEW_BOT_LOGIN_KEYWORDS = {
     "codex",
@@ -60,7 +63,7 @@ class GhCommandError(RuntimeError):
 def parse_args():
     parser = argparse.ArgumentParser(
         description=(
-            "Normalize PR/CI/review state for Codex PR babysitting and optionally "
+            "Normalize PR/CI/review state for PR babysitting and optionally "
             "trigger flaky reruns."
         )
     )
@@ -537,14 +540,21 @@ def extract_login(user_obj):
 
 
 def is_bot_login(login):
-    return bool(login) and login.endswith("[bot]")
+    lower_login = str(login or "").lower()
+    return bool(lower_login) and (
+        lower_login.endswith("[bot]")
+        or lower_login in REVIEW_BOT_LOGINS
+    )
 
 
 def is_actionable_review_bot_login(login):
     if not is_bot_login(login):
         return False
     lower_login = login.lower()
-    return any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
+    return (
+        lower_login in REVIEW_BOT_LOGINS
+        or any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
+    )
 
 
 def is_trusted_human_review_author(item, authenticated_login):

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -539,18 +539,26 @@ def extract_login(user_obj):
     return ""
 
 
+def normalize_review_bot_login(login):
+    lower_login = str(login or "").lower()
+    if lower_login.endswith("[bot]"):
+        return lower_login[: -len("[bot]")]
+    return lower_login
+
+
 def is_bot_login(login):
     lower_login = str(login or "").lower()
+    canonical_login = normalize_review_bot_login(lower_login)
     return bool(lower_login) and (
         lower_login.endswith("[bot]")
-        or lower_login in REVIEW_BOT_LOGINS
+        or canonical_login in REVIEW_BOT_LOGINS
     )
 
 
 def is_actionable_review_bot_login(login):
     if not is_bot_login(login):
         return False
-    lower_login = login.lower()
+    lower_login = normalize_review_bot_login(login)
     return (
         lower_login in REVIEW_BOT_LOGINS
         or any(keyword in lower_login for keyword in REVIEW_BOT_LOGIN_KEYWORDS)
@@ -585,6 +593,12 @@ def is_generic_codex_summary_review(item):
     return (
         "here are some automated review suggestions for this pull request" in body
         or "about codex in github" in body
+        or (
+            "## pull request overview" in body
+            and "### reviewed changes" in body
+            and "copilot reviewed" in body
+            and "changed files in this pull request" in body
+        )
     )
 
 

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -28,6 +28,7 @@ PENDING_CHECK_STATES = {
     "REQUESTED",
 }
 REVIEW_BOT_LOGINS = {
+    "chatgpt-codex-connector",
     "copilot-pull-request-reviewer",
 }
 REVIEW_BOT_LOGIN_KEYWORDS = {

--- a/.codex/skills/babysit-pr/scripts/test_review_bots.py
+++ b/.codex/skills/babysit-pr/scripts/test_review_bots.py
@@ -16,12 +16,35 @@ class ActionableReviewBotTests(unittest.TestCase):
     def test_exact_copilot_reviewer_is_actionable(self):
         self.assertTrue(gh_pr_watch.is_actionable_review_bot_login("copilot-pull-request-reviewer"))
 
+    def test_copilot_bot_login_variant_is_actionable(self):
+        self.assertTrue(
+            gh_pr_watch.is_actionable_review_bot_login("copilot-pull-request-reviewer[bot]")
+        )
+        self.assertTrue(
+            gh_pr_codex_feedback.is_actionable_review_bot_login("copilot-pull-request-reviewer[bot]")
+        )
+
     def test_other_copilot_logins_are_not_actionable(self):
         self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("copilot-helper[bot]"))
 
     def test_non_bot_login_with_keyword_is_not_actionable(self):
         self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("codex-reviewer"))
         self.assertFalse(gh_pr_codex_feedback.is_actionable_review_bot_login("codex-reviewer"))
+
+    def test_generic_copilot_overview_review_is_non_blocking(self):
+        item = {
+            "kind": "review",
+            "author": "copilot-pull-request-reviewer[bot]",
+            "body": (
+                "## Pull request overview\n\n"
+                "Updates the babysit-pr watcher.\n\n"
+                "### Reviewed changes\n\n"
+                "Copilot reviewed 4 out of 4 changed files in this pull request and generated 2 comments."
+            ),
+            "review_state": "COMMENTED",
+        }
+
+        self.assertTrue(gh_pr_watch.is_non_blocking_review_item(item))
 
 
 class FeedbackListingTests(unittest.TestCase):

--- a/.codex/skills/babysit-pr/scripts/test_review_bots.py
+++ b/.codex/skills/babysit-pr/scripts/test_review_bots.py
@@ -24,6 +24,10 @@ class ActionableReviewBotTests(unittest.TestCase):
             gh_pr_codex_feedback.is_actionable_review_bot_login("copilot-pull-request-reviewer[bot]")
         )
 
+    def test_exact_codex_connector_login_is_actionable(self):
+        self.assertTrue(gh_pr_watch.is_actionable_review_bot_login("chatgpt-codex-connector"))
+        self.assertTrue(gh_pr_codex_feedback.is_actionable_review_bot_login("chatgpt-codex-connector"))
+
     def test_other_copilot_logins_are_not_actionable(self):
         self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("copilot-helper[bot]"))
 

--- a/.codex/skills/babysit-pr/scripts/test_review_bots.py
+++ b/.codex/skills/babysit-pr/scripts/test_review_bots.py
@@ -19,6 +19,10 @@ class ActionableReviewBotTests(unittest.TestCase):
     def test_other_copilot_logins_are_not_actionable(self):
         self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("copilot-helper[bot]"))
 
+    def test_non_bot_login_with_keyword_is_not_actionable(self):
+        self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("codex-reviewer"))
+        self.assertFalse(gh_pr_codex_feedback.is_actionable_review_bot_login("codex-reviewer"))
+
 
 class FeedbackListingTests(unittest.TestCase):
     def test_feedback_listing_includes_exact_copilot_reviewer_only(self):

--- a/.codex/skills/babysit-pr/scripts/test_review_bots.py
+++ b/.codex/skills/babysit-pr/scripts/test_review_bots.py
@@ -1,0 +1,138 @@
+import pathlib
+import sys
+import unittest
+from unittest.mock import patch
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import gh_pr_codex_feedback
+import gh_pr_watch
+
+
+class ActionableReviewBotTests(unittest.TestCase):
+    def test_exact_copilot_reviewer_is_actionable(self):
+        self.assertTrue(gh_pr_watch.is_actionable_review_bot_login("copilot-pull-request-reviewer"))
+
+    def test_other_copilot_logins_are_not_actionable(self):
+        self.assertFalse(gh_pr_watch.is_actionable_review_bot_login("copilot-helper[bot]"))
+
+
+class FeedbackListingTests(unittest.TestCase):
+    def test_feedback_listing_includes_exact_copilot_reviewer_only(self):
+        pr = {
+            "number": 632,
+            "repo": "Electivus/Apex-Log-Viewer",
+            "head_sha": "abc123",
+            "url": "https://github.com/Electivus/Apex-Log-Viewer/pull/632",
+        }
+
+        reviews_payload = [
+            {
+                "user": {"login": "copilot-pull-request-reviewer"},
+                "commit_id": "abc123",
+                "node_id": "PRR_kwDO1",
+                "body": "Copilot top-level review",
+                "submitted_at": "2026-03-22T23:00:00Z",
+                "html_url": "https://github.com/Electivus/Apex-Log-Viewer/pull/632#pullrequestreview-1",
+                "state": "COMMENTED",
+            },
+            {
+                "user": {"login": "copilot-helper[bot]"},
+                "commit_id": "abc123",
+                "node_id": "PRR_kwDO2",
+                "body": "Should not be included",
+                "submitted_at": "2026-03-22T23:01:00Z",
+                "html_url": "https://github.com/Electivus/Apex-Log-Viewer/pull/632#pullrequestreview-2",
+                "state": "COMMENTED",
+            },
+        ]
+
+        threads_payload = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "id": "PRRT_kwDOthread1",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "id": "PRRC_kwDOignore",
+                                                "databaseId": 1001,
+                                                "body": "Ignored comment",
+                                                "path": "file.py",
+                                                "line": 10,
+                                                "url": "https://example.com/ignore",
+                                                "createdAt": "2026-03-22T22:59:00Z",
+                                                "author": {"login": "some-other-bot"},
+                                            },
+                                            {
+                                                "id": "PRRC_kwDOcopilot",
+                                                "databaseId": 1002,
+                                                "body": "Copilot thread comment",
+                                                "path": "file.py",
+                                                "line": 11,
+                                                "url": "https://example.com/copilot",
+                                                "createdAt": "2026-03-22T23:02:00Z",
+                                                "author": {"login": "copilot-pull-request-reviewer"},
+                                            },
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PRRT_kwDOthread2",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "id": "PRRC_kwDOothercopilot",
+                                                "databaseId": 1003,
+                                                "body": "Should stay excluded",
+                                                "path": "file.py",
+                                                "line": 12,
+                                                "url": "https://example.com/other",
+                                                "createdAt": "2026-03-22T23:03:00Z",
+                                                "author": {"login": "copilot-helper[bot]"},
+                                            }
+                                        ]
+                                    },
+                                },
+                            ],
+                            "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        }
+                    }
+                }
+            }
+        }
+
+        with patch.object(
+            gh_pr_codex_feedback,
+            "gh_api_list_paginated",
+            return_value=reviews_payload,
+        ), patch.object(
+            gh_pr_codex_feedback,
+            "graphql_json",
+            return_value=threads_payload,
+        ):
+            items = gh_pr_codex_feedback.list_feedback_items(pr)
+
+        self.assertEqual(
+            [item["author"] for item in items],
+            [
+                "copilot-pull-request-reviewer",
+                "copilot-pull-request-reviewer",
+            ],
+        )
+        self.assertEqual([item["kind"] for item in items], ["review", "thread"])
+        self.assertEqual(items[1]["database_id"], "1002")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Conventional Commit Title
- `fix(babysit-pr): support copilot reviewer feedback`

## Summary
- Treat the exact `copilot-pull-request-reviewer` login as actionable in the babysit-pr watcher.
- Extend the feedback helper to list, acknowledge, reply to, and resolve feedback from that reviewer while continuing to exclude other Copilot-like logins.
- Add targeted Python regression tests and update the babysit-pr skill docs to document the approved bot set.

## Linked Issues
- None.

## Screenshots / GIFs (UI)
- N/A.

## Verification Steps
- `python3 -m unittest discover -s .codex/skills/babysit-pr/scripts -p 'test_*.py'`
- `python3 -m py_compile .codex/skills/babysit-pr/scripts/gh_pr_watch.py .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py .codex/skills/babysit-pr/scripts/test_review_bots.py`
- `git diff --check`

## Risk / Rollback
- Risk is limited to babysit-pr review-bot classification and feedback-thread handling.
- Roll back by reverting commit `478d6bb`.

## Checklist
- [ ] `npm run build` passes
- [ ] `npm test` (or `npm run test:all`) passes; integration tests prefixed with `integration`
- [ ] Lint/Types: `npm run lint` and `npm run check-types`
- [x] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added
