### PR TITLE
[codex] fix(tests): require explicit dev hub config

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -27,6 +27,7 @@ Required repository secrets:
 Key behavior:
 
 - The workflow uses a fixed alias, `ALV_E2E_SCRATCH_CI`, so the E2E scratch-org helpers can find and reuse the same org across runs.
+- The workflow passes `SF_DEVHUB_AUTH_URL` together with an explicit `SF_DEVHUB_ALIAS`; the E2E helpers do not auto-discover or retry alternate Dev Hub aliases.
 - `SF_TEST_KEEP_ORG` is enabled for `pull_request` runs only when reuse is possible (`SF_SCRATCH_CI_SFDX_AUTH_URL` is available) or when the workflow can rotate the auth secret (`GH_SECRETS_ROTATOR_PAT` is configured). This avoids keeping throwaway scratch orgs when reuse bootstrap is unavailable.
 - On `workflow_dispatch`, setting `keep_scratch_org=false` forces the scratch org to be deleted after the run even if it was reused, providing a manual reset path for corrupted state.
 - A best-effort login step restores the reusable scratch org from `SF_SCRATCH_CI_SFDX_AUTH_URL` before the tests start. If that auth URL is missing or stale, the E2E helpers fall back to creating a new scratch org through the Dev Hub.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -48,8 +48,8 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 Tests do not require an authenticated org by default. If you want the runner to authenticate a Dev Hub and create a scratch org automatically:
 
 - `SF_DEVHUB_AUTH_URL`: SFDX URL for the Dev Hub auth.
-- `SF_DEVHUB_ALIAS`: Alias for the Dev Hub (default `DevHub`).
-- `SF_SETUP_SCRATCH=1`: Enables scratch org creation when a Dev Hub is available.
+- `SF_DEVHUB_ALIAS`: Alias for the Dev Hub.
+- `SF_SETUP_SCRATCH=1`: Enables scratch org creation and requires `SF_DEVHUB_AUTH_URL` or `SF_DEVHUB_ALIAS` to be explicitly set.
 - `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_Test_Scratch`).
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Skip deleting the scratch org during cleanup.
@@ -58,7 +58,7 @@ Tests do not require an authenticated org by default. If you want the runner to 
 
 The Playwright suite validates the webview UX end-to-end by:
 
-1. Authenticating a Dev Hub (CI via `SF_DEVHUB_AUTH_URL`, local via an existing auth)
+1. Validating/authenticating the explicitly configured Dev Hub
 2. Creating/reusing a scratch org
 3. Seeding an Apex log (anonymous Apex with a unique marker)
 4. Launching VS Code and verifying the Logs panel + Log Viewer show that log
@@ -72,14 +72,16 @@ From the repo root:
 
 Useful env vars:
 
-- `SF_DEVHUB_AUTH_URL`: Optional locally; required in CI. If not set, the E2E suite assumes you already have a Dev Hub authenticated locally.
-- `SF_DEVHUB_ALIAS`: Dev Hub alias to use. If unset, local runs prefer `DevHubElectivus` when available.
+- `SF_DEVHUB_AUTH_URL`: Explicit Dev Hub auth for the run. Set this or `SF_DEVHUB_ALIAS`.
+- `SF_DEVHUB_ALIAS`: Explicit Dev Hub alias to use. Set this or `SF_DEVHUB_AUTH_URL`.
 - `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_E2E_Scratch`).
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).
 - `SF_E2E_DEBUG_FLAGS_USERNAME`: Optional username for the Debug Flags E2E user. If unset, tests auto-manage `alv.debugflags.<orgid>@example.com` (create if missing, reuse if present). If the org has no spare Salesforce licenses, tests fall back to the authenticated user.
 - `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`: Opt-in fallback that points the isolated VS Code run at your machine-wide extensions dir when a required support extension cannot be copied or installed into the temporary E2E profile.
 - `ALV_E2E_TIMING=1`: Prints per-step harness timings for scratch-org setup, VS Code startup, command-palette activation, and webview discovery.
+
+The E2E helpers no longer auto-discover or retry alternate Dev Hub aliases. Missing, invalid, or failing `SF_DEVHUB_AUTH_URL` / `SF_DEVHUB_ALIAS` values now fail the run immediately.
 
 Troubleshooting:
 

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -114,6 +114,45 @@ function delay(ms) {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+function readEnvValue(name) {
+  const value = String(process.env[name] || '').trim();
+  return value || undefined;
+}
+
+function parseJsonOutput(stdout) {
+  const text = String(stdout || '').trim();
+  if (!text) {
+    return undefined;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractDevHubIdentifier(json, explicitAlias) {
+  if (explicitAlias) {
+    return explicitAlias;
+  }
+
+  const result = json && typeof json === 'object' ? json.result ?? {} : {};
+  const username = typeof result.username === 'string' ? result.username.trim() : '';
+  const alias = typeof result.alias === 'string' ? result.alias.trim() : '';
+  return alias || username || undefined;
+}
+
+function resolveRequiredDevHubConfig({ requireConfig }) {
+  const authUrl = readEnvValue('SF_DEVHUB_AUTH_URL');
+  const alias = readEnvValue('SF_DEVHUB_ALIAS');
+
+  if (requireConfig && !authUrl && !alias) {
+    throw new Error('Missing required Dev Hub configuration. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS.');
+  }
+
+  return { authUrl, alias };
+}
+
 async function killLeakedVSCodeProcesses(markers) {
   const normalized = Array.from(new Set(markers.map(normalizeForMatch).filter(Boolean)));
   if (normalized.length === 0) {
@@ -278,78 +317,134 @@ async function ensureSfCliInstalled() {
   return cli;
 }
 
-async function ensureDevHub(cli, { authUrl, alias }) {
-  if (!cli || !authUrl) {
-    return;
+async function ensureDevHub(cli, { authUrl, alias }, helpers = {}) {
+  const execFileAsyncFn = helpers.execFileAsync || execFileAsync;
+  const mkdtempSyncFn = helpers.mkdtempSync || mkdtempSync;
+  const writeFileSyncFn = helpers.writeFileSync || writeFileSync;
+  const rmSyncFn = helpers.rmSync || rmSync;
+  const joinFn = helpers.join || join;
+  const tmpdirFn = helpers.tmpdir || tmpdir;
+
+  if (!cli) {
+    return undefined;
   }
-  try {
-    const tmp = mkdtempSync(join(tmpdir(), 'alv-'));
-    const file = join(tmp, 'devhub.sfdxurl');
-    writeFileSync(file, authUrl, 'utf8');
+  if (!authUrl && !alias) {
+    throw new Error('Missing required Dev Hub configuration. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS.');
+  }
+  if (!authUrl) {
     if (cli === 'sf') {
-      await execFileAsync('sf', [
-        'org',
-        'login',
-        'sfdx-url',
-        '--sfdx-url-file',
-        file,
-        '--alias',
-        alias,
-        '--set-default-dev-hub',
-        '--json'
-      ]);
-      await execFileAsync('sf', ['config', 'set', `target-dev-hub=${alias}`, `target-org=${alias}`, '--global']);
+      await execFileAsyncFn('sf', ['org', 'display', '-o', alias, '--json']);
+      await execFileAsyncFn('sf', ['config', 'set', `target-dev-hub=${alias}`, `target-org=${alias}`, '--global']);
     } else {
-      await execFileAsync('sfdx', ['force:auth:sfdxurl:store', '-f', file, '-a', alias, '-d', '--json']);
-      await execFileAsync('sfdx', [
+      await execFileAsyncFn('sfdx', ['force:org:display', '-u', alias, '--json']);
+      await execFileAsyncFn('sfdx', [
         'force:config:set',
         `defaultdevhubusername=${alias}`,
         `defaultusername=${alias}`,
         '--global'
       ]);
     }
-  } catch (e) {
-    console.warn('[test-setup] Dev Hub auth failed:', e && e.message ? e.message : e);
+    return alias;
+  }
+
+  const tmp = mkdtempSyncFn(joinFn(tmpdirFn(), 'alv-'));
+  const file = joinFn(tmp, 'devhub.sfdxurl');
+  writeFileSyncFn(file, authUrl, 'utf8');
+  try {
+    if (cli === 'sf') {
+      const args = [
+        'org',
+        'login',
+        'sfdx-url',
+        '--sfdx-url-file',
+        file,
+        '--set-default-dev-hub',
+        '--json'
+      ];
+      if (alias) {
+        args.splice(5, 0, '--alias', alias);
+      }
+      const { stdout } = await execFileAsyncFn('sf', args);
+      const resolvedAlias = extractDevHubIdentifier(parseJsonOutput(stdout), alias);
+      if (!resolvedAlias) {
+        throw new Error('Dev Hub login succeeded but did not return a usable alias or username. Set SF_DEVHUB_ALIAS explicitly.');
+      }
+      await execFileAsyncFn('sf', ['config', 'set', `target-dev-hub=${resolvedAlias}`, `target-org=${resolvedAlias}`, '--global']);
+      return resolvedAlias;
+    } else {
+      const args = ['force:auth:sfdxurl:store', '-f', file, '-d', '--json'];
+      if (alias) {
+        args.splice(3, 0, '-a', alias);
+      }
+      const { stdout } = await execFileAsyncFn('sfdx', args);
+      const resolvedAlias = extractDevHubIdentifier(parseJsonOutput(stdout), alias);
+      if (!resolvedAlias) {
+        throw new Error('Dev Hub login succeeded but did not return a usable alias or username. Set SF_DEVHUB_ALIAS explicitly.');
+      }
+      await execFileAsyncFn('sfdx', [
+        'force:config:set',
+        `defaultdevhubusername=${resolvedAlias}`,
+        `defaultusername=${resolvedAlias}`,
+        '--global'
+      ]);
+      return resolvedAlias;
+    }
+  } finally {
+    try {
+      rmSyncFn(tmp, { recursive: true, force: true });
+    } catch {}
   }
 }
 
-async function ensureDefaultScratch(cli, { alias, durationDays, definitionJson, keep }) {
+async function ensureDefaultScratch(cli, { alias, devHubAlias, durationDays, definitionJson, keep }, helpers = {}) {
+  const execFileAsyncFn = helpers.execFileAsync || execFileAsync;
+  const mkdtempSyncFn = helpers.mkdtempSync || mkdtempSync;
+  const writeFileSyncFn = helpers.writeFileSync || writeFileSync;
+  const rmSyncFn = helpers.rmSync || rmSync;
+  const joinFn = helpers.join || join;
+
   if (!cli) {
     return { cleanup: async () => {} };
   }
+
+  // If already exists, set as default and return
   try {
-    // If already exists, set as default and return
-    try {
-      if (cli === 'sf') {
-        await execFileAsync('sf', ['org', 'display', '-o', alias, '--json']);
-      } else {
-        await execFileAsync('sfdx', ['force:org:display', '-u', alias, '--json']);
-      }
-      if (cli === 'sf') {
-        await execFileAsync('sf', ['config', 'set', `target-org=${alias}`, '--global']);
-      } else {
-        await execFileAsync('sfdx', ['force:config:set', `defaultusername=${alias}`, '--global']);
-      }
-      console.log(`[test-setup] Using existing scratch org '${alias}' as default.`);
-      return { alias, cleanup: async () => {} };
-    } catch (e) {
-      console.warn(`[test-setup] Failed to check existing scratch org '${alias}':`, e && e.message ? e.message : e);
-    }
-
-    const tmp = mkdtempSync(join(tmpdir(), 'alv-'));
-    const defFile = join(tmp, 'project-scratch-def.json');
-    const def = definitionJson || {
-      orgName: 'apex-log-viewer-tests',
-      edition: 'Developer',
-      hasSampleData: false
-    };
-    writeFileSync(defFile, JSON.stringify(def), 'utf8');
-
     if (cli === 'sf') {
-      await execFileAsync('sf', [
+      await execFileAsyncFn('sf', ['org', 'display', '-o', alias, '--json']);
+    } else {
+      await execFileAsyncFn('sfdx', ['force:org:display', '-u', alias, '--json']);
+    }
+    if (cli === 'sf') {
+      await execFileAsyncFn('sf', ['config', 'set', `target-org=${alias}`, '--global']);
+    } else {
+      await execFileAsyncFn('sfdx', ['force:config:set', `defaultusername=${alias}`, '--global']);
+    }
+    console.log(`[test-setup] Using existing scratch org '${alias}' as default.`);
+    return { alias, cleanup: async () => {} };
+  } catch (e) {
+    console.warn(`[test-setup] Failed to check existing scratch org '${alias}':`, e && e.message ? e.message : e);
+  }
+
+  const tmp = mkdtempSyncFn(joinFn(tmpdir(), 'alv-'));
+  const defFile = joinFn(tmp, 'project-scratch-def.json');
+  const def = definitionJson || {
+    orgName: 'apex-log-viewer-tests',
+    edition: 'Developer',
+    hasSampleData: false
+  };
+  if (!devHubAlias) {
+    throw new Error('Missing required Dev Hub identifier for scratch org creation.');
+  }
+  writeFileSyncFn(defFile, JSON.stringify(def), 'utf8');
+
+  try {
+    if (cli === 'sf') {
+      await execFileAsyncFn('sf', [
         'org',
         'create',
         'scratch',
+        '--target-dev-hub',
+        devHubAlias,
         '--alias',
         alias,
         '--definition-file',
@@ -362,8 +457,10 @@ async function ensureDefaultScratch(cli, { alias, durationDays, definitionJson, 
         '--json'
       ]);
     } else {
-      await execFileAsync('sfdx', [
+      await execFileAsyncFn('sfdx', [
         'force:org:create',
+        '-v',
+        devHubAlias,
         '-s',
         '-f',
         defFile,
@@ -384,9 +481,9 @@ async function ensureDefaultScratch(cli, { alias, durationDays, definitionJson, 
       }
       try {
         if (cli === 'sf') {
-          await execFileAsync('sf', ['org', 'delete', 'scratch', '-o', alias, '--no-prompt', '--json']);
+          await execFileAsyncFn('sf', ['org', 'delete', 'scratch', '-o', alias, '--no-prompt', '--json']);
         } else {
-          await execFileAsync('sfdx', ['force:org:delete', '-u', alias, '-p', '--json']);
+          await execFileAsyncFn('sfdx', ['force:org:delete', '-u', alias, '-p', '--json']);
         }
         console.log(`[test-setup] Deleted scratch org '${alias}'.`);
       } catch (e) {
@@ -394,42 +491,52 @@ async function ensureDefaultScratch(cli, { alias, durationDays, definitionJson, 
       }
     };
     return { alias, cleanup };
-  } catch (e) {
-    console.warn('[test-setup] Scratch org setup failed:', e && e.message ? e.message : e);
-    return { cleanup: async () => {} };
+  } finally {
+    try {
+      rmSyncFn(tmp, { recursive: true, force: true });
+    } catch {}
   }
 }
 
-async function pretestSetup(scope = 'all', opts = {}) {
+async function pretestSetup(scope = 'all', opts = {}, helpers = {}) {
+  const ensureSfCliInstalledFn = helpers.ensureSfCliInstalled || ensureSfCliInstalled;
+  const ensureDevHubFn = helpers.ensureDevHub || ensureDevHub;
+  const ensureDefaultScratchFn = helpers.ensureDefaultScratch || ensureDefaultScratch;
+  const mkdtempSyncFn = helpers.mkdtempSync || mkdtempSync;
+  const writeFileSyncFn = helpers.writeFileSync || writeFileSync;
+  const mkdirSyncFn = helpers.mkdirSync || mkdirSync;
+  const rmSyncFn = helpers.rmSync || rmSync;
+  const joinFn = helpers.join || join;
+
   const smokeVsix = !!opts.smokeVsix;
   const normalizedScope = String(scope || '').trim().toLowerCase();
-  const devhubAuthUrl = process.env.SF_DEVHUB_AUTH_URL || process.env.SFDX_AUTH_URL;
-  const devhubAlias = process.env.SF_DEVHUB_ALIAS || 'DevHub';
   const scratchAlias = process.env.SF_SCRATCH_ALIAS || 'ALV_Test_Scratch';
   const keepScratch = /^1|true$/i.test(String(process.env.SF_TEST_KEEP_ORG || ''));
   const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1);
+  const shouldSetupScratch = normalizedScope !== 'unit' && !smokeVsix && Boolean(readEnvValue('SF_SETUP_SCRATCH') || readEnvValue('SF_DEVHUB_AUTH_URL'));
+  const devHubConfig = resolveRequiredDevHubConfig({ requireConfig: shouldSetupScratch });
   // When running unit tests, skip any Salesforce CLI/Dev Hub setup.
   // Keep only the temporary workspace preparation below.
   let cleanup = async () => {};
   if (normalizedScope !== 'unit' && !smokeVsix) {
-    const cli = await ensureSfCliInstalled();
+    const cli = await ensureSfCliInstalledFn();
     if (!cli) {
+      if (shouldSetupScratch) {
+        throw new Error('[test-setup] Salesforce CLI not found; scratch org setup requires the Salesforce CLI.');
+      }
       console.warn('[test-setup] Salesforce CLI not found; skipping org setup.');
       // Continue to workspace creation so tests still have a workspace.
     } else {
-      if (devhubAuthUrl) {
-        console.log('[test-setup] Authenticating Dev Hub from env...');
-        await ensureDevHub(cli, { authUrl: devhubAuthUrl, alias: devhubAlias });
-      }
-
-      const toggle = process.env.SF_SETUP_SCRATCH || devhubAuthUrl;
-      if (toggle) {
-        const res = await ensureDefaultScratch(cli, {
+      if (shouldSetupScratch) {
+        console.log('[test-setup] Validating Dev Hub configuration...');
+        const resolvedDevHubAlias = await ensureDevHubFn(cli, devHubConfig);
+        const res = await ensureDefaultScratchFn(cli, {
           alias: scratchAlias,
+          devHubAlias: resolvedDevHubAlias,
           durationDays,
           definitionJson: undefined,
           keep: keepScratch
-        });
+        }, helpers);
         if (res && res.cleanup) {
           cleanup = res.cleanup;
         }
@@ -439,7 +546,7 @@ async function pretestSetup(scope = 'all', opts = {}) {
   // Create a temporary VS Code workspace with expected sfdx-project.json
   try {
     const apiVersion = String(process.env.SF_TEST_API_VERSION || '60.0');
-    const ws = mkdtempSync(join(tmpdir(), 'alv-ws-'));
+    const ws = mkdtempSyncFn(joinFn(tmpdir(), 'alv-ws-'));
     const proj = {
       packageDirectories: [{ path: 'force-app', default: true }],
       name: 'apex-log-viewer-tests',
@@ -447,12 +554,12 @@ async function pretestSetup(scope = 'all', opts = {}) {
       sfdcLoginUrl: 'https://login.salesforce.com',
       sourceApiVersion: apiVersion
     };
-    writeFileSync(join(ws, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
-    mkdirSync(join(ws, 'force-app'), { recursive: true });
+    writeFileSyncFn(joinFn(ws, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
+    mkdirSyncFn(joinFn(ws, 'force-app'), { recursive: true });
     // Optional: enable verbose logs via env. Creates .vscode/settings.json in the temp workspace.
     try {
-      const vsdir = join(ws, '.vscode');
-      mkdirSync(vsdir, { recursive: true });
+      const vsdir = joinFn(ws, '.vscode');
+      mkdirSyncFn(vsdir, { recursive: true });
       const settings = {};
       const wantTrace = /^1|true$/i.test(String(process.env.SF_LOG_TRACE || ''));
       if (wantTrace) {
@@ -463,7 +570,7 @@ async function pretestSetup(scope = 'all', opts = {}) {
         settings['window.logLevel'] = String(logLevel);
       }
       if (Object.keys(settings).length > 0) {
-        writeFileSync(join(vsdir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf8');
+        writeFileSyncFn(joinFn(vsdir, 'settings.json'), JSON.stringify(settings, null, 2), 'utf8');
       }
     } catch (e) {
       console.warn('[test-setup] Failed to write VS Code settings:', e && e.message ? e.message : e);
@@ -472,7 +579,7 @@ async function pretestSetup(scope = 'all', opts = {}) {
     const prevCleanup = cleanup;
     cleanup = async () => {
       try {
-        rmSync(ws, { recursive: true, force: true });
+        rmSyncFn(ws, { recursive: true, force: true });
       } catch (e) {
         console.warn('[test-setup] Failed to remove temp workspace:', e && e.message ? e.message : e);
       }
@@ -865,4 +972,16 @@ async function run() {
   }
 }
 
-run();
+if (require.main === module) {
+  run().catch(error => {
+    console.error('[test-runner] Failed:', error && error.message ? error.message : error);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ensureDefaultScratch,
+  ensureDevHub,
+  pretestSetup,
+  resolveRequiredDevHubConfig
+};

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -124,11 +124,23 @@ function parseJsonOutput(stdout) {
   if (!text) {
     return undefined;
   }
-  try {
-    return JSON.parse(text);
-  } catch {
-    return undefined;
+
+  const candidates = [text];
+  const firstBrace = text.indexOf('{');
+  const lastBrace = text.lastIndexOf('}');
+  if (firstBrace >= 0 && lastBrace > firstBrace) {
+    candidates.push(text.slice(firstBrace, lastBrace + 1));
   }
+
+  for (const candidate of candidates) {
+    try {
+      return JSON.parse(candidate);
+    } catch {
+      // Try the next extraction candidate.
+    }
+  }
+
+  return undefined;
 }
 
 function extractDevHubIdentifier(json, explicitAlias) {
@@ -334,15 +346,8 @@ async function ensureDevHub(cli, { authUrl, alias }, helpers = {}) {
   if (!authUrl) {
     if (cli === 'sf') {
       await execFileAsyncFn('sf', ['org', 'display', '-o', alias, '--json']);
-      await execFileAsyncFn('sf', ['config', 'set', `target-dev-hub=${alias}`, `target-org=${alias}`, '--global']);
     } else {
       await execFileAsyncFn('sfdx', ['force:org:display', '-u', alias, '--json']);
-      await execFileAsyncFn('sfdx', [
-        'force:config:set',
-        `defaultdevhubusername=${alias}`,
-        `defaultusername=${alias}`,
-        '--global'
-      ]);
     }
     return alias;
   }
@@ -369,7 +374,6 @@ async function ensureDevHub(cli, { authUrl, alias }, helpers = {}) {
       if (!resolvedAlias) {
         throw new Error('Dev Hub login succeeded but did not return a usable alias or username. Set SF_DEVHUB_ALIAS explicitly.');
       }
-      await execFileAsyncFn('sf', ['config', 'set', `target-dev-hub=${resolvedAlias}`, `target-org=${resolvedAlias}`, '--global']);
       return resolvedAlias;
     } else {
       const args = ['force:auth:sfdxurl:store', '-f', file, '-d', '--json'];
@@ -381,12 +385,6 @@ async function ensureDevHub(cli, { authUrl, alias }, helpers = {}) {
       if (!resolvedAlias) {
         throw new Error('Dev Hub login succeeded but did not return a usable alias or username. Set SF_DEVHUB_ALIAS explicitly.');
       }
-      await execFileAsyncFn('sfdx', [
-        'force:config:set',
-        `defaultdevhubusername=${resolvedAlias}`,
-        `defaultusername=${resolvedAlias}`,
-        '--global'
-      ]);
       return resolvedAlias;
     }
   } finally {

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -2,7 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
-const { pretestSetup, resolveRequiredDevHubConfig } = require("./run-tests");
+const { ensureDevHub, pretestSetup, resolveRequiredDevHubConfig } = require("./run-tests");
 
 const originalEnv = { ...process.env };
 
@@ -77,4 +77,58 @@ test("pretestSetup propagates Dev Hub auth failures instead of continuing", asyn
 
   assert.equal(ensureDefaultScratchCalled, false);
   process.env = { ...originalEnv };
+});
+
+test("ensureDevHub validates an explicit alias without mutating global CLI config", async () => {
+  const calls = [];
+
+  const resolvedAlias = await ensureDevHub("sf", { alias: "ConfiguredDevHub" }, {
+    execFileAsync: async (file, args) => {
+      calls.push([file, args]);
+      return { stdout: '{"status":0,"result":{}}' };
+    },
+  });
+
+  assert.equal(resolvedAlias, "ConfiguredDevHub");
+  assert.deepEqual(calls, [
+    ["sf", ["org", "display", "-o", "ConfiguredDevHub", "--json"]],
+  ]);
+});
+
+test("ensureDevHub extracts the username from noisy sf auth output when no alias is provided", async () => {
+  const calls = [];
+
+  const resolvedAlias = await ensureDevHub("sf", { authUrl: "force://redacted" }, {
+    execFileAsync: async (file, args) => {
+      calls.push([file, args]);
+      return {
+        stdout: [
+          "Warning: config updated",
+          '{"status":0,"result":{"username":"devhub@example.com"}}',
+          "Done"
+        ].join("\n")
+      };
+    },
+    mkdtempSync: () => "C:\\temp\\alv-auth",
+    writeFileSync: () => {},
+    rmSync: () => {},
+    join: (...parts) => parts.join("\\"),
+    tmpdir: () => "C:\\temp",
+  });
+
+  assert.equal(resolvedAlias, "devhub@example.com");
+  assert.deepEqual(calls, [
+    [
+      "sf",
+      [
+        "org",
+        "login",
+        "sfdx-url",
+        "--sfdx-url-file",
+        "C:\\temp\\alv-auth\\devhub.sfdxurl",
+        "--set-default-dev-hub",
+        "--json"
+      ]
+    ],
+  ]);
 });

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -2,6 +2,9 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
+const { pretestSetup, resolveRequiredDevHubConfig } = require("./run-tests");
+
+const originalEnv = { ...process.env };
 
 test("xvfb re-exec preserves original CLI flags", () => {
   const script = fs.readFileSync(path.join(__dirname, "run-tests.js"), "utf8");
@@ -10,4 +13,68 @@ test("xvfb re-exec preserves original CLI flags", () => {
     script,
     /spawn\('xvfb-run', \[[\s\S]*process\.execPath,\s*__filename,\s*\.\.\.process\.argv\.slice\(2\)/,
   );
+});
+
+test("resolveRequiredDevHubConfig ignores the legacy SFDX_AUTH_URL fallback", () => {
+  process.env = {
+    ...originalEnv,
+    SFDX_AUTH_URL: "legacy-auth-url"
+  };
+  delete process.env.SF_DEVHUB_AUTH_URL;
+  delete process.env.SF_DEVHUB_ALIAS;
+
+  assert.throws(
+    () => resolveRequiredDevHubConfig({ requireConfig: true }),
+    /Missing required Dev Hub configuration\. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS\./,
+  );
+
+  process.env = { ...originalEnv };
+});
+
+test("pretestSetup fails fast when scratch setup is enabled without explicit Dev Hub config", async () => {
+  process.env = {
+    ...originalEnv,
+    SF_SETUP_SCRATCH: "1"
+  };
+
+  delete process.env.SF_DEVHUB_AUTH_URL;
+  delete process.env.SF_DEVHUB_ALIAS;
+
+  await assert.rejects(
+    () =>
+      pretestSetup("integration", {}, {
+        ensureSfCliInstalled: async () => "sf",
+      }),
+    /Missing required Dev Hub configuration\. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS\./,
+  );
+
+  process.env = { ...originalEnv };
+});
+
+test("pretestSetup propagates Dev Hub auth failures instead of continuing", async () => {
+  let ensureDefaultScratchCalled = false;
+
+  process.env = {
+    ...originalEnv,
+    SF_SETUP_SCRATCH: "1",
+    SF_DEVHUB_ALIAS: "ConfiguredDevHub"
+  };
+
+  await assert.rejects(
+    () =>
+      pretestSetup("integration", {}, {
+        ensureSfCliInstalled: async () => "sf",
+        ensureDevHub: async () => {
+          throw new Error("dev hub auth failed");
+        },
+        ensureDefaultScratch: async () => {
+          ensureDefaultScratchCalled = true;
+          return { cleanup: async () => {} };
+        },
+      }),
+    /dev hub auth failed/,
+  );
+
+  assert.equal(ensureDefaultScratchCalled, false);
+  process.env = { ...originalEnv };
 });

--- a/test/e2e/docs/docsScreenshots.e2e.ts
+++ b/test/e2e/docs/docsScreenshots.e2e.ts
@@ -5,7 +5,7 @@ import { executeCommandId, runCommand, runCommandWhenAvailable } from '../utils/
 import { emitDocsTailLog, prepareDocsScreenshotScenario } from '../utils/docsScenario';
 import { dismissAllNotifications } from '../utils/notifications';
 import { ensureScratchOrg } from '../utils/scratchOrg';
-import { resolveSfCliInvocation, runSfJson } from '../utils/sfCli';
+import { resolveSfCliInvocation } from '../utils/sfCli';
 import { createTempWorkspace } from '../utils/tempWorkspace';
 import { ensureDebugFlagsTestUser, getOrgAuth, getUserDebugTraceFlag, removeUserDebugTraceFlags } from '../utils/tooling';
 import { ensureAuxiliaryBarClosed, launchVsCode } from '../utils/vscode';
@@ -154,24 +154,6 @@ async function ensureTailDebugLevelReady(frame: Frame): Promise<void> {
   await expect.poll(hasSelectedDebugLevel, { timeout: 30_000 }).toBe(true);
 }
 
-async function selectConnectedDevHubAliasForDocs(): Promise<void> {
-  const orgList = await runSfJson(['org', 'list']);
-  const devHubs = Array.isArray(orgList?.result?.devHubs) ? orgList.result.devHubs : [];
-  const connectedDevHub =
-    devHubs.find((org: any) => String(org?.connectedStatus || '').trim().toLowerCase() === 'connected') ?? devHubs[0];
-  const candidate =
-    typeof connectedDevHub?.alias === 'string' && connectedDevHub.alias.trim()
-      ? connectedDevHub.alias.trim()
-      : typeof connectedDevHub?.username === 'string'
-        ? connectedDevHub.username.trim()
-        : '';
-
-  if (candidate) {
-    process.env.SF_DEVHUB_ALIAS = candidate;
-    console.info('[docs] Using Dev Hub alias for screenshots (value redacted).');
-  }
-}
-
 async function prepareLogsHero(page: Page, query: string, options?: { maximizePanel?: boolean }): Promise<Frame> {
   await runCommandWhenAvailable(page, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
   await dismissAllNotifications(page);
@@ -215,7 +197,6 @@ test('captures README screenshots from a realistic scratch-org scenario', async 
   };
 
   try {
-    await selectConnectedDevHubAliasForDocs();
     console.info('[docs] Ensuring scratch org...');
     const scratch = await ensureScratchOrg();
     cleanupScratchOrg = scratch.cleanup;

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -7,37 +7,81 @@ jest.mock('../sfCli', () => ({
 
 const runSfJsonMock = jest.mocked(runSfJson);
 
+const FALLBACK_DEV_HUB_ALIASES = [
+  'DevHubElectivus',
+  'DevHub',
+  'ElectivusDevHub',
+  'InsuranceOrgTrialCreme6DevHub'
+];
+
 describe('ensureScratchOrg', () => {
   const originalEnv = { ...process.env };
   let consoleInfoSpy: jest.SpiedFunction<typeof console.info>;
+  let consoleWarnSpy: jest.SpiedFunction<typeof console.warn>;
 
   beforeEach(() => {
     process.env = {
       ...originalEnv,
-      SF_DEVHUB_ALIAS: 'VlocityIndustriesInsuranceDevHub',
+      SF_DEVHUB_ALIAS: 'ConfiguredDevHub',
       SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
       SF_TEST_KEEP_ORG: '1'
     };
     runSfJsonMock.mockReset();
     consoleInfoSpy = jest.spyOn(console, 'info').mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
     consoleInfoSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
   });
 
   afterAll(() => {
     process.env = originalEnv;
   });
 
-  test('recreates a scratch org when the local alias points to a deleted org', async () => {
+  test('fails before any scratch lookup when dev hub config is missing', async () => {
+    process.env = {
+      ...originalEnv,
+      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
+      SF_TEST_KEEP_ORG: '1'
+    };
+
+    delete process.env.SF_DEVHUB_ALIAS;
+    delete process.env.SF_DEVHUB_AUTH_URL;
+
+    await expect(ensureScratchOrg()).rejects.toThrow(
+      'Missing required Dev Hub configuration. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS.'
+    );
+    expect(runSfJsonMock).not.toHaveBeenCalled();
+  });
+
+  test('recreates a scratch org using only the explicitly configured dev hub alias', async () => {
+    let scratchDisplayCount = 0;
+
     runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ConfiguredDevHub')) {
+        return { status: 0, result: {} };
+      }
+
       if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        scratchDisplayCount += 1;
+        if (scratchDisplayCount === 1) {
+          return {
+            status: 0,
+            result: {
+              status: 'Deleted',
+              expirationDate: '2026-03-07',
+              alias: 'ALV_E2E_Scratch'
+            }
+          };
+        }
+
         return {
           status: 0,
           result: {
-            status: 'Deleted',
-            expirationDate: '2026-03-07',
+            status: 'Active',
+            expirationDate: '2099-03-07',
             alias: 'ALV_E2E_Scratch'
           }
         };
@@ -51,11 +95,12 @@ describe('ensureScratchOrg', () => {
         return { status: 0, result: {} };
       }
 
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('VlocityIndustriesInsuranceDevHub')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch') {
+      if (
+        args[0] === 'org' &&
+        args[1] === 'create' &&
+        args[2] === 'scratch' &&
+        args.includes('ConfiguredDevHub')
+      ) {
         return { status: 0, result: {} };
       }
 
@@ -74,22 +119,34 @@ describe('ensureScratchOrg', () => {
     const scratch = await ensureScratchOrg();
 
     expect(scratch).toMatchObject({
-      devHubAlias: 'VlocityIndustriesInsuranceDevHub',
+      devHubAlias: 'ConfiguredDevHub',
       scratchAlias: 'ALV_E2E_Scratch',
       created: true
     });
     expect(runSfJsonMock).toHaveBeenCalledWith(['org', 'logout', '--target-org', 'ALV_E2E_Scratch', '--no-prompt']);
     expect(runSfJsonMock).toHaveBeenCalledWith(['alias', 'unset', 'ALV_E2E_Scratch']);
     expect(runSfJsonMock).toHaveBeenCalledWith(
-      expect.arrayContaining(['org', 'create', 'scratch', '--alias', 'ALV_E2E_Scratch']),
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'ConfiguredDevHub', '--alias', 'ALV_E2E_Scratch']),
       expect.any(Object)
     );
+
+    const displayAliases = runSfJsonMock.mock.calls
+      .filter(([args]) => args[0] === 'org' && args[1] === 'display' && args.includes('-o'))
+      .map(([args]) => args[args.indexOf('-o') + 1]);
+    for (const fallbackAlias of FALLBACK_DEV_HUB_ALIASES) {
+      expect(displayAliases).not.toContain(fallbackAlias);
+    }
+
     expect(consoleInfoSpy).toHaveBeenCalledWith("[e2e] scratch org created for alias 'ALV_E2E_Scratch'.");
     await scratch.cleanup();
   });
 
   test('reuses an active scratch org when the alias is still valid', async () => {
     runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ConfiguredDevHub')) {
+        return { status: 0, result: {} };
+      }
+
       if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
         return {
           status: 0,
@@ -116,7 +173,7 @@ describe('ensureScratchOrg', () => {
     const scratch = await ensureScratchOrg();
 
     expect(scratch).toMatchObject({
-      devHubAlias: 'VlocityIndustriesInsuranceDevHub',
+      devHubAlias: 'ConfiguredDevHub',
       scratchAlias: 'ALV_E2E_Scratch',
       created: false
     });
@@ -128,117 +185,96 @@ describe('ensureScratchOrg', () => {
     await scratch.cleanup();
   });
 
-  test('prefers DevHubElectivus locally when multiple fallback dev hubs are authenticated', async () => {
-    process.env = {
-      ...originalEnv,
-      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
-      SF_TEST_KEEP_ORG: '1'
-    };
-
-    delete process.env.SF_DEVHUB_ALIAS;
-    delete process.env.SF_DEVHUB_AUTH_URL;
-
+  test('fails immediately when the configured dev hub alias is not authenticated', async () => {
     runSfJsonMock.mockImplementation(async args => {
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
-        throw new Error('NamedOrgNotFoundError: No authorization information found for ALV_E2E_Scratch.');
-      }
-
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHub')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('ElectivusDevHub')) {
-        throw new Error('NamedOrgNotFoundError: No authorization information found for ElectivusDevHub.');
-      }
-
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHubElectivus')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch' && args.includes('DevHubElectivus')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'data' && args[1] === 'query') {
-        return {
-          status: 0,
-          result: {
-            records: [{ Id: '7dl000000000001AAA' }]
-          }
-        };
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ConfiguredDevHub')) {
+        throw new Error('NamedOrgNotFoundError: No authorization information found for ConfiguredDevHub.');
       }
 
       throw new Error(`Unexpected sf command: ${args.join(' ')}`);
     });
 
-    const scratch = await ensureScratchOrg();
-
-    expect(scratch).toMatchObject({
-      devHubAlias: 'DevHubElectivus',
-      scratchAlias: 'ALV_E2E_Scratch',
-      created: true
-    });
-    expect(runSfJsonMock).toHaveBeenCalledWith(
-      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'DevHubElectivus']),
-      expect.any(Object)
+    await expect(ensureScratchOrg()).rejects.toThrow(
+      "Dev Hub alias 'ConfiguredDevHub' is not authenticated or unavailable."
     );
-    await scratch.cleanup();
+
+    expect(runSfJsonMock).toHaveBeenCalledTimes(1);
+    expect(runSfJsonMock).toHaveBeenCalledWith(['org', 'display', '-o', 'ConfiguredDevHub']);
   });
 
-  test('falls back to another authenticated dev hub when the preferred alias hits the scratch signup limit', async () => {
+  test('fails immediately when SF_DEVHUB_AUTH_URL authentication fails', async () => {
+    process.env = {
+      ...originalEnv,
+      SF_DEVHUB_ALIAS: 'ConfiguredDevHub',
+      SF_DEVHUB_AUTH_URL: 'force://redacted',
+      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
+      SF_TEST_KEEP_ORG: '1'
+    };
+
     runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'login' && args[2] === 'sfdx-url') {
+        throw new Error('INVALID_AUTH_URL: failed to authenticate Dev Hub');
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    await expect(ensureScratchOrg()).rejects.toThrow('INVALID_AUTH_URL: failed to authenticate Dev Hub');
+
+    expect(runSfJsonMock).toHaveBeenCalledTimes(1);
+    expect(runSfJsonMock.mock.calls[0]?.[0]).toEqual(
+      expect.arrayContaining([
+        'org',
+        'login',
+        'sfdx-url',
+        '--sfdx-url-file',
+        expect.any(String),
+        '--set-default-dev-hub',
+        '--alias',
+        'ConfiguredDevHub'
+      ])
+    );
+  });
+
+  test('fails on scratch signup limit without trying another dev hub alias', async () => {
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ConfiguredDevHub')) {
+        return { status: 0, result: {} };
+      }
+
       if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
         throw new Error('NamedOrgNotFoundError: No authorization information found for ALV_E2E_Scratch.');
-      }
-
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('VlocityIndustriesInsuranceDevHub')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'org' && args[1] === 'display' && args.includes('DevHub')) {
-        return { status: 0, result: {} };
       }
 
       if (
         args[0] === 'org' &&
         args[1] === 'create' &&
         args[2] === 'scratch' &&
-        args.includes('VlocityIndustriesInsuranceDevHub')
+        args.includes('ConfiguredDevHub')
       ) {
-        throw new Error('LIMIT_EXCEEDED: The signup request failed because this organization has reached its daily scratch org signup limit');
-      }
-
-      if (args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch' && args.includes('DevHub')) {
-        return { status: 0, result: {} };
-      }
-
-      if (args[0] === 'data' && args[1] === 'query') {
-        return {
-          status: 0,
-          result: {
-            records: [{ Id: '7dl000000000001AAA' }]
-          }
-        };
+        throw new Error(
+          'LIMIT_EXCEEDED: The signup request failed because this organization has reached its daily scratch org signup limit'
+        );
       }
 
       throw new Error(`Unexpected sf command: ${args.join(' ')}`);
     });
 
-    const scratch = await ensureScratchOrg();
+    await expect(ensureScratchOrg()).rejects.toThrow(
+      "Failed to create scratch org 'ALV_E2E_Scratch': LIMIT_EXCEEDED: The signup request failed because this organization has reached its daily scratch org signup limit"
+    );
 
-    expect(scratch).toMatchObject({
-      devHubAlias: 'DevHub',
-      scratchAlias: 'ALV_E2E_Scratch',
-      created: true
-    });
-    expect(runSfJsonMock).toHaveBeenCalledWith(
-      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'VlocityIndustriesInsuranceDevHub']),
-      expect.any(Object)
+    const createScratchCalls = runSfJsonMock.mock.calls.filter(
+      ([args]) => args[0] === 'org' && args[1] === 'create' && args[2] === 'scratch'
     );
-    expect(runSfJsonMock).toHaveBeenCalledWith(
-      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'DevHub']),
-      expect.any(Object)
+    expect(createScratchCalls).toHaveLength(1);
+    expect(createScratchCalls[0]?.[0]).toEqual(
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'ConfiguredDevHub'])
     );
-    await scratch.cleanup();
+
+    const allArgs = runSfJsonMock.mock.calls.flatMap(([args]) => args);
+    for (const fallbackAlias of FALLBACK_DEV_HUB_ALIASES) {
+      expect(allArgs).not.toContain(fallbackAlias);
+    }
   });
 });

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -12,12 +12,10 @@ type ScratchOrgResult = {
   cleanup: () => Promise<void>;
 };
 
-const LOCAL_DEV_HUB_FALLBACK_ALIASES = [
-  'DevHubElectivus',
-  'DevHub',
-  'ElectivusDevHub',
-  'InsuranceOrgTrialCreme6DevHub'
-] as const;
+type DevHubConfig = {
+  authUrl?: string;
+  alias?: string;
+};
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
@@ -50,34 +48,51 @@ function toOrgAuth(display: OrgDisplaySummary | undefined): OrgAuth | undefined 
   };
 }
 
+function readEnvValue(name: 'SF_DEVHUB_AUTH_URL' | 'SF_DEVHUB_ALIAS'): string | undefined {
+  const value = String(process.env[name] || '').trim();
+  return value || undefined;
+}
+
+function mapOrgDisplay(result: any): OrgDisplaySummary {
+  const org = result?.result ?? {};
+  return {
+    status: typeof org.status === 'string' ? org.status.trim() : undefined,
+    expirationDate: typeof org.expirationDate === 'string' ? org.expirationDate.trim() : undefined,
+    accessToken: typeof org.accessToken === 'string' ? org.accessToken : undefined,
+    instanceUrl:
+      typeof org.instanceUrl === 'string'
+        ? org.instanceUrl
+        : typeof org.instance_url === 'string'
+          ? org.instance_url
+          : typeof org.loginUrl === 'string'
+            ? org.loginUrl
+            : undefined,
+    username: typeof org.username === 'string' ? org.username : undefined
+  };
+}
+
+function resolveRequiredDevHubConfig(): DevHubConfig {
+  const authUrl = readEnvValue('SF_DEVHUB_AUTH_URL');
+  const alias = readEnvValue('SF_DEVHUB_ALIAS');
+  if (!authUrl && !alias) {
+    throw new Error('Missing required Dev Hub configuration. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS.');
+  }
+  return { authUrl, alias };
+}
+
+async function getOrgDisplayOrThrow(alias: string): Promise<OrgDisplaySummary> {
+  return mapOrgDisplay(await runSfJson(['org', 'display', '-o', alias]));
+}
+
 async function getOrgDisplay(alias: string): Promise<OrgDisplaySummary | undefined> {
   try {
-    const result = await runSfJson(['org', 'display', '-o', alias]);
-    const org = result?.result ?? {};
-    return {
-      status: typeof org.status === 'string' ? org.status.trim() : undefined,
-      expirationDate: typeof org.expirationDate === 'string' ? org.expirationDate.trim() : undefined,
-      accessToken: typeof org.accessToken === 'string' ? org.accessToken : undefined,
-      instanceUrl:
-        typeof org.instanceUrl === 'string'
-          ? org.instanceUrl
-          : typeof org.instance_url === 'string'
-            ? org.instance_url
-            : typeof org.loginUrl === 'string'
-              ? org.loginUrl
-              : undefined,
-      username: typeof org.username === 'string' ? org.username : undefined
-    };
+    return await getOrgDisplayOrThrow(alias);
   } catch (error) {
     console.warn(
       `[e2e] sf org display failed for alias '${alias}': ${error instanceof Error ? error.message : String(error)}`
     );
     return undefined;
   }
-}
-
-async function tryOrgDisplay(alias: string): Promise<boolean> {
-  return Boolean(await getOrgDisplay(alias));
 }
 
 function isReusableScratchOrg(display: OrgDisplaySummary | undefined, nowMs = Date.now()): boolean {
@@ -120,43 +135,6 @@ async function clearStaleScratchOrg(alias: string): Promise<void> {
   }
 }
 
-async function resolveDefaultDevHubAlias(): Promise<string> {
-  if (process.env.SF_DEVHUB_ALIAS) {
-    return String(process.env.SF_DEVHUB_ALIAS).trim();
-  }
-  if (process.env.SF_DEVHUB_AUTH_URL) {
-    return 'DevHub';
-  }
-
-  // Local convenience: prefer the current team DevHub alias when available.
-  // Keep legacy aliases as fallbacks for older local setups.
-  for (const alias of LOCAL_DEV_HUB_FALLBACK_ALIASES) {
-    if (await tryOrgDisplay(alias)) {
-      return alias;
-    }
-  }
-  return 'DevHub';
-}
-
-async function getFallbackDevHubAliases(primaryAlias: string): Promise<string[]> {
-  const normalizedPrimary = String(primaryAlias || '').trim().toLowerCase();
-  const candidates = Array.from(
-    new Set(
-      LOCAL_DEV_HUB_FALLBACK_ALIASES.map(alias => String(alias || '').trim()).filter(Boolean).filter(
-        alias => alias.toLowerCase() !== normalizedPrimary
-      )
-    )
-  );
-
-  const available: string[] = [];
-  for (const alias of candidates) {
-    if (await tryOrgDisplay(alias)) {
-      available.push(alias);
-    }
-  }
-  return available;
-}
-
 function shouldKeepScratchOrg(): boolean {
   if (process.env.SF_TEST_KEEP_ORG !== undefined) {
     return envFlag('SF_TEST_KEEP_ORG');
@@ -164,78 +142,37 @@ function shouldKeepScratchOrg(): boolean {
   return !envFlag('CI');
 }
 
-function isScratchOrgSignupLimitError(error: unknown): boolean {
-  const message = String(error instanceof Error ? error.message : error || '').toLowerCase();
-  return message.includes('limit_exceeded') && message.includes('scratch org signup limit');
-}
-
-async function createScratchOrgWithFallback(options: {
-  devHubAlias: string;
-  scratchAlias: string;
-  definitionFile: string;
-  durationDays: number;
-  cwd: string;
-}): Promise<string> {
-  const fallbackAliases = await getFallbackDevHubAliases(options.devHubAlias);
-  const candidates = [options.devHubAlias, ...fallbackAliases];
-  let lastError: unknown;
-
-  for (let index = 0; index < candidates.length; index += 1) {
-    const candidate = candidates[index]!;
-    try {
-      await runSfJson(
-        [
-          'org',
-          'create',
-          'scratch',
-          '--target-dev-hub',
-          candidate,
-          '--alias',
-          options.scratchAlias,
-          '--definition-file',
-          options.definitionFile,
-          '--duration-days',
-          String(options.durationDays),
-          '--wait',
-          '15'
-        ],
-        { cwd: options.cwd }
-      );
-      return candidate;
-    } catch (error) {
-      lastError = error;
-      const hasNextCandidate = index + 1 < candidates.length;
-      if (!hasNextCandidate || !isScratchOrgSignupLimitError(error)) {
-        throw error;
-      }
-      const nextCandidate = candidates[index + 1]!;
-      console.warn(
-        `[e2e] scratch org signup limit reached for Dev Hub '${candidate}'; trying fallback '${nextCandidate}'.`
-      );
-    }
-  }
-
-  throw lastError instanceof Error ? lastError : new Error(String(lastError || 'Unknown scratch org creation failure'));
-}
-
-async function ensureDevHubAuth(devHubAlias: string): Promise<void> {
-  const authUrl = String(process.env.SF_DEVHUB_AUTH_URL || '').trim();
+async function ensureDevHubAuth(config: DevHubConfig): Promise<string> {
+  const authUrl = config.authUrl;
   if (!authUrl) {
-    // Assume already authenticated locally; surface a helpful error if not.
-    const ok = await tryOrgDisplay(devHubAlias);
-    if (!ok) {
-      throw new Error(
-        `Dev Hub not found. Set SF_DEVHUB_ALIAS (current: '${devHubAlias}') or provide SF_DEVHUB_AUTH_URL to authenticate in CI.`
-      );
+    const devHubAlias = config.alias;
+    if (!devHubAlias) {
+      throw new Error('Missing required Dev Hub configuration. Set SF_DEVHUB_AUTH_URL or SF_DEVHUB_ALIAS.');
     }
-    return;
+    try {
+      await getOrgDisplayOrThrow(devHubAlias);
+    } catch (error) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new Error(`Dev Hub alias '${devHubAlias}' is not authenticated or unavailable. ${detail}`.trim());
+    }
+    return devHubAlias;
   }
 
   const dir = await mkdtemp(path.join(tmpdir(), 'alv-devhub-'));
   const filePath = path.join(dir, 'devhub.sfdxurl');
   await writeFile(filePath, authUrl, 'utf8');
   try {
-    await runSfJson(['org', 'login', 'sfdx-url', '--sfdx-url-file', filePath, '--alias', devHubAlias]);
+    const args = ['org', 'login', 'sfdx-url', '--sfdx-url-file', filePath, '--set-default-dev-hub'];
+    if (config.alias) {
+      args.push('--alias', config.alias);
+    }
+    const result = await runSfJson(args);
+    const loginUsername = typeof result?.result?.username === 'string' ? result.result.username.trim() : '';
+    const resolvedDevHubAlias = config.alias || loginUsername;
+    if (!resolvedDevHubAlias) {
+      throw new Error('Dev Hub login succeeded but did not return a usable alias or username. Set SF_DEVHUB_ALIAS explicitly.');
+    }
+    return resolvedDevHubAlias;
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -280,7 +217,8 @@ async function waitForScratchOrgReady(targetOrg: string, auth?: OrgAuth): Promis
 
 export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
   return await timeE2eStep('scratch.ensure', async () => {
-    let devHubAlias = await resolveDefaultDevHubAlias();
+    const devHubConfig = resolveRequiredDevHubConfig();
+    const devHubAlias = await ensureDevHubAuth(devHubConfig);
     const scratchAlias = String(process.env.SF_SCRATCH_ALIAS || 'ALV_E2E_Scratch').trim();
     const durationDays = Number(process.env.SF_SCRATCH_DURATION || 1) || 1;
     const keep = shouldKeepScratchOrg();
@@ -316,8 +254,6 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
       );
       await clearStaleScratchOrg(scratchAlias);
     }
-
-    await ensureDevHubAuth(devHubAlias);
 
     const tmp = await mkdtemp(path.join(tmpdir(), 'alv-scratch-'));
     const defFile = path.join(tmp, 'project-scratch-def.json');
@@ -369,13 +305,24 @@ export async function ensureScratchOrg(): Promise<ScratchOrgResult> {
     );
 
     try {
-      devHubAlias = await createScratchOrgWithFallback({
-        devHubAlias,
-        scratchAlias,
-        definitionFile: defFile,
-        durationDays,
-        cwd: tmp
-      });
+      await runSfJson(
+        [
+          'org',
+          'create',
+          'scratch',
+          '--target-dev-hub',
+          devHubAlias,
+          '--alias',
+          scratchAlias,
+          '--definition-file',
+          defFile,
+          '--duration-days',
+          String(durationDays),
+          '--wait',
+          '15'
+        ],
+        { cwd: tmp }
+      );
     } catch (_e) {
       await cleanup();
       const msg = _e instanceof Error ? _e.message : String(_e);


### PR DESCRIPTION
## Summary
This change hardens the scratch-org test setup so Dev Hub configuration must be provided explicitly. The E2E helpers and the shared test runner now fail fast when `SF_DEVHUB_AUTH_URL` and `SF_DEVHUB_ALIAS` are both missing, and they stop retrying alternate Dev Hub aliases after authentication or scratch creation failures.

## Problem
We had recently added convenience behavior that tried to infer a Dev Hub alias locally, retried other known aliases when the preferred one failed, and let the shared runner continue after Dev Hub authentication problems. That made local and CI failures harder to reason about because a misconfigured environment could still appear to work by silently switching to a different Dev Hub or by treating an auth failure as a warning.

## Fix
The scratch-org helper now accepts only the explicitly provided `SF_DEVHUB_AUTH_URL` and `SF_DEVHUB_ALIAS` inputs, validates that at least one of them is present, and uses exactly one Dev Hub for the whole flow. If the alias is missing, not authenticated, or the auth URL fails to log in, the test run now fails immediately. Scratch creation also uses a single `--target-dev-hub` without retrying other aliases.

The shared `scripts/run-tests.js` path now follows the same contract. It no longer falls back to `SFDX_AUTH_URL`, no longer assumes a default `DevHub` alias, and no longer swallows Dev Hub auth errors when scratch setup is enabled. The docs screenshot flow was updated to stop auto-populating `SF_DEVHUB_ALIAS` from `sf org list`, so it matches the same explicit configuration rule.

## Validation
- `npm run test:e2e:utils -- scratchOrg`
- `npm run test:scripts`
- `npm run check-types`
