### PR TITLE
chore(release): prepare 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 ## Unreleased
 
+## [0.36.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.34.0...v0.36.0) (2026-03-23)
+
+### Features
+
+- Telemetry: instrument log search/filter flows, emit sanitized Debug Flags search telemetry, and classify Salesforce CLI failures into stable telemetry error codes for improved observability. ([#634](https://github.com/Electivus/Apex-Log-Viewer/pull/634))
+
+### Chores
+
+- Telemetry/ops: add Azure Monitor infrastructure, deployment/reporting helpers, and telemetry-aware Playwright E2E configuration for maintainers. ([#632](https://github.com/Electivus/Apex-Log-Viewer/pull/632))
+- CI/E2E: reuse a shared scratch org in GitHub Actions with serialized access and auth secret rotation to reduce scratch-org churn across pull requests. ([#628](https://github.com/Electivus/Apex-Log-Viewer/pull/628))
+- Docs/maintainers: remove outdated design and plan documents that no longer reflect the current architecture and release workflow. ([#626](https://github.com/Electivus/Apex-Log-Viewer/pull/626))
+
+### Tests
+
+- Telemetry: add coverage for search/filter instrumentation, sanitized debug-flag telemetry payloads, CLI error classification, and the related webview/extension host flows. ([#634](https://github.com/Electivus/Apex-Log-Viewer/pull/634))
+- E2E/CI: add scratch-org reuse coverage so the GitHub Actions lifecycle keeps the shared org and secret rotation behavior under test. ([#628](https://github.com/Electivus/Apex-Log-Viewer/pull/628))
+
 ## [0.34.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.32.0...v0.34.0) (2026-03-20)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.34.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.34.0",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.34.0",
+  "version": "0.36.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
# Pull Request Template

## Conventional Commit Title
- `chore(release): prepare 0.36.0`

## Summary
- Bump `package.json` and `package-lock.json` to `0.36.0` for the next stable channel release.
- Add the `0.36.0` changelog entry covering the changes since `v0.34.0`.
- Prepare the stable release PR for the even-minor `0.36.x` channel.

## Linked Issues
- None.

## Screenshots / GIFs (UI)
- Not applicable.

## Verification Steps
- `npm run build` (passed locally under Node `22.22.1` via `nvm use 22`).
- `npm run test:ci`:
- `test:unit:ci` passed locally.
- `test:integration:ci` stalled after launching VS Code Stable with the Salesforce extensions installed; the local run reported an unresponsive extension host and was terminated after capturing the hang.

## Risk / Rollback
- Low risk: release metadata only (`CHANGELOG.md`, `package.json`, `package-lock.json`).
- Roll back by reverting commit `eadfe2e` or by closing this PR if `0.36.0` should not proceed.
