### PR TITLE
[codex] split marketplace publish jobs in release workflows

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -322,8 +322,8 @@ jobs:
             gh release upload "$TAG" "$FILE" --clobber
           done
 
-  marketplace:
-    name: Publish to Marketplaces (pre-release channel)
+  publish_marketplace:
+    name: Publish to VS Code Marketplace (pre-release channel)
     needs: [assemble_release, prepare, check_changes]
     if: github.repository == 'Electivus/Apex-Log-Viewer' && needs.check_changes.outputs.has_changes == 'true'
     runs-on: ubuntu-latest
@@ -337,17 +337,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Install dependencies
-        run: npm ci --workspaces=false
-
-      - name: Set nightly version in apps/vscode-extension/package.json
-        env:
-          VERSION: ${{ needs.prepare.outputs.version }}
-        run: |
-          node -e "const fs=require('fs');const pkgPath='apps/vscode-extension/package.json';const pkg=JSON.parse(fs.readFileSync(pkgPath,'utf8'));pkg.version=process.env.VERSION;fs.writeFileSync(pkgPath,JSON.stringify(pkg,null,2)+'\n')"
 
       - name: Download VSIX artifact from prerelease job
         uses: actions/download-artifact@v8
@@ -374,6 +363,28 @@ jobs:
             npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
           done
 
+  publish_open_vsx:
+    name: Publish to Open VSX (pre-release channel)
+    needs: [assemble_release, prepare, check_changes]
+    if: github.repository == 'Electivus/Apex-Log-Viewer' && needs.check_changes.outputs.has_changes == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: marketplace
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+
+      - name: Download VSIX artifact from prerelease job
+        uses: actions/download-artifact@v8
+        with:
+          name: nightly-vsix
+          path: .
+
       - name: Publish pre-release to Open VSX from VSIX
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}
@@ -396,12 +407,11 @@ jobs:
           done
 
   rollback_prerelease:
-    name: Roll back GitHub pre-release (if publish failed)
-    needs: [assemble_release, marketplace, prepare, check_changes]
+    name: Roll back GitHub pre-release (if assembly failed)
+    needs: [assemble_release, prepare, check_changes]
     if: >
       always() && needs.check_changes.outputs.has_changes == 'true' &&
-      (needs.assemble_release.result == 'failure' || needs.assemble_release.result == 'cancelled' ||
-      needs.marketplace.result == 'failure' || needs.marketplace.result == 'cancelled')
+      (needs.assemble_release.result == 'failure' || needs.assemble_release.result == 'cancelled')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
@@ -413,7 +423,7 @@ jobs:
         run: |
           set -euo pipefail
           if gh release view "$TAG" >/dev/null 2>&1; then
-            echo "Deleting pre-release $TAG due to downstream failure"
+            echo "Deleting pre-release $TAG due to assembly failure"
             gh release delete "$TAG" --yes --cleanup-tag
           else
             echo "Pre-release $TAG does not exist; nothing to delete"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -166,15 +166,19 @@ jobs:
             *.vsix
           if-no-files-found: error
 
-  publish:
-    name: Publish to Marketplaces
+  prepare_publish:
+    name: Prepare release publishing
     if: github.repository == 'Electivus/Apex-Log-Viewer'
     needs: package
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    outputs:
+      version: ${{ steps.determine_channel.outputs.version }}
+      pre_release: ${{ steps.determine_channel.outputs.pre_release }}
+      channel_suffix: ${{ steps.determine_channel.outputs.channel_suffix }}
+      artifact_name: apex-log-viewer-${{ steps.determine_channel.outputs.version }}-${{ steps.determine_channel.outputs.channel_suffix }}-publish-vsix
     permissions:
       contents: write
-    environment: marketplace
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -183,10 +187,6 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: package-lock.json
-      - name: Install dependencies
-        run: npm ci --workspaces=false
 
       - name: Verify tag matches extension package version
         shell: bash
@@ -198,9 +198,6 @@ jobs:
             echo "Tag $GITHUB_REF_NAME != apps/vscode-extension/package.json version $PKG_VERSION" >&2
             exit 1
           fi
-
-      - name: Build + generate NLS assets
-        run: npm run package
 
       - name: Determine channel (stable vs pre-release)
         id: determine_channel
@@ -284,61 +281,12 @@ jobs:
           fi
           find "${VSIX_DIR}" -name '*.vsix' -exec mv {} . \;
 
-      - name: Publish from VSIX artifact
-        env:
-          VSCE_PAT: ${{ secrets.VSCE_PAT }}
-          PRE_RELEASE: ${{ steps.determine_channel.outputs.pre_release }}
-          VERSION: ${{ steps.determine_channel.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${VSCE_PAT}" ]; then
-            echo "VSCE_PAT not set; skipping Marketplace publish."
-            exit 0
-          fi
-          shopt -s nullglob
-          FILES=( *.vsix )
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "No VSIX found to publish" >&2
-            exit 1
-          fi
-          for FILE in "${FILES[@]}"; do
-            if [ "${PRE_RELEASE}" = "true" ]; then
-              echo "Publishing pre-release ${VERSION} from ${FILE}"
-              npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
-            else
-              echo "Publishing stable ${VERSION} from ${FILE}"
-              npx --yes @vscode/vsce publish --packagePath "${FILE}"
-            fi
-          done
-
-      - name: Publish to Open VSX from VSIX artifact
-        env:
-          OVSX_PAT: ${{ secrets.OVSX_PAT }}
-          PRE_RELEASE: ${{ steps.determine_channel.outputs.pre_release }}
-          VERSION: ${{ steps.determine_channel.outputs.version }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [ -z "${OVSX_PAT}" ]; then
-            echo "OVSX_PAT not set; skipping Open VSX publish."
-            exit 0
-          fi
-          shopt -s nullglob
-          FILES=( *.vsix )
-          if [ ${#FILES[@]} -eq 0 ]; then
-            echo "No VSIX found to publish" >&2
-            exit 1
-          fi
-          for FILE in "${FILES[@]}"; do
-            if [ "${PRE_RELEASE}" = "true" ]; then
-              echo "Publishing pre-release ${VERSION} to Open VSX from ${FILE}"
-              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release
-            else
-              echo "Publishing stable ${VERSION} to Open VSX from ${FILE}"
-              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}"
-            fi
-          done
+      - name: Upload VSIX artifact for marketplace publish jobs
+        uses: actions/upload-artifact@v7
+        with:
+          name: apex-log-viewer-${{ steps.determine_channel.outputs.version }}-${{ steps.determine_channel.outputs.channel_suffix }}-publish-vsix
+          path: |
+            ./*.vsix
 
       - name: Create or update GitHub release (pre-release)
         if: steps.determine_channel.outputs.pre_release == 'true'
@@ -379,3 +327,97 @@ jobs:
           gh release upload "$TAG" ./*.vsix --clobber
 
   # Note: CHANGELOG.md is maintained manually by the project.
+
+  publish_marketplace:
+    name: Publish to VS Code Marketplace
+    if: github.repository == 'Electivus/Apex-Log-Viewer'
+    needs: prepare_publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: marketplace
+    steps:
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.prepare_publish.outputs.artifact_name }}
+          path: .
+
+      - name: Publish from VSIX artifact
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}
+          PRE_RELEASE: ${{ needs.prepare_publish.outputs.pre_release }}
+          VERSION: ${{ needs.prepare_publish.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${VSCE_PAT}" ]; then
+            echo "VSCE_PAT not set; skipping Marketplace publish."
+            exit 0
+          fi
+          shopt -s nullglob
+          FILES=( *.vsix )
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No VSIX found to publish" >&2
+            exit 1
+          fi
+          for FILE in "${FILES[@]}"; do
+            if [ "${PRE_RELEASE}" = "true" ]; then
+              echo "Publishing pre-release ${VERSION} from ${FILE}"
+              npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
+            else
+              echo "Publishing stable ${VERSION} from ${FILE}"
+              npx --yes @vscode/vsce publish --packagePath "${FILE}"
+            fi
+          done
+
+  publish_open_vsx:
+    name: Publish to Open VSX
+    if: github.repository == 'Electivus/Apex-Log-Viewer'
+    needs: prepare_publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: marketplace
+    steps:
+      - name: Setup Node.js 22
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Download VSIX artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: ${{ needs.prepare_publish.outputs.artifact_name }}
+          path: .
+
+      - name: Publish to Open VSX from VSIX artifact
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}
+          PRE_RELEASE: ${{ needs.prepare_publish.outputs.pre_release }}
+          VERSION: ${{ needs.prepare_publish.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${OVSX_PAT}" ]; then
+            echo "OVSX_PAT not set; skipping Open VSX publish."
+            exit 0
+          fi
+          shopt -s nullglob
+          FILES=( *.vsix )
+          if [ ${#FILES[@]} -eq 0 ]; then
+            echo "No VSIX found to publish" >&2
+            exit 1
+          fi
+          for FILE in "${FILES[@]}"; do
+            if [ "${PRE_RELEASE}" = "true" ]; then
+              echo "Publishing pre-release ${VERSION} to Open VSX from ${FILE}"
+              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release
+            else
+              echo "Publishing stable ${VERSION} to Open VSX from ${FILE}"
+              npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}"
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,6 +287,7 @@ jobs:
           name: apex-log-viewer-${{ steps.determine_channel.outputs.version }}-${{ steps.determine_channel.outputs.channel_suffix }}-publish-vsix
           path: |
             ./*.vsix
+          if-no-files-found: error
 
       - name: Create or update GitHub release (pre-release)
         if: steps.determine_channel.outputs.pre_release == 'true'
@@ -336,10 +337,10 @@ jobs:
     timeout-minutes: 15
     environment: marketplace
     steps:
-      - name: Setup Node.js 22
+      - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8
@@ -383,10 +384,10 @@ jobs:
     timeout-minutes: 15
     environment: marketplace
     steps:
-      - name: Setup Node.js 22
+      - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
-          node-version: '22'
+          node-version-file: .nvmrc
 
       - name: Download VSIX artifact
         uses: actions/download-artifact@v8


### PR DESCRIPTION
## Summary

Split the release and pre-release marketplace publication steps into independent GitHub Actions jobs so a rerun of one failed marketplace job does not republish the other marketplace.

## Problem

The real failure mode happened in run 23708096584:

- Attempt 1 published the pre-release successfully to the VS Code Marketplace and then failed on Open VSX.
- Attempt 2 reran the same combined publish job after the token was fixed, which forced Marketplace publication to run again before Open VSX could retry.

Because both marketplaces lived in the same job, GitHub Actions job reruns were too coarse-grained for partial publish recovery.

## Root Cause

Both `.github/workflows/prerelease.yml` and `.github/workflows/release.yml` coupled VS Code Marketplace and Open VSX publication inside the same downstream job. That meant a rerun of the failed job retried both marketplaces, even when one of them had already published the version successfully.

The nightly pre-release workflow also rolled back the GitHub pre-release whenever downstream publish failed, which made recovery more fragile after a partial external publish succeeded.

## Fix

- Split the nightly pre-release publish phase into `publish_marketplace` and `publish_open_vsx` jobs that both consume the already assembled VSIX artifact.
- Restrict nightly rollback to assembly failures so a single marketplace failure does not delete the GitHub pre-release and tag.
- Refactor tagged releases to use a shared `prepare_publish` job for common channel detection, release setup, asset collection, and GitHub Release upload.
- Add separate `publish_marketplace` and `publish_open_vsx` jobs for tagged releases, both consuming the prepared VSIX artifact.

## Validation

- Verified the real failure pattern with `gh` against run `23708096584`, including attempts 1 and 2.
- Re-ran local workflow validation after the final commit with YAML parsing plus inter-job `needs` checks: `workflow yaml parse and needs validation OK`.
