### PR TITLE
[codex] test(e2e): cover pooled cleanup auth-url fallback

### DIFF
--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -1175,7 +1175,7 @@ describe('ensureScratchOrg', () => {
     process.env.SF_SCRATCH_POOL_NAME = 'alv-e2e';
     process.env.SF_DEVHUB_AUTH_URL = 'force://devhub-auth';
 
-    let poolScratchDisplayCount = 0;
+    let simulateCleanupAuthUrlMissing = false;
 
     fetchSpy.mockImplementation(async input => {
       const url = String(input);
@@ -1209,8 +1209,7 @@ describe('ensureScratchOrg', () => {
         return { status: 0, result: {} };
       }
       if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_POOL_06B')) {
-        poolScratchDisplayCount += 1;
-        if (poolScratchDisplayCount < 3) {
+        if (!simulateCleanupAuthUrlMissing) {
           return {
             status: 0,
             result: {
@@ -1239,6 +1238,7 @@ describe('ensureScratchOrg', () => {
     });
 
     const scratch = await ensureScratchOrg();
+    simulateCleanupAuthUrlMissing = true;
     await scratch.cleanup();
 
     const releaseCall = fetchSpy.mock.calls.find(([input]) =>

--- a/test/e2e/utils/__tests__/scratchOrg.test.ts
+++ b/test/e2e/utils/__tests__/scratchOrg.test.ts
@@ -1170,6 +1170,90 @@ describe('ensureScratchOrg', () => {
     expect(releaseBody.errorMessage).toContain('failing test');
   });
 
+  test('marks pooled leases for recreation when cleanup cannot read a refreshed scratch auth url', async () => {
+    process.env.SF_SCRATCH_STRATEGY = 'pool';
+    process.env.SF_SCRATCH_POOL_NAME = 'alv-e2e';
+    process.env.SF_DEVHUB_AUTH_URL = 'force://devhub-auth';
+
+    let poolScratchDisplayCount = 0;
+
+    fetchSpy.mockImplementation(async input => {
+      const url = String(input);
+      if (isPoolConfigQuery(url)) {
+        return createPoolConfigResponse();
+      }
+      if (url.endsWith('/services/apexrest/alv/scratch-pool/v1/acquire')) {
+        return createJsonResponse({
+          ok: true,
+          poolKey: 'alv-e2e',
+          slotKey: 'slot-06b',
+          scratchAlias: 'ALV_E2E_POOL_06B',
+          leaseToken: 'lease-missing-auth-url',
+          needsCreate: false,
+          scratchUsername: 'slot06b@example.com',
+          scratchLoginUrl: 'https://test.salesforce.com',
+          scratchAuthUrl: 'force://slot06b-auth'
+        });
+      }
+      if (url.endsWith('/services/apexrest/alv/scratch-pool/v1/finalize')) {
+        return createJsonResponse({ ok: true });
+      }
+      if (url.endsWith('/services/apexrest/alv/scratch-pool/v1/release')) {
+        return createJsonResponse({ ok: true });
+      }
+      throw new Error(`Unexpected fetch url: ${url}`);
+    });
+
+    runSfJsonMock.mockImplementation(async args => {
+      if (args[0] === 'org' && args[1] === 'login' && args[2] === 'sfdx-url') {
+        return { status: 0, result: {} };
+      }
+      if (args[0] === 'org' && args[1] === 'display' && args.includes('ALV_E2E_POOL_06B')) {
+        poolScratchDisplayCount += 1;
+        if (poolScratchDisplayCount < 3) {
+          return {
+            status: 0,
+            result: {
+              status: 'Active',
+              expirationDate: '2099-03-07',
+              accessToken: 'scratch-token',
+              instanceUrl: 'https://slot06b.scratch.my.salesforce.com',
+              username: 'slot06b@example.com',
+              sfdxAuthUrl: 'force://slot06b-auth-updated'
+            }
+          };
+        }
+
+        return {
+          status: 0,
+          result: {
+            status: 'Active',
+            expirationDate: '2099-03-07',
+            accessToken: 'scratch-token',
+            instanceUrl: 'https://slot06b.scratch.my.salesforce.com',
+            username: 'slot06b@example.com'
+          }
+        };
+      }
+      throw new Error(`Unexpected sf command: ${args.join(' ')}`);
+    });
+
+    const scratch = await ensureScratchOrg();
+    await scratch.cleanup();
+
+    const releaseCall = fetchSpy.mock.calls.find(([input]) =>
+      String(input).endsWith('/services/apexrest/alv/scratch-pool/v1/release')
+    );
+    expect(releaseCall).toBeDefined();
+    const releaseBody = JSON.parse(String(releaseCall?.[1]?.body || '{}'));
+    expect(releaseBody.success).toBe(true);
+    expect(releaseBody.needsRecreate).toBe(true);
+    expect(Object.prototype.hasOwnProperty.call(releaseBody, 'scratchAuthUrl')).toBe(false);
+    expect(consoleWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("scratch org 'ALV_E2E_POOL_06B' did not expose an sfdxAuthUrl")
+    );
+  });
+
   test('marks pooled leases for recreation after heartbeat failures exceed the TTL', async () => {
     process.env.SF_SCRATCH_STRATEGY = 'pool';
     process.env.SF_SCRATCH_POOL_NAME = 'alv-e2e';


### PR DESCRIPTION
## Summary
The pooled scratch-org flow gained stronger lease-health and cleanup logic in the recent pool rollout, but the Jest coverage around cleanup still missed one important branch: the worker can finish successfully and still fail to refresh the pooled scratch `sfdxAuthUrl` during teardown. When that happens, the lease must be released as `needsRecreate=true` so the pool does not try to hand the slot back out as healthy.

This matters to users because a pooled slot that no longer exposes a usable auth URL is effectively unrecoverable for the next worker. Without regression coverage here, later refactors could silently stop marking that slot for recreation and leave the pool re-serving a broken scratch org.

The root cause was test coverage, not production behavior. The cleanup path already attempted to refresh the auth URL and flipped `needsRecreate` when it could not, but there was no focused test proving that fallback path stayed intact.

## What changed
I added one narrow regression in `test/e2e/utils/__tests__/scratchOrg.test.ts` that reuses a pooled scratch org, then simulates teardown-time `org display` output with no `sfdxAuthUrl`. The new test asserts that cleanup releases the lease as successful work with `needsRecreate=true`, omits `scratchAuthUrl` from the release payload, and emits the expected warning.

No production code changed in this PR. The existing behavior was preserved; this PR just locks it in with coverage.

## Validation
I validated the new coverage with:

- `npx jest --config jest.config.e2e-utils.cjs --runInBand test/e2e/utils/__tests__/scratchOrg.test.ts -t "marks pooled leases for recreation when cleanup cannot read a refreshed scratch auth url"`
- `npx jest --config jest.config.e2e-utils.cjs --runInBand test/e2e/utils/__tests__/scratchOrg.test.ts`
- `npx jest --config jest.config.e2e-utils.cjs --runInBand test/e2e/utils/__tests__/scratchOrg.test.ts --coverage --collectCoverageFrom=test/e2e/utils/scratchOrg.ts`
- `npm run test:e2e:utils`
- `npm run check-types`
