### PR TITLE
feat(telemetry): improve observability coverage

### DIFF
--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -205,6 +205,7 @@ Stop only when one of the following is true:
 
 - PR merged or closed (stop as soon as a poll/snapshot confirms this).
 - PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, no unresolved review threads, and no merge conflict risk.
+- A separate approval/thumbs-up signal is not required, but any GitHub-reported merge blocking state (for example `BLOCKED`) still means the PR is not ready.
 - User intervention is required and Codex cannot safely proceed alone.
 
 Keep polling when:

--- a/.codex/skills/babysit-pr/SKILL.md
+++ b/.codex/skills/babysit-pr/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: babysit-pr
-description: Babysit a GitHub pull request after creation by continuously polling CI checks/workflow runs, new review comments, and mergeability state until the PR is ready to merge (or merged/closed). Diagnose failures, retry likely flaky failures up to 3 times, auto-fix/push branch-related issues when appropriate, and stop only when user help is required (for example CI infrastructure issues, exhausted flaky retries, or ambiguous/blocking situations). Use when the user asks Codex to monitor a PR, watch CI, handle review comments, or keep an eye on failures and feedback on an open PR.
+description: Use when the user asks Codex to monitor a GitHub pull request, watch CI, handle review comments, or keep an eye on failures and feedback on an open PR.
 ---
 
 # PR Babysitter
@@ -9,7 +9,7 @@ description: Babysit a GitHub pull request after creation by continuously pollin
 Babysit a PR persistently until one of these terminal outcomes occurs:
 
 - The PR is merged or closed.
-- CI is successful, there are no unaddressed review comments surfaced by the watcher, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk). A `👍` reaction on the PR itself also counts as a ready signal and can satisfy the review gate.
+- CI is successful, there are no unaddressed review comments surfaced by the watcher, and there are no potential merge conflicts (PR is mergeable / not reporting conflict risk).
 - A situation requires user help (for example CI infrastructure issues, repeated flaky failures after retry budget is exhausted, permission problems, or ambiguity that cannot be resolved safely).
 
 Do not stop merely because a single snapshot returns `idle` while checks are still pending.
@@ -34,7 +34,7 @@ Accept any of the following:
 9. If a review item is incorrect, already handled, or otherwise non-actionable, mark it as intentionally rejected/ignored and continue watching.
 10. If the failure is likely flaky/unrelated and `retry_failed_checks` is present, rerun failed jobs with `--retry-failed-now`.
 11. If both actionable review feedback and `retry_failed_checks` are present, prioritize review feedback first; a new commit will retrigger CI, so avoid rerunning flaky checks on the old SHA unless you intentionally defer the review change.
-12. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state, and check whether the PR itself has received a `👍` reaction.
+12. On every loop, verify mergeability / merge-conflict status (for example via `gh pr view`) in addition to CI and review state.
 13. After any push, rerun, or follow-up issue capture, immediately return to step 1 and continue polling on the updated SHA/state.
 14. If you had been using `--watch` before pausing to patch/commit/push, relaunch `--watch` yourself in the same turn immediately after the push (do not wait for the user to re-invoke the skill).
 15. Repeat polling until the PR is green + review-clean + mergeable, `stop_pr_closed` appears, or a user-help-required blocker is reached.
@@ -182,7 +182,7 @@ Use this loop in a live Codex session:
 7. Retry failed checks only when `retry_failed_checks` is present and you are not about to replace the current SHA with a review/CI fix commit.
 8. If you pushed a commit or triggered a rerun, report the action briefly and continue polling (do not stop).
 9. After a review-fix push, proactively restart continuous monitoring (`--watch`) in the same turn unless a strict stop condition has already been reached.
-10. If everything is passing, mergeable, not blocked on required review approval, and there are no unaddressed review items or unresolved review threads, report success and stop. If the PR itself has a `👍` reaction, treat that as an approval signal for readiness even if GitHub still reports `REVIEW_REQUIRED`.
+10. If everything is passing, mergeable, and there are no unaddressed review items or unresolved review threads, report success and stop.
 11. If blocked on a user-help-required issue (infra outage, exhausted flaky retries, unclear reviewer request, permissions), report the blocker and stop.
 12. Otherwise sleep according to the polling cadence below and repeat.
 
@@ -204,7 +204,7 @@ Use adaptive polling and continue monitoring even after CI turns green:
 Stop only when one of the following is true:
 
 - PR merged or closed (stop as soon as a poll/snapshot confirms this).
-- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, no unresolved review threads, and no merge conflict risk. A `👍` reaction on the PR itself counts as satisfying the review gate for this readiness check.
+- PR is ready to merge: CI succeeded, no surfaced unaddressed review comments, no unresolved review threads, and no merge conflict risk.
 - User intervention is required and Codex cannot safely proceed alone.
 
 Keep polling when:
@@ -214,7 +214,6 @@ Keep polling when:
 - Review state is quiet but CI is not terminal.
 - CI is green but mergeability is unknown/pending.
 - CI is green and mergeable, but the PR is still open and you are waiting for possible new review comments or merge-conflict changes per the green-state cadence.
-- The PR is green but blocked on review approval (`REVIEW_REQUIRED` / similar); continue polling on the green-state cadence and surface any new review comments without asking for confirmation to keep watching.
 
 ## Output Expectations
 Provide concise progress updates while monitoring and a final summary that includes:
@@ -223,7 +222,7 @@ Provide concise progress updates while monitoring and a final summary that inclu
 - Treat push confirmations, intermediate CI snapshots, and review-action updates as progress updates only; do not emit the final summary or end the babysitting session unless a strict stop condition is met.
 - A user request to "monitor" is not satisfied by a couple of sample polls; remain in the loop until a strict stop condition or an explicit user interruption.
 - A review-fix commit + push is not a completion event; immediately resume live monitoring (`--watch`) in the same turn and continue reporting progress updates.
-- When CI first transitions to all green for the current SHA, emit a one-time celebratory progress update (do not repeat it on every green poll). Preferred style: `🚀 CI is all green! 33/33 passed. Still on watch for review approval.`
+- When CI first transitions to all green for the current SHA, emit a one-time celebratory progress update (do not repeat it on every green poll). Preferred style: `🚀 CI is all green! 33/33 passed. Still on watch for new review feedback.`
 - Do not send the final summary while a watcher terminal is still running unless the watcher has emitted/confirmed a strict stop condition; otherwise continue with progress updates.
 
 - Final PR SHA

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -40,10 +40,6 @@ TRUSTED_AUTHOR_ASSOCIATIONS = {
     "MEMBER",
     "COLLABORATOR",
 }
-MERGE_BLOCKING_REVIEW_DECISIONS = {
-    "REVIEW_REQUIRED",
-    "CHANGES_REQUESTED",
-}
 NON_BLOCKING_REVIEW_STATES = {
     "APPROVED",
     "DISMISSED",
@@ -938,15 +934,8 @@ def is_pr_ready_to_merge(
         return False
     if str(pr.get("mergeable") or "") != "MERGEABLE":
         return False
-    has_ready_reaction = bool(ready_reactions)
     merge_state_status = str(pr.get("merge_state_status") or "")
-    review_decision = str(pr.get("review_decision") or "")
-    review_gate_blocked = review_decision in MERGE_BLOCKING_REVIEW_DECISIONS
     if merge_state_status in {"DIRTY", "DRAFT", "UNKNOWN"}:
-        return False
-    if merge_state_status == "BLOCKED" and not (has_ready_reaction and review_gate_blocked):
-        return False
-    if review_gate_blocked and not has_ready_reaction:
         return False
     return True
 

--- a/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
+++ b/.codex/skills/babysit-pr/scripts/gh_pr_watch.py
@@ -935,7 +935,7 @@ def is_pr_ready_to_merge(
     if str(pr.get("mergeable") or "") != "MERGEABLE":
         return False
     merge_state_status = str(pr.get("merge_state_status") or "")
-    if merge_state_status in {"DIRTY", "DRAFT", "UNKNOWN"}:
+    if merge_state_status in MERGE_CONFLICT_OR_BLOCKING_STATES:
         return False
     return True
 

--- a/.codex/skills/babysit-pr/scripts/test_ready_state.py
+++ b/.codex/skills/babysit-pr/scripts/test_ready_state.py
@@ -32,9 +32,9 @@ class ReadyStateTests(unittest.TestCase):
         checks.update(overrides)
         return checks
 
-    def test_review_required_no_longer_blocks_ready_state(self):
+    def test_blocked_pr_is_not_ready_even_when_review_decision_is_empty(self):
         ready = gh_pr_watch.is_pr_ready_to_merge(
-            self._base_pr(merge_state_status="BLOCKED", review_decision="REVIEW_REQUIRED"),
+            self._base_pr(merge_state_status="BLOCKED", review_decision=""),
             self._green_checks(),
             new_review_items=[],
             unresolved_review_threads=[],
@@ -42,11 +42,11 @@ class ReadyStateTests(unittest.TestCase):
             ready_reactions=[],
         )
 
-        self.assertTrue(ready)
+        self.assertFalse(ready)
 
-    def test_recommend_actions_stops_when_only_approval_is_missing(self):
+    def test_recommend_actions_does_not_stop_when_github_still_blocks_merge(self):
         actions = gh_pr_watch.recommend_actions(
-            self._base_pr(merge_state_status="BLOCKED", review_decision="REVIEW_REQUIRED"),
+            self._base_pr(merge_state_status="BLOCKED", review_decision=""),
             self._green_checks(),
             failed_runs=[],
             new_review_items=[],
@@ -57,7 +57,7 @@ class ReadyStateTests(unittest.TestCase):
             max_retries=3,
         )
 
-        self.assertEqual(actions, ["stop_ready_to_merge"])
+        self.assertEqual(actions, ["idle"])
 
     def test_dirty_pr_is_not_ready_even_when_checks_are_green(self):
         ready = gh_pr_watch.is_pr_ready_to_merge(

--- a/.codex/skills/babysit-pr/scripts/test_ready_state.py
+++ b/.codex/skills/babysit-pr/scripts/test_ready_state.py
@@ -1,0 +1,76 @@
+import pathlib
+import sys
+import unittest
+
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import gh_pr_watch
+
+
+class ReadyStateTests(unittest.TestCase):
+    def _base_pr(self, **overrides):
+        pr = {
+            "closed": False,
+            "merged": False,
+            "mergeable": "MERGEABLE",
+            "merge_state_status": "CLEAN",
+            "review_decision": "",
+        }
+        pr.update(overrides)
+        return pr
+
+    def _green_checks(self, **overrides):
+        checks = {
+            "all_terminal": True,
+            "failed_count": 0,
+            "pending_count": 0,
+            "passed_count": 5,
+        }
+        checks.update(overrides)
+        return checks
+
+    def test_review_required_no_longer_blocks_ready_state(self):
+        ready = gh_pr_watch.is_pr_ready_to_merge(
+            self._base_pr(merge_state_status="BLOCKED", review_decision="REVIEW_REQUIRED"),
+            self._green_checks(),
+            new_review_items=[],
+            unresolved_review_threads=[],
+            blocking_non_thread_feedback=[],
+            ready_reactions=[],
+        )
+
+        self.assertTrue(ready)
+
+    def test_recommend_actions_stops_when_only_approval_is_missing(self):
+        actions = gh_pr_watch.recommend_actions(
+            self._base_pr(merge_state_status="BLOCKED", review_decision="REVIEW_REQUIRED"),
+            self._green_checks(),
+            failed_runs=[],
+            new_review_items=[],
+            unresolved_review_threads=[],
+            blocking_non_thread_feedback=[],
+            ready_reactions=[],
+            retries_used=0,
+            max_retries=3,
+        )
+
+        self.assertEqual(actions, ["stop_ready_to_merge"])
+
+    def test_dirty_pr_is_not_ready_even_when_checks_are_green(self):
+        ready = gh_pr_watch.is_pr_ready_to_merge(
+            self._base_pr(merge_state_status="DIRTY", review_decision="REVIEW_REQUIRED"),
+            self._green_checks(),
+            new_review_items=[],
+            unresolved_review_threads=[],
+            blocking_non_thread_feedback=[],
+            ready_reactions=[],
+        )
+
+        self.assertFalse(ready)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/panel/DebugFlagsPanel.ts
+++ b/src/panel/DebugFlagsPanel.ts
@@ -12,6 +12,7 @@ import {
   upsertTraceFlag
 } from '../salesforce/traceflags';
 import { DEBUG_LEVEL_PRESETS } from '../shared/debugLevelPresets';
+import { bucketQueryLength } from '../shared/telemetryBuckets';
 import { clearApexLogs } from '../services/apexLogCleanup';
 import type { DebugFlagsFromWebviewMessage, DebugFlagsToWebviewMessage } from '../shared/debugFlagsMessages';
 import type { DebugLevelRecord, TraceFlagTarget, TraceFlagTargetStatus } from '../shared/debugFlagsTypes';
@@ -235,6 +236,7 @@ export class DebugFlagsPanel {
 
   private async searchUsers(): Promise<void> {
     const token = ++this.usersToken;
+    const t0 = Date.now();
     this.post({ type: 'debugFlagsLoading', scope: 'users', value: true });
     try {
       const auth = await this.getSelectedAuth();
@@ -242,6 +244,18 @@ export class DebugFlagsPanel {
       if (token !== this.usersToken || this.disposed) {
         return;
       }
+      safeSendEvent(
+        'debugFlags.searchUsers',
+        {
+          outcome: 'ok',
+          sourceView: this.lastSourceView,
+          queryLength: bucketQueryLength(this.usersQuery)
+        },
+        {
+          durationMs: Date.now() - t0,
+          count: users.length
+        }
+      );
       this.post({ type: 'debugFlagsUsers', query: this.usersQuery, data: users });
       const selectedUserTarget = this.selectedTarget?.type === 'user' ? this.selectedTarget : undefined;
       if (selectedUserTarget && !users.some(user => user.id === selectedUserTarget.userId)) {
@@ -254,6 +268,17 @@ export class DebugFlagsPanel {
         return;
       }
       const msg = getErrorMessage(e);
+      safeSendEvent(
+        'debugFlags.searchUsers',
+        {
+          outcome: 'error',
+          sourceView: this.lastSourceView,
+          queryLength: bucketQueryLength(this.usersQuery)
+        },
+        {
+          durationMs: Date.now() - t0
+        }
+      );
       logWarn('DebugFlagsPanel: user search failed ->', msg);
       this.post({
         type: 'debugFlagsError',

--- a/src/provider/logsMessageHandler.ts
+++ b/src/provider/logsMessageHandler.ts
@@ -1,4 +1,5 @@
 import type { WebviewToExtensionMessage } from '../shared/messages';
+import { safeSendEvent } from '../shared/telemetry';
 import { logInfo } from '../utils/logger';
 
 export class LogsMessageHandler {
@@ -68,6 +69,28 @@ export class LogsMessageHandler {
         break;
       case 'searchQuery':
         await this.setSearchQuery(typeof message.value === 'string' ? message.value : '');
+        break;
+      case 'trackLogsSearch':
+        safeSendEvent(
+          'logs.search',
+          message.outcome === 'searched' && message.queryLength
+            ? { outcome: message.outcome, queryLength: message.queryLength }
+            : { outcome: message.outcome }
+        );
+        break;
+      case 'trackLogsFilter':
+        safeSendEvent(
+          'logs.filter',
+          {
+            outcome: message.outcome,
+            hasUser: String(message.hasUser),
+            hasOperation: String(message.hasOperation),
+            hasStatus: String(message.hasStatus),
+            hasCodeUnit: String(message.hasCodeUnit),
+            errorsOnly: String(message.errorsOnly)
+          },
+          { activeCount: message.activeCount }
+        );
         break;
       case 'setLogsColumns':
         await this.setLogsColumns(message.value);

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -12,6 +12,7 @@ import {
   markExecOverriddenForTests
 } from './exec';
 import { resolvePATHFromLoginShell } from './path';
+import { classifyCliOutputText, createCliTelemetryError, getCliTelemetryCode } from './cliTelemetry';
 
 // Short-lived in-memory cache for auth (avoid storing tokens on disk)
 type AuthCache = { value: OrgAuth; expiresAt: number };
@@ -71,7 +72,7 @@ function stripAnsi(value: string): string {
 function parseCliJson(stdout: string): any {
   const raw = String(stdout || '').trim();
   if (!raw) {
-    throw new Error('empty CLI output');
+    throw createCliTelemetryError('EMPTY_OUTPUT', 'empty CLI output');
   }
   try {
     return JSON.parse(raw);
@@ -81,10 +82,40 @@ function parseCliJson(stdout: string): any {
     const start = cleaned.indexOf('{');
     const end = cleaned.lastIndexOf('}');
     if (start >= 0 && end > start) {
-      return JSON.parse(cleaned.slice(start, end + 1));
+      try {
+        return JSON.parse(cleaned.slice(start, end + 1));
+      } catch {}
     }
-    throw new Error('invalid CLI JSON output');
+    throw createCliTelemetryError('INVALID_JSON', 'invalid CLI JSON output');
   }
+}
+
+function readOrgAuthFromCliOutput(stdout: string): OrgAuth {
+  const parsed = parseCliJson(stdout);
+  const result = parsed.result || parsed;
+  const accessToken: string | undefined = result.accessToken || result.access_token;
+  const instanceUrl: string | undefined = result.instanceUrl || result.instance_url || result.loginUrl;
+  const username: string | undefined = result.username;
+  if (accessToken && instanceUrl) {
+    try {
+      logTrace('getOrgAuth: success for user', username || '(unknown)', 'at', instanceUrl);
+    } catch {}
+    return { accessToken, instanceUrl, username } as OrgAuth;
+  }
+
+  const hints = [
+    parsed?.name,
+    parsed?.message,
+    result?.message,
+    result?.error,
+    result?.errorCode,
+    result?.warnings
+  ]
+    .flat()
+    .filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
+    .join('\n');
+  const classified = classifyCliOutputText(hints);
+  throw createCliTelemetryError(classified || 'MISSING_AUTH_FIELDS', 'CLI JSON missing auth fields');
 }
 
 function getSfCliProgramCandidates(): string[] {
@@ -147,27 +178,17 @@ export async function getOrgAuth(
         logTrace('getOrgAuth: trying', program, args.join(' '));
       } catch {}
       const { stdout } = await execCommand(program, args, undefined, CLI_TIMEOUT_MS, signal);
-      const parsed = parseCliJson(stdout);
-      const result = parsed.result || parsed;
-      const accessToken: string | undefined = result.accessToken || result.access_token;
-      const instanceUrl: string | undefined = result.instanceUrl || result.instance_url || result.loginUrl;
-      const username: string | undefined = result.username;
-      if (accessToken && instanceUrl) {
-        try {
-          logTrace('getOrgAuth: success for user', username || '(unknown)', 'at', instanceUrl);
-        } catch {}
-        const auth = { accessToken, instanceUrl, username } as OrgAuth;
-        if (execOverriddenForTests && authTtl > 0) {
-          authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
-          enforceAuthCacheLimit();
-        }
-        if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
-          try {
-            await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
-          } catch {}
-        }
-        return auth;
+      const auth = readOrgAuthFromCliOutput(stdout);
+      if (execOverriddenForTests && authTtl > 0) {
+        authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
+        enforceAuthCacheLimit();
       }
+      if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
+        try {
+          await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+        } catch {}
+      }
+      return auth;
     } catch (_e) {
       const e: any = _e;
       if (signal?.aborted) {
@@ -180,7 +201,7 @@ export async function getOrgAuth(
         safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: program });
         throw e;
       } else {
-        safeSendException('cli.getOrgAuth', { code: String(e.code || ''), command: program });
+        safeSendException('cli.getOrgAuth', { code: getCliTelemetryCode(e), command: program });
       }
       try {
         logTrace('getOrgAuth: attempt failed for', program);
@@ -197,27 +218,17 @@ export async function getOrgAuth(
             logTrace('getOrgAuth(login PATH): trying', program, args.join(' '));
           } catch {}
           const { stdout } = await execCommand(program, args, env2, CLI_TIMEOUT_MS, signal);
-          const parsed = parseCliJson(stdout);
-          const result = parsed.result || parsed;
-          const accessToken: string | undefined = result.accessToken || result.access_token;
-          const instanceUrl: string | undefined = result.instanceUrl || result.instance_url || result.loginUrl;
-          const username: string | undefined = result.username;
-          if (accessToken && instanceUrl) {
-            try {
-              logTrace('getOrgAuth(login PATH): success for user', username || '(unknown)', 'at', instanceUrl);
-            } catch {}
-            const auth = { accessToken, instanceUrl, username } as OrgAuth;
-            if (execOverriddenForTests && authTtl > 0) {
-              authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
-              enforceAuthCacheLimit();
-            }
-            if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
-              try {
-                await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
-              } catch {}
-            }
-            return auth;
+          const auth = readOrgAuthFromCliOutput(stdout);
+          if (execOverriddenForTests && authTtl > 0) {
+            authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
+            enforceAuthCacheLimit();
           }
+          if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
+            try {
+              await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+            } catch {}
+          }
+          return auth;
         } catch (_e) {
           const e: any = _e;
           if (signal?.aborted) {
@@ -229,7 +240,7 @@ export async function getOrgAuth(
             safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: program });
             throw e;
           } else {
-            safeSendException('cli.getOrgAuth', { code: String(e.code || ''), command: program });
+            safeSendException('cli.getOrgAuth', { code: getCliTelemetryCode(e), command: program });
           }
           try {
             logTrace('getOrgAuth(login PATH): attempt failed for', program);

--- a/src/salesforce/cliTelemetry.ts
+++ b/src/salesforce/cliTelemetry.ts
@@ -1,0 +1,86 @@
+type CliTelemetryError = Error & { code?: string; telemetryCode?: string };
+
+const DEFAULT_ORG_PATTERNS = [
+  /no default username/i,
+  /no default target org/i,
+  /use -o or set a default org/i,
+  /set a default org/i,
+  /default org/i
+];
+
+const AUTH_REQUIRED_PATTERNS = [
+  /authorize an org/i,
+  /run .*org login/i,
+  /not authenticated/i,
+  /authentication failed/i,
+  /no authorization information found/i,
+  /expired access\/refresh token/i,
+  /invalid_grant/i
+];
+
+function normalizeCliTelemetryCode(rawCode: unknown): string {
+  const raw = String(rawCode ?? '').trim();
+  if (!raw) {
+    return 'UNKNOWN';
+  }
+  if (/^\d+$/.test(raw)) {
+    return `EXIT_${raw}`;
+  }
+  const sanitized = raw
+    .toUpperCase()
+    .replace(/[^A-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '');
+  return sanitized || 'UNKNOWN';
+}
+
+export function classifyCliOutputText(text: string): string | undefined {
+  const value = String(text || '').trim();
+  if (!value) {
+    return undefined;
+  }
+  if (DEFAULT_ORG_PATTERNS.some(pattern => pattern.test(value))) {
+    return 'DEFAULT_ORG_MISSING';
+  }
+  if (AUTH_REQUIRED_PATTERNS.some(pattern => pattern.test(value))) {
+    return 'AUTH_REQUIRED';
+  }
+  return undefined;
+}
+
+export function classifyCliExecTelemetryCode(
+  rawCode: unknown,
+  stderr?: string,
+  stdout?: string,
+  message?: string
+): string {
+  const explicit = String(rawCode ?? '').trim();
+  if (explicit === 'ENOENT') {
+    return 'ENOENT';
+  }
+  if (explicit === 'ETIMEDOUT') {
+    return 'ETIMEDOUT';
+  }
+  const classifiedFromText = classifyCliOutputText([stderr, stdout, message].filter(Boolean).join('\n'));
+  if (classifiedFromText) {
+    return classifiedFromText;
+  }
+  return normalizeCliTelemetryCode(rawCode);
+}
+
+export function createCliTelemetryError(code: string, message: string): CliTelemetryError {
+  const error = new Error(message) as CliTelemetryError;
+  error.code = code;
+  error.telemetryCode = code;
+  return error;
+}
+
+export function getCliTelemetryCode(error: unknown): string {
+  const candidate = error as CliTelemetryError | undefined;
+  if (candidate?.telemetryCode) {
+    return normalizeCliTelemetryCode(candidate.telemetryCode);
+  }
+  if (candidate?.code) {
+    return normalizeCliTelemetryCode(candidate.code);
+  }
+  return 'UNKNOWN';
+}

--- a/src/salesforce/exec.ts
+++ b/src/salesforce/exec.ts
@@ -2,6 +2,7 @@ import * as cp from 'child_process';
 import { logTrace, logWarn } from '../utils/logger';
 import { localize } from '../utils/localize';
 import { safeSendException } from '../shared/telemetry';
+import { classifyCliExecTelemetryCode } from './cliTelemetry';
 const crossSpawn = require('cross-spawn');
 
 export const CLI_TIMEOUT_MS = 120000;
@@ -186,6 +187,7 @@ export function execCommand(
           const cmdStr = [program, ...args].join(' ').trim();
           const e = new Error(`CLI not found: ${cmdStr}`) as any;
           e.code = 'ENOENT';
+          e.telemetryCode = 'ENOENT';
           try {
             logTrace('execCommand ENOENT for', program);
           } catch {}
@@ -196,7 +198,8 @@ export function execCommand(
         try {
           logTrace('execCommand error for', program, '->', (stderr || err.message || '').split('\n')[0]);
         } catch {}
-        safeSendException('cli.exec', { code: String(err.code || ''), command: program });
+        const telemetryCode = classifyCliExecTelemetryCode(err.code, stderr, stdout, err.message);
+        safeSendException('cli.exec', { code: telemetryCode, command: program });
         const code = typeof err.code === 'number' || typeof err.code === 'string' ? err.code : undefined;
         const cmdStr2 = [program, ...args].join(' ').trim();
         const detail = stderr || err.message;
@@ -208,6 +211,9 @@ export function execCommand(
         if (code !== undefined) {
           (e as any).code = code;
         }
+        e.telemetryCode = telemetryCode;
+        e.stdout = stdout;
+        e.stderr = stderr;
         reject(e);
         return;
       }
@@ -237,6 +243,7 @@ export function execCommand(
         )
       );
       err.code = 'ETIMEDOUT';
+      err.telemetryCode = 'ETIMEDOUT';
       inFlightExecs.delete(key);
       safeSendException('cli.exec', { code: 'ETIMEDOUT', command: program });
       reject(err);

--- a/src/shared/messages.ts
+++ b/src/shared/messages.ts
@@ -14,6 +14,17 @@ export type WebviewToExtensionMessage =
   | { type: 'replay'; logId: string }
   | { type: 'loadMore' }
   | { type: 'searchQuery'; value: string }
+  | { type: 'trackLogsSearch'; outcome: 'searched' | 'cleared'; queryLength?: '1-3' | '4-10' | '11-30' | '31+' }
+  | {
+      type: 'trackLogsFilter';
+      outcome: 'changed' | 'cleared';
+      hasUser: boolean;
+      hasOperation: boolean;
+      hasStatus: boolean;
+      hasCodeUnit: boolean;
+      errorsOnly: boolean;
+      activeCount: number;
+    }
   | { type: 'setLogsColumns'; value: LogsColumnsConfig }
   // Tail view messages
   | { type: 'tailStart'; debugLevel?: string }

--- a/src/shared/telemetryBuckets.ts
+++ b/src/shared/telemetryBuckets.ts
@@ -1,0 +1,18 @@
+export type QueryLengthBucket = '0' | '1-3' | '4-10' | '11-30' | '31+';
+
+export function bucketQueryLength(value: string | number | null | undefined): QueryLengthBucket {
+  const length = typeof value === 'number' ? value : String(value ?? '').trim().length;
+  if (length <= 0) {
+    return '0';
+  }
+  if (length <= 3) {
+    return '1-3';
+  }
+  if (length <= 10) {
+    return '4-10';
+  }
+  if (length <= 30) {
+    return '11-30';
+  }
+  return '31+';
+}

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -101,4 +101,209 @@ suite('cli telemetry', () => {
     __resetExecFileImplForTests();
     assert.ok(calls.some(c => c.properties?.code === 'ETIMEDOUT'));
   });
+
+  test('classifies default-org CLI failures without leaking exit code 1', async () => {
+    const calls: any[] = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      const err: any = new Error('default org missing');
+      err.code = 1;
+      cb(err, '', 'No default username found. Use -o or set a default org.');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(
+      calls.some(c => c.name === 'cli.exec' && c.properties?.code === 'DEFAULT_ORG_MISSING'),
+      'expected cli.exec to classify the error'
+    );
+    assert.ok(
+      calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'DEFAULT_ORG_MISSING'),
+      'expected cli.getOrgAuth to reuse the classified code'
+    );
+    assert.ok(!calls.some(c => c.properties?.code === '1'), 'should not emit the raw exit code 1');
+  });
+
+  test('classifies empty CLI output during auth parsing', async () => {
+    const calls: any[] = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      cb(null, '   ', '');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'EMPTY_OUTPUT'));
+    assert.ok(!calls.some(c => c.properties?.code === '1'), 'should not emit the raw exit code 1');
+  });
+
+  test('classifies invalid CLI JSON during auth parsing', async () => {
+    const calls: any[] = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      cb(null, 'not-json', '');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'INVALID_JSON'));
+    assert.ok(!calls.some(c => c.properties?.code === '1'), 'should not emit the raw exit code 1');
+  });
+
+  test('classifies missing auth fields when CLI JSON lacks credentials', async () => {
+    const calls: any[] = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((_program: string, _args: readonly string[] | undefined, _opts: any, cb: any) => {
+      cb(null, JSON.stringify({ result: { username: 'user@example.com' } }), '');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined));
+    __resetExecFileImplForTests();
+    assert.ok(calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'MISSING_AUTH_FIELDS'));
+    assert.ok(!calls.some(c => c.properties?.code === '1'), 'should not emit the raw exit code 1');
+  });
 });

--- a/src/test/debugFlagsPanel.test.ts
+++ b/src/test/debugFlagsPanel.test.ts
@@ -1,17 +1,22 @@
 import assert from 'assert/strict';
 import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
 import * as traceflags from '../salesforce/traceflags';
+import * as telemetry from '../shared/telemetry';
 import { createEmptyDebugLevelRecord } from '../shared/debugLevelPresets';
 
 suite('DebugFlagsPanel', () => {
   const originalListDebugLevelDetails = traceflags.listDebugLevelDetails;
   const originalGetActiveUserDebugLevel = traceflags.getActiveUserDebugLevel;
   const originalGetTraceFlagTargetStatus = traceflags.getTraceFlagTargetStatus;
+  const originalListActiveUsers = traceflags.listActiveUsers;
+  const originalSafeSendEvent = telemetry.safeSendEvent;
 
   teardown(() => {
     (traceflags as any).listDebugLevelDetails = originalListDebugLevelDetails;
     (traceflags as any).getActiveUserDebugLevel = originalGetActiveUserDebugLevel;
     (traceflags as any).getTraceFlagTargetStatus = originalGetTraceFlagTargetStatus;
+    (traceflags as any).listActiveUsers = originalListActiveUsers;
+    (telemetry as any).safeSendEvent = originalSafeSendEvent;
   });
 
   test('sendDebugLevelData ignores stale bootstrap results', async () => {
@@ -96,5 +101,69 @@ suite('DebugFlagsPanel', () => {
     assert.equal(panelLike.selectedOrg, 'new@example.com');
     assert.equal(panelLike.selectedTarget, undefined);
     assert.equal(bootstrapped, 1);
+  });
+
+  test('searchUsers emits sanitized telemetry on success', async () => {
+    const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
+    (telemetry as any).safeSendEvent = (name: string, properties?: Record<string, string>, measurements?: Record<string, number>) => {
+      events.push({ name, properties, measurements });
+    };
+    (traceflags as any).listActiveUsers = async () => [
+      { id: '005000000000001AAA', name: 'Alice', username: 'alice@example.com' },
+      { id: '005000000000002AAA', name: 'Bob', username: 'bob@example.com' }
+    ];
+
+    const panelLike = {
+      disposed: false,
+      usersToken: 0,
+      usersQuery: 'alice',
+      lastSourceView: 'logs',
+      selectedTarget: undefined,
+      getSelectedAuth: async () => ({ username: 'user@example.com' }),
+      post: () => undefined
+    };
+
+    await (DebugFlagsPanel as any).prototype.searchUsers.call(panelLike);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.name, 'debugFlags.searchUsers');
+    assert.deepEqual(events[0]?.properties, {
+      outcome: 'ok',
+      sourceView: 'logs',
+      queryLength: '4-10'
+    });
+    assert.equal(events[0]?.measurements?.count, 2);
+    assert.equal(typeof events[0]?.measurements?.durationMs, 'number');
+  });
+
+  test('searchUsers emits sanitized telemetry on error', async () => {
+    const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
+    (telemetry as any).safeSendEvent = (name: string, properties?: Record<string, string>, measurements?: Record<string, number>) => {
+      events.push({ name, properties, measurements });
+    };
+    (traceflags as any).listActiveUsers = async () => {
+      throw new Error('boom');
+    };
+
+    const panelLike = {
+      disposed: false,
+      usersToken: 0,
+      usersQuery: '',
+      lastSourceView: 'tail',
+      selectedTarget: undefined,
+      getSelectedAuth: async () => ({ username: 'user@example.com' }),
+      post: () => undefined
+    };
+
+    await (DebugFlagsPanel as any).prototype.searchUsers.call(panelLike);
+
+    assert.equal(events.length, 1);
+    assert.equal(events[0]?.name, 'debugFlags.searchUsers');
+    assert.deepEqual(events[0]?.properties, {
+      outcome: 'error',
+      sourceView: 'tail',
+      queryLength: '0'
+    });
+    assert.equal(typeof events[0]?.measurements?.durationMs, 'number');
   });
 });

--- a/src/test/logsMessageHandler.test.ts
+++ b/src/test/logsMessageHandler.test.ts
@@ -1,0 +1,81 @@
+import assert from 'assert/strict';
+
+const proxyquire: any = require('proxyquire').noCallThru();
+
+suite('LogsMessageHandler telemetry', () => {
+  function createHandler(events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }>) {
+    const { LogsMessageHandler } = proxyquire('../provider/logsMessageHandler', {
+      '../shared/telemetry': {
+        safeSendEvent: (name: string, properties?: Record<string, string>, measurements?: Record<string, number>) => {
+          events.push({ name, properties, measurements });
+        },
+        '@noCallThru': true
+      },
+      '../utils/logger': {
+        logInfo: () => undefined,
+        '@noCallThru': true
+      }
+    });
+
+    return new LogsMessageHandler(
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      () => undefined,
+      async () => undefined,
+      async () => undefined
+    );
+  }
+
+  test('emits logs.search for sanitized search telemetry messages', async () => {
+    const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
+    const handler = createHandler(events);
+
+    await handler.handle({ type: 'trackLogsSearch', outcome: 'searched', queryLength: '4-10' } as any);
+
+    assert.deepEqual(events, [
+      {
+        name: 'logs.search',
+        properties: { outcome: 'searched', queryLength: '4-10' },
+        measurements: undefined
+      }
+    ]);
+  });
+
+  test('emits logs.filter for sanitized filter telemetry messages', async () => {
+    const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
+    const handler = createHandler(events);
+
+    await handler.handle({
+      type: 'trackLogsFilter',
+      outcome: 'changed',
+      hasUser: false,
+      hasOperation: true,
+      hasStatus: false,
+      hasCodeUnit: false,
+      errorsOnly: true,
+      activeCount: 2
+    } as any);
+
+    assert.deepEqual(events, [
+      {
+        name: 'logs.filter',
+        properties: {
+          outcome: 'changed',
+          hasUser: 'false',
+          hasOperation: 'true',
+          hasStatus: 'false',
+          hasCodeUnit: 'false',
+          errorsOnly: 'true'
+        },
+        measurements: { activeCount: 2 }
+      }
+    ]);
+  });
+});

--- a/src/webview/__tests__/logsApp.test.tsx
+++ b/src/webview/__tests__/logsApp.test.tsx
@@ -24,6 +24,10 @@ describe('Logs webview App', () => {
     });
   }
 
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('responds to extension messages and exposes key actions', async () => {
     const { vscode, posted } = createVsCodeMock();
     const bus = new EventTarget();
@@ -251,6 +255,66 @@ describe('Logs webview App', () => {
     await waitFor(() => {
       const loadCalls = posted.filter(msg => msg.type === 'loadMore').length;
       expect(loadCalls).toBeGreaterThan(baselineLoads);
+    });
+  });
+
+  it('posts sanitized telemetry messages for search and filters', async () => {
+    jest.useFakeTimers();
+
+    const { vscode, posted } = createVsCodeMock();
+    const bus = new EventTarget();
+    render(<LogsApp vscode={vscode} messageBus={bus} />);
+
+    sendMessage(bus, {
+      type: 'logs',
+      data: [
+        {
+          Id: '07L00000000000AAW',
+          StartTime: '2025-09-21T22:10:00.000Z',
+          Operation: 'ExecuteAnonymous',
+          Application: 'Developer Console',
+          DurationMilliseconds: 90,
+          Status: 'Success',
+          Request: 'XYZ',
+          LogLength: 1024,
+          LogUser: { Name: 'Alice' }
+        }
+      ],
+      hasMore: false
+    });
+    sendMessage(bus, { type: 'loading', value: false });
+
+    const searchInput = screen.getByPlaceholderText('Search logs…');
+    fireEvent.change(searchInput, { target: { value: 'error' } });
+
+    await act(async () => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(posted).toEqual(
+      expect.arrayContaining([
+        { type: 'trackLogsSearch', outcome: 'searched', queryLength: '4-10' } as any
+      ])
+    );
+
+    const errorsOnlySwitch = screen.getByTestId('logs-errors-only-switch');
+    fireEvent.click(errorsOnlySwitch);
+
+    await waitFor(() => {
+      expect(posted).toEqual(
+        expect.arrayContaining([
+          {
+            type: 'trackLogsFilter',
+            outcome: 'changed',
+            hasUser: false,
+            hasOperation: false,
+            hasStatus: false,
+            hasCodeUnit: false,
+            errorsOnly: true,
+            activeCount: 1
+          } as any
+        ])
+      );
     });
   });
 

--- a/src/webview/main.tsx
+++ b/src/webview/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from 'react-dom/client';
 import { getMessages, type Messages } from './i18n';
 import type { OrgItem, ApexLogRow } from '../shared/types';
 import type { ExtensionToWebviewMessage, WebviewToExtensionMessage } from '../shared/messages';
+import { bucketQueryLength } from '../shared/telemetryBuckets';
 import {
   DEFAULT_LOGS_COLUMNS_CONFIG,
   normalizeLogsColumnsConfig,
@@ -57,6 +58,8 @@ export function LogsApp({
   const queryRef = useRef('');
   const [searchStatus, setSearchStatus] = useState<'idle' | 'loading'>('idle');
   const [pendingLogCount, setPendingLogCount] = useState(0);
+  const lastTrackedSearchRef = useRef<string | undefined>(undefined);
+  const lastTrackedFilterStateRef = useRef<string | undefined>(undefined);
 
   // Search + filters
   const [query, setQueryState] = useState('');
@@ -204,6 +207,82 @@ export function LogsApp({
       setPendingLogCount(0);
     }
   }, [query]);
+
+  useEffect(() => {
+    if (!messageBus) {
+      return;
+    }
+    const normalized = query.trim();
+    const previousTracked = lastTrackedSearchRef.current;
+    const timeout = window.setTimeout(() => {
+      if (!normalized) {
+        if (!previousTracked) {
+          lastTrackedSearchRef.current = '';
+          return;
+        }
+        vscode.postMessage({ type: 'trackLogsSearch', outcome: 'cleared' });
+        lastTrackedSearchRef.current = '';
+        return;
+      }
+
+      const nextTracked = normalized.toLowerCase();
+      if (previousTracked === nextTracked) {
+        return;
+      }
+      const queryLength = bucketQueryLength(normalized);
+      if (queryLength === '0') {
+        return;
+      }
+
+      vscode.postMessage({
+        type: 'trackLogsSearch',
+        outcome: 'searched',
+        queryLength
+      });
+      lastTrackedSearchRef.current = nextTracked;
+    }, 350);
+
+    return () => window.clearTimeout(timeout);
+  }, [messageBus, query, vscode]);
+
+  useEffect(() => {
+    if (!messageBus) {
+      return;
+    }
+    const rawState = JSON.stringify({
+      filterUser,
+      filterOperation,
+      filterStatus,
+      filterCodeUnit,
+      errorsOnly
+    });
+    const previousTracked = lastTrackedFilterStateRef.current;
+    if (previousTracked === undefined) {
+      lastTrackedFilterStateRef.current = rawState;
+      return;
+    }
+    if (previousTracked === rawState) {
+      return;
+    }
+
+    const hasUser = Boolean(filterUser);
+    const hasOperation = Boolean(filterOperation);
+    const hasStatus = Boolean(filterStatus);
+    const hasCodeUnit = Boolean(filterCodeUnit);
+    const activeCount = [hasUser, hasOperation, hasStatus, hasCodeUnit, errorsOnly].filter(Boolean).length;
+
+    vscode.postMessage({
+      type: 'trackLogsFilter',
+      outcome: activeCount === 0 ? 'cleared' : 'changed',
+      hasUser,
+      hasOperation,
+      hasStatus,
+      hasCodeUnit,
+      errorsOnly,
+      activeCount
+    });
+    lastTrackedFilterStateRef.current = rawState;
+  }, [errorsOnly, filterCodeUnit, filterOperation, filterStatus, filterUser, messageBus, vscode]);
 
   const onRefresh = () => {
     vscode.postMessage({ type: 'refresh' });

--- a/telemetry.json
+++ b/telemetry.json
@@ -273,6 +273,64 @@
         }
       }
     },
+    "logs.search": {
+      "description": "Search usage in the logs view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["searched", "cleared"]
+        },
+        "queryLength": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["1-3", "4-10", "11-30", "31+"]
+        }
+      }
+    },
+    "logs.filter": {
+      "description": "Filter usage in the logs view.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["changed", "cleared"]
+        },
+        "hasUser": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        },
+        "hasOperation": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        },
+        "hasStatus": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        },
+        "hasCodeUnit": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        },
+        "errorsOnly": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["true", "false"]
+        }
+      },
+      "measurements": {
+        "activeCount": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
     "logs.cleanup": {
       "description": "Log-cleanup outcome from the logs or debug-flags views.",
       "properties": {
@@ -398,6 +456,38 @@
           "purpose": "PerformanceAndHealth"
         },
         "removedCount": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight"
+        }
+      }
+    },
+    "debugFlags.searchUsers": {
+      "description": "User search outcome in the Debug Flags panel.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        },
+        "sourceView": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["logs", "tail", "unknown"]
+        },
+        "queryLength": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "values": ["0", "1-3", "4-10", "11-30", "31+"]
+        }
+      },
+      "measurements": {
+        "durationMs": {
+          "classification": "SystemMetaData",
+          "purpose": "PerformanceAndHealth"
+        },
+        "count": {
           "classification": "SystemMetaData",
           "purpose": "FeatureInsight"
         }


### PR DESCRIPTION
# Pull Request Template

## Conventional Commit Title
- `feat(telemetry): improve observability coverage`

## Summary
- Add sanitized telemetry for logs search/filter and Debug Flags user search.
- Replace raw CLI exit-code buckets with classified telemetry codes so Azure Monitor shows actionable root causes instead of generic `1`.
- Update the `babysit-pr` watcher/skill so review approval is no longer treated as a readiness gate when the PR is already green and mergeable.

## Linked Issues
- None found.

## Screenshots / GIFs (UI)
- Not applicable. The webview changes are telemetry-only and do not change visible UI behavior.

## Verification Steps
- `npm run build`
- `npm test`
- `npm run lint`
- `npm run check-types`
- `python3 -m unittest discover -s .codex/skills/babysit-pr/scripts -p "test_*.py"`
- `python3 -m py_compile .codex/skills/babysit-pr/scripts/gh_pr_watch.py .codex/skills/babysit-pr/scripts/gh_pr_codex_feedback.py .codex/skills/babysit-pr/scripts/test_review_bots.py .codex/skills/babysit-pr/scripts/test_ready_state.py`
- `git diff --check`

## Risk / Rollback
- Low to medium risk. The product-facing changes are limited to telemetry emission paths and tests, while the babysitter change only affects local PR monitoring logic.
- Roll back by reverting commit `4819652` for the babysitter behavior or `25ab5b8` for the telemetry changes.

## Checklist
- [x] `npm run build` passes
- [x] `npm test` (or `npm run test:all`) passes; integration tests prefixed with `integration`
- [x] Lint/Types: `npm run lint` and `npm run check-types`
- [x] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added
