### PR TITLE
[codex] test(e2e): cover default dev hub alias fallback

### DIFF
--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -68,7 +68,7 @@ describe('ensureScratchOrg', () => {
     delete process.env.SF_DEVHUB_AUTH_URL;
     delete process.env.SF_SCRATCH_STRATEGY;
     delete process.env.SF_SCRATCH_POOL_NAME;
-
+    delete process.env.SFDX_AUTH_URL;
     runSfJsonMock.mockReset();
     getOrgAuthMock.mockReset();
     assertToolingReadyMock.mockReset();
@@ -292,6 +292,75 @@ describe('ensureScratchOrg', () => {
         'ConfiguredDevHub'
       ])
     );
+  });
+
+  test('uses the default dev hub alias when SF_DEVHUB_AUTH_URL is set without SF_DEVHUB_ALIAS', async () => {
+    process.env = {
+      ...originalEnv,
+      SF_DEVHUB_ALIAS: 'LeakedLocalAlias',
+      SF_DEVHUB_AUTH_URL: 'force://redacted',
+      SF_SCRATCH_ALIAS: 'ALV_E2E_Scratch',
+      SF_TEST_KEEP_ORG: '1'
+    };
+    delete process.env.SF_DEVHUB_ALIAS;
+
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'login' && args[2] === 'sfdx-url') {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_Scratch')) {
+        throw new Error('NamedOrgNotFoundError: No authorization information found for ALV_E2E_Scratch.');
+      }
+
+      if (
+        args[0] === 'org' &&
+        args[1] === 'create' &&
+        args[2] === 'scratch' &&
+        args.includes('ConfiguredDevHub')
+      ) {
+        return { status: 0, result: {} };
+      }
+
+      if (args[0] === 'data' && args[1] === 'query') {
+        return {
+          status: 0,
+          result: {
+            records: [{ Id: '7dl000000000001AAA' }]
+          }
+        };
+      }
+
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+
+    expect(scratch).toMatchObject({
+      devHubAlias: 'ConfiguredDevHub',
+      scratchAlias: 'ALV_E2E_Scratch',
+      created: true,
+      strategy: 'single'
+    });
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        'org',
+        'login',
+        'sfdx-url',
+        '--sfdx-url-file',
+        expect.any(String),
+        '--set-default-dev-hub',
+        '--alias',
+        'ConfiguredDevHub'
+      ])
+    );
+    const allArgs = runSfJsonMock.mock.calls.flatMap(([args]) => args);
+    expect(allArgs).not.toContain('LeakedLocalAlias');
+    expect(runSfJsonMock).toHaveBeenCalledWith(
+      expect.arrayContaining(['org', 'create', 'scratch', '--target-dev-hub', 'ConfiguredDevHub']),
+      expect.any(Object)
+    );
+    await scratch.cleanup();
   });
 
   test('fails on scratch signup limit without trying another dev hub alias', async () => {

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -303,6 +303,8 @@ describe('ensureScratchOrg', () => {
       SF_TEST_KEEP_ORG: '1'
     };
     delete process.env.SF_DEVHUB_ALIAS;
+    delete process.env.SF_SCRATCH_STRATEGY;
+    delete process.env.SF_SCRATCH_POOL_NAME;
 
     runSfJsonMock.mockImplementation(async args => {
       if (args[0] === 'org' && args[1] === 'login' && args[2] === 'sfdx-url') {

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -271,7 +271,6 @@ async function ensureDevHubAuth(config: DevHubConfig): Promise<string> {
   const filePath = path.join(dir, 'devhub.sfdxurl');
   await writeFile(filePath, authUrl, 'utf8');
   try {
-    const args = ['org', 'login', 'sfdx-url', '--sfdx-url-file', filePath, '--set-default-dev-hub'];
     const resolvedDevHubAlias = config.alias || DEFAULT_DEV_HUB_ALIAS;
     args.push('--alias', resolvedDevHubAlias);
     await runSfJson(args);

--- a/test/e2e/utils/scratchOrg.ts
+++ b/test/e2e/utils/scratchOrg.ts
@@ -271,6 +271,7 @@ async function ensureDevHubAuth(config: DevHubConfig): Promise<string> {
   const filePath = path.join(dir, 'devhub.sfdxurl');
   await writeFile(filePath, authUrl, 'utf8');
   try {
+    const args = ['org', 'login', 'sfdx-url', '--sfdx-url-file', filePath, '--set-default-dev-hub'];
     const resolvedDevHubAlias = config.alias || DEFAULT_DEV_HUB_ALIAS;
     args.push('--alias', resolvedDevHubAlias);
     await runSfJson(args);


### PR DESCRIPTION
## Summary

This PR now focuses on the still-missing regression coverage that remained after the scratch-org pool merge landed on `main`.

## Issue

`ensureDevHubAuth` now defaults auth-url logins to the repo's standard `ConfiguredDevHub` alias, but the Jest suite still did not prove that behavior when `SF_DEVHUB_AUTH_URL` is present and `SF_DEVHUB_ALIAS` is intentionally absent. That left a gap where workstation environment leakage could hide whether the helper was using the intended default alias or a developer-specific alias from the shell.

## Root Cause

The existing tests covered explicit aliases and auth failures, but not the success path where auth-url login must fall back to the default alias. The fixture setup also did not clear the legacy `SFDX_AUTH_URL` env var, and the new regression scenario needed to explicitly remove a simulated leaked `SF_DEVHUB_ALIAS` before exercising the helper.

## Fix

The PR adds a focused regression in `test/e2e/utils/__tests__/scratchOrg.test.ts` that proves auth-url login uses `ConfiguredDevHub` when no explicit alias is configured, forwards that alias into `--target-dev-hub`, and does not inherit a leaked alias from the environment. The shared fixture setup also clears `SFDX_AUTH_URL` so local shells cannot skew the scenario.

## Validation

- `npx jest --config jest.config.e2e-utils.cjs --runInBand test/e2e/utils/__tests__/scratchOrg.test.ts -t "uses the default dev hub alias when SF_DEVHUB_AUTH_URL is set without SF_DEVHUB_ALIAS"`
- `npm run test:e2e:utils`
- `npm run check-types`