### PR TITLE
[codex] add editor-area logs and tail views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Logs/Tail: add optional editor-area tabs for the main Logs and Tail webviews, keeping the default docked panels intact while letting users move those sessions into other editor groups or windows.
+
 ### Bug Fixes
 
 - Tail/Docs: refresh the Tail view bootstrap when reopening it, keep debug-level selection resilient for scratch-org flows, and close VS Code auxiliary UI during docs capture so maintainer screenshots stay stable and complete.
@@ -13,6 +17,7 @@
 ### Tests
 
 - Docs/E2E: add a manual `npm run docs:screenshots` flow that seeds deterministic scratch-org data, captures the README PNG set, and exercises the refreshed docs-maintenance path.
+- Logs/Tail: cover editor-area commands, singleton editor panels, editor-hosted webview lifecycle, and telemetry catalog updates for the new editor-entry flows.
 
 ## [0.36.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.34.0...v0.36.0) (2026-03-23)
 

--- a/package.json
+++ b/package.json
@@ -358,14 +358,12 @@
       {
         "command": "sfLogs.openLogsEditor",
         "title": "%command.openLogsEditor.title%",
-        "category": "Electivus Apex Logs",
-        "icon": "$(open-preview)"
+        "category": "Electivus Apex Logs"
       },
       {
         "command": "sfLogs.openTailEditor",
         "title": "%command.openTailEditor.title%",
-        "category": "Electivus Apex Logs",
-        "icon": "$(open-preview)"
+        "category": "Electivus Apex Logs"
       },
       {
         "command": "sfLogs.openLogInViewer",

--- a/package.json
+++ b/package.json
@@ -356,6 +356,18 @@
         "category": "Electivus Apex Logs"
       },
       {
+        "command": "sfLogs.openLogsEditor",
+        "title": "%command.openLogsEditor.title%",
+        "category": "Electivus Apex Logs",
+        "icon": "$(open-preview)"
+      },
+      {
+        "command": "sfLogs.openTailEditor",
+        "title": "%command.openTailEditor.title%",
+        "category": "Electivus Apex Logs",
+        "icon": "$(open-preview)"
+      },
+      {
         "command": "sfLogs.openLogInViewer",
         "title": "%command.openLogInViewer.title%",
         "category": "Electivus Apex Logs"
@@ -389,19 +401,31 @@
     "menus": {
       "view/title": [
         {
+          "command": "sfLogs.openLogsEditor",
+          "when": "view == sfLogViewer",
+          "group": "navigation@10",
+          "icon": "$(open-preview)"
+        },
+        {
+          "command": "sfLogs.openTailEditor",
+          "when": "view == sfLogTail",
+          "group": "navigation@10",
+          "icon": "$(open-preview)"
+        },
+        {
           "command": "sfLogs.troubleshootWebview",
           "when": "view == sfLogViewer || view == sfLogTail",
-          "group": "navigation@97"
+          "group": "moreActions@97"
         },
         {
           "command": "sfLogs.resetCliCache",
           "when": "view == sfLogViewer || view == sfLogTail",
-          "group": "navigation@98"
+          "group": "moreActions@98"
         },
         {
           "command": "sfLogs.showOutput",
           "when": "view == sfLogViewer || view == sfLogTail",
-          "group": "navigation@99"
+          "group": "moreActions@99"
         }
       ],
       "editor/title": [

--- a/package.nls.json
+++ b/package.nls.json
@@ -8,6 +8,8 @@
   "command.refresh.title": "Refresh Logs",
   "command.selectOrg.title": "Select Org",
   "command.tail.title": "Tail Logs",
+  "command.openLogsEditor.title": "Open Logs in Editor Area",
+  "command.openTailEditor.title": "Open Tail in Editor Area",
   "command.openLogInViewer.title": "Open in Apex Log Viewer",
   "command.troubleshootWebview.title": "Troubleshoot Webview Error",
   "configuration.title": "Electivus Apex Logs",

--- a/package.nls.pt-br.json
+++ b/package.nls.pt-br.json
@@ -8,6 +8,8 @@
   "command.refresh.title": "Atualizar Logs",
   "command.selectOrg.title": "Selecionar Org",
   "command.tail.title": "Tail de Logs",
+  "command.openLogsEditor.title": "Abrir Logs na Área do Editor",
+  "command.openTailEditor.title": "Abrir Tail na Área do Editor",
   "command.openLogInViewer.title": "Abrir no Apex Log Viewer",
   "command.troubleshootWebview.title": "Corrigir Erro de Webview",
   "configuration.title": "Electivus Apex Logs",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,6 +11,8 @@ import { activateTelemetry, safeSendEvent, safeSendException, disposeTelemetry }
 import { CacheManager } from './utils/cacheManager';
 import { LogViewerPanel } from './panel/LogViewerPanel';
 import { DebugFlagsPanel } from './panel/DebugFlagsPanel';
+import { LogsEditorPanel } from './panel/LogsEditorPanel';
+import { TailEditorPanel } from './panel/TailEditorPanel';
 import { getBooleanConfig, affectsConfiguration } from './utils/config';
 import { getErrorMessage } from './utils/error';
 import { listOrgs, getOrgAuth } from './salesforce/cli';
@@ -37,6 +39,8 @@ export async function activate(context: vscode.ExtensionContext) {
   const activationStart = Date.now();
   LogViewerPanel.initialize(context);
   DebugFlagsPanel.initialize(context);
+  LogsEditorPanel.initialize(context);
+  TailEditorPanel.initialize(context);
   const salesforceProject = await findSalesforceProjectInfo();
   const hasSalesforceProject = !!salesforceProject;
   // Init TTL cache (best-effort; no-op if unavailable)
@@ -85,6 +89,7 @@ export async function activate(context: vscode.ExtensionContext) {
   }
   const provider = new SfLogsViewProvider(context);
   context.subscriptions.push(
+    provider,
     vscode.window.registerWebviewViewProvider(SfLogsViewProvider.viewType, provider, {
       webviewOptions: { retainContextWhenHidden: true }
     })
@@ -93,6 +98,7 @@ export async function activate(context: vscode.ExtensionContext) {
   // Register Tail view provider
   const tailProvider = new SfLogTailViewProvider(context);
   context.subscriptions.push(
+    tailProvider,
     vscode.window.registerWebviewViewProvider(SfLogTailViewProvider.viewType, tailProvider, {
       webviewOptions: { retainContextWhenHidden: true }
     })
@@ -166,6 +172,30 @@ export async function activate(context: vscode.ExtensionContext) {
         await tailProvider.refreshViewState();
       } catch (e) {
         logWarn('Command sfLogs.tail: failed to open tail view ->', getErrorMessage(e));
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sfLogs.openLogsEditor', async () => {
+      safeSendEvent('command.openLogsEditor', { outcome: 'invoked' });
+      try {
+        await LogsEditorPanel.show({ selectedOrg: provider.getSelectedOrg() });
+      } catch (e) {
+        logWarn('Command sfLogs.openLogsEditor failed ->', getErrorMessage(e));
+        safeSendEvent('command.openLogsEditor', { outcome: 'error' });
+      }
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sfLogs.openTailEditor', async () => {
+      safeSendEvent('command.openTailEditor', { outcome: 'invoked' });
+      try {
+        await TailEditorPanel.show({ selectedOrg: tailProvider.getSelectedOrg() ?? provider.getSelectedOrg() });
+      } catch (e) {
+        logWarn('Command sfLogs.openTailEditor failed ->', getErrorMessage(e));
+        safeSendEvent('command.openTailEditor', { outcome: 'error' });
       }
     })
   );

--- a/src/panel/LogsEditorPanel.ts
+++ b/src/panel/LogsEditorPanel.ts
@@ -23,6 +23,7 @@ export class LogsEditorPanel {
 
     if (this.instance) {
       this.instance.reveal();
+      await this.instance.syncSelectedOrg(options?.selectedOrg);
       return;
     }
 
@@ -56,6 +57,10 @@ export class LogsEditorPanel {
 
   private reveal(): void {
     this.panel.reveal(undefined, false);
+  }
+
+  private async syncSelectedOrg(selectedOrg?: string): Promise<void> {
+    await this.controller.syncSelectedOrg(selectedOrg);
   }
 
   private dispose(): void {

--- a/src/panel/LogsEditorPanel.ts
+++ b/src/panel/LogsEditorPanel.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
+import { localize } from '../utils/localize';
+
+interface ShowOptions {
+  selectedOrg?: string;
+}
+
+export class LogsEditorPanel {
+  private static context: vscode.ExtensionContext | undefined;
+  private static instance: LogsEditorPanel | undefined;
+  private static readonly viewType = 'sfLogViewer.editorPanel';
+
+  static initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
+  }
+
+  static async show(options?: ShowOptions): Promise<void> {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+
+    if (this.instance) {
+      this.instance.reveal();
+      return;
+    }
+
+    this.instance = new LogsEditorPanel(context, options);
+  }
+
+  private readonly panel: vscode.WebviewPanel;
+  private readonly controller: SfLogsViewProvider;
+
+  private constructor(context: vscode.ExtensionContext, options?: ShowOptions) {
+    this.controller = new SfLogsViewProvider(context);
+    if (typeof options?.selectedOrg === 'string' && options.selectedOrg.trim()) {
+      this.controller.setSelectedOrg(options.selectedOrg);
+    }
+
+    this.panel = vscode.window.createWebviewPanel(
+      LogsEditorPanel.viewType,
+      localize('salesforce.logs.view.name', 'Electivus Apex Logs'),
+      { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')]
+      }
+    );
+
+    this.controller.resolveWebviewPanel(this.panel);
+    this.panel.onDidDispose(() => this.dispose());
+    context.subscriptions.push(this.panel);
+  }
+
+  private reveal(): void {
+    this.panel.reveal(undefined, false);
+  }
+
+  private dispose(): void {
+    if (LogsEditorPanel.instance === this) {
+      LogsEditorPanel.instance = undefined;
+    }
+    this.controller.dispose();
+  }
+}

--- a/src/panel/TailEditorPanel.ts
+++ b/src/panel/TailEditorPanel.ts
@@ -1,0 +1,67 @@
+import * as vscode from 'vscode';
+import { SfLogTailViewProvider } from '../provider/SfLogTailViewProvider';
+import { localize } from '../utils/localize';
+
+interface ShowOptions {
+  selectedOrg?: string;
+}
+
+export class TailEditorPanel {
+  private static context: vscode.ExtensionContext | undefined;
+  private static instance: TailEditorPanel | undefined;
+  private static readonly viewType = 'sfLogTail.editorPanel';
+
+  static initialize(context: vscode.ExtensionContext): void {
+    this.context = context;
+  }
+
+  static async show(options?: ShowOptions): Promise<void> {
+    const context = this.context;
+    if (!context) {
+      return;
+    }
+
+    if (this.instance) {
+      this.instance.reveal();
+      return;
+    }
+
+    this.instance = new TailEditorPanel(context, options);
+  }
+
+  private readonly panel: vscode.WebviewPanel;
+  private readonly controller: SfLogTailViewProvider;
+
+  private constructor(context: vscode.ExtensionContext, options?: ShowOptions) {
+    this.controller = new SfLogTailViewProvider(context);
+    if (typeof options?.selectedOrg === 'string' && options.selectedOrg.trim()) {
+      this.controller.setSelectedOrg(options.selectedOrg);
+    }
+
+    this.panel = vscode.window.createWebviewPanel(
+      TailEditorPanel.viewType,
+      localize('salesforce.tail.view.name', 'Electivus Apex Logs Tail'),
+      { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [vscode.Uri.joinPath(context.extensionUri, 'media')]
+      }
+    );
+
+    this.controller.resolveWebviewPanel(this.panel);
+    this.panel.onDidDispose(() => this.dispose());
+    context.subscriptions.push(this.panel);
+  }
+
+  private reveal(): void {
+    this.panel.reveal(undefined, false);
+  }
+
+  private dispose(): void {
+    if (TailEditorPanel.instance === this) {
+      TailEditorPanel.instance = undefined;
+    }
+    this.controller.dispose();
+  }
+}

--- a/src/panel/TailEditorPanel.ts
+++ b/src/panel/TailEditorPanel.ts
@@ -23,6 +23,7 @@ export class TailEditorPanel {
 
     if (this.instance) {
       this.instance.reveal();
+      await this.instance.syncSelectedOrg(options?.selectedOrg);
       return;
     }
 
@@ -56,6 +57,10 @@ export class TailEditorPanel {
 
   private reveal(): void {
     this.panel.reveal(undefined, false);
+  }
+
+  private async syncSelectedOrg(selectedOrg?: string): Promise<void> {
+    await this.controller.syncSelectedOrg(selectedOrg);
   }
 
   private dispose(): void {

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -212,6 +212,26 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     this.selectedOrg = username;
   }
 
+  public async syncSelectedOrg(username?: string): Promise<void> {
+    const next = typeof username === 'string' ? username.trim() || undefined : undefined;
+    if (!next || next === this.selectedOrg) {
+      return;
+    }
+
+    const previous = this.selectedOrg;
+    this.setSelectedOrg(next);
+    this.tailService.setOrg(next);
+    if (previous !== next) {
+      this.tailService.stop();
+    }
+
+    if (!this.view || this.disposed) {
+      return;
+    }
+
+    await this.refreshViewState();
+  }
+
   private async sendDebugLevels(): Promise<void> {
     const t0 = Date.now();
     // Load auth; if this fails, surface empty list once

--- a/src/provider/SfLogTailViewProvider.ts
+++ b/src/provider/SfLogTailViewProvider.ts
@@ -14,10 +14,14 @@ import { getNumberConfig, affectsConfiguration } from '../utils/config';
 import { getErrorMessage } from '../utils/error';
 import { LogViewerPanel } from '../panel/LogViewerPanel';
 import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
+import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
 
-export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
+export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = 'sfLogTail';
-  private view?: vscode.WebviewView;
+  private view?: { webview: vscode.Webview };
+  private host?: BoundWebviewHost;
+  private readonly disposables: vscode.Disposable[] = [];
+  private hostDisposables: vscode.Disposable[] = [];
   private disposed = false;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
@@ -26,7 +30,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     this.tailService.setOrg(this.selectedOrg);
 
     // React to tail buffer size changes live
-    this.context.subscriptions.push(
+    this.disposables.push(
       vscode.workspace.onDidChangeConfiguration(e => {
         if (affectsConfiguration(e, 'sfLogs.tailBufferSize')) {
           try {
@@ -38,52 +42,32 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         }
       })
     );
-  }
-
-  resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
-    this.view = webviewView;
-    this.disposed = false;
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
-    };
-    webviewView.webview.html = this.getHtmlForWebview(webviewView.webview);
-    logInfo('Tail webview resolved.');
-
-    this.context.subscriptions.push(
-      webviewView.onDidDispose(() => {
-        this.disposed = true;
-        this.view = undefined;
-        // Stop timers and clear caches, but keep TailService reusable when the view reopens
-        this.tailService.stop();
-        logInfo('Tail webview disposed; stopped tail.');
-      })
-    );
-
-    this.context.subscriptions.push(
-      webviewView.onDidChangeVisibility(() => {
-        if (!webviewView.visible || this.disposed) {
-          return;
-        }
-        void this.refreshViewState();
-      })
-    );
 
     // Track window activity to adapt polling cadence (requires VS Code 1.89+; @types 1.90)
     try {
       this.tailService.setWindowActive(vscode.window.state?.active ?? true);
-      const d = vscode.window.onDidChangeWindowState(e => {
-        this.tailService.setWindowActive(e.active);
-        if (e.active && this.tailService.isRunning() && !this.disposed) {
-          this.tailService.promptPoll();
-        }
-      });
-      this.context.subscriptions.push(d);
+      this.disposables.push(
+        vscode.window.onDidChangeWindowState(e => {
+          this.tailService.setWindowActive(e.active);
+          if (e.active && this.tailService.isRunning() && !this.disposed) {
+            this.tailService.promptPoll();
+          }
+        })
+      );
     } catch (e) {
       logWarn('Tail: window state tracking failed ->', getErrorMessage(e));
     }
+  }
 
-    webviewView.webview.onDidReceiveMessage(async (message: WebviewToExtensionMessage) => {
+  resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
+    this.bindHost(createWebviewViewHost(webviewView));
+  }
+
+  public resolveWebviewPanel(panel: vscode.WebviewPanel): void {
+    this.bindHost(createWebviewPanelHost(panel));
+  }
+
+  private async onMessage(message: WebviewToExtensionMessage): Promise<void> {
       const t = (message as any)?.type;
       if (t) {
         logInfo('Tail: received message from webview:', t);
@@ -151,7 +135,21 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         this.post({ type: 'tailReset' });
         return;
       }
-    });
+  }
+
+  public getSelectedOrg(): string | undefined {
+    return this.selectedOrg;
+  }
+
+  public dispose(): void {
+    this.disposed = true;
+    this.view = undefined;
+    this.host = undefined;
+    this.tailService.stop();
+    vscode.Disposable.from(...this.hostDisposables).dispose();
+    this.hostDisposables = [];
+    vscode.Disposable.from(...this.disposables).dispose();
+    this.disposables.length = 0;
   }
 
   private getHtmlForWebview(webview: vscode.Webview): string {
@@ -210,7 +208,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
-  private setSelectedOrg(username?: string): void {
+  public setSelectedOrg(username?: string): void {
     this.selectedOrg = username;
   }
 
@@ -343,5 +341,42 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider {
         } catch {}
       }
     }
+  }
+
+  private bindHost(host: BoundWebviewHost): void {
+    vscode.Disposable.from(...this.hostDisposables).dispose();
+    this.hostDisposables = [];
+    this.host = host;
+    this.view = host;
+    this.disposed = false;
+    host.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
+    };
+    host.webview.html = this.getHtmlForWebview(host.webview);
+    logInfo(`Tail webview resolved (${host.kind}).`);
+
+    this.hostDisposables.push(
+      host.onDidDispose(() => {
+        if (this.host !== host) {
+          return;
+        }
+        this.disposed = true;
+        this.view = undefined;
+        this.host = undefined;
+        // Stop timers and clear caches, but keep controller disposal separate.
+        this.tailService.stop();
+        logInfo(`Tail webview disposed; stopped tail (${host.kind}).`);
+      }),
+      host.onDidBecomeVisible(() => {
+        if (this.disposed) {
+          return;
+        }
+        void this.refreshViewState();
+      }),
+      host.webview.onDidReceiveMessage(message => {
+        void this.onMessage(message as WebviewToExtensionMessage);
+      })
+    );
   }
 }

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -20,12 +20,16 @@ import { ensureApexLogsDir, purgeSavedLogs, getLogIdFromLogFilePath } from '../u
 import { ripgrepSearch, type RipgrepMatch } from '../utils/ripgrep';
 import { DEFAULT_LOGS_COLUMNS_CONFIG, normalizeLogsColumnsConfig, type NormalizedLogsColumnsConfig } from '../shared/logsColumns';
 import type { LogTriageSummary } from '../shared/logTriage';
+import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
 
 const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
 
-export class SfLogsViewProvider implements vscode.WebviewViewProvider {
+export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = 'sfLogViewer';
-  private view?: vscode.WebviewView;
+  private view?: { webview: vscode.Webview };
+  private host?: BoundWebviewHost;
+  private readonly disposables: vscode.Disposable[] = [];
+  private hostDisposables: vscode.Disposable[] = [];
   private pageLimit = 100;
   private currentOffset = 0;
   private disposed = false;
@@ -70,7 +74,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       value => this.setSearchQuery(value),
       value => this.saveLogsColumns(value)
     );
-    this.context.subscriptions.push(
+    this.disposables.push(
       vscode.workspace.onDidChangeConfiguration(e => {
         const prevFullBodies = this.configManager.shouldLoadFullLogBodies();
         this.configManager.handleChange(e);
@@ -87,34 +91,35 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
-    this.view = webviewView;
-    this.disposed = false;
-    webviewView.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
-    };
-    webviewView.webview.html = this.getHtmlForWebview(webviewView.webview);
-    logInfo('Logs webview resolved.');
-    // Dispose handling: stop posting and bump token to invalidate in-flight work
-    this.context.subscriptions.push(
-      webviewView.onDidDispose(() => {
-        this.disposed = true;
-        this.view = undefined;
-        this.refreshToken++;
-        this.cancelErrorScan();
-        logInfo('Logs webview disposed.');
-      })
-    );
+    this.bindHost(createWebviewViewHost(webviewView));
+  }
 
-    this.context.subscriptions.push(
-      webviewView.webview.onDidReceiveMessage(message => {
-        void this.messageHandler.handle(message);
-      })
-    );
+  public resolveWebviewPanel(panel: vscode.WebviewPanel): void {
+    this.bindHost(createWebviewPanelHost(panel));
   }
 
   public hasResolvedView(): boolean {
     return Boolean(this.view) && !this.disposed;
+  }
+
+  public getSelectedOrg(): string | undefined {
+    return this.orgManager.getSelectedOrg();
+  }
+
+  public dispose(): void {
+    this.disposed = true;
+    this.view = undefined;
+    this.host = undefined;
+    this.refreshToken++;
+    this.cancelErrorScan();
+    if (this.searchAbortController) {
+      this.searchAbortController.abort();
+      this.searchAbortController = undefined;
+    }
+    vscode.Disposable.from(...this.hostDisposables).dispose();
+    this.hostDisposables = [];
+    vscode.Disposable.from(...this.disposables).dispose();
+    this.disposables.length = 0;
   }
 
   public async refresh() {
@@ -1330,6 +1335,41 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider {
       selectedOrg: this.orgManager.getSelectedOrg(),
       sourceView: 'logs'
     });
+  }
+
+  private bindHost(host: BoundWebviewHost): void {
+    vscode.Disposable.from(...this.hostDisposables).dispose();
+    this.hostDisposables = [];
+    this.host = host;
+    this.view = host;
+    this.disposed = false;
+    host.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
+    };
+    host.webview.html = this.getHtmlForWebview(host.webview);
+    logInfo(`Logs webview resolved (${host.kind}).`);
+
+    this.hostDisposables.push(
+      host.onDidDispose(() => {
+        if (this.host !== host) {
+          return;
+        }
+        this.disposed = true;
+        this.view = undefined;
+        this.host = undefined;
+        this.refreshToken++;
+        this.cancelErrorScan();
+        if (this.searchAbortController) {
+          this.searchAbortController.abort();
+          this.searchAbortController = undefined;
+        }
+        logInfo(`Logs webview disposed (${host.kind}).`);
+      }),
+      host.webview.onDidReceiveMessage(message => {
+        void this.messageHandler.handle(message);
+      })
+    );
   }
 
   private post(msg: ExtensionToWebviewMessage): void {

--- a/src/provider/SfLogsViewProvider.ts
+++ b/src/provider/SfLogsViewProvider.ts
@@ -1315,6 +1315,21 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     this.orgManager.setSelectedOrg(username);
   }
 
+  public async syncSelectedOrg(username?: string): Promise<void> {
+    const next = typeof username === 'string' ? username.trim() || undefined : undefined;
+    if (!next || next === this.orgManager.getSelectedOrg()) {
+      return;
+    }
+
+    this.setSelectedOrg(next);
+    if (!this.view || this.disposed) {
+      return;
+    }
+
+    await this.sendOrgs();
+    await this.refresh();
+  }
+
   public async tailLogs() {
     await vscode.commands.executeCommand('workbench.view.extension.salesforceTailPanel');
     try {

--- a/src/provider/webviewHost.ts
+++ b/src/provider/webviewHost.ts
@@ -1,0 +1,53 @@
+import * as vscode from 'vscode';
+
+export interface BoundWebviewHost {
+  readonly kind: 'panel' | 'editor';
+  readonly webview: vscode.Webview;
+  readonly visible: boolean;
+  onDidDispose(listener: () => void): vscode.Disposable;
+  onDidBecomeVisible(listener: () => void): vscode.Disposable;
+}
+
+export function createWebviewViewHost(view: vscode.WebviewView): BoundWebviewHost {
+  return {
+    kind: 'panel',
+    get webview() {
+      return view.webview;
+    },
+    get visible() {
+      return view.visible;
+    },
+    onDidDispose(listener: () => void): vscode.Disposable {
+      return view.onDidDispose(listener);
+    },
+    onDidBecomeVisible(listener: () => void): vscode.Disposable {
+      return view.onDidChangeVisibility(() => {
+        if (view.visible) {
+          listener();
+        }
+      });
+    }
+  };
+}
+
+export function createWebviewPanelHost(panel: vscode.WebviewPanel): BoundWebviewHost {
+  return {
+    kind: 'editor',
+    get webview() {
+      return panel.webview;
+    },
+    get visible() {
+      return panel.visible;
+    },
+    onDidDispose(listener: () => void): vscode.Disposable {
+      return panel.onDidDispose(listener);
+    },
+    onDidBecomeVisible(listener: () => void): vscode.Disposable {
+      return panel.onDidChangeViewState(event => {
+        if (event.webviewPanel.visible) {
+          listener();
+        }
+      });
+    }
+  };
+}

--- a/src/test/extension.activation.gating.test.ts
+++ b/src/test/extension.activation.gating.test.ts
@@ -46,6 +46,8 @@ function createExtensionHarness(options: {
   const infoMessages: string[] = [];
   const warningMessages: string[] = [];
   const errorMessages: string[] = [];
+  const logsEditorShows: Array<{ selectedOrg?: string }> = [];
+  const tailEditorShows: Array<{ selectedOrg?: string }> = [];
 
   const vscodeStub = {
     version: '1.101.0',
@@ -87,6 +89,7 @@ function createExtensionHarness(options: {
 
   class FakeLogsViewProvider {
     public static viewType = 'sfLogViewer';
+    private selectedOrg: string | undefined;
 
     constructor(_context: any) {}
 
@@ -98,15 +101,36 @@ function createExtensionHarness(options: {
 
     public async sendOrgs(): Promise<void> {}
 
-    public setSelectedOrg(_username: string): void {}
+    public setSelectedOrg(username?: string): void {
+      this.selectedOrg = username;
+    }
+
+    public getSelectedOrg(): string | undefined {
+      return this.selectedOrg;
+    }
 
     public async tailLogs(): Promise<void> {}
+
+    public dispose(): void {}
   }
 
   class FakeTailViewProvider {
     public static viewType = 'sfLogTail';
+    private selectedOrg: string | undefined;
 
     constructor(_context: any) {}
+
+    public getSelectedOrg(): string | undefined {
+      return this.selectedOrg;
+    }
+
+    public setSelectedOrg(username?: string): void {
+      this.selectedOrg = username;
+    }
+
+    public async refreshViewState(): Promise<void> {}
+
+    public dispose(): void {}
   }
 
   class FakeCodeLensProvider {}
@@ -127,6 +151,22 @@ function createExtensionHarness(options: {
     './panel/DebugFlagsPanel': {
       DebugFlagsPanel: {
         initialize: () => undefined
+      }
+    },
+    './panel/LogsEditorPanel': {
+      LogsEditorPanel: {
+        initialize: () => undefined,
+        show: async (options?: { selectedOrg?: string }) => {
+          logsEditorShows.push(options ?? {});
+        }
+      }
+    },
+    './panel/TailEditorPanel': {
+      TailEditorPanel: {
+        initialize: () => undefined,
+        show: async (options?: { selectedOrg?: string }) => {
+          tailEditorShows.push(options ?? {});
+        }
       }
     },
     './salesforce/http': {
@@ -205,7 +245,9 @@ function createExtensionHarness(options: {
     logViewerShows,
     infoMessages,
     warningMessages,
-    errorMessages
+    errorMessages,
+    logsEditorShows,
+    tailEditorShows
   };
 }
 
@@ -241,6 +283,8 @@ suite('extension activation gating', () => {
     assert.deepEqual(harness.setApiVersionCalls, []);
     assert.equal(harness.timeoutCallbacks.length, 0, 'should not schedule CLI preload outside Salesforce projects');
     assert.ok(harness.commands.has('sfLogs.refresh'), 'refresh command should stay registered');
+    assert.ok(harness.commands.has('sfLogs.openLogsEditor'), 'open logs editor command should stay registered');
+    assert.ok(harness.commands.has('sfLogs.openTailEditor'), 'open tail editor command should stay registered');
     assert.ok(harness.commands.has('sfLogs.openLogInViewer'), 'open log viewer command should stay registered');
     assert.ok(harness.commands.has('sfLogs.troubleshootWebview'), 'webview troubleshooting command should stay registered');
 

--- a/src/test/extension.activation.test.ts
+++ b/src/test/extension.activation.test.ts
@@ -13,10 +13,14 @@ suite('integration: extension activation and commands', () => {
     console.log('Has sfLogs.refresh?', commands.includes('sfLogs.refresh'));
     console.log('Has sfLogs.selectOrg?', commands.includes('sfLogs.selectOrg'));
     console.log('Has sfLogs.tail?', commands.includes('sfLogs.tail'));
+    console.log('Has sfLogs.openLogsEditor?', commands.includes('sfLogs.openLogsEditor'));
+    console.log('Has sfLogs.openTailEditor?', commands.includes('sfLogs.openTailEditor'));
     console.log('Has sfLogs.troubleshootWebview?', commands.includes('sfLogs.troubleshootWebview'));
     assert.ok(commands.includes('sfLogs.refresh'), 'registers sfLogs.refresh');
     assert.ok(commands.includes('sfLogs.selectOrg'), 'registers sfLogs.selectOrg');
     assert.ok(commands.includes('sfLogs.tail'), 'registers sfLogs.tail');
+    assert.ok(commands.includes('sfLogs.openLogsEditor'), 'registers sfLogs.openLogsEditor');
+    assert.ok(commands.includes('sfLogs.openTailEditor'), 'registers sfLogs.openTailEditor');
     assert.ok(commands.includes('sfLogs.troubleshootWebview'), 'registers sfLogs.troubleshootWebview');
 
     // Executing refresh should be a no-op (no view resolved yet) and not throw.

--- a/src/test/logService.test.ts
+++ b/src/test/logService.test.ts
@@ -77,7 +77,7 @@ suite('LogService', () => {
       svc.loadLogHeads(logs, {} as OrgAuth, 0, (id: string, code: string) => {
         seen.push({ id, code });
       }, undefined, { selectedOrg: 'default' });
-      await new Promise(r => setTimeout(r, 30));
+      await waitForCondition(() => seen.length === 1, { timeoutMs: 500, intervalMs: 10 });
       assert.deepEqual(seen, [{ id: '1', code: 'Unit' }]);
     } finally {
       await fs.rm(tmpDir, { recursive: true, force: true });

--- a/src/test/logsEditorPanel.test.ts
+++ b/src/test/logsEditorPanel.test.ts
@@ -34,12 +34,13 @@ function createPanel() {
 }
 
 suite('LogsEditorPanel', () => {
-  test('creates a panel once and reuses it without resetting the org seed', async () => {
+  test('creates a panel once and syncs the selected org when reusing it', async () => {
     const createdProviders: any[] = [];
     const panel = createPanel();
 
     class FakeLogsProvider {
       selectedOrgs: Array<string | undefined> = [];
+      syncedOrgs: Array<string | undefined> = [];
       resolvedPanels: any[] = [];
 
       constructor(_context: any) {
@@ -48,6 +49,10 @@ suite('LogsEditorPanel', () => {
 
       setSelectedOrg(org?: string): void {
         this.selectedOrgs.push(org);
+      }
+
+      async syncSelectedOrg(org?: string): Promise<void> {
+        this.syncedOrgs.push(org);
       }
 
       resolveWebviewPanel(nextPanel: any): void {
@@ -88,6 +93,7 @@ suite('LogsEditorPanel', () => {
 
     assert.equal(createdProviders.length, 1, 'should create only one provider/controller');
     assert.deepEqual(createdProviders[0]?.selectedOrgs, ['first@example.com']);
+    assert.deepEqual(createdProviders[0]?.syncedOrgs, ['second@example.com']);
     assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
     assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
   });

--- a/src/test/logsEditorPanel.test.ts
+++ b/src/test/logsEditorPanel.test.ts
@@ -1,0 +1,149 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+function createDisposable() {
+  return { dispose: () => undefined };
+}
+
+function createPanel() {
+  let onDispose: (() => void) | undefined;
+  return {
+    active: true,
+    visible: true,
+    options: {},
+    title: 'Electivus Apex Logs',
+    viewColumn: 1,
+    webview: {},
+    revealCount: 0,
+    reveal() {
+      this.revealCount += 1;
+    },
+    onDidDispose(listener: () => void) {
+      onDispose = listener;
+      return createDisposable();
+    },
+    onDidChangeViewState() {
+      return createDisposable();
+    },
+    fireDispose() {
+      onDispose?.();
+    }
+  };
+}
+
+suite('LogsEditorPanel', () => {
+  test('creates a panel once and reuses it without resetting the org seed', async () => {
+    const createdProviders: any[] = [];
+    const panel = createPanel();
+
+    class FakeLogsProvider {
+      selectedOrgs: Array<string | undefined> = [];
+      resolvedPanels: any[] = [];
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(org?: string): void {
+        this.selectedOrgs.push(org);
+      }
+
+      resolveWebviewPanel(nextPanel: any): void {
+        this.resolvedPanels.push(nextPanel);
+      }
+
+      dispose(): void {}
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panel
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { LogsEditorPanel } = proxyquireStrict('../panel/LogsEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogsViewProvider': { SfLogsViewProvider: FakeLogsProvider },
+      '../utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    LogsEditorPanel.initialize(context as any);
+    await LogsEditorPanel.show({ selectedOrg: 'first@example.com' });
+    await LogsEditorPanel.show({ selectedOrg: 'second@example.com' });
+
+    assert.equal(createdProviders.length, 1, 'should create only one provider/controller');
+    assert.deepEqual(createdProviders[0]?.selectedOrgs, ['first@example.com']);
+    assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
+    assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
+  });
+
+  test('clears the singleton after dispose so a new editor panel can be created', async () => {
+    const createdProviders: any[] = [];
+    const panels = [createPanel(), createPanel()];
+    let panelIndex = 0;
+
+    class FakeLogsProvider {
+      disposeCount = 0;
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(_org?: string): void {}
+
+      resolveWebviewPanel(_panel: any): void {}
+
+      dispose(): void {
+        this.disposeCount += 1;
+      }
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panels[panelIndex++]
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { LogsEditorPanel } = proxyquireStrict('../panel/LogsEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogsViewProvider': { SfLogsViewProvider: FakeLogsProvider },
+      '../utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    LogsEditorPanel.initialize(context as any);
+    await LogsEditorPanel.show({ selectedOrg: 'first@example.com' });
+    panels[0]!.fireDispose();
+    await LogsEditorPanel.show({ selectedOrg: 'second@example.com' });
+
+    assert.equal(createdProviders.length, 2, 'should create a new provider after dispose');
+    assert.equal(createdProviders[0]?.disposeCount, 1, 'should dispose the previous provider on panel close');
+  });
+});

--- a/src/test/provider.logs.behavior.test.ts
+++ b/src/test/provider.logs.behavior.test.ts
@@ -32,6 +32,8 @@ async function waitForCondition(
     }
     await new Promise(resolve => setTimeout(resolve, intervalMs));
   }
+
+  assert.fail(`waitForCondition timed out after ${timeoutMs} ms`);
 }
 
 suite('SfLogsViewProvider behavior', () => {

--- a/src/test/provider.logs.behavior.test.ts
+++ b/src/test/provider.logs.behavior.test.ts
@@ -19,6 +19,21 @@ function makeContext() {
   return context;
 }
 
+async function waitForCondition(
+  predicate: () => boolean,
+  options: { timeoutMs?: number; intervalMs?: number } = {}
+): Promise<void> {
+  const timeoutMs = Math.max(0, Math.floor(options.timeoutMs ?? 500));
+  const intervalMs = Math.max(1, Math.floor(options.intervalMs ?? 10));
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (predicate()) {
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, intervalMs));
+  }
+}
+
 suite('SfLogsViewProvider behavior', () => {
   const origGetOrgAuth = cli.getOrgAuth;
   const origFetchApexLogs = http.fetchApexLogs;
@@ -91,8 +106,7 @@ suite('SfLogsViewProvider behavior', () => {
 
     try {
       await provider.refresh();
-      // Allow background tasks to complete
-      await new Promise(r => setTimeout(r, 50));
+      await waitForCondition(() => posted.filter(m => typeof m?.codeUnitStarted === 'string').length === 2);
 
       const init = posted.find(m => m?.type === 'init');
       const logs = posted.find(m => m?.type === 'logs');

--- a/src/test/provider.webview.test.ts
+++ b/src/test/provider.webview.test.ts
@@ -156,4 +156,30 @@ suite('SfLogsViewProvider webview', () => {
 
     assert.deepEqual(calls, ['sendOrgs', 'refresh']);
   });
+
+  test('syncSelectedOrg refreshes an existing editor session when the org changes', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+
+    const provider = new SfLogsViewProvider(context);
+    const webview = new MockWebview();
+    const panel = new MockWebviewPanel('sfLogViewer.editorPanel', webview);
+    const calls: string[] = [];
+
+    provider.resolveWebviewPanel(panel);
+    provider.setSelectedOrg('first@example.com');
+    (provider as any).sendOrgs = async () => {
+      calls.push('sendOrgs');
+    };
+    (provider as any).refresh = async () => {
+      calls.push('refresh');
+    };
+
+    await provider.syncSelectedOrg('second@example.com');
+
+    assert.equal(provider.getSelectedOrg(), 'second@example.com');
+    assert.deepEqual(calls, ['sendOrgs', 'refresh']);
+  });
 });

--- a/src/test/provider.webview.test.ts
+++ b/src/test/provider.webview.test.ts
@@ -47,6 +47,47 @@ class MockWebviewView implements vscode.WebviewView {
   onDidDispose: vscode.Event<void> = () => new MockDisposable();
 }
 
+class MockWebviewPanel implements vscode.WebviewPanel {
+  readonly active = true;
+  readonly visible = true;
+  readonly options: vscode.WebviewPanelOptions = {};
+  public title = 'Electivus Apex Logs';
+  public viewColumn: vscode.ViewColumn = vscode.ViewColumn.Active;
+  public webview: vscode.Webview;
+  private disposeListener: (() => void) | undefined;
+  private viewStateListener:
+    | ((event: vscode.WebviewPanelOnDidChangeViewStateEvent) => void)
+    | undefined;
+
+  constructor(public viewType: string, webview: vscode.Webview) {
+    this.webview = webview;
+  }
+
+  reveal(_viewColumn?: vscode.ViewColumn, _preserveFocus?: boolean): void {
+    /* noop */
+  }
+
+  dispose(): void {
+    this.disposeListener?.();
+  }
+
+  onDidDispose(listener: () => void): vscode.Disposable {
+    this.disposeListener = listener;
+    return new MockDisposable();
+  }
+
+  onDidChangeViewState(
+    listener: (e: vscode.WebviewPanelOnDidChangeViewStateEvent) => any
+  ): vscode.Disposable {
+    this.viewStateListener = listener;
+    return new MockDisposable();
+  }
+
+  fireVisible(): void {
+    this.viewStateListener?.({ webviewPanel: this } as vscode.WebviewPanelOnDidChangeViewStateEvent);
+  }
+}
+
 suite('SfLogsViewProvider webview', () => {
   test('sets HTML with CSP and main.js on resolve', async () => {
     const context = {
@@ -72,5 +113,47 @@ suite('SfLogsViewProvider webview', () => {
     } as unknown as vscode.ExtensionContext;
     const provider = new SfLogsViewProvider(context);
     await provider.refresh(); // should not throw or attempt CLI/network without a view
+  });
+
+  test('sets HTML with CSP and main.js when resolved as editor panel', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+
+    const provider = new SfLogsViewProvider(context);
+    const webview = new MockWebview();
+    const panel = new MockWebviewPanel('sfLogViewer.editorPanel', webview);
+
+    provider.resolveWebviewPanel(panel);
+
+    assert.equal(webview.options.enableScripts, true, 'enableScripts should be set for editor panel');
+    assert.ok(webview.html.includes('Content-Security-Policy'), 'CSP meta should be present');
+    assert.ok(webview.html.includes('media/main.js'), 'bundled webview script should be referenced');
+  });
+
+  test('editor panel ready message triggers org bootstrap and refresh flow', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+
+    const provider = new SfLogsViewProvider(context);
+    const webview = new MockWebview();
+    const panel = new MockWebviewPanel('sfLogViewer.editorPanel', webview);
+    const calls: string[] = [];
+
+    (provider as any).sendOrgs = async () => {
+      calls.push('sendOrgs');
+    };
+    (provider as any).refresh = async () => {
+      calls.push('refresh');
+    };
+
+    provider.resolveWebviewPanel(panel);
+    webview.emit({ type: 'ready' });
+    await new Promise(resolve => setTimeout(resolve, 0));
+
+    assert.deepEqual(calls, ['sendOrgs', 'refresh']);
   });
 });

--- a/src/test/tailEditorPanel.test.ts
+++ b/src/test/tailEditorPanel.test.ts
@@ -34,12 +34,13 @@ function createPanel() {
 }
 
 suite('TailEditorPanel', () => {
-  test('creates a panel once and reuses it without resetting the org seed', async () => {
+  test('creates a panel once and syncs the selected org when reusing it', async () => {
     const createdProviders: any[] = [];
     const panel = createPanel();
 
     class FakeTailProvider {
       selectedOrgs: Array<string | undefined> = [];
+      syncedOrgs: Array<string | undefined> = [];
       resolvedPanels: any[] = [];
 
       constructor(_context: any) {
@@ -48,6 +49,10 @@ suite('TailEditorPanel', () => {
 
       setSelectedOrg(org?: string): void {
         this.selectedOrgs.push(org);
+      }
+
+      async syncSelectedOrg(org?: string): Promise<void> {
+        this.syncedOrgs.push(org);
       }
 
       resolveWebviewPanel(nextPanel: any): void {
@@ -88,6 +93,7 @@ suite('TailEditorPanel', () => {
 
     assert.equal(createdProviders.length, 1, 'should create only one provider/controller');
     assert.deepEqual(createdProviders[0]?.selectedOrgs, ['tail-first@example.com']);
+    assert.deepEqual(createdProviders[0]?.syncedOrgs, ['tail-second@example.com']);
     assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
     assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
   });

--- a/src/test/tailEditorPanel.test.ts
+++ b/src/test/tailEditorPanel.test.ts
@@ -1,0 +1,149 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+function createDisposable() {
+  return { dispose: () => undefined };
+}
+
+function createPanel() {
+  let onDispose: (() => void) | undefined;
+  return {
+    active: true,
+    visible: true,
+    options: {},
+    title: 'Electivus Apex Logs Tail',
+    viewColumn: 1,
+    webview: {},
+    revealCount: 0,
+    reveal() {
+      this.revealCount += 1;
+    },
+    onDidDispose(listener: () => void) {
+      onDispose = listener;
+      return createDisposable();
+    },
+    onDidChangeViewState() {
+      return createDisposable();
+    },
+    fireDispose() {
+      onDispose?.();
+    }
+  };
+}
+
+suite('TailEditorPanel', () => {
+  test('creates a panel once and reuses it without resetting the org seed', async () => {
+    const createdProviders: any[] = [];
+    const panel = createPanel();
+
+    class FakeTailProvider {
+      selectedOrgs: Array<string | undefined> = [];
+      resolvedPanels: any[] = [];
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(org?: string): void {
+        this.selectedOrgs.push(org);
+      }
+
+      resolveWebviewPanel(nextPanel: any): void {
+        this.resolvedPanels.push(nextPanel);
+      }
+
+      dispose(): void {}
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panel
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { TailEditorPanel } = proxyquireStrict('../panel/TailEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogTailViewProvider': { SfLogTailViewProvider: FakeTailProvider },
+      '../utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    TailEditorPanel.initialize(context as any);
+    await TailEditorPanel.show({ selectedOrg: 'tail-first@example.com' });
+    await TailEditorPanel.show({ selectedOrg: 'tail-second@example.com' });
+
+    assert.equal(createdProviders.length, 1, 'should create only one provider/controller');
+    assert.deepEqual(createdProviders[0]?.selectedOrgs, ['tail-first@example.com']);
+    assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
+    assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
+  });
+
+  test('clears the singleton after dispose so a new editor panel can be created', async () => {
+    const createdProviders: any[] = [];
+    const panels = [createPanel(), createPanel()];
+    let panelIndex = 0;
+
+    class FakeTailProvider {
+      disposeCount = 0;
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(_org?: string): void {}
+
+      resolveWebviewPanel(_panel: any): void {}
+
+      dispose(): void {
+        this.disposeCount += 1;
+      }
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panels[panelIndex++]
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { TailEditorPanel } = proxyquireStrict('../panel/TailEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogTailViewProvider': { SfLogTailViewProvider: FakeTailProvider },
+      '../utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    TailEditorPanel.initialize(context as any);
+    await TailEditorPanel.show({ selectedOrg: 'tail-first@example.com' });
+    panels[0]!.fireDispose();
+    await TailEditorPanel.show({ selectedOrg: 'tail-second@example.com' });
+
+    assert.equal(createdProviders.length, 2, 'should create a new provider after dispose');
+    assert.equal(createdProviders[0]?.disposeCount, 1, 'should dispose the previous provider on panel close');
+  });
+});

--- a/src/test/tailService.test.ts
+++ b/src/test/tailService.test.ts
@@ -489,4 +489,29 @@ suite('TailService', () => {
     assert.ok(posted.some(message => message?.type === 'sendDebugLevelsCalled'), 'should refresh debug levels on ready');
     assert.equal((provider as any).tailService.isRunning(), false, 'editor tail should stay idle until explicit start');
   });
+
+  test('syncSelectedOrg refreshes an existing editor tail session and stops the current stream', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+    const provider = new SfLogTailViewProvider(context);
+    const webview = new MockWebview();
+    const panel = new MockWebviewPanel('sfLogTail.editorPanel', webview);
+    const calls: string[] = [];
+
+    provider.resolveWebviewPanel(panel);
+    provider.setSelectedOrg('tail-first@example.com');
+    (provider as any).tailService.setOrg('tail-first@example.com');
+    (provider as any).tailService.tailRunning = true;
+    (provider as any).refreshViewState = async () => {
+      calls.push('refreshViewState');
+    };
+
+    await provider.syncSelectedOrg('tail-second@example.com');
+
+    assert.equal(provider.getSelectedOrg(), 'tail-second@example.com');
+    assert.equal((provider as any).tailService.isRunning(), false, 'should stop the previous tail session');
+    assert.deepEqual(calls, ['refreshViewState']);
+  });
 });

--- a/src/test/tailService.test.ts
+++ b/src/test/tailService.test.ts
@@ -55,6 +55,47 @@ class MockWebviewView implements vscode.WebviewView {
   onDidDispose: vscode.Event<void> = () => new MockDisposable();
 }
 
+class MockWebviewPanel implements vscode.WebviewPanel {
+  readonly active = true;
+  readonly visible = true;
+  readonly options: vscode.WebviewPanelOptions = {};
+  public title = 'Electivus Apex Logs Tail';
+  public viewColumn: vscode.ViewColumn = vscode.ViewColumn.Active;
+  public webview: vscode.Webview;
+  private disposeListener: (() => void) | undefined;
+  private viewStateListener:
+    | ((event: vscode.WebviewPanelOnDidChangeViewStateEvent) => void)
+    | undefined;
+
+  constructor(public viewType: string, webview: vscode.Webview) {
+    this.webview = webview;
+  }
+
+  reveal(_viewColumn?: vscode.ViewColumn, _preserveFocus?: boolean): void {
+    /* noop */
+  }
+
+  dispose(): void {
+    this.disposeListener?.();
+  }
+
+  onDidDispose(listener: () => void): vscode.Disposable {
+    this.disposeListener = listener;
+    return new MockDisposable();
+  }
+
+  onDidChangeViewState(
+    listener: (e: vscode.WebviewPanelOnDidChangeViewStateEvent) => any
+  ): vscode.Disposable {
+    this.viewStateListener = listener;
+    return new MockDisposable();
+  }
+
+  fireVisible(): void {
+    this.viewStateListener?.({ webviewPanel: this } as vscode.WebviewPanelOnDidChangeViewStateEvent);
+  }
+}
+
 suite('TailService', () => {
   const originalDebugFlagsShow = DebugFlagsPanel.show;
 
@@ -416,5 +457,36 @@ suite('TailService', () => {
     assert.equal(opened.length, 1);
     assert.equal(opened[0]?.selectedOrg, 'tail-user@example.com');
     assert.equal(opened[0]?.sourceView, 'tail');
+  });
+
+  test('editor tail panel resolves html and stays idle after ready', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+    const provider = new SfLogTailViewProvider(context);
+    const posted: any[] = [];
+    const webview = new MockWebview();
+    webview.postMessage = (message: any) => {
+      posted.push(message);
+      return Promise.resolve(true);
+    };
+    const panel = new MockWebviewPanel('sfLogTail.editorPanel', webview);
+
+    (provider as any).sendOrgs = async () => {
+      posted.push({ type: 'sendOrgsCalled' });
+    };
+    (provider as any).sendDebugLevels = async () => {
+      posted.push({ type: 'sendDebugLevelsCalled' });
+    };
+
+    provider.resolveWebviewPanel(panel);
+    await webview.emit({ type: 'ready' });
+
+    assert.ok(webview.html.includes('media/tail.js'));
+    assert.ok(posted.some(message => message?.type === 'init'), 'should post init message');
+    assert.ok(posted.some(message => message?.type === 'sendOrgsCalled'), 'should refresh org state on ready');
+    assert.ok(posted.some(message => message?.type === 'sendDebugLevelsCalled'), 'should refresh debug levels on ready');
+    assert.equal((provider as any).tailService.isRunning(), false, 'editor tail should stay idle until explicit start');
   });
 });

--- a/telemetry.json
+++ b/telemetry.json
@@ -93,6 +93,28 @@
         }
       }
     },
+    "command.openLogsEditor": {
+      "description": "Open-logs-editor command outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked", "error"]
+        }
+      }
+    },
+    "command.openTailEditor": {
+      "description": "Open-tail-editor command outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["invoked", "error"]
+        }
+      }
+    },
     "command.openLogInViewer": {
       "description": "Open-log-in-viewer command was invoked from VS Code.",
       "properties": {


### PR DESCRIPTION
## Summary
This PR adds optional editor-area hosts for the main Logs and Tail views while keeping the docked Panel layout unchanged. Users can now open those sessions as editor tabs and move them to another editor group, floating window, or monitor. It also tightens the title-bar UX by keeping only the primary open-in-editor action as an icon and moving maintenance actions into the More Actions menu.

## Problem / user impact
The extension's main Logs and Tail experiences were confined to the Panel region. That made it awkward to keep them visible on another screen or in a detached VS Code window. After the first implementation, the title bar also became crowded because every action rendered as text and consumed horizontal space.

## Root cause
`sfLogViewer` and `sfLogTail` were only exposed as `WebviewViewProvider` instances bound to contributed panel views. Their lifecycle and message handling lived directly inside those providers, so there was no lightweight way to host the same sessions inside `WebviewPanel`s in the editor area. On top of that, the `view/title` menu contributions kept utility actions in the main navigation group, which caused long labels to consume toolbar space.

## Fix
This change refactors the logs and tail providers to bind against a small host adapter that works for either a contributed view or an editor panel. On top of that, it adds singleton editor hosts for Logs and Tail, new commands to open them in the editor area, manifest/localization/telemetry updates, and focused tests for editor-hosted behavior. The toolbar contribution was also adjusted so the primary open-in-editor action stays as an icon while troubleshooting, output, and cache-reset actions move under the three-dots More Actions menu.

## Validation
- `npm run check-types`
- `npm run test:webview`
- `npm run test:unit`
