### PR TITLE
[codex] reduce auth retries and cache active debug level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - Tail/Docs: refresh the Tail view bootstrap when reopening it, keep debug-level selection resilient for scratch-org flows, and close VS Code auxiliary UI during docs capture so maintainer screenshots stay stable and complete.
+- CLI/Debug Flags: stop retrying redundant Salesforce auth commands after terminal auth/default-org failures, preserve clearer user-facing auth guidance, and cache the active user debug-level lookup so repeated Debug Flags reads avoid unnecessary TraceFlag round trips.
 
 ### Docs
 
@@ -22,6 +23,7 @@
 
 - Docs/E2E: add a manual `npm run docs:screenshots` flow that seeds deterministic scratch-org data, captures the README PNG set, and exercises the refreshed docs-maintenance path.
 - Logs/Tail: cover editor-area commands, singleton editor panels, editor-hosted webview lifecycle, and telemetry catalog updates for the new editor-entry flows.
+- CLI/Debug Flags: cover terminal auth short-circuiting, cached active debug-level reads, and cache invalidation after trace-flag updates.
 
 ## [0.36.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.34.0...v0.36.0) (2026-03-23)
 

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -124,6 +124,61 @@ function getSfCliProgramCandidates(): string[] {
   return Array.from(new Set(programs));
 }
 
+type CliCandidateFamily = {
+  program: string;
+  attempts: string[][];
+};
+
+function buildOrgAuthCandidateFamilies(targetUsernameOrAlias?: string): CliCandidateFamily[] {
+  const targetArgs = targetUsernameOrAlias ? ['-o', targetUsernameOrAlias] : [];
+  return [
+    ...getSfCliProgramCandidates().map(program => ({
+      program,
+      attempts: [
+        ['org', 'display', '--json', '--verbose', ...targetArgs],
+        ['org', 'user', 'display', '--json', '--verbose', ...targetArgs],
+        ['org', 'user', 'display', '--json', ...targetArgs],
+        ['org', 'display', '--json', ...targetArgs]
+      ]
+    })),
+    {
+      program: 'sfdx',
+      attempts: [['force:org:display', '--json', ...(targetUsernameOrAlias ? ['-u', targetUsernameOrAlias] : [])]]
+    }
+  ];
+}
+
+function getCliAuthTerminalCode(code: string, targetUsernameOrAlias?: string): string | undefined {
+  if (code === 'AUTH_REQUIRED') {
+    return code;
+  }
+  if (!targetUsernameOrAlias && code === 'DEFAULT_ORG_MISSING') {
+    return code;
+  }
+  return undefined;
+}
+
+function createCliAuthUserError(code: string): Error | undefined {
+  switch (code) {
+    case 'DEFAULT_ORG_MISSING':
+      return new Error(
+        localize(
+          'cliDefaultOrgMissing',
+          'No default Salesforce org is configured. Select an org in the extension or run "sf org login web" and set a default org.'
+        )
+      );
+    case 'AUTH_REQUIRED':
+      return new Error(
+        localize(
+          'cliAuthRequired',
+          'Salesforce CLI is not authenticated. Run "sf org login web" to authenticate.'
+        )
+      );
+    default:
+      return undefined;
+  }
+}
+
 export async function getOrgAuth(
   targetUsernameOrAlias?: string,
   forceRefresh?: boolean,
@@ -162,91 +217,126 @@ export async function getOrgAuth(
       return persisted;
     }
   }
-  const candidates: Array<{ program: string; args: string[] }> = [
-    ...getSfCliProgramCandidates().flatMap(program => [
-      { program, args: ['org', 'display', '--json', '--verbose', ...(t ? ['-o', t] : [])] },
-      { program, args: ['org', 'user', 'display', '--json', '--verbose', ...(t ? ['-o', t] : [])] },
-      { program, args: ['org', 'user', 'display', '--json', ...(t ? ['-o', t] : [])] },
-      { program, args: ['org', 'display', '--json', ...(t ? ['-o', t] : [])] }
-    ]),
-    { program: 'sfdx', args: ['force:org:display', '--json', ...(t ? ['-u', t] : [])] }
-  ];
+  const candidateFamilies = buildOrgAuthCandidateFamilies(t);
   let sawEnoent = false;
-  for (const { program, args } of candidates) {
-    try {
+  let terminalAuthCode: string | undefined;
+  for (const family of candidateFamilies) {
+    for (const args of family.attempts) {
       try {
-        logTrace('getOrgAuth: trying', program, args.join(' '));
-      } catch {}
-      const { stdout } = await execCommand(program, args, undefined, CLI_TIMEOUT_MS, signal);
-      const auth = readOrgAuthFromCliOutput(stdout);
-      if (execOverriddenForTests && authTtl > 0) {
-        authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
-        enforceAuthCacheLimit();
-      }
-      if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
         try {
-          await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+          logTrace('getOrgAuth: trying', family.program, args.join(' '));
+        } catch {}
+        const { stdout } = await execCommand(family.program, args, undefined, CLI_TIMEOUT_MS, signal);
+        const auth = readOrgAuthFromCliOutput(stdout);
+        if (execOverriddenForTests && authTtl > 0) {
+          authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
+          enforceAuthCacheLimit();
+        }
+        if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
+          try {
+            await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+          } catch {}
+        }
+        return auth;
+      } catch (_e) {
+        const e: any = _e;
+        if (signal?.aborted) {
+          throw new Error('aborted');
+        }
+        if (e && e.code === 'ENOENT') {
+          sawEnoent = true;
+          safeSendException('cli.getOrgAuth', { code: 'ENOENT', command: family.program });
+        } else if (e && e.code === 'ETIMEDOUT') {
+          safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: family.program });
+          throw e;
+        } else {
+          const telemetryCode = getCliTelemetryCode(e);
+          safeSendException('cli.getOrgAuth', { code: telemetryCode, command: family.program });
+          terminalAuthCode = getCliAuthTerminalCode(telemetryCode, t) || terminalAuthCode;
+          if (terminalAuthCode) {
+            break;
+          }
+        }
+        try {
+          logTrace('getOrgAuth: attempt failed for', family.program);
         } catch {}
       }
-      return auth;
-    } catch (_e) {
-      const e: any = _e;
-      if (signal?.aborted) {
-        throw new Error('aborted');
-      }
-      if (e && e.code === 'ENOENT') {
-        sawEnoent = true;
-        safeSendException('cli.getOrgAuth', { code: 'ENOENT', command: program });
-      } else if (e && e.code === 'ETIMEDOUT') {
-        safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: program });
-        throw e;
-      } else {
-        safeSendException('cli.getOrgAuth', { code: getCliTelemetryCode(e), command: program });
-      }
-      try {
-        logTrace('getOrgAuth: attempt failed for', program);
-      } catch {}
     }
+    if (terminalAuthCode) {
+      continue;
+    }
+  }
+  if (terminalAuthCode) {
+    throw (
+      createCliAuthUserError(terminalAuthCode) ||
+      new Error(
+        localize(
+          'cliAuthFailed',
+          'Failed to retrieve Salesforce org authentication. Run "sf org login web" to authenticate.'
+        )
+      )
+    );
   }
   if (sawEnoent) {
     const loginPath = await resolvePATHFromLoginShell();
     if (loginPath) {
       const env2: NodeJS.ProcessEnv = { ...process.env, PATH: loginPath };
-      for (const { program, args } of candidates) {
-        try {
+      for (const family of candidateFamilies) {
+        for (const args of family.attempts) {
           try {
-            logTrace('getOrgAuth(login PATH): trying', program, args.join(' '));
-          } catch {}
-          const { stdout } = await execCommand(program, args, env2, CLI_TIMEOUT_MS, signal);
-          const auth = readOrgAuthFromCliOutput(stdout);
-          if (execOverriddenForTests && authTtl > 0) {
-            authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
-            enforceAuthCacheLimit();
-          }
-          if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
             try {
-              await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+              logTrace('getOrgAuth(login PATH): trying', family.program, args.join(' '));
+            } catch {}
+            const { stdout } = await execCommand(family.program, args, env2, CLI_TIMEOUT_MS, signal);
+            const auth = readOrgAuthFromCliOutput(stdout);
+            if (execOverriddenForTests && authTtl > 0) {
+              authCacheByUser.set(cacheKey, { value: auth, expiresAt: now + authTtl });
+              enforceAuthCacheLimit();
+            }
+            if (enabled && authPersistTtl > 0 && !execOverriddenForTests) {
+              try {
+                await CacheManager.set('cli', `orgAuth:${cacheKey}`, auth, authPersistTtl);
+              } catch {}
+            }
+            return auth;
+          } catch (_e) {
+            const e: any = _e;
+            if (signal?.aborted) {
+              throw new Error('aborted');
+            }
+            if (e && e.code === 'ENOENT') {
+              safeSendException('cli.getOrgAuth', { code: 'ENOENT', command: family.program });
+            } else if (e && e.code === 'ETIMEDOUT') {
+              safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: family.program });
+              throw e;
+            } else {
+              const telemetryCode = getCliTelemetryCode(e);
+              safeSendException('cli.getOrgAuth', { code: telemetryCode, command: family.program });
+              terminalAuthCode = getCliAuthTerminalCode(telemetryCode, t) || terminalAuthCode;
+              if (terminalAuthCode) {
+                break;
+              }
+            }
+            try {
+              logTrace('getOrgAuth(login PATH): attempt failed for', family.program);
             } catch {}
           }
-          return auth;
-        } catch (_e) {
-          const e: any = _e;
-          if (signal?.aborted) {
-            throw new Error('aborted');
-          }
-          if (e && e.code === 'ENOENT') {
-            safeSendException('cli.getOrgAuth', { code: 'ENOENT', command: program });
-          } else if (e && e.code === 'ETIMEDOUT') {
-            safeSendException('cli.getOrgAuth', { code: 'ETIMEDOUT', command: program });
-            throw e;
-          } else {
-            safeSendException('cli.getOrgAuth', { code: getCliTelemetryCode(e), command: program });
-          }
-          try {
-            logTrace('getOrgAuth(login PATH): attempt failed for', program);
-          } catch {}
+        }
+        if (terminalAuthCode) {
+          break;
         }
       }
+    }
+    if (terminalAuthCode) {
+      throw (
+        createCliAuthUserError(terminalAuthCode) ||
+        new Error(
+          localize(
+            'cliAuthFailed',
+            'Failed to retrieve Salesforce org authentication. Run "sf org login web" to authenticate.'
+          )
+        )
+      );
     }
     safeSendException('cli.getOrgAuth', { code: 'CLI_NOT_FOUND' });
     throw new Error(

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -252,8 +252,9 @@ export async function getOrgAuth(
         } else {
           const telemetryCode = getCliTelemetryCode(e);
           safeSendException('cli.getOrgAuth', { code: telemetryCode, command: family.program });
-          terminalAuthCode = getCliAuthTerminalCode(telemetryCode, t) || terminalAuthCode;
-          if (terminalAuthCode) {
+          const nextTerminalAuthCode = getCliAuthTerminalCode(telemetryCode, t);
+          if (nextTerminalAuthCode) {
+            terminalAuthCode = nextTerminalAuthCode;
             break;
           }
         }
@@ -309,8 +310,9 @@ export async function getOrgAuth(
             } else {
               const telemetryCode = getCliTelemetryCode(e);
               safeSendException('cli.getOrgAuth', { code: telemetryCode, command: family.program });
-              terminalAuthCode = getCliAuthTerminalCode(telemetryCode, t) || terminalAuthCode;
-              if (terminalAuthCode) {
+              const nextTerminalAuthCode = getCliAuthTerminalCode(telemetryCode, t);
+              if (nextTerminalAuthCode) {
+                terminalAuthCode = nextTerminalAuthCode;
                 break;
               }
             }

--- a/src/salesforce/cli.ts
+++ b/src/salesforce/cli.ts
@@ -262,11 +262,8 @@ export async function getOrgAuth(
         } catch {}
       }
     }
-    if (terminalAuthCode) {
-      continue;
-    }
   }
-  if (terminalAuthCode) {
+  if (terminalAuthCode && !sawEnoent) {
     throw (
       createCliAuthUserError(terminalAuthCode) ||
       new Error(
@@ -321,9 +318,6 @@ export async function getOrgAuth(
               logTrace('getOrgAuth(login PATH): attempt failed for', family.program);
             } catch {}
           }
-        }
-        if (terminalAuthCode) {
-          break;
         }
       }
     }

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -811,8 +811,8 @@ export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): 
         if (result?.success === false) {
           throw new Error(`Failed to delete USER_DEBUG TraceFlag '${id}'.`);
         }
+        removedCount += 1;
       }
-      removedCount += ids.length;
     }
 
     return {

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -747,47 +747,52 @@ export async function upsertTraceFlag(
   const traceFlagIds: string[] = [];
   const apiVersion = getEffectiveApiVersion(auth);
 
-  for (const tracedEntityId of resolved.tracedEntityIds) {
-    const existingId = await getLatestTraceFlagId(auth, tracedEntityId);
-    if (existingId) {
-      const updateResult = await updateToolingRecord(auth, apiVersion, 'TraceFlag', existingId, {
+  try {
+    for (const tracedEntityId of resolved.tracedEntityIds) {
+      const existingId = await getLatestTraceFlagId(auth, tracedEntityId);
+      if (existingId) {
+        const updateResult = await updateToolingRecord(auth, apiVersion, 'TraceFlag', existingId, {
+          DebugLevelId: debugLevelId,
+          StartDate: start,
+          ExpirationDate: exp
+        });
+        if (updateResult?.success === false) {
+          throw new Error('Failed to update USER_DEBUG TraceFlag.');
+        }
+        updatedCount += 1;
+        traceFlagIds.push(existingId);
+        continue;
+      }
+
+      const payload = {
+        TracedEntityId: tracedEntityId,
+        LogType: 'USER_DEBUG',
         DebugLevelId: debugLevelId,
         StartDate: start,
         ExpirationDate: exp
-      });
-      if (updateResult?.success === false) {
-        throw new Error('Failed to update USER_DEBUG TraceFlag.');
+      };
+      const res = await createToolingRecord(auth, apiVersion, 'TraceFlag', payload);
+      if (!res || !res.success || !res.id) {
+        throw new Error('Failed to create USER_DEBUG TraceFlag.');
       }
-      updatedCount += 1;
-      traceFlagIds.push(existingId);
-      continue;
+      createdCount += 1;
+      traceFlagIds.push(String(res.id));
     }
 
-    const payload = {
-      TracedEntityId: tracedEntityId,
-      LogType: 'USER_DEBUG',
-      DebugLevelId: debugLevelId,
-      StartDate: start,
-      ExpirationDate: exp
+    const traceFlagId = traceFlagIds.length === 1 ? traceFlagIds[0] : undefined;
+    return {
+      created: resolved.tracedEntityIds.length === 1 ? createdCount === 1 : createdCount > 0 && updatedCount === 0,
+      traceFlagId,
+      traceFlagIds,
+      createdCount,
+      updatedCount,
+      resolvedTargetCount: resolved.tracedEntityIds.length
     };
-    const res = await createToolingRecord(auth, apiVersion, 'TraceFlag', payload);
-    if (!res || !res.success || !res.id) {
-      throw new Error('Failed to create USER_DEBUG TraceFlag.');
+  } finally {
+    if (createdCount > 0 || updatedCount > 0) {
+      invalidateActiveUserDebugLevelCache(auth);
     }
-    createdCount += 1;
-    traceFlagIds.push(String(res.id));
   }
-
-  const traceFlagId = traceFlagIds.length === 1 ? traceFlagIds[0] : undefined;
-  invalidateActiveUserDebugLevelCache(auth);
-  return {
-    created: resolved.tracedEntityIds.length === 1 ? createdCount === 1 : createdCount > 0 && updatedCount === 0,
-    traceFlagId,
-    traceFlagIds,
-    createdCount,
-    updatedCount,
-    resolvedTargetCount: resolved.tracedEntityIds.length
-  };
 }
 
 export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): Promise<RemoveTraceFlagsResult> {
@@ -798,22 +803,27 @@ export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): 
 
   let removedCount = 0;
   const apiVersion = getEffectiveApiVersion(auth);
-  for (const tracedEntityId of resolved.tracedEntityIds) {
-    const ids = await listTraceFlagIds(auth, tracedEntityId);
-    for (const id of ids) {
-      const result = await deleteToolingRecord(auth, apiVersion, 'TraceFlag', id);
-      if (result?.success === false) {
-        throw new Error(`Failed to delete USER_DEBUG TraceFlag '${id}'.`);
+  try {
+    for (const tracedEntityId of resolved.tracedEntityIds) {
+      const ids = await listTraceFlagIds(auth, tracedEntityId);
+      for (const id of ids) {
+        const result = await deleteToolingRecord(auth, apiVersion, 'TraceFlag', id);
+        if (result?.success === false) {
+          throw new Error(`Failed to delete USER_DEBUG TraceFlag '${id}'.`);
+        }
       }
+      removedCount += ids.length;
     }
-    removedCount += ids.length;
-  }
 
-  invalidateActiveUserDebugLevelCache(auth);
-  return {
-    removedCount,
-    resolvedTargetCount: resolved.tracedEntityIds.length
-  };
+    return {
+      removedCount,
+      resolvedTargetCount: resolved.tracedEntityIds.length
+    };
+  } finally {
+    if (removedCount > 0) {
+      invalidateActiveUserDebugLevelCache(auth);
+    }
+  }
 }
 
 export async function getUserTraceFlagStatus(auth: OrgAuth, userId: string): Promise<TraceFlagTargetStatus> {

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -779,9 +779,7 @@ export async function upsertTraceFlag(
   }
 
   const traceFlagId = traceFlagIds.length === 1 ? traceFlagIds[0] : undefined;
-  if (!isSpecialTraceFlagTarget(input.target)) {
-    invalidateActiveUserDebugLevelCache(auth);
-  }
+  invalidateActiveUserDebugLevelCache(auth);
   return {
     created: resolved.tracedEntityIds.length === 1 ? createdCount === 1 : createdCount > 0 && updatedCount === 0,
     traceFlagId,
@@ -811,9 +809,7 @@ export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): 
     removedCount += ids.length;
   }
 
-  if (!isSpecialTraceFlagTarget(target)) {
-    invalidateActiveUserDebugLevelCache(auth);
-  }
+  invalidateActiveUserDebugLevelCache(auth);
   return {
     removedCount,
     resolvedTargetCount: resolved.tracedEntityIds.length

--- a/src/salesforce/traceflags.ts
+++ b/src/salesforce/traceflags.ts
@@ -69,6 +69,7 @@ const DEBUG_LEVEL_FIELDS =
 const DEBUG_LEVEL_EXTENDED_FIELDS_MIN_API_VERSION = '63.0';
 const DEFAULT_TAIL_DEBUG_LEVEL = { ...DEBUG_LEVEL_PRESETS[0]!.record };
 const debugLevelApiVersionByOrg = new Map<string, string>();
+const activeUserDebugLevelCache = new Map<string, { value: string | undefined; expiresAt: number }>();
 
 function getDebugLevelsCacheConfig() {
   try {
@@ -119,6 +120,10 @@ function getDebugLevelApiVersionCacheKey(auth: OrgAuth): string {
     .toLowerCase()}|${String(auth.username || '')
     .trim()
     .toLowerCase()}`;
+}
+
+function getActiveUserDebugLevelCacheKey(auth: OrgAuth): string {
+  return getDebugLevelApiVersionCacheKey(auth);
 }
 
 function getSpecialTargetCacheKey(auth: OrgAuth, targetType: Exclude<TraceFlagTarget['type'], 'user'>): string {
@@ -218,6 +223,11 @@ async function invalidateDebugLevelsCache(auth: OrgAuth): Promise<void> {
 
 export function __resetDebugLevelApiVersionCacheForTests(): void {
   debugLevelApiVersionByOrg.clear();
+  activeUserDebugLevelCache.clear();
+}
+
+function invalidateActiveUserDebugLevelCache(auth: OrgAuth): void {
+  activeUserDebugLevelCache.delete(getActiveUserDebugLevelCacheKey(auth));
 }
 
 function mapDebugLevelRecord(record: DebugLevelQueryRecord): DebugLevelRecord {
@@ -357,12 +367,30 @@ export async function listActiveUsers(auth: OrgAuth, query = '', limit = 50): Pr
 }
 
 export async function getActiveUserDebugLevel(auth: OrgAuth): Promise<string | undefined> {
+  const { enabled, ttl } = getDebugLevelsCacheConfig();
+  const cacheKey = getActiveUserDebugLevelCacheKey(auth);
+  if (enabled && ttl > 0) {
+    const cached = activeUserDebugLevelCache.get(cacheKey);
+    if (cached) {
+      if (cached.expiresAt > Date.now()) {
+        return cached.value;
+      }
+      activeUserDebugLevelCache.delete(cacheKey);
+    }
+  }
   const userId = await getCurrentUserId(auth);
   if (!userId) {
     return undefined;
   }
   const status = await getTraceFlagTargetStatus(auth, { type: 'user', userId });
-  return status.traceFlagId ? status.debugLevelName : undefined;
+  const activeDebugLevel = status.traceFlagId ? status.debugLevelName : undefined;
+  if (enabled && ttl > 0) {
+    activeUserDebugLevelCache.set(cacheKey, {
+      value: activeDebugLevel,
+      expiresAt: Date.now() + ttl
+    });
+  }
+  return activeDebugLevel;
 }
 
 // Format date as Salesforce datetime: YYYY-MM-DDTHH:mm:ss.SSS+0000 (UTC)
@@ -494,6 +522,7 @@ export async function createDebugLevel(auth: OrgAuth, input: DebugLevelRecord): 
     throw new Error('Failed to create DebugLevel.');
   }
   await invalidateDebugLevelsCache(auth);
+  invalidateActiveUserDebugLevelCache(auth);
   return { id: String(res.id) };
 }
 
@@ -523,6 +552,7 @@ export async function updateDebugLevel(auth: OrgAuth, debugLevelId: string, inpu
     throw new Error('Failed to update DebugLevel.');
   }
   await invalidateDebugLevelsCache(auth);
+  invalidateActiveUserDebugLevelCache(auth);
 }
 
 export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Promise<void> {
@@ -535,6 +565,7 @@ export async function deleteDebugLevel(auth: OrgAuth, debugLevelId: string): Pro
     throw new Error('Failed to delete DebugLevel.');
   }
   await invalidateDebugLevelsCache(auth);
+  invalidateActiveUserDebugLevelCache(auth);
 }
 
 async function getLatestTraceFlagRecord(
@@ -748,6 +779,9 @@ export async function upsertTraceFlag(
   }
 
   const traceFlagId = traceFlagIds.length === 1 ? traceFlagIds[0] : undefined;
+  if (!isSpecialTraceFlagTarget(input.target)) {
+    invalidateActiveUserDebugLevelCache(auth);
+  }
   return {
     created: resolved.tracedEntityIds.length === 1 ? createdCount === 1 : createdCount > 0 && updatedCount === 0,
     traceFlagId,
@@ -777,6 +811,9 @@ export async function removeTraceFlags(auth: OrgAuth, target: TraceFlagTarget): 
     removedCount += ids.length;
   }
 
+  if (!isSpecialTraceFlagTarget(target)) {
+    invalidateActiveUserDebugLevelCache(auth);
+  }
   return {
     removedCount,
     resolvedTargetCount: resolved.tracedEntityIds.length

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -160,6 +160,136 @@ suite('cli telemetry', () => {
     assert.ok(!calls.some(c => c.properties?.code === '1'), 'should not emit the raw exit code 1');
   });
 
+  test('stops retrying redundant sf auth commands after a default-org failure and surfaces a specific error', async () => {
+    const calls: any[] = [];
+    const attempts: Array<{ program: string; args: string[] }> = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      attempts.push({ program, args: Array.isArray(args) ? [...args] : [] });
+      const err: any = new Error('default org missing');
+      err.code = 1;
+      cb(err, '', 'No default username found. Use -o or set a default org.');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined), (e: any) => {
+      assert.match(String(e?.message || ''), /default org|default username|set a default org/i);
+      return true;
+    });
+    __resetExecFileImplForTests();
+
+    assert.deepEqual(
+      attempts.map(attempt => attempt.program),
+      ['sf', 'sfdx'],
+      'expected to stop after the first semantic failure for each CLI family'
+    );
+    assert.ok(
+      calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'DEFAULT_ORG_MISSING'),
+      'expected semantic auth failure telemetry'
+    );
+    assert.ok(!calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_FAILED'));
+  });
+
+  test('stops retrying redundant sf auth commands after an auth-required failure and surfaces login guidance', async () => {
+    const calls: any[] = [];
+    const attempts: Array<{ program: string; args: string[] }> = [];
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(_name: string, def?: T) => def,
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      attempts.push({ program, args: Array.isArray(args) ? [...args] : [] });
+      const err: any = new Error('auth required');
+      err.code = 1;
+      cb(err, '', 'No authorization information found. Run "sf org login web" to authorize an org.');
+      return undefined as any;
+    }) as any);
+
+    await assert.rejects(getOrgAuth(undefined), (e: any) => {
+      assert.match(String(e?.message || ''), /org login web|authenticate|authorization/i);
+      return true;
+    });
+    __resetExecFileImplForTests();
+
+    assert.deepEqual(
+      attempts.map(attempt => attempt.program),
+      ['sf', 'sfdx'],
+      'expected to stop after the first semantic failure for each CLI family'
+    );
+    assert.ok(
+      calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_REQUIRED'),
+      'expected semantic auth-required telemetry'
+    );
+    assert.ok(!calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_FAILED'));
+  });
+
   test('classifies empty CLI output during auth parsing', async () => {
     const calls: any[] = [];
     const telemetry = (name: string, properties: Record<string, string>) => {

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -290,6 +290,189 @@ suite('cli telemetry', () => {
     assert.ok(!calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_FAILED'));
   });
 
+  test('retries with login-shell PATH before surfacing a terminal auth error from a mixed failure set', async () => {
+    const calls: any[] = [];
+    const attempts: Array<{ program: string; path: string | undefined }> = [];
+    let loginPathCalls = 0;
+    const telemetry = (name: string, properties: Record<string, string>) => {
+      calls.push({ name, properties });
+    };
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(name: string, def?: T) => (name === 'sfLogs.cliPath' ? ('C:\\stale\\sf.cmd' as T) : def),
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => {
+          loginPathCalls++;
+          return 'C:\\login-shell\\bin';
+        },
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, _args: readonly string[] | undefined, opts: any, cb: any) => {
+      const pathValue = String(opts?.env?.PATH || '');
+      attempts.push({ program, path: pathValue || undefined });
+      if (!pathValue && program === 'C:\\stale\\sf.cmd') {
+        const err: any = new Error('not found');
+        err.code = 'ENOENT';
+        cb(err, '', '');
+        return undefined as any;
+      }
+      if (!pathValue && program === 'sf') {
+        const err: any = new Error('auth required');
+        err.code = 1;
+        cb(err, '', 'No authorization information found. Run "sf org login web" to authorize an org.');
+        return undefined as any;
+      }
+      if (pathValue === 'C:\\login-shell\\bin' && program === 'sf') {
+        cb(
+          null,
+          JSON.stringify({
+            result: {
+              accessToken: '00D-token',
+              instanceUrl: 'https://example.my.salesforce.com',
+              username: 'user@example.com'
+            }
+          }),
+          ''
+        );
+        return undefined as any;
+      }
+      const err: any = new Error('not found');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    const auth = await getOrgAuth(undefined);
+    __resetExecFileImplForTests();
+
+    assert.equal(auth.instanceUrl, 'https://example.my.salesforce.com');
+    assert.equal(loginPathCalls, 1, 'expected login-shell PATH fallback to run');
+    assert.ok(
+      attempts.some(attempt => attempt.program === 'sf' && attempt.path === 'C:\\login-shell\\bin'),
+      'expected a retry with the login-shell PATH'
+    );
+    assert.ok(
+      calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_REQUIRED'),
+      'expected the mixed semantic failure to stay classified in telemetry'
+    );
+  });
+
+  test('continues to the next CLI family on login-shell PATH after a terminal failure in the current family', async () => {
+    const attempts: Array<{ program: string; path: string | undefined }> = [];
+    let loginPathCalls = 0;
+    const telemetry = () => undefined;
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(name: string, def?: T) => (name === 'sfLogs.cliPath' ? ('C:\\stale\\sf.cmd' as T) : def),
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => {
+          loginPathCalls++;
+          return 'C:\\login-shell\\bin';
+        },
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, _args: readonly string[] | undefined, opts: any, cb: any) => {
+      const pathValue = String(opts?.env?.PATH || '');
+      attempts.push({ program, path: pathValue || undefined });
+      if (!pathValue) {
+        const err: any = new Error('not found');
+        err.code = 'ENOENT';
+        cb(err, '', '');
+        return undefined as any;
+      }
+      if (pathValue === 'C:\\login-shell\\bin' && program === 'C:\\stale\\sf.cmd') {
+        const err: any = new Error('auth required');
+        err.code = 1;
+        cb(err, '', 'No authorization information found. Run "sf org login web" to authorize an org.');
+        return undefined as any;
+      }
+      if (pathValue === 'C:\\login-shell\\bin' && program === 'sf') {
+        cb(
+          null,
+          JSON.stringify({
+            result: {
+              accessToken: '00D-token',
+              instanceUrl: 'https://example.my.salesforce.com',
+              username: 'user@example.com'
+            }
+          }),
+          ''
+        );
+        return undefined as any;
+      }
+      const err: any = new Error('not found');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    const auth = await getOrgAuth(undefined);
+    __resetExecFileImplForTests();
+
+    assert.equal(auth.username, 'user@example.com');
+    assert.equal(loginPathCalls, 1, 'expected one login-shell PATH resolution');
+    assert.ok(
+      attempts.some(attempt => attempt.program === 'C:\\stale\\sf.cmd' && attempt.path === 'C:\\login-shell\\bin'),
+      'expected the configured CLI family to be retried on login-shell PATH'
+    );
+    assert.ok(
+      attempts.some(attempt => attempt.program === 'sf' && attempt.path === 'C:\\login-shell\\bin'),
+      'expected the next CLI family to still run on login-shell PATH'
+    );
+  });
+
   test('classifies empty CLI output during auth parsing', async () => {
     const calls: any[] = [];
     const telemetry = (name: string, properties: Record<string, string>) => {

--- a/src/test/cli.telemetry.test.ts
+++ b/src/test/cli.telemetry.test.ts
@@ -290,6 +290,88 @@ suite('cli telemetry', () => {
     assert.ok(!calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_FAILED'));
   });
 
+  test('does not reuse a prior terminal auth code across CLI families on the initial PATH', async () => {
+    const attempts: Array<{ program: string; args: string[] }> = [];
+    const telemetry = () => undefined;
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(name: string, def?: T) => (name === 'sfLogs.cliPath' ? ('C:\\stale\\sf.cmd' as T) : def),
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => undefined,
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, _opts: any, cb: any) => {
+      const argList = Array.isArray(args) ? [...args] : [];
+      attempts.push({ program, args: argList });
+      if (program === 'C:\\stale\\sf.cmd') {
+        const err: any = new Error('auth required');
+        err.code = 1;
+        cb(err, '', 'No authorization information found. Run "sf org login web" to authorize an org.');
+        return undefined as any;
+      }
+      if (program === 'sf') {
+        if (argList.join(' ') === 'org display --json --verbose') {
+          const err: any = new Error('unsupported command shape');
+          err.code = 1;
+          cb(err, '', 'Unexpected argument: --verbose');
+          return undefined as any;
+        }
+        cb(
+          null,
+          JSON.stringify({
+            result: {
+              accessToken: '00D-token',
+              instanceUrl: 'https://example.my.salesforce.com',
+              username: 'user@example.com'
+            }
+          }),
+          ''
+        );
+        return undefined as any;
+      }
+      const err: any = new Error('not found');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    const auth = await getOrgAuth(undefined);
+    __resetExecFileImplForTests();
+
+    assert.equal(auth.username, 'user@example.com');
+    assert.deepEqual(
+      attempts.filter(attempt => attempt.program === 'sf').map(attempt => attempt.args.join(' ')).slice(0, 2),
+      ['org display --json --verbose', 'org user display --json --verbose'],
+      'expected the plain sf family to continue after a non-terminal error'
+    );
+  });
+
   test('retries with login-shell PATH before surfacing a terminal auth error from a mixed failure set', async () => {
     const calls: any[] = [];
     const attempts: Array<{ program: string; path: string | undefined }> = [];
@@ -380,6 +462,103 @@ suite('cli telemetry', () => {
     assert.ok(
       calls.some(c => c.name === 'cli.getOrgAuth' && c.properties?.code === 'AUTH_REQUIRED'),
       'expected the mixed semantic failure to stay classified in telemetry'
+    );
+  });
+
+  test('does not reuse a prior terminal auth code across CLI families on login-shell PATH', async () => {
+    const attempts: Array<{ program: string; args: string[]; path: string | undefined }> = [];
+    let loginPathCalls = 0;
+    const telemetry = () => undefined;
+    const cliStubs = {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, '@noCallThru': true },
+      '../utils/config': {
+        getBooleanConfig: (_name: string, def: boolean) => def,
+        getConfig: <T>(name: string, def?: T) => (name === 'sfLogs.cliPath' ? ('C:\\stale\\sf.cmd' as T) : def),
+        getNumberConfig: (_name: string, def: number) => def,
+        '@noCallThru': true
+      },
+      '../utils/cacheManager': {
+        CacheManager: {
+          get: () => undefined,
+          set: async () => undefined,
+          delete: async () => undefined
+        },
+        '@noCallThru': true
+      },
+      './path': {
+        resolvePATHFromLoginShell: async () => {
+          loginPathCalls++;
+          return 'C:\\login-shell\\bin';
+        },
+        '@noCallThru': true
+      }
+    };
+    const execModule = proxyquire('../salesforce/exec', {
+      '../shared/telemetry': { safeSendException: telemetry, '@noCallThru': true },
+      '../utils/logger': { logTrace: () => undefined, logWarn: () => undefined, '@noCallThru': true }
+    });
+    const { getOrgAuth } = proxyquire('../salesforce/cli', {
+      ...cliStubs,
+      './exec': execModule,
+      '@noCallThru': true
+    });
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, opts: any, cb: any) => {
+      const argList = Array.isArray(args) ? [...args] : [];
+      const pathValue = String(opts?.env?.PATH || '');
+      attempts.push({ program, args: argList, path: pathValue || undefined });
+      if (!pathValue) {
+        const err: any = new Error('not found');
+        err.code = 'ENOENT';
+        cb(err, '', '');
+        return undefined as any;
+      }
+      if (pathValue === 'C:\\login-shell\\bin' && program === 'C:\\stale\\sf.cmd') {
+        const err: any = new Error('auth required');
+        err.code = 1;
+        cb(err, '', 'No authorization information found. Run "sf org login web" to authorize an org.');
+        return undefined as any;
+      }
+      if (pathValue === 'C:\\login-shell\\bin' && program === 'sf') {
+        if (argList.join(' ') === 'org display --json --verbose') {
+          const err: any = new Error('unsupported command shape');
+          err.code = 1;
+          cb(err, '', 'Unexpected argument: --verbose');
+          return undefined as any;
+        }
+        cb(
+          null,
+          JSON.stringify({
+            result: {
+              accessToken: '00D-token',
+              instanceUrl: 'https://example.my.salesforce.com',
+              username: 'user@example.com'
+            }
+          }),
+          ''
+        );
+        return undefined as any;
+      }
+      const err: any = new Error('not found');
+      err.code = 'ENOENT';
+      cb(err, '', '');
+      return undefined as any;
+    }) as any);
+
+    const auth = await getOrgAuth(undefined);
+    __resetExecFileImplForTests();
+
+    assert.equal(auth.instanceUrl, 'https://example.my.salesforce.com');
+    assert.equal(loginPathCalls, 1, 'expected one login-shell PATH resolution');
+    assert.deepEqual(
+      attempts
+        .filter(attempt => attempt.program === 'sf' && attempt.path === 'C:\\login-shell\\bin')
+        .map(attempt => attempt.args.join(' '))
+        .slice(0, 2),
+      ['org display --json --verbose', 'org user display --json --verbose'],
+      'expected the plain sf family to continue after a non-terminal login-shell failure'
     );
   });
 

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -441,6 +441,89 @@ suite('traceflags user management', () => {
     assert.equal(traceFlagQueryCount, 2, 'expected a fresh trace-flag read after invalidation');
   });
 
+  test('upsertTraceFlag invalidates the cached active debug level for current special-target users', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    let traceFlagQueryCount = 0;
+    let activeDebugLevelName = 'ALV_OLD';
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("FROM User WHERE Username = 'user@example.com'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM DebugLevel WHERE DeveloperName = 'ALV_NEW'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7dl000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7tf000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA' AND LogType = 'USER_DEBUG'")) {
+          traceFlagQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000001AAA',
+                  StartDate: '2026-03-25T00:00:00.000+0000',
+                  ExpirationDate: '2099-03-25T01:00:00.000+0000',
+                  DebugLevel: { DeveloperName: activeDebugLevelName }
+                }
+              ]
+            }
+          };
+        }
+      }
+      if (
+        req.method === 'PATCH' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000001AAA')
+      ) {
+        activeDebugLevelName = 'ALV_NEW';
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.DebugLevelId, '7dl000000000001AAA');
+        return {
+          statusCode: 204
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const before = await getActiveUserDebugLevel(auth);
+    await upsertTraceFlag(auth, {
+      target: { type: 'platformIntegration' },
+      debugLevelName: 'ALV_NEW',
+      ttlMinutes: 30
+    });
+    const after = await getActiveUserDebugLevel(auth);
+
+    assert.equal(before, 'ALV_OLD');
+    assert.equal(after, 'ALV_NEW');
+    assert.equal(traceFlagQueryCount, 2, 'expected a fresh trace-flag read after special-target invalidation');
+  });
+
   test('getTraceFlagTargetStatus resolves Automated Process across all active matches and aggregates USER_DEBUG status', async () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -524,6 +524,114 @@ suite('traceflags user management', () => {
     assert.equal(traceFlagQueryCount, 2, 'expected a fresh trace-flag read after special-target invalidation');
   });
 
+  test('upsertTraceFlag invalidates the cached active debug level after a partial special-target failure', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    let traceFlagQueryCount = 0;
+    let activeDebugLevelName = 'ALV_OLD';
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("FROM User WHERE Username = 'user@example.com'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }, { Id: '005000000000002AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM DebugLevel WHERE DeveloperName = 'ALV_NEW'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7dl000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7tf000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM TraceFlag WHERE TracedEntityId = '005000000000002AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7tf000000000002AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA' AND LogType = 'USER_DEBUG'")) {
+          traceFlagQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000001AAA',
+                  StartDate: '2026-03-25T00:00:00.000+0000',
+                  ExpirationDate: '2099-03-25T01:00:00.000+0000',
+                  DebugLevel: { DeveloperName: activeDebugLevelName }
+                }
+              ]
+            }
+          };
+        }
+      }
+      if (
+        req.method === 'PATCH' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000001AAA')
+      ) {
+        activeDebugLevelName = 'ALV_NEW';
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.DebugLevelId, '7dl000000000001AAA');
+        return {
+          statusCode: 204
+        };
+      }
+      if (
+        req.method === 'PATCH' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000002AAA')
+      ) {
+        return {
+          statusCode: 200,
+          body: { success: false, errors: [{ message: 'boom' }] }
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const before = await getActiveUserDebugLevel(auth);
+    await assert.rejects(
+      async () =>
+        await upsertTraceFlag(auth, {
+          target: { type: 'platformIntegration' },
+          debugLevelName: 'ALV_NEW',
+          ttlMinutes: 30
+        }),
+      /Failed to update USER_DEBUG TraceFlag/
+    );
+    const after = await getActiveUserDebugLevel(auth);
+
+    assert.equal(before, 'ALV_OLD');
+    assert.equal(after, 'ALV_NEW');
+    assert.equal(
+      traceFlagQueryCount,
+      2,
+      'expected a fresh trace-flag read after the partially successful special-target write'
+    );
+  });
+
   test('getTraceFlagTargetStatus resolves Automated Process across all active matches and aggregates USER_DEBUG status', async () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert/strict';
 import { EventEmitter } from 'events';
+import { workspace } from 'vscode';
 import type { OrgAuth } from '../salesforce/types';
 import {
   __resetApiVersionFallbackStateForTests,
@@ -14,6 +15,7 @@ import {
   __resetUserIdCacheForTests,
   createDebugLevel,
   deleteDebugLevel,
+  getActiveUserDebugLevel,
   getTraceFlagTargetStatus,
   getUserTraceFlagStatus,
   listDebugLevels,
@@ -103,6 +105,7 @@ function isSpecialTargetUserResolutionQuery(soql: string, userType: string): boo
 }
 
 suite('traceflags user management', () => {
+  const originalGetConfiguration = workspace.getConfiguration;
   const auth: OrgAuth = {
     accessToken: 'token',
     instanceUrl: 'https://example.my.salesforce.com',
@@ -114,6 +117,7 @@ suite('traceflags user management', () => {
     __resetApiVersionFallbackStateForTests();
     __resetDebugLevelApiVersionCacheForTests();
     __resetUserIdCacheForTests();
+    (workspace.getConfiguration as any) = originalGetConfiguration;
     setApiVersion('64.0');
   });
 
@@ -315,6 +319,126 @@ suite('traceflags user management', () => {
     );
     assert.equal(calls.filter(call => call.path.includes('/services/data/v66.0/tooling/query')).length, 1);
     assert.equal(calls.filter(call => call.path.includes('/services/data/v64.0/tooling/query')).length, 1);
+  });
+
+  test('getActiveUserDebugLevel caches repeated reads for the same user', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    let userQueryCount = 0;
+    let traceFlagQueryCount = 0;
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("FROM User WHERE Username = 'user@example.com'")) {
+          userQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA'")) {
+          traceFlagQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000001AAA',
+                  StartDate: '2026-03-25T00:00:00.000+0000',
+                  ExpirationDate: '2099-03-25T01:00:00.000+0000',
+                  DebugLevel: { DeveloperName: 'ALV_E2E' }
+                }
+              ]
+            }
+          };
+        }
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const first = await getActiveUserDebugLevel(auth);
+    const second = await getActiveUserDebugLevel(auth);
+
+    assert.equal(first, 'ALV_E2E');
+    assert.equal(second, 'ALV_E2E');
+    assert.equal(userQueryCount, 1, 'expected current user lookup to stay cached');
+    assert.equal(traceFlagQueryCount, 1, 'expected active debug level lookup to stay cached');
+  });
+
+  test('upsertUserTraceFlag invalidates the cached active debug level', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    let traceFlagQueryCount = 0;
+    let activeDebugLevelName = 'ALV_OLD';
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("FROM User WHERE Username = 'user@example.com'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM DebugLevel WHERE DeveloperName = 'ALV_NEW'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7dl000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7tf000000000001AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA' AND LogType = 'USER_DEBUG'")) {
+          traceFlagQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: [
+                {
+                  Id: '7tf000000000001AAA',
+                  StartDate: '2026-03-25T00:00:00.000+0000',
+                  ExpirationDate: '2099-03-25T01:00:00.000+0000',
+                  DebugLevel: { DeveloperName: activeDebugLevelName }
+                }
+              ]
+            }
+          };
+        }
+      }
+      if (
+        req.method === 'PATCH' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000001AAA')
+      ) {
+        activeDebugLevelName = 'ALV_NEW';
+        const parsed = JSON.parse(req.body);
+        assert.equal(parsed.DebugLevelId, '7dl000000000001AAA');
+        return {
+          statusCode: 204
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const before = await getActiveUserDebugLevel(auth);
+    await upsertUserTraceFlag(auth, {
+      userId: '005000000000001AAA',
+      debugLevelName: 'ALV_NEW',
+      ttlMinutes: 30
+    });
+    const after = await getActiveUserDebugLevel(auth);
+
+    assert.equal(before, 'ALV_OLD');
+    assert.equal(after, 'ALV_NEW');
+    assert.equal(traceFlagQueryCount, 2, 'expected a fresh trace-flag read after invalidation');
   });
 
   test('getTraceFlagTargetStatus resolves Automated Process across all active matches and aggregates USER_DEBUG status', async () => {

--- a/src/test/traceflags.userFlags.test.ts
+++ b/src/test/traceflags.userFlags.test.ts
@@ -632,6 +632,90 @@ suite('traceflags user management', () => {
     );
   });
 
+  test('removeTraceFlags invalidates the cached active debug level after a partial special-target delete failure', async () => {
+    (workspace.getConfiguration as any) = () => ({ get: () => undefined });
+    let traceFlagQueryCount = 0;
+    let currentUserHasActiveTraceFlag = true;
+    installHttpsStub(req => {
+      if (req.method === 'GET' && req.path.includes('/services/data/v')) {
+        const soql = decodeSoql(req.path);
+        if (soql.includes("FROM User WHERE Username = 'user@example.com'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }]
+            }
+          };
+        }
+        if (isSpecialTargetUserResolutionQuery(soql, 'CloudIntegrationUser')) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '005000000000001AAA' }, { Id: '005000000000002AAA' }]
+            }
+          };
+        }
+        if (soql.includes("SELECT Id FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA'")) {
+          return {
+            statusCode: 200,
+            body: {
+              records: [{ Id: '7tf000000000001AAA' }, { Id: '7tf000000000002AAA' }]
+            }
+          };
+        }
+        if (soql.includes("FROM TraceFlag WHERE TracedEntityId = '005000000000001AAA' AND LogType = 'USER_DEBUG'")) {
+          traceFlagQueryCount++;
+          return {
+            statusCode: 200,
+            body: {
+              records: currentUserHasActiveTraceFlag
+                ? [
+                    {
+                      Id: '7tf000000000001AAA',
+                      StartDate: '2026-03-25T00:00:00.000+0000',
+                      ExpirationDate: '2099-03-25T01:00:00.000+0000',
+                      DebugLevel: { DeveloperName: 'ALV_OLD' }
+                    }
+                  ]
+                : []
+            }
+          };
+        }
+      }
+      if (
+        req.method === 'DELETE' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000001AAA')
+      ) {
+        currentUserHasActiveTraceFlag = false;
+        return {
+          statusCode: 204
+        };
+      }
+      if (
+        req.method === 'DELETE' &&
+        req.path.endsWith('/services/data/v64.0/tooling/sobjects/TraceFlag/7tf000000000002AAA')
+      ) {
+        return {
+          statusCode: 500,
+          body: '{"message":"boom"}'
+        };
+      }
+      throw new Error(`Unexpected request: ${req.method} ${req.path}`);
+    });
+
+    const before = await getActiveUserDebugLevel(auth);
+    await assert.rejects(async () => await removeTraceFlags(auth, { type: 'platformIntegration' }), /HTTP 500/);
+    const after = await getActiveUserDebugLevel(auth);
+
+    assert.equal(before, 'ALV_OLD');
+    assert.equal(after, undefined);
+    assert.equal(
+      traceFlagQueryCount,
+      2,
+      'expected a fresh trace-flag read after the partially successful special-target delete'
+    );
+  });
+
   test('getTraceFlagTargetStatus resolves Automated Process across all active matches and aggregates USER_DEBUG status', async () => {
     const calls = installHttpsStub(req => {
       if (req.method === 'GET' && req.path.includes('/query?q=')) {


### PR DESCRIPTION
## Summary
- stop retrying redundant Salesforce auth commands after terminal auth and default-org failures, and preserve clearer user-facing auth guidance
- cache the active user debug-level lookup and invalidate it after DebugLevel and TraceFlag writes
- add regression coverage for terminal auth short-circuiting, active debug-level caching, and cache invalidation

## Validation
- npm run compile-tests
- npm run build:extension
- node scripts/run-tests-cli.js --scope=unit --timeout=900000
- npm run check-types