### PR TITLE
[codex] chore(release): prepare 0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+## [0.36.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.34.0...v0.36.0) (2026-03-23)
+
+### Features
+
+- Telemetry: expand observability coverage with sanitized Logs search/filter and Debug Flags user-search events, classified CLI failure codes, and updated telemetry schema coverage for Azure Monitor analysis. ([#634](https://github.com/Electivus/Apex-Log-Viewer/pull/634))
+
+### Bug Fixes
+
+- Maintainers/automation: make the repo-local `babysit-pr` watcher understand Copilot feedback, keep Codex Eyes reviews in the in-review state, and consolidate trusted bot review handling so readiness tracking matches actual mergeability. ([#633](https://github.com/Electivus/Apex-Log-Viewer/pull/633)) ([#637](https://github.com/Electivus/Apex-Log-Viewer/pull/637)) ([#640](https://github.com/Electivus/Apex-Log-Viewer/pull/640))
+
+### Chores
+
+- Maintainers/automation: add the repo-local `babysit-pr` skill and supporting scripts for PR monitoring workflows. ([#627](https://github.com/Electivus/Apex-Log-Viewer/pull/627))
+- Telemetry/ops: add versioned Azure Monitor infrastructure, workbook scaffolding, deployment/report helpers, and docs/CI updates for telemetry-enabled validation flows. ([#632](https://github.com/Electivus/Apex-Log-Viewer/pull/632))
+- Docs/specs: remove outdated support-minimization and lazy-replay planning documents and replace them with the finalized new-window launch design. ([#626](https://github.com/Electivus/Apex-Log-Viewer/pull/626)) ([226f978](https://github.com/Electivus/Apex-Log-Viewer/commit/226f978ddbb3d8daab3843f8c0d2189062e5b208)) ([54e89e9](https://github.com/Electivus/Apex-Log-Viewer/commit/54e89e9b00f0bbe6db6d7e8a0a6ac4a797c31c50)) ([a9b73fb](https://github.com/Electivus/Apex-Log-Viewer/commit/a9b73fb3ce4984b3b6bbe5173583fec201f3294e))
+
+### Tests
+
+- E2E/CI: reuse a shared scratch org in GitHub Actions, serialize concurrent runs, rotate the auth URL, and extend scratch-org reuse coverage. ([#628](https://github.com/Electivus/Apex-Log-Viewer/pull/628))
+
 ## [0.34.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.32.0...v0.34.0) (2026-03-20)
 
 ### Features

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.34.0",
+  "version": "0.36.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "apex-log-viewer",
-      "version": "0.34.0",
+      "version": "0.36.0",
       "license": "MIT",
       "dependencies": {
         "@jsforce/jsforce-node": "^3.10.14",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.34.0",
+  "version": "0.36.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
## Summary

This PR prepares the stable `0.36.0` release.

It bumps `package.json` and `package-lock.json` from `0.34.0` to `0.36.0` and adds a `CHANGELOG.md` section covering everything merged since `v0.34.0`, including the `0.35.x` pre-release train.

## Why

This repository treats even minor versions as stable releases. `0.36.0` is the next stable after `0.34.0`, so the release PR needs to consolidate the work that landed through `0.35.1`, `0.35.2`, and `0.35.3` before the release tag is created.

## Changelog Coverage

- telemetry observability improvements and Azure Monitor ops automation
- repo-local `babysit-pr` skill introduction plus reviewer-handling fixes
- GitHub Actions E2E scratch-org reuse
- docs/spec cleanup and finalized new-window launch design

## Verification

- `source ~/.nvm/nvm.sh && nvm use >/dev/null && npm run build`
- `source ~/.nvm/nvm.sh && nvm use >/dev/null && npm run test:ci`
