### PR TITLE
perf(ci): cache vscode test assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,33 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Resolve VS Code cache metadata
+        id: vscode-cache
+        shell: bash
+        env:
+          VSCODE_TARGET: stable
+        run: |
+          set -euo pipefail
+          target="${VSCODE_TARGET:-stable}"
+          if [[ "${target}" == "stable" ]]; then
+            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
+            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
+            version="${vscode_meta[0]}"
+            build="${vscode_meta[1]}"
+          else
+            safe_target="${target//[^A-Za-z0-9._-]/-}"
+            version="${safe_target}"
+            build="${safe_target}"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore VS Code test cache
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test/vscode-*
+          key: vscode-test-${{ runner.os }}-${{ steps.vscode-cache.outputs.version }}-${{ steps.vscode-cache.outputs.build }}
+
       - name: Install dependencies
         run: npm ci
         env:
@@ -81,6 +108,31 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: package-lock.json
+      - name: Resolve VS Code cache metadata
+        id: vscode-cache
+        shell: bash
+        env:
+          VSCODE_TARGET: stable
+        run: |
+          set -euo pipefail
+          target="${VSCODE_TARGET:-stable}"
+          if [[ "${target}" == "stable" ]]; then
+            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
+            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
+            version="${vscode_meta[0]}"
+            build="${vscode_meta[1]}"
+          else
+            safe_target="${target//[^A-Za-z0-9._-]/-}"
+            version="${safe_target}"
+            build="${safe_target}"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+      - name: Restore VS Code test cache
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test/vscode-*
+          key: vscode-test-${{ runner.os }}-${{ steps.vscode-cache.outputs.version }}-${{ steps.vscode-cache.outputs.build }}
       - name: Install dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,24 +46,10 @@ jobs:
 
       - name: Resolve VS Code cache metadata
         id: vscode-cache
-        shell: bash
         env:
           VSCODE_TARGET: stable
-        run: |
-          set -euo pipefail
-          target="${VSCODE_TARGET:-stable}"
-          if [[ "${target}" == "stable" ]]; then
-            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
-            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
-            version="${vscode_meta[0]}"
-            build="${vscode_meta[1]}"
-          else
-            safe_target="${target//[^A-Za-z0-9._-]/-}"
-            version="${safe_target}"
-            build="${safe_target}"
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+          VSCODE_PLATFORM: linux-x64
+        run: node scripts/resolve-vscode-cache-metadata.js
 
       - name: Restore VS Code test cache
         uses: actions/cache@v4
@@ -110,24 +96,10 @@ jobs:
           cache-dependency-path: package-lock.json
       - name: Resolve VS Code cache metadata
         id: vscode-cache
-        shell: bash
         env:
           VSCODE_TARGET: stable
-        run: |
-          set -euo pipefail
-          target="${VSCODE_TARGET:-stable}"
-          if [[ "${target}" == "stable" ]]; then
-            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
-            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
-            version="${vscode_meta[0]}"
-            build="${vscode_meta[1]}"
-          else
-            safe_target="${target//[^A-Za-z0-9._-]/-}"
-            version="${safe_target}"
-            build="${safe_target}"
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+          VSCODE_PLATFORM: linux-x64
+        run: node scripts/resolve-vscode-cache-metadata.js
       - name: Restore VS Code test cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -62,6 +62,33 @@ jobs:
           cache: npm
           cache-dependency-path: package-lock.json
 
+      - name: Resolve VS Code cache metadata
+        id: vscode-cache
+        shell: bash
+        env:
+          VSCODE_TARGET: ${{ github.event.inputs.vscode_version || 'stable' }}
+        run: |
+          set -euo pipefail
+          target="${VSCODE_TARGET:-stable}"
+          if [[ "${target}" == "stable" ]]; then
+            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
+            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
+            version="${vscode_meta[0]}"
+            build="${vscode_meta[1]}"
+          else
+            safe_target="${target//[^A-Za-z0-9._-]/-}"
+            version="${safe_target}"
+            build="${safe_target}"
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+
+      - name: Restore VS Code test cache
+        uses: actions/cache@v4
+        with:
+          path: .vscode-test/vscode-*
+          key: vscode-test-${{ runner.os }}-${{ steps.vscode-cache.outputs.version }}-${{ steps.vscode-cache.outputs.build }}
+
       - name: Install Salesforce CLI
         run: npm install -g @salesforce/cli
 

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -64,24 +64,10 @@ jobs:
 
       - name: Resolve VS Code cache metadata
         id: vscode-cache
-        shell: bash
         env:
           VSCODE_TARGET: ${{ github.event.inputs.vscode_version || 'stable' }}
-        run: |
-          set -euo pipefail
-          target="${VSCODE_TARGET:-stable}"
-          if [[ "${target}" == "stable" ]]; then
-            json="$(curl -fsSL https://update.code.visualstudio.com/api/update/linux-x64/stable/latest)"
-            mapfile -t vscode_meta < <(printf '%s' "${json}" | node -e "let data='';process.stdin.on('data',chunk=>data+=chunk);process.stdin.on('end',()=>{const parsed=JSON.parse(data);console.log(parsed.productVersion || parsed.name || 'stable');console.log(parsed.version || parsed.hash || parsed.productVersion || 'stable');});")
-            version="${vscode_meta[0]}"
-            build="${vscode_meta[1]}"
-          else
-            safe_target="${target//[^A-Za-z0-9._-]/-}"
-            version="${safe_target}"
-            build="${safe_target}"
-          fi
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
-          echo "build=${build}" >> "${GITHUB_OUTPUT}"
+          VSCODE_PLATFORM: linux-x64
+        run: node scripts/resolve-vscode-cache-metadata.js
 
       - name: Restore VS Code test cache
         uses: actions/cache@v4

--- a/package.json
+++ b/package.json
@@ -465,7 +465,7 @@
     "compile-tests": "node -e \"try{require('fs').rmSync('out/test',{recursive:true,force:true})}catch(e){}\" && tsc -p tsconfig.test.json",
     "watch-tests": "tsc -p tsconfig.test.json -w",
     "pretest": "npm run test:linux-deps && npm run build:extension && npm run compile-tests",
-    "test:scripts": "node --test scripts/run-tests-cli.test.js scripts/run-tests.test.js scripts/deploy-azure-monitor.test.js scripts/azure-monitor-helpers.test.js scripts/run-playwright-e2e-telemetry.test.js scripts/scratch-pool-admin.test.js",
+    "test:scripts": "node --test scripts/run-tests-cli.test.js scripts/run-tests.test.js scripts/deploy-azure-monitor.test.js scripts/azure-monitor-helpers.test.js scripts/run-playwright-e2e.test.js scripts/run-playwright-e2e-telemetry.test.js scripts/resolve-vscode-cache-metadata.test.js scripts/scratch-pool-admin.test.js",
     "test": "npm run test:webview && npm run test:scripts && node scripts/run-tests-cli.js --scope=unit --coverage && npm run coverage:merge",
     "test:unit": "npm run test:webview && npm run test:e2e:utils && npm run test:scripts && npm run pretest && node scripts/run-tests-cli.js --scope=unit",
     "test:integration": "npm run test:scripts && npm run pretest && node scripts/run-tests-cli.js --scope=integration --install-deps --timeout=900000",

--- a/scripts/resolve-vscode-cache-metadata.js
+++ b/scripts/resolve-vscode-cache-metadata.js
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+'use strict';
+
+const { appendFileSync } = require('node:fs');
+
+function sanitizeOutputValue(value, fallback) {
+  const normalized = String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9._-]+/g, '-');
+  return normalized || fallback;
+}
+
+function formatGitHubOutput(metadata) {
+  return `version=${metadata.version}\nbuild=${metadata.build}\n`;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+async function fetchStableMetadata(options = {}) {
+  const fetchImpl = options.fetchImpl || global.fetch;
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch is unavailable');
+  }
+
+  const response = await fetchImpl(
+    `https://update.code.visualstudio.com/api/update/${options.platform}/stable/latest`
+  );
+  if (!response || response.ok === false) {
+    const status = response && typeof response.status !== 'undefined' ? `status ${response.status}` : 'request failed';
+    throw new Error(`VS Code metadata lookup failed (${status})`);
+  }
+
+  const payload = await response.json();
+  return {
+    build: sanitizeOutputValue(payload && (payload.version || payload.hash || payload.productVersion), 'stable'),
+    version: sanitizeOutputValue(payload && (payload.productVersion || payload.name), 'stable')
+  };
+}
+
+async function resolveVscodeCacheMetadata(options = {}) {
+  const target = sanitizeOutputValue(options.target || process.env.VSCODE_TARGET || 'stable', 'stable');
+  if (target !== 'stable') {
+    return { build: target, version: target };
+  }
+
+  const logger = options.logger || console;
+  const platform = sanitizeOutputValue(options.platform || process.env.VSCODE_PLATFORM || 'linux-x64', 'linux-x64');
+  const maxAttempts = Number.isInteger(options.maxAttempts) ? options.maxAttempts : 3;
+  const sleepImpl = options.sleepImpl || sleep;
+  let lastError;
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await fetchStableMetadata({
+        fetchImpl: options.fetchImpl,
+        platform
+      });
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxAttempts) {
+        await sleepImpl(attempt * 2_000);
+      }
+    }
+  }
+
+  logger.warn(
+    `[ci] Falling back to '${target}' for VS Code cache metadata after ${maxAttempts} failed attempt(s): ${
+      lastError && lastError.message ? lastError.message : lastError
+    }`
+  );
+  return { build: target, version: target };
+}
+
+async function main(options = {}) {
+  const env = options.env || process.env;
+  const metadata = await resolveVscodeCacheMetadata({
+    fetchImpl: options.fetchImpl,
+    logger: options.logger,
+    maxAttempts: options.maxAttempts,
+    platform: env.VSCODE_PLATFORM,
+    sleepImpl: options.sleepImpl,
+    target: env.VSCODE_TARGET
+  });
+
+  const output = formatGitHubOutput(metadata);
+  if (env.GITHUB_OUTPUT) {
+    appendFileSync(env.GITHUB_OUTPUT, output, 'utf8');
+  } else if (options.stdout && typeof options.stdout.write === 'function') {
+    options.stdout.write(output);
+  } else {
+    process.stdout.write(output);
+  }
+
+  return metadata;
+}
+
+if (require.main === module) {
+  main().catch(error => {
+    console.error(
+      '[ci] Failed to resolve VS Code cache metadata:',
+      error && error.message ? error.message : error
+    );
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  formatGitHubOutput,
+  main,
+  resolveVscodeCacheMetadata,
+  sanitizeOutputValue
+};

--- a/scripts/resolve-vscode-cache-metadata.test.js
+++ b/scripts/resolve-vscode-cache-metadata.test.js
@@ -1,0 +1,114 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  formatGitHubOutput,
+  resolveVscodeCacheMetadata,
+  sanitizeOutputValue
+} = require('./resolve-vscode-cache-metadata');
+
+test('resolveVscodeCacheMetadata returns fetched stable metadata when the update API succeeds', async () => {
+  const metadata = await resolveVscodeCacheMetadata({
+    fetchImpl: async () => ({
+      ok: true,
+      async json() {
+        return {
+          productVersion: '1.113.0',
+          version: 'commit-sha'
+        };
+      }
+    })
+  });
+
+  assert.deepEqual(metadata, {
+    build: 'commit-sha',
+    version: '1.113.0'
+  });
+});
+
+test('resolveVscodeCacheMetadata retries stable metadata fetches before falling back', async () => {
+  let attempts = 0;
+
+  const metadata = await resolveVscodeCacheMetadata({
+    fetchImpl: async () => {
+      attempts += 1;
+      throw new Error(`temporary failure ${attempts}`);
+    },
+    sleepImpl: async () => {}
+  });
+
+  assert.equal(attempts, 3);
+  assert.deepEqual(metadata, {
+    build: 'stable',
+    version: 'stable'
+  });
+});
+
+test('resolveVscodeCacheMetadata uses a sanitized target for non-stable versions without fetching', async () => {
+  let fetchCalls = 0;
+
+  const metadata = await resolveVscodeCacheMetadata({
+    fetchImpl: async () => {
+      fetchCalls += 1;
+      throw new Error('should not fetch');
+    },
+    target: ' insiders/latest '
+  });
+
+  assert.equal(fetchCalls, 0);
+  assert.deepEqual(metadata, {
+    build: 'insiders-latest',
+    version: 'insiders-latest'
+  });
+});
+
+test('formatGitHubOutput emits version and build lines for GitHub Actions', () => {
+  assert.equal(formatGitHubOutput({ version: '1.113.0', build: 'commit-sha' }), 'version=1.113.0\nbuild=commit-sha\n');
+});
+
+test('sanitizeOutputValue normalizes blank or invalid output values to the fallback', () => {
+  assert.equal(sanitizeOutputValue(' stable ', 'fallback'), 'stable');
+  assert.equal(sanitizeOutputValue('   ', 'fallback'), 'fallback');
+  assert.equal(sanitizeOutputValue('release/preview', 'fallback'), 'release-preview');
+});
+
+test('script entrypoint writes resolved metadata into GITHUB_OUTPUT', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-vscode-cache-meta-'));
+  const githubOutputPath = path.join(tempDir, 'github-output.txt');
+
+  try {
+    const modulePath = require.resolve('./resolve-vscode-cache-metadata');
+    const { spawnSync } = require('node:child_process');
+    const result = spawnSync(
+      process.execPath,
+      [
+        '-e',
+        [
+          "global.fetch = async () => ({",
+          "  ok: true,",
+          "  async json() {",
+          "    return { productVersion: '1.114.0', version: 'stable-commit' };",
+          '  }',
+          '});',
+          `require(${JSON.stringify(modulePath)}).main();`
+        ].join('\n')
+      ],
+      {
+        cwd: __dirname,
+        env: {
+          ...process.env,
+          GITHUB_OUTPUT: githubOutputPath
+        },
+        encoding: 'utf8'
+      }
+    );
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.equal(fs.readFileSync(githubOutputPath, 'utf8'), 'version=1.114.0\nbuild=stable-commit\n');
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});

--- a/scripts/run-playwright-e2e.js
+++ b/scripts/run-playwright-e2e.js
@@ -2,8 +2,18 @@
 'use strict';
 
 const { execFile, spawn } = require('child_process');
+const { existsSync } = require('fs');
 const { platform } = require('os');
 const path = require('path');
+
+const requiredBuildArtifacts = [
+  'dist/extension.js',
+  'media/webview.css',
+  'media/main.js',
+  'media/tail.js',
+  'media/logViewer.js',
+  'media/debugFlags.js'
+];
 
 function execFileAsync(file, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -30,6 +40,54 @@ function exitWithChildResult(code, signal) {
     console.error('[e2e] Child process exited with null exit code.');
   }
   process.exit(1);
+}
+
+function resolveBuildInvocation(targetPlatform = process.platform) {
+  if (targetPlatform === 'win32') {
+    return {
+      command: process.env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', 'npm.cmd', 'run', 'build']
+    };
+  }
+
+  return {
+    command: 'npm',
+    args: ['run', 'build']
+  };
+}
+
+function findMissingBuildArtifacts(repoRoot) {
+  return requiredBuildArtifacts.filter(relativePath => !existsSync(path.join(repoRoot, relativePath)));
+}
+
+function spawnAsync(command, args, options = {}, spawnImpl = spawn) {
+  return new Promise((resolve, reject) => {
+    const child = spawnImpl(command, args, options);
+    child.on('error', reject);
+    child.on('exit', (code, signal) => resolve({ code, signal }));
+  });
+}
+
+async function ensureBuildArtifacts(repoRoot, options = {}) {
+  const missingArtifacts = findMissingBuildArtifacts(repoRoot);
+  if (!missingArtifacts.length) {
+    return;
+  }
+
+  console.log(
+    `[e2e] Missing build artifacts (${missingArtifacts.join(', ')}). Running npm run build before Playwright...`
+  );
+  const buildInvocation = resolveBuildInvocation();
+  const result = await spawnAsync(
+    buildInvocation.command,
+    buildInvocation.args,
+    { cwd: repoRoot, env: process.env, stdio: 'inherit' },
+    options.spawnImpl
+  );
+  if (result.code !== 0) {
+    const details = typeof result.code === 'number' ? `exit code ${result.code}` : `signal ${result.signal || 'unknown'}`;
+    throw new Error(`npm run build failed while preparing Playwright E2E (${details}).`);
+  }
 }
 
 function resolvePlaywrightInvocation(extraArgs) {
@@ -75,6 +133,7 @@ async function main() {
   }
 
   const repoRoot = path.join(__dirname, '..');
+  await ensureBuildArtifacts(repoRoot);
   const invocation = resolvePlaywrightInvocation(process.argv.slice(2));
   const child = spawn(invocation.command, invocation.args, {
     stdio: 'inherit',
@@ -84,7 +143,17 @@ async function main() {
   child.on('exit', exitWithChildResult);
 }
 
-main().catch(err => {
-  console.error('[e2e] Failed to run Playwright E2E tests:', err && err.message ? err.message : err);
-  process.exit(1);
-});
+if (require.main === module) {
+  main().catch(err => {
+    console.error('[e2e] Failed to run Playwright E2E tests:', err && err.message ? err.message : err);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ensureBuildArtifacts,
+  findMissingBuildArtifacts,
+  requiredBuildArtifacts,
+  resolveBuildInvocation,
+  resolvePlaywrightInvocation
+};

--- a/scripts/run-playwright-e2e.test.js
+++ b/scripts/run-playwright-e2e.test.js
@@ -1,0 +1,95 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { EventEmitter } = require('node:events');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+
+const {
+  ensureBuildArtifacts,
+  findMissingBuildArtifacts,
+  requiredBuildArtifacts,
+  resolveBuildInvocation
+} = require('./run-playwright-e2e');
+
+function createTempRepo() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'alv-run-playwright-e2e-'));
+}
+
+function cleanupTempRepo(repoRoot) {
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+}
+
+function writeArtifacts(repoRoot, artifactPaths) {
+  for (const relativePath of artifactPaths) {
+    const absolutePath = path.join(repoRoot, relativePath);
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, '// test artifact\n', 'utf8');
+  }
+}
+
+test('findMissingBuildArtifacts reports the missing build outputs', () => {
+  const repoRoot = createTempRepo();
+  try {
+    writeArtifacts(repoRoot, ['dist/extension.js', 'media/main.js']);
+
+    assert.deepEqual(findMissingBuildArtifacts(repoRoot), [
+      'media/webview.css',
+      'media/tail.js',
+      'media/logViewer.js',
+      'media/debugFlags.js'
+    ]);
+  } finally {
+    cleanupTempRepo(repoRoot);
+  }
+});
+
+test('ensureBuildArtifacts skips npm run build when all required outputs already exist', async () => {
+  const repoRoot = createTempRepo();
+  try {
+    writeArtifacts(repoRoot, requiredBuildArtifacts);
+
+    let spawnCalls = 0;
+    await ensureBuildArtifacts(repoRoot, {
+      spawnImpl() {
+        spawnCalls += 1;
+        return new EventEmitter();
+      }
+    });
+
+    assert.equal(spawnCalls, 0);
+  } finally {
+    cleanupTempRepo(repoRoot);
+  }
+});
+
+test('ensureBuildArtifacts runs npm run build when required outputs are missing', async () => {
+  const repoRoot = createTempRepo();
+  try {
+    let recordedCall;
+
+    await ensureBuildArtifacts(repoRoot, {
+      spawnImpl(command, args, options) {
+        recordedCall = { command, args, options };
+        const child = new EventEmitter();
+        process.nextTick(() => child.emit('exit', 0, null));
+        return child;
+      }
+    });
+
+    assert.ok(recordedCall);
+    assert.equal(recordedCall.command, resolveBuildInvocation().command);
+    assert.deepEqual(recordedCall.args, resolveBuildInvocation().args);
+    assert.equal(recordedCall.options.cwd, repoRoot);
+    assert.equal(recordedCall.options.stdio, 'inherit');
+  } finally {
+    cleanupTempRepo(repoRoot);
+  }
+});
+
+test('resolveBuildInvocation uses cmd.exe on Windows to avoid npm.cmd spawn issues', () => {
+  const invocation = resolveBuildInvocation('win32');
+
+  assert.equal(invocation.command, process.env.ComSpec || 'cmd.exe');
+  assert.deepEqual(invocation.args, ['/d', '/s', '/c', 'npm.cmd', 'run', 'build']);
+});

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -1,4 +1,7 @@
+import path from 'node:path';
 import {
+  resolveCachedSupportExtensionsDir,
+  resolveVscodeCachePath,
   resolveWindowSizeArg,
   resolveExtensionsDirForMissingDependencies,
   resolveSupportExtensionIds,
@@ -61,6 +64,32 @@ describe('extensions dir fallback policy', () => {
       extensionsDir: '/home/test/.vscode/extensions',
       warning: '[e2e] Falling back to local VS Code extensions dir: /home/test/.vscode/extensions'
     });
+  });
+});
+
+describe('VS Code cache paths', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  test('defaults the VS Code cache path to the repo-local .vscode-test directory', () => {
+    delete process.env.VSCODE_TEST_CACHE_PATH;
+
+    expect(resolveVscodeCachePath('/workspace/alv')).toBe(path.join('/workspace/alv', '.vscode-test'));
+  });
+
+  test('honors VSCODE_TEST_CACHE_PATH when set', () => {
+    process.env.VSCODE_TEST_CACHE_PATH = '../shared-vscode-cache';
+
+    expect(resolveVscodeCachePath('/workspace/alv')).toBe(path.resolve('../shared-vscode-cache'));
+  });
+
+  test('stores shared support extensions under the VS Code cache root', () => {
+    expect(resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test')).toBe(
+      path.join('/workspace/alv/.vscode-test', 'extensions')
+    );
   });
 });
 

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -1,6 +1,7 @@
 import path from 'node:path';
 import {
   resolveCachedSupportExtensionsDir,
+  resolveSupportExtensionsLockPath,
   resolveVscodeCachePath,
   resolveWindowSizeArg,
   resolveExtensionsDirForMissingDependencies,
@@ -21,7 +22,7 @@ describe('resolveSupportExtensionIds', () => {
         [' salesforce.salesforcedx-vscode-core ', '', 'salesforce.salesforcedx-vscode-core'],
         ['salesforce.salesforcedx-vscode-apex-replay-debugger', 'salesforce.salesforcedx-vscode-core']
       )
-    ).toEqual(['salesforce.salesforcedx-vscode-core', 'salesforce.salesforcedx-vscode-apex-replay-debugger']);
+    ).toEqual(['salesforce.salesforcedx-vscode-apex-replay-debugger', 'salesforce.salesforcedx-vscode-core']);
   });
 });
 
@@ -86,10 +87,57 @@ describe('VS Code cache paths', () => {
     expect(resolveVscodeCachePath('/workspace/alv')).toBe(path.resolve('../shared-vscode-cache'));
   });
 
-  test('stores shared support extensions under the VS Code cache root', () => {
-    expect(resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test')).toBe(
-      path.join('/workspace/alv/.vscode-test', 'extensions')
+  test('stores support extensions under a version-scoped cache directory', () => {
+    const extensionsDir = resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+      'salesforce.salesforcedx-vscode-core'
+    ]);
+
+    expect(path.dirname(extensionsDir)).toBe(path.join('/workspace/alv/.vscode-test', 'extensions', 'stable'));
+  });
+
+  test('normalizes the support extension cache key by extension set', () => {
+    expect(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+        ' salesforce.salesforcedx-vscode-core ',
+        'salesforce.salesforcedx-vscode-apex-replay-debugger',
+        'salesforce.salesforcedx-vscode-core'
+      ])
+    ).toBe(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+        'salesforce.salesforcedx-vscode-apex-replay-debugger',
+        'salesforce.salesforcedx-vscode-core'
+      ])
     );
+  });
+
+  test('isolates support extension cache directories when the version or extension set changes', () => {
+    expect(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+        'salesforce.salesforcedx-vscode-core'
+      ])
+    ).not.toBe(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+        'salesforce.salesforcedx-vscode-apex-replay-debugger'
+      ])
+    );
+
+    expect(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+        'salesforce.salesforcedx-vscode-core'
+      ])
+    ).not.toBe(
+      resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'insiders', [
+        'salesforce.salesforcedx-vscode-core'
+      ])
+    );
+  });
+
+  test('stores the support extensions lock inside the resolved cache directory', () => {
+    const extensionsDir = resolveCachedSupportExtensionsDir('/workspace/alv/.vscode-test', 'stable', [
+      'salesforce.salesforcedx-vscode-core'
+    ]);
+
+    expect(resolveSupportExtensionsLockPath(extensionsDir)).toBe(path.join(extensionsDir, '.install.lock'));
   });
 });
 

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -34,6 +34,16 @@ function getVsCodeVersion(): string {
   return v || 'stable';
 }
 
+export function resolveVscodeCachePath(extensionDevelopmentPath: string): string {
+  return process.env.VSCODE_TEST_CACHE_PATH
+    ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
+    : path.join(extensionDevelopmentPath, '.vscode-test');
+}
+
+export function resolveCachedSupportExtensionsDir(vscodeCachePath: string): string {
+  return path.join(vscodeCachePath, 'extensions');
+}
+
 function envFlag(name: string): boolean {
   const value = String(process.env[name] || '')
     .trim()
@@ -428,9 +438,7 @@ export async function launchVsCode(options: {
   windowSize?: Partial<VscodeWindowSize>;
 }): Promise<VscodeLaunch> {
   const vscodeVersion = getVsCodeVersion();
-  const vscodeCachePath = process.env.VSCODE_TEST_CACHE_PATH
-    ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
-    : path.join(options.extensionDevelopmentPath, '.vscode-test');
+  const vscodeCachePath = resolveVscodeCachePath(options.extensionDevelopmentPath);
   const vscodeDownloadLockPath = path.join(vscodeCachePath, `.download-${sanitizeLockNamePart(vscodeVersion)}.lock`);
   const vscodeExecutablePath = await timeE2eStep('vscode.download', async () =>
     await withFileLock(vscodeDownloadLockPath, async () =>
@@ -439,24 +447,27 @@ export async function launchVsCode(options: {
   );
 
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
-  let extensionsDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-exts-'));
-  let shouldCleanupExtensionsDir = true;
+  let extensionsDir = resolveCachedSupportExtensionsDir(vscodeCachePath);
+  const supportExtensionsLockPath = path.join(vscodeCachePath, `.extensions-${sanitizeLockNamePart(vscodeVersion)}.lock`);
+  let shouldCleanupExtensionsDir = false;
+  await mkdir(extensionsDir, { recursive: true });
 
   // The extension is loaded via --extensionDevelopmentPath. Some E2E scenarios still
-  // need support extensions in the isolated profile (for example Replay Debugger),
+  // need support extensions in a reusable test cache (for example Replay Debugger),
   // so install manifest references plus scenario-specific ids.
   try {
     const resolvedExtensionsDir = await timeE2eStep('vscode.ensureSupportExtensions', async () =>
-      await ensureExtensionDependenciesInstalled({
-        vscodeExecutablePath,
-        extensionDevelopmentPath: options.extensionDevelopmentPath,
-        userDataDir,
-        extensionsDir,
-        extraExtensionIds: options.extensionIds
-      })
+      await withFileLock(supportExtensionsLockPath, async () =>
+        await ensureExtensionDependenciesInstalled({
+          vscodeExecutablePath,
+          extensionDevelopmentPath: options.extensionDevelopmentPath,
+          userDataDir,
+          extensionsDir,
+          extraExtensionIds: options.extensionIds
+        })
+      )
     );
     if (resolvedExtensionsDir !== extensionsDir) {
-      await removePathBestEffort(extensionsDir);
       extensionsDir = resolvedExtensionsDir;
       shouldCleanupExtensionsDir = false;
     }

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, readFile, cp, access, readdir, mkdir, open, stat, unlink, utimes } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
+import { createHash } from 'node:crypto';
 import { spawnSync } from 'node:child_process';
 import { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath } from '@vscode/test-electron';
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright';
@@ -40,8 +41,24 @@ export function resolveVscodeCachePath(extensionDevelopmentPath: string): string
     : path.join(extensionDevelopmentPath, '.vscode-test');
 }
 
-export function resolveCachedSupportExtensionsDir(vscodeCachePath: string): string {
-  return path.join(vscodeCachePath, 'extensions');
+function getSupportExtensionsCacheKey(vscodeVersion: string, extensionIds: string[]): string {
+  const normalizedIds = resolveSupportExtensionIds(extensionIds);
+  return createHash('sha1')
+    .update(JSON.stringify({ vscodeVersion: String(vscodeVersion || 'stable').trim() || 'stable', extensionIds: normalizedIds }))
+    .digest('hex')
+    .slice(0, 12);
+}
+
+export function resolveCachedSupportExtensionsDir(
+  vscodeCachePath: string,
+  vscodeVersion: string,
+  extensionIds: string[] = []
+): string {
+  return path.join(vscodeCachePath, 'extensions', sanitizeLockNamePart(vscodeVersion || 'stable'), getSupportExtensionsCacheKey(vscodeVersion, extensionIds));
+}
+
+export function resolveSupportExtensionsLockPath(extensionsDir: string): string {
+  return path.join(extensionsDir, '.install.lock');
 }
 
 function envFlag(name: string): boolean {
@@ -54,7 +71,7 @@ function envFlag(name: string): boolean {
 export function resolveSupportExtensionIds(extensionIds: unknown[] = [], extraExtensionIds: string[] = []): string[] {
   return Array.from(
     new Set([...extensionIds, ...extraExtensionIds].map(String).map(value => value.trim()).filter(Boolean))
-  );
+  ).sort((a, b) => a.localeCompare(b));
 }
 
 export function shouldAllowLocalExtensionsDirFallback(): boolean {
@@ -327,12 +344,11 @@ function installExtensions(args: {
 
 async function ensureExtensionDependenciesInstalled(args: {
   vscodeExecutablePath: string;
-  extensionDevelopmentPath: string;
   userDataDir: string;
   extensionsDir: string;
-  extraExtensionIds?: string[];
+  extensionIds: string[];
 }): Promise<string> {
-  const deps = await readExtensionReferences(args.extensionDevelopmentPath, args.extraExtensionIds ?? []);
+  const deps = resolveSupportExtensionIds(args.extensionIds);
   if (!deps.length) {
     return args.extensionsDir;
   }
@@ -439,6 +455,7 @@ export async function launchVsCode(options: {
 }): Promise<VscodeLaunch> {
   const vscodeVersion = getVsCodeVersion();
   const vscodeCachePath = resolveVscodeCachePath(options.extensionDevelopmentPath);
+  const supportExtensionIds = await readExtensionReferences(options.extensionDevelopmentPath, options.extensionIds ?? []);
   const vscodeDownloadLockPath = path.join(vscodeCachePath, `.download-${sanitizeLockNamePart(vscodeVersion)}.lock`);
   const vscodeExecutablePath = await timeE2eStep('vscode.download', async () =>
     await withFileLock(vscodeDownloadLockPath, async () =>
@@ -447,8 +464,8 @@ export async function launchVsCode(options: {
   );
 
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
-  let extensionsDir = resolveCachedSupportExtensionsDir(vscodeCachePath);
-  const supportExtensionsLockPath = path.join(vscodeCachePath, `.extensions-${sanitizeLockNamePart(vscodeVersion)}.lock`);
+  let extensionsDir = resolveCachedSupportExtensionsDir(vscodeCachePath, vscodeVersion, supportExtensionIds);
+  const supportExtensionsLockPath = resolveSupportExtensionsLockPath(extensionsDir);
   let shouldCleanupExtensionsDir = false;
   await mkdir(extensionsDir, { recursive: true });
 
@@ -460,10 +477,9 @@ export async function launchVsCode(options: {
       await withFileLock(supportExtensionsLockPath, async () =>
         await ensureExtensionDependenciesInstalled({
           vscodeExecutablePath,
-          extensionDevelopmentPath: options.extensionDevelopmentPath,
           userDataDir,
           extensionsDir,
-          extraExtensionIds: options.extensionIds
+          extensionIds: supportExtensionIds
         })
       )
     );


### PR DESCRIPTION
## Summary
- cache VS Code test downloads in CI and Playwright E2E runs using exact update metadata from the VS Code update API
- reuse E2E support extension installs from `.vscode-test/extensions` with a file lock so repeated runs do not reinstall the same support extensions
- add focused tests for VS Code cache path resolution

## Linked Issues
- Relates-to n/a

## Verification Steps
- `npm run test:e2e:utils`
- `npm run compile`
- Parsed `.github/workflows/ci.yml` and `.github/workflows/e2e-playwright.yml` with the local `yaml` parser

## Risk / Rollback
- Main risk is stale or incorrect VS Code cache metadata causing a cache miss rather than a bad build result.
- Rollback is straightforward: revert the workflow cache steps and the shared E2E support-extension cache changes in this PR.

## Checklist
- [x] `npm run build` passes
- [ ] `npm test` (or `npm run test:all`) passes; integration tests prefixed with `integration`
- [x] Lint/Types: `npm run lint` and `npm run check-types`
- [ ] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added