### PR TITLE
[codex] fix logs startup request fan-out and auth hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
+- Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.
+
+### Tests
+
+- Runtime/Logs: add targeted coverage for concurrent startup behavior, runtime request coalescing, auth-hint reuse during log downloads, Tail ready-state refresh gating, and Windows PATH resolution fast paths.
+
 ## [0.38.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.36.0...v0.38.0) (2026-03-27)
 
 ### Features

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -355,7 +355,7 @@ export async function activate(context: vscode.ExtensionContext) {
 
   // Removed legacy openTailPanel command to avoid focus changes
 
-  // Preload CLI caches (org list and default org auth) in background
+  // Preload runtime org list cache in background
   try {
     const enabled = getBooleanConfig('sfLogs.cliCache.enabled', true);
     // Heuristic: skip when running inside VS Code test harness to avoid interfering with unit tests

--- a/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
@@ -23,6 +23,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   private readonly disposables: vscode.Disposable[] = [];
   private hostDisposables: vscode.Disposable[] = [];
   private disposed = false;
+  private ready = false;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
 
@@ -73,6 +74,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         logInfo('Tail: received message from webview:', t);
       }
       if (message?.type === 'ready') {
+        this.ready = true;
         this.post({ type: 'init', locale: vscode.env.language });
         await this.refreshViewState();
         return;
@@ -369,6 +371,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     this.host = host;
     this.view = host;
     this.disposed = false;
+    this.ready = false;
     host.webview.options = {
       enableScripts: true,
       localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
@@ -382,6 +385,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
           return;
         }
         this.disposed = true;
+        this.ready = false;
         this.view = undefined;
         this.host = undefined;
         // Stop timers and clear caches, but keep controller disposal separate.
@@ -389,7 +393,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         logInfo(`Tail webview disposed; stopped tail (${host.kind}).`);
       }),
       host.onDidBecomeVisible(() => {
-        if (this.disposed) {
+        if (this.disposed || !this.ready) {
           return;
         }
         void this.refreshViewState();

--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -155,13 +155,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           clearListCache();
           this.pageLimit = this.configManager.getPageLimit();
           await this.orgManager.ensureProjectDefaultSelected();
-          const auth = await runtimeClient.getOrgAuth({ username: this.orgManager.getSelectedOrg() });
-          if (isCurrentRefresh()) {
-            const existingWarning = getApiVersionFallbackWarning(auth);
-            if (existingWarning) {
-              this.post({ type: 'warning', message: existingWarning });
-            }
-          }
+          const selectedOrg = this.orgManager.getSelectedOrg();
+          const authPromise = runtimeClient.getOrgAuth({ username: selectedOrg });
           if (ct.isCancellationRequested || !isCurrentRefresh()) {
             return;
           }
@@ -170,7 +165,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.cursorId = undefined;
           const logs = (await runtimeClient.logsList(
             {
-              username: this.orgManager.getSelectedOrg(),
+              username: selectedOrg,
               limit: this.pageLimit
             },
             controller.signal
@@ -185,16 +180,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             this.cursorStartTime = last?.StartTime;
             this.cursorId = last?.Id;
           }
-          if (isCurrentRefresh()) {
-            const warning = getApiVersionFallbackWarning(auth);
-            if (warning) {
-              this.post({ type: 'warning', message: warning });
-            }
-          }
           if (!isCurrentRefresh()) {
             return;
           }
-          this.preloadFullLogBodies(logs, auth, token, controller.signal);
           this.post({
             type: 'init',
             locale: vscode.env.language,
@@ -206,21 +194,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.setCurrentLogs(logs);
           this.postKnownErrorStateForLogs(logs);
           this.purgeLogCache(controller.signal);
-          this.logService.loadLogHeads(
-            logs,
-            auth,
-            token,
-            (logId, codeUnit) => {
-              if (token === this.refreshToken && !this.disposed) {
-                this.post({ type: 'logHead', logId, codeUnitStarted: codeUnit });
-              }
-            },
-            controller.signal,
-            {
-              preferLocalBodies: this.configManager.shouldLoadFullLogBodies(),
-              selectedOrg: this.orgManager.getSelectedOrg()
-            }
-          );
+          this.startAuthHydration(logs, authPromise, token, selectedOrg, controller.signal);
           this.startErrorScanForCurrentLogs(token, controller.signal);
           if (this.lastSearchQuery.trim()) {
             this.rerunActiveSearch();
@@ -258,18 +232,13 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     this.post({ type: 'loading', value: true });
     this.post({ type: 'warning', message: undefined });
     try {
-      const auth = await runtimeClient.getOrgAuth({ username: this.orgManager.getSelectedOrg() });
-      if (isCurrentRefresh()) {
-        const existingWarning = getApiVersionFallbackWarning(auth);
-        if (existingWarning) {
-          this.post({ type: 'warning', message: existingWarning });
-        }
-      }
+      const selectedOrg = this.orgManager.getSelectedOrg();
+      const authPromise = runtimeClient.getOrgAuth({ username: selectedOrg });
       if (!isCurrentRefresh()) {
         return;
       }
       const logs = (await runtimeClient.logsList({
-        username: this.orgManager.getSelectedOrg(),
+        username: selectedOrg,
         limit: this.pageLimit,
         cursor:
           this.cursorStartTime && this.cursorId
@@ -283,29 +252,15 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.cursorStartTime = last?.StartTime;
         this.cursorId = last?.Id;
       }
-      if (isCurrentRefresh()) {
-        const warning = getApiVersionFallbackWarning(auth);
-        if (warning) {
-          this.post({ type: 'warning', message: warning });
-        }
-      }
       if (!isCurrentRefresh()) {
         return;
       }
-      this.preloadFullLogBodies(logs, auth, token);
       const hasMore = logs.length === this.pageLimit;
       this.post({ type: 'appendLogs', data: logs, hasMore });
       this.setCurrentLogs([...this.currentLogs, ...logs]);
       this.postKnownErrorStateForLogs(logs);
       this.purgeLogCache();
-      this.logService.loadLogHeads(logs, auth, token, (logId, codeUnit) => {
-        if (token === this.refreshToken && !this.disposed) {
-          this.post({ type: 'logHead', logId, codeUnitStarted: codeUnit });
-        }
-      }, undefined, {
-        preferLocalBodies: this.configManager.shouldLoadFullLogBodies(),
-        selectedOrg: this.orgManager.getSelectedOrg()
-      });
+      this.startAuthHydration(logs, authPromise, token, selectedOrg);
       this.startErrorScanForCurrentLogs(token);
       this.rerunActiveSearch();
       try {
@@ -325,7 +280,53 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
   }
 
-  private preloadFullLogBodies(logs: ApexLogRow[], auth: OrgAuth, refreshToken: number, signal?: AbortSignal): void {
+  private startAuthHydration(
+    logs: ApexLogRow[],
+    authPromise: Promise<OrgAuth>,
+    refreshToken: number,
+    selectedOrg?: string,
+    signal?: AbortSignal
+  ): void {
+    void authPromise
+      .then(auth => {
+        if (signal?.aborted || refreshToken !== this.refreshToken || this.disposed) {
+          return;
+        }
+        const warning = getApiVersionFallbackWarning(auth);
+        if (warning) {
+          this.post({ type: 'warning', message: warning });
+        }
+        this.preloadFullLogBodies(logs, auth, refreshToken, signal, selectedOrg);
+        this.logService.loadLogHeads(
+          logs,
+          auth,
+          refreshToken,
+          (logId, codeUnit) => {
+            if (refreshToken === this.refreshToken && !this.disposed) {
+              this.post({ type: 'logHead', logId, codeUnitStarted: codeUnit });
+            }
+          },
+          signal,
+          {
+            preferLocalBodies: this.configManager.shouldLoadFullLogBodies(),
+            selectedOrg
+          }
+        );
+      })
+      .catch(e => {
+        if (!signal?.aborted && refreshToken === this.refreshToken && !this.disposed) {
+          logWarn('Logs: auth hydration failed ->', getErrorMessage(e));
+        }
+      });
+  }
+
+  private preloadFullLogBodies(
+    logs: ApexLogRow[],
+    auth: OrgAuth,
+    refreshToken: number,
+    signal?: AbortSignal,
+    selectedOrg?: string
+  ): void {
     if (!this.configManager.shouldLoadFullLogBodies()) {
       return;
     }
@@ -351,7 +352,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       }, 150);
     };
     void this.logService
-      .ensureLogsSaved(logs, this.orgManager.getSelectedOrg(), signal, {
+      .ensureLogsSaved(logs, selectedOrg, signal, {
+        authHint: auth,
         onItemComplete: result => {
           if (signal?.aborted || this.disposed) {
             return;
@@ -370,7 +372,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             }
           }, signal, {
             preferLocalBodies: true,
-            selectedOrg: this.orgManager.getSelectedOrg()
+            selectedOrg
           });
           scheduleSearchRerun();
         }
@@ -1245,7 +1247,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       {
         location: vscode.ProgressLocation.Notification,
         title: localize('listingOrgs', 'Listing Salesforce orgs…'),
-        cancellable: true
+        cancellable: false
       },
       async (_progress, ct) => {
         try {

--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -156,7 +156,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.pageLimit = this.configManager.getPageLimit();
           await this.orgManager.ensureProjectDefaultSelected();
           const selectedOrg = this.orgManager.getSelectedOrg();
-          const authPromise = runtimeClient.getOrgAuth({ username: selectedOrg });
+          const authHandle = this.observeDeferredAuth({ username: selectedOrg });
           if (ct.isCancellationRequested || !isCurrentRefresh()) {
             return;
           }
@@ -194,6 +194,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.setCurrentLogs(logs);
           this.postKnownErrorStateForLogs(logs);
           this.purgeLogCache(controller.signal);
+          const authPromise = authHandle.handoff();
           this.startAuthHydration(logs, authPromise, token, selectedOrg, controller.signal);
           this.startErrorScanForCurrentLogs(token, controller.signal);
           if (this.lastSearchQuery.trim()) {
@@ -233,7 +234,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     this.post({ type: 'warning', message: undefined });
     try {
       const selectedOrg = this.orgManager.getSelectedOrg();
-      const authPromise = runtimeClient.getOrgAuth({ username: selectedOrg });
+      const authHandle = this.observeDeferredAuth({ username: selectedOrg });
       if (!isCurrentRefresh()) {
         return;
       }
@@ -260,6 +261,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       this.setCurrentLogs([...this.currentLogs, ...logs]);
       this.postKnownErrorStateForLogs(logs);
       this.purgeLogCache();
+      const authPromise = authHandle.handoff();
       this.startAuthHydration(logs, authPromise, token, selectedOrg);
       this.startErrorScanForCurrentLogs(token);
       this.rerunActiveSearch();
@@ -318,6 +320,23 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           logWarn('Logs: auth hydration failed ->', getErrorMessage(e));
         }
       });
+  }
+
+  private observeDeferredAuth(params: { username?: string }): { handoff: () => Promise<OrgAuth> } {
+    const observed = runtimeClient.getOrgAuth(params).then(
+      auth => ({ ok: true as const, auth }),
+      error => ({ ok: false as const, error })
+    );
+
+    return {
+      handoff: () =>
+        observed.then(result => {
+          if (result.ok) {
+            return result.auth;
+          }
+          throw result.error;
+        })
+    };
   }
 
   private preloadFullLogBodies(

--- a/apps/vscode-extension/src/provider/logsMessageHandler.ts
+++ b/apps/vscode-extension/src/provider/logsMessageHandler.ts
@@ -26,12 +26,26 @@ export class LogsMessageHandler {
       case 'ready':
         logInfo('Logs: message ready');
         this.setLoading(true);
+        let readyError: unknown;
         try {
           const sendOrgsPromise = this.sendOrgs();
-          await this.refresh();
-          await sendOrgsPromise;
+          try {
+            await this.refresh();
+          } catch (error) {
+            readyError = error;
+          }
+          try {
+            await sendOrgsPromise;
+          } catch (error) {
+            if (readyError === undefined) {
+              readyError = error;
+            }
+          }
         } finally {
           this.setLoading(false);
+        }
+        if (readyError !== undefined) {
+          throw readyError;
         }
         break;
       case 'refresh':

--- a/apps/vscode-extension/src/provider/logsMessageHandler.ts
+++ b/apps/vscode-extension/src/provider/logsMessageHandler.ts
@@ -26,9 +26,13 @@ export class LogsMessageHandler {
       case 'ready':
         logInfo('Logs: message ready');
         this.setLoading(true);
-        await this.sendOrgs();
-        await this.refresh();
-        this.setLoading(false);
+        try {
+          const sendOrgsPromise = this.sendOrgs();
+          await this.refresh();
+          await sendOrgsPromise;
+        } finally {
+          this.setLoading(false);
+        }
         break;
       case 'refresh':
         logInfo('Logs: message refresh');

--- a/apps/vscode-extension/src/provider/logsMessageHandler.ts
+++ b/apps/vscode-extension/src/provider/logsMessageHandler.ts
@@ -26,26 +26,11 @@ export class LogsMessageHandler {
       case 'ready':
         logInfo('Logs: message ready');
         this.setLoading(true);
-        let readyError: unknown;
         try {
-          const sendOrgsPromise = this.sendOrgs();
-          try {
-            await this.refresh();
-          } catch (error) {
-            readyError = error;
-          }
-          try {
-            await sendOrgsPromise;
-          } catch (error) {
-            if (readyError === undefined) {
-              readyError = error;
-            }
-          }
+          await this.sendOrgs();
+          await this.refresh();
         } finally {
           this.setLoading(false);
-        }
-        if (readyError !== undefined) {
-          throw readyError;
         }
         break;
       case 'refresh':

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -56,6 +56,8 @@ export class RuntimeClient extends EventEmitter {
   private initializePromise: Promise<InitializeResult> | undefined;
   private nextRequestId = 0;
   private readonly pendingRequests = new Map<string, PendingRequest>();
+  private readonly inFlightOrgLists = new Map<string, Promise<OrgListItem[]>>();
+  private readonly inFlightOrgAuth = new Map<string, Promise<OrgAuth>>();
   private restartDelayMs = 250;
   private restartPromise: Promise<void> | undefined;
   private readonly clientName: string;
@@ -125,14 +127,38 @@ export class RuntimeClient extends EventEmitter {
     if (!this.requestHandler) {
       await this.initialize();
     }
-    return this.request<OrgListItem[]>('org/list', params);
+    const key = JSON.stringify({ forceRefresh: params.forceRefresh === true });
+    const pending = this.inFlightOrgLists.get(key);
+    if (pending) {
+      return pending;
+    }
+    const request = this.request<OrgListItem[]>('org/list', params);
+    const tracked = request.finally(() => {
+      if (this.inFlightOrgLists.get(key) === tracked) {
+        this.inFlightOrgLists.delete(key);
+      }
+    });
+    this.inFlightOrgLists.set(key, tracked);
+    return tracked;
   }
 
   async getOrgAuth(params: OrgAuthParams = {}): Promise<OrgAuth> {
     if (!this.requestHandler) {
       await this.initialize();
     }
-    return this.request<OrgAuth>('org/auth', params);
+    const key = JSON.stringify({ username: typeof params.username === 'string' ? params.username.trim() : '' });
+    const pending = this.inFlightOrgAuth.get(key);
+    if (pending) {
+      return pending;
+    }
+    const request = this.request<OrgAuth>('org/auth', params);
+    const tracked = request.finally(() => {
+      if (this.inFlightOrgAuth.get(key) === tracked) {
+        this.inFlightOrgAuth.delete(key);
+      }
+    });
+    this.inFlightOrgAuth.set(key, tracked);
+    return tracked;
   }
 
   async logsList(params: LogsListParams = {}, signal?: AbortSignal): Promise<RuntimeLogRow[]> {

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -422,6 +422,58 @@ suite('LogService', () => {
     assert.ok(statuses.includes('existing'));
   });
 
+  test('ensureLogsSaved reuses authHint without calling CLI auth again', async () => {
+    let authCalls = 0;
+    const writeTargets: string[] = [];
+    const lookupCalls: Array<{ logId: string; username?: string }> = [];
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => 'body'
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => {
+          authCalls++;
+          return { username: 'u', accessToken: 't', instanceUrl: 'url' };
+        }
+      },
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async (username: string | undefined, logId: string) => ({
+          dir: '/tmp',
+          filePath: `/tmp/${username ?? 'none'}_${logId}.log`
+        }),
+        findExistingLogFile: async (logId: string, username?: string) => {
+          lookupCalls.push({ logId, username });
+          return undefined;
+        }
+      },
+      fs: {
+        promises: {
+          writeFile: async (target: string) => {
+            writeTargets.push(target);
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved(
+      [{ Id: '1' } as ApexLogRow],
+      'default',
+      undefined,
+      {
+        authHint: { username: 'u', accessToken: 't', instanceUrl: 'url' }
+      } as any
+    );
+
+    assert.equal(authCalls, 0, 'should avoid a duplicate CLI auth lookup when authHint is provided');
+    assert.ok(lookupCalls.length >= 1, 'should check for existing files before writing');
+    assert.equal(lookupCalls.every(call => call.logId === '1' && call.username === 'u'), true);
+    assert.deepEqual(writeTargets, ['/tmp/u_1.log']);
+    assert.equal(summary.downloaded, 1);
+  });
+
   test('summarizeLogTextWithHeuristics returns a summary for error event lines', async () => {
     const { summarizeLogTextWithHeuristics } = proxyquireStrict('../../../../src/services/logTriage', {});
 

--- a/apps/vscode-extension/src/test/logsMessageHandler.test.ts
+++ b/apps/vscode-extension/src/test/logsMessageHandler.test.ts
@@ -115,7 +115,7 @@ suite('LogsMessageHandler telemetry', () => {
       async () => undefined,
       async () => undefined,
       async () => undefined,
-      value => calls.push(`loading:${value}`),
+      (value: boolean) => calls.push(`loading:${value}`),
       async () => undefined,
       async () => undefined
     );
@@ -130,5 +130,59 @@ suite('LogsMessageHandler telemetry', () => {
 
     assert.equal(calls.at(-1), 'loading:false');
     assert.equal(events.length, 0);
+  });
+
+  test('waits for sendOrgs to settle before surfacing a refresh failure on ready', async () => {
+    const calls: string[] = [];
+    const refreshError = new Error('refresh failed');
+    const sendOrgsError = new Error('sendOrgs failed');
+    let rejectSendOrgs: ((error: Error) => void) | undefined;
+    const sendOrgsStarted = new Promise<void>((_resolve, reject) => {
+      rejectSendOrgs = reject;
+    });
+
+    const { LogsMessageHandler } = proxyquire('../provider/logsMessageHandler', {
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/utils/logger': {
+        logInfo: () => undefined,
+        '@noCallThru': true
+      }
+    });
+
+    const handler = new LogsMessageHandler(
+      async () => {
+        calls.push('refresh');
+        throw refreshError;
+      },
+      async () => undefined,
+      async () => undefined,
+      async () => {
+        calls.push('sendOrgs');
+        await sendOrgsStarted;
+      },
+      () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      (value: boolean) => calls.push(`loading:${value}`),
+      async () => undefined,
+      async () => undefined
+    );
+
+    let settled = false;
+    const pending = handler.handle({ type: 'ready' } as any).finally(() => {
+      settled = true;
+    });
+
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.equal(settled, false);
+
+    rejectSendOrgs?.(sendOrgsError);
+    await assert.rejects(pending, error => error === refreshError);
+    assert.equal(calls.at(-1), 'loading:false');
   });
 });

--- a/apps/vscode-extension/src/test/logsMessageHandler.test.ts
+++ b/apps/vscode-extension/src/test/logsMessageHandler.test.ts
@@ -78,4 +78,57 @@ suite('LogsMessageHandler telemetry', () => {
       }
     ]);
   });
+
+  test('starts refresh without waiting for org list on ready', async () => {
+    const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
+    const calls: string[] = [];
+    let releaseSendOrgs: (() => void) | undefined;
+    const sendOrgsStarted = new Promise<void>(resolve => {
+      releaseSendOrgs = resolve;
+    });
+
+    const { LogsMessageHandler } = proxyquire('../provider/logsMessageHandler', {
+      '../shared/telemetry': {
+        safeSendEvent: (name: string, properties?: Record<string, string>, measurements?: Record<string, number>) => {
+          events.push({ name, properties, measurements });
+        },
+        '@noCallThru': true
+      },
+      '../../../../src/utils/logger': {
+        logInfo: () => undefined,
+        '@noCallThru': true
+      }
+    });
+
+    const handler = new LogsMessageHandler(
+      async () => {
+        calls.push('refresh');
+      },
+      async () => undefined,
+      async () => undefined,
+      async () => {
+        calls.push('sendOrgs');
+        await sendOrgsStarted;
+      },
+      () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      async () => undefined,
+      value => calls.push(`loading:${value}`),
+      async () => undefined,
+      async () => undefined
+    );
+
+    const pending = handler.handle({ type: 'ready' } as any);
+    await new Promise(resolve => setTimeout(resolve, 10));
+
+    assert.deepEqual(calls.slice(0, 3), ['loading:true', 'sendOrgs', 'refresh']);
+
+    releaseSendOrgs?.();
+    await pending;
+
+    assert.equal(calls.at(-1), 'loading:false');
+    assert.equal(events.length, 0);
+  });
 });

--- a/apps/vscode-extension/src/test/logsMessageHandler.test.ts
+++ b/apps/vscode-extension/src/test/logsMessageHandler.test.ts
@@ -79,7 +79,7 @@ suite('LogsMessageHandler telemetry', () => {
     ]);
   });
 
-  test('starts refresh without waiting for org list on ready', async () => {
+  test('waits for org list before starting refresh on ready', async () => {
     const events: Array<{ name: string; properties?: Record<string, string>; measurements?: Record<string, number> }> = [];
     const calls: string[] = [];
     let releaseSendOrgs: (() => void) | undefined;
@@ -123,23 +123,20 @@ suite('LogsMessageHandler telemetry', () => {
     const pending = handler.handle({ type: 'ready' } as any);
     await new Promise(resolve => setTimeout(resolve, 10));
 
-    assert.deepEqual(calls.slice(0, 3), ['loading:true', 'sendOrgs', 'refresh']);
+    assert.deepEqual(calls, ['loading:true', 'sendOrgs']);
 
     releaseSendOrgs?.();
+    await new Promise(resolve => setTimeout(resolve, 10));
+    assert.deepEqual(calls.slice(0, 3), ['loading:true', 'sendOrgs', 'refresh']);
     await pending;
 
     assert.equal(calls.at(-1), 'loading:false');
     assert.equal(events.length, 0);
   });
 
-  test('waits for sendOrgs to settle before surfacing a refresh failure on ready', async () => {
+  test('surfaces sendOrgs failure before starting refresh on ready', async () => {
     const calls: string[] = [];
-    const refreshError = new Error('refresh failed');
     const sendOrgsError = new Error('sendOrgs failed');
-    let rejectSendOrgs: ((error: Error) => void) | undefined;
-    const sendOrgsStarted = new Promise<void>((_resolve, reject) => {
-      rejectSendOrgs = reject;
-    });
 
     const { LogsMessageHandler } = proxyquire('../provider/logsMessageHandler', {
       '../shared/telemetry': {
@@ -155,13 +152,12 @@ suite('LogsMessageHandler telemetry', () => {
     const handler = new LogsMessageHandler(
       async () => {
         calls.push('refresh');
-        throw refreshError;
       },
       async () => undefined,
       async () => undefined,
       async () => {
         calls.push('sendOrgs');
-        await sendOrgsStarted;
+        throw sendOrgsError;
       },
       () => undefined,
       async () => undefined,
@@ -173,16 +169,7 @@ suite('LogsMessageHandler telemetry', () => {
       async () => undefined
     );
 
-    let settled = false;
-    const pending = handler.handle({ type: 'ready' } as any).finally(() => {
-      settled = true;
-    });
-
-    await new Promise(resolve => setTimeout(resolve, 10));
-    assert.equal(settled, false);
-
-    rejectSendOrgs?.(sendOrgsError);
-    await assert.rejects(pending, error => error === refreshError);
-    assert.equal(calls.at(-1), 'loading:false');
+    await assert.rejects(handler.handle({ type: 'ready' } as any), error => error === sendOrgsError);
+    assert.deepEqual(calls, ['loading:true', 'sendOrgs', 'loading:false']);
   });
 });

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -257,14 +257,14 @@ suite('SfLogsViewProvider behavior', () => {
     } as any;
     (provider as any).logService.loadLogHeads = () => {};
 
-    const calls: Array<{ logs: any[]; signal?: AbortSignal }> = [];
+    const calls: Array<{ logs: any[]; signal?: AbortSignal; options?: any }> = [];
     (provider as any).logService.ensureLogsSaved = async (
       logs: any[],
       _org: string | undefined,
       signal?: AbortSignal,
-      _options?: any
+      options?: any
     ) => {
-      calls.push({ logs, signal });
+      calls.push({ logs, signal, options });
     };
     const purged: Array<{ keepIds?: Set<string>; maxAgeMs?: number; signal?: AbortSignal }> = [];
     workspace.purgeSavedLogs = async (opts: any) => {
@@ -282,6 +282,7 @@ suite('SfLogsViewProvider behavior', () => {
       'should pass fetched logs to ensureLogsSaved'
     );
     assert.equal(typeof calls[0]?.signal?.aborted, 'boolean', 'should pass abort signal to ensureLogsSaved');
+    assert.equal(calls[0]?.options?.authHint?.username, 'u', 'should pass auth hint to ensureLogsSaved');
     assert.equal(purged.length, 1, 'should purge cached logs after refresh');
     const keepIds = Array.from(purged[0]?.keepIds ?? []);
     assert.deepEqual(
@@ -414,6 +415,65 @@ suite('SfLogsViewProvider behavior', () => {
     assert.ok(triageSignal, 'should start runtime triage');
     assert.equal(triageSignal?.aborted, true, 'scan signal should be aborted when refresh is cancelled');
     assert.ok(posted.some(m => m?.type === 'errorScanStatus' && m?.state === 'running'), 'should have started scan status');
+  });
+
+  test('refresh posts logs before org auth completes', async () => {
+    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
+    let releaseAuth!: () => void;
+    const authGate = new Promise<void>(resolve => {
+      releaseAuth = resolve;
+    });
+    cli.getOrgAuth = async () => {
+      await authGate;
+      return { username: 'u', instanceUrl: 'i', accessToken: 't' };
+    };
+    cli.logsList = async () => [{ Id: '07L000000000001AA', LogLength: 10 }];
+    workspace.purgeSavedLogs = async () => 0;
+
+    const context = makeContext();
+    const posted: any[] = [];
+    const provider = new SfLogsViewProvider(context);
+    (provider as any).configManager.shouldLoadFullLogBodies = () => false;
+    (provider as any).logService.loadLogHeads = () => {};
+    (provider as any).view = {
+      webview: {
+        postMessage: (m: any) => {
+          posted.push(m);
+          return Promise.resolve(true);
+        }
+      }
+    } as any;
+
+    const refreshPromise = provider.refresh();
+    await new Promise(resolve => setTimeout(resolve, 20));
+    const postedLogsBeforeAuth = posted.some(m => m?.type === 'logs');
+    releaseAuth();
+    await refreshPromise;
+
+    assert.equal(postedLogsBeforeAuth, true, 'should render logs without waiting for org auth');
+  });
+
+  test('sendOrgs uses a non-cancellable progress notification', async () => {
+    const { SfLogsViewProvider, cli, vscode: vscodeMock } = createProviderHarness();
+    cli.orgList = async () => [{ username: 'demo@example.com', alias: 'Demo', isDefaultUsername: true }];
+
+    const context = makeContext();
+    const provider = new SfLogsViewProvider(context);
+    let progressOptions: any;
+    vscodeMock.window.withProgress = async (opts: any, task: any) => {
+      progressOptions = opts;
+      return task(
+        { report: () => {} },
+        {
+          onCancellationRequested: () => {},
+          isCancellationRequested: false
+        }
+      );
+    };
+
+    await provider.sendOrgs();
+
+    assert.equal(progressOptions?.cancellable, false, 'org listing progress should not advertise cancellation');
   });
 
   test('preloadFullLogBodies re-runs active search after downloads complete', async () => {

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -187,6 +187,84 @@ function createProviderHarness() {
 }
 
 suite('SfLogsViewProvider behavior', () => {
+  test('refresh handles deferred auth rejection when logs listing fails', async () => {
+    const { SfLogsViewProvider, cli } = createProviderHarness();
+    let rejectAuth: ((error: Error) => void) | undefined;
+    cli.getOrgAuth = async () =>
+      await new Promise((_resolve, reject) => {
+        rejectAuth = reject;
+      });
+    cli.logsList = async () => {
+      throw new Error('logs list failed');
+    };
+
+    const context = makeContext();
+    const posted: any[] = [];
+    const provider = new SfLogsViewProvider(context);
+    (provider as any).view = {
+      webview: {
+        postMessage: (m: any) => {
+          posted.push(m);
+          return Promise.resolve(true);
+        }
+      }
+    } as any;
+
+    let unhandled: unknown;
+    const onUnhandled = (error: unknown) => {
+      unhandled = error;
+    };
+    process.once('unhandledRejection', onUnhandled);
+    try {
+      await provider.refresh();
+      rejectAuth?.(new Error('auth failed after refresh error'));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      assert.equal(unhandled, undefined);
+      assert.equal(posted.some(message => message?.type === 'error'), true);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
+  });
+
+  test('loadMore handles deferred auth rejection when logs listing fails', async () => {
+    const { SfLogsViewProvider, cli } = createProviderHarness();
+    let rejectAuth: ((error: Error) => void) | undefined;
+    cli.getOrgAuth = async () =>
+      await new Promise((_resolve, reject) => {
+        rejectAuth = reject;
+      });
+    cli.logsList = async () => {
+      throw new Error('load more failed');
+    };
+
+    const context = makeContext();
+    const posted: any[] = [];
+    const provider = new SfLogsViewProvider(context);
+    (provider as any).view = {
+      webview: {
+        postMessage: (m: any) => {
+          posted.push(m);
+          return Promise.resolve(true);
+        }
+      }
+    } as any;
+
+    let unhandled: unknown;
+    const onUnhandled = (error: unknown) => {
+      unhandled = error;
+    };
+    process.once('unhandledRejection', onUnhandled);
+    try {
+      await (provider as any).loadMore();
+      rejectAuth?.(new Error('auth failed after loadMore error'));
+      await new Promise(resolve => setTimeout(resolve, 0));
+      assert.equal(unhandled, undefined);
+      assert.equal(posted.some(message => message?.type === 'error'), true);
+    } finally {
+      process.removeListener('unhandledRejection', onUnhandled);
+    }
+  });
+
   test('refresh posts logs and logHead with code unit', async () => {
     const { SfLogsViewProvider, cli } = createProviderHarness();
     const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'alv-provider-heads-'));

--- a/apps/vscode-extension/src/test/resolvePATHFromLoginShell.test.ts
+++ b/apps/vscode-extension/src/test/resolvePATHFromLoginShell.test.ts
@@ -44,7 +44,91 @@ suite('resolvePATHFromLoginShell', () => {
     __resetExecFileImplForTests();
   });
 
-  test('getLoginShellEnv preserves current PATH and still injects explicit sf.cmd on win32', async () => {
+  test('getLoginShellEnv uses the login-shell PATH when the current PATH does not resolve sf on win32', async () => {
+    const execModule = loadExecModule();
+    const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
+    const { getLoginShellEnv, __resetLoginShellPATHForTests } = loadPathModule({
+      platform: 'win32',
+      execModule
+    });
+    __resetLoginShellPATHForTests();
+
+    const originalPath = process.env.PATH;
+    const originalPathCase = process.env.Path;
+    const originalComSpec = process.env.ComSpec;
+    const currentPath = 'C:\\Users\\k2\\AppData\\Roaming\\fnm\\aliases\\default';
+    const loginPath = 'C:\\Users\\k2\\AppData\\Roaming\\fnm\\current\\bin';
+    const sfShim = `${loginPath}\\sf.cmd`;
+    process.env.PATH = currentPath;
+    process.env.Path = currentPath;
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+    let calls = 0;
+    __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, opts: any, cb: any) => {
+      calls++;
+      if (calls === 1) {
+        assert.match(program.toLowerCase(), /cmd\.exe$/);
+        assert.deepEqual(args, ['/d', '/s', '/c', 'where sf']);
+        assert.equal(opts?.env?.PATH, currentPath);
+        assert.equal(opts?.env?.Path, currentPath);
+        cb(new Error('where failed'), '', '');
+        return undefined as any;
+      }
+
+      if (calls === 2) {
+        assert.equal(program, 'C:\\Program Files\\Git\\bin\\bash.exe');
+        assert.deepEqual(args, [
+          '-lc',
+          'command -v sf.cmd >/dev/null 2>&1 && cygpath -w "$(command -v sf.cmd)" || command -v sf >/dev/null 2>&1 && cygpath -w "$(command -v sf)"'
+        ]);
+        assert.equal(opts?.env?.PATH, currentPath);
+        assert.equal(opts?.env?.Path, currentPath);
+        cb(undefined, '', '');
+        return undefined as any;
+      }
+
+      if (calls === 3) {
+        assert.equal(program, 'pwsh');
+        assert.deepEqual(args, ['-NoLogo', '-Login', '-Command', '$env:PATH']);
+        cb(null, loginPath, '');
+        return undefined as any;
+      }
+
+      assert.match(program.toLowerCase(), /cmd\.exe$/);
+      assert.deepEqual(args, ['/d', '/s', '/c', 'where sf']);
+      assert.equal(opts?.env?.PATH, loginPath);
+      assert.equal(opts?.env?.Path, loginPath);
+      cb(null, `${loginPath}\\sf\r\n${sfShim}`, '');
+      return undefined as any;
+    }) as any);
+
+    try {
+      const envValue = await getLoginShellEnv();
+      assert.equal(envValue?.PATH, loginPath);
+      assert.equal(envValue?.Path, loginPath);
+      assert.equal(envValue?.ALV_SF_BIN_PATH, sfShim);
+      assert.equal(calls, 4);
+    } finally {
+      if (originalPath === undefined) {
+        delete process.env.PATH;
+      } else {
+        process.env.PATH = originalPath;
+      }
+      if (originalPathCase === undefined) {
+        delete process.env.Path;
+      } else {
+        process.env.Path = originalPathCase;
+      }
+      if (originalComSpec === undefined) {
+        delete process.env.ComSpec;
+      } else {
+        process.env.ComSpec = originalComSpec;
+      }
+      __resetExecFileImplForTests();
+    }
+  });
+
+  test('getLoginShellEnv skips login-shell probing when current PATH already resolves sf.cmd on win32', async () => {
     const execModule = loadExecModule();
     const { __setExecFileImplForTests, __resetExecFileImplForTests } = execModule;
     const { getLoginShellEnv, __resetLoginShellPATHForTests } = loadPathModule({
@@ -65,13 +149,6 @@ suite('resolvePATHFromLoginShell', () => {
     let calls = 0;
     __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, opts: any, cb: any) => {
       calls++;
-      if (calls === 1) {
-        assert.equal(program, 'pwsh');
-        assert.deepEqual(args, ['-NoLogo', '-Login', '-Command', '$env:PATH']);
-        cb(null, currentPath, '');
-        return undefined as any;
-      }
-
       assert.match(program.toLowerCase(), /cmd\.exe$/);
       assert.deepEqual(args, ['/d', '/s', '/c', 'where sf']);
       assert.equal(opts?.env?.PATH, currentPath);
@@ -85,7 +162,7 @@ suite('resolvePATHFromLoginShell', () => {
       assert.equal(envValue?.PATH, currentPath);
       assert.equal(envValue?.Path, currentPath);
       assert.equal(envValue?.ALV_SF_BIN_PATH, sfShim);
-      assert.equal(calls, 2);
+      assert.equal(calls, 1);
     } finally {
       if (originalPath === undefined) {
         delete process.env.PATH;
@@ -126,15 +203,38 @@ suite('resolvePATHFromLoginShell', () => {
     __setExecFileImplForTests(((program: string, args: readonly string[] | undefined, opts: any, cb: any) => {
       calls++;
       if (calls === 1) {
+        assert.match(program.toLowerCase(), /cmd\.exe$/);
+        assert.deepEqual(args, ['/d', '/s', '/c', 'where sf']);
+        assert.equal(opts?.env?.PATH, currentPath);
+        assert.equal(opts?.env?.Path, currentPath);
+        cb(new Error('where failed'), '', '');
+        return undefined as any;
+      }
+
+      if (calls === 2) {
+        assert.equal(program, 'C:\\Program Files\\Git\\bin\\bash.exe');
+        assert.deepEqual(args, [
+          '-lc',
+          'command -v sf.cmd >/dev/null 2>&1 && cygpath -w "$(command -v sf.cmd)" || command -v sf >/dev/null 2>&1 && cygpath -w "$(command -v sf)"'
+        ]);
+        assert.equal(opts?.env?.PATH, currentPath);
+        assert.equal(opts?.env?.Path, currentPath);
+        cb(undefined, '', '');
+        return undefined as any;
+      }
+
+      if (calls === 3) {
         assert.equal(program, 'pwsh');
         assert.deepEqual(args, ['-NoLogo', '-Login', '-Command', '$env:PATH']);
         cb(null, currentPath, '');
         return undefined as any;
       }
 
-      if (calls === 2) {
+      if (calls === 4) {
         assert.match(program.toLowerCase(), /cmd\.exe$/);
         assert.deepEqual(args, ['/d', '/s', '/c', 'where sf']);
+        assert.equal(opts?.env?.PATH, currentPath);
+        assert.equal(opts?.env?.Path, currentPath);
         cb(new Error('where failed'), '', '');
         return undefined as any;
       }
@@ -153,7 +253,7 @@ suite('resolvePATHFromLoginShell', () => {
     try {
       const envValue = await getLoginShellEnv();
       assert.equal(envValue?.ALV_SF_BIN_PATH, sfShim);
-      assert.equal(calls, 3);
+      assert.equal(calls, 5);
     } finally {
       if (originalPath === undefined) {
         delete process.env.PATH;

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -140,6 +140,66 @@ suite('runtime client', () => {
     assert.equal(auth.username, 'demo@example.com');
   });
 
+  test('coalesces concurrent orgList requests with identical params', async () => {
+    let orgListCalls = 0;
+    let resolveOrgList: ((value: unknown) => void) | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async (method, params) => {
+        assert.equal(method, 'org/list');
+        assert.deepEqual(params, { forceRefresh: false });
+        orgListCalls++;
+        return await new Promise(resolve => {
+          resolveOrgList = resolve;
+        });
+      }
+    });
+
+    const first = client.orgList({ forceRefresh: false });
+    const second = client.orgList({ forceRefresh: false });
+
+    assert.equal(orgListCalls, 1);
+    resolveOrgList?.([
+      {
+        username: 'demo@example.com',
+        alias: 'Demo',
+        isDefaultUsername: true
+      }
+    ]);
+
+    const [left, right] = await Promise.all([first, second]);
+    assert.equal(orgListCalls, 1);
+    assert.deepEqual(left, right);
+  });
+
+  test('coalesces concurrent getOrgAuth requests for the same username', async () => {
+    let authCalls = 0;
+    let resolveAuth: ((value: unknown) => void) | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async (method, params) => {
+        assert.equal(method, 'org/auth');
+        assert.deepEqual(params, { username: 'demo@example.com' });
+        authCalls++;
+        return await new Promise(resolve => {
+          resolveAuth = resolve;
+        });
+      }
+    });
+
+    const first = client.getOrgAuth({ username: 'demo@example.com' });
+    const second = client.getOrgAuth({ username: 'demo@example.com' });
+
+    assert.equal(authCalls, 1);
+    resolveAuth?.({
+      username: 'demo@example.com',
+      instanceUrl: 'https://example.my.salesforce.com',
+      accessToken: 'token'
+    });
+
+    const [left, right] = await Promise.all([first, second]);
+    assert.equal(authCalls, 1);
+    assert.deepEqual(left, right);
+  });
+
   test('prepares daemon env before starting the runtime process', async () => {
     let prepareCalls = 0;
     let seenEnv: NodeJS.ProcessEnv | undefined;

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -4,6 +4,8 @@ import type {
   DaemonProcess,
   JsonRpcErrorResponse,
   JsonRpcSuccessResponse,
+  OrgAuth,
+  OrgListItem,
 } from '../../../../../packages/app-server-client-ts/src/index';
 import { resolveBundledBinary, resolveBundledBinaryCandidates } from '../../runtime/bundledBinary';
 import { RuntimeClient } from '../../runtime/runtimeClient';
@@ -142,15 +144,15 @@ suite('runtime client', () => {
 
   test('coalesces concurrent orgList requests with identical params', async () => {
     let orgListCalls = 0;
-    let resolveOrgList: ((value: unknown) => void) | undefined;
+    let resolveOrgList: ((value: OrgListItem[]) => void) | undefined;
     const client = new RuntimeClient({
-      requestHandler: async (method, params) => {
+      requestHandler: async <TResult>(method: string, params: unknown) => {
         assert.equal(method, 'org/list');
         assert.deepEqual(params, { forceRefresh: false });
         orgListCalls++;
-        return await new Promise(resolve => {
+        return (await new Promise<OrgListItem[]>(resolve => {
           resolveOrgList = resolve;
-        });
+        })) as TResult;
       }
     });
 
@@ -173,15 +175,15 @@ suite('runtime client', () => {
 
   test('coalesces concurrent getOrgAuth requests for the same username', async () => {
     let authCalls = 0;
-    let resolveAuth: ((value: unknown) => void) | undefined;
+    let resolveAuth: ((value: OrgAuth) => void) | undefined;
     const client = new RuntimeClient({
-      requestHandler: async (method, params) => {
+      requestHandler: async <TResult>(method: string, params: unknown) => {
         assert.equal(method, 'org/auth');
         assert.deepEqual(params, { username: 'demo@example.com' });
         authCalls++;
-        return await new Promise(resolve => {
+        return (await new Promise<OrgAuth>(resolve => {
           resolveAuth = resolve;
-        });
+        })) as TResult;
       }
     });
 

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -545,6 +545,28 @@ suite('TailService', () => {
     assert.equal((provider as any).tailService.isRunning(), false, 'editor tail should stay idle until explicit start');
   });
 
+  test('editor tail panel ignores visibility refreshes until ready', async () => {
+    const context = {
+      extensionUri: vscode.Uri.file(path.resolve('.')),
+      subscriptions: [] as vscode.Disposable[]
+    } as unknown as vscode.ExtensionContext;
+    const provider = new SfLogTailViewProvider(context);
+    const webview = new MockWebview();
+    const panel = new MockWebviewPanel('sfLogTail.editorPanel', webview);
+    const calls: string[] = [];
+
+    (provider as any).refreshViewState = async () => {
+      calls.push('refreshViewState');
+    };
+
+    provider.resolveWebviewPanel(panel);
+    panel.fireVisible();
+    assert.deepEqual(calls, [], 'should not refresh while the webview has not reported ready');
+
+    await webview.emit({ type: 'ready' });
+    assert.deepEqual(calls, ['refreshViewState'], 'should refresh once after ready');
+  });
+
   test('syncSelectedOrg refreshes an existing editor tail session and stops the current stream', async () => {
     const context = {
       extensionUri: vscode.Uri.file(path.resolve('.')),

--- a/src/salesforce/path.ts
+++ b/src/salesforce/path.ts
@@ -32,9 +32,21 @@ export async function resolvePATHFromLoginShell(): Promise<string | undefined> {
 }
 
 export async function getLoginShellEnv(): Promise<NodeJS.ProcessEnv | undefined> {
-  const loginPath = await resolvePATHFromLoginShell();
   const env2: NodeJS.ProcessEnv = { ...process.env };
-  const effectivePath = loginPath || env2.PATH || env2.Path;
+  const currentPath = env2.PATH || env2.Path;
+  if (currentPath) {
+    env2.PATH = currentPath;
+    env2.Path = currentPath;
+  }
+  if (os.platform() === 'win32') {
+    const currentSfCliPath = await resolveSfCliPath(env2);
+    if (currentSfCliPath) {
+      env2.ALV_SF_BIN_PATH = currentSfCliPath;
+      return env2;
+    }
+  }
+  const loginPath = await resolvePATHFromLoginShell();
+  const effectivePath = loginPath || currentPath;
   if (effectivePath) {
     env2.PATH = effectivePath;
     env2.Path = effectivePath;

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -37,6 +37,7 @@ export type EnsureLogsSavedSummary = {
 
 export type EnsureLogsSavedOptions = {
   downloadMissing?: boolean;
+  authHint?: OrgAuth;
   onMissing?: (logId: string) => void;
   onItemComplete?: (result: EnsureLogsSavedItemResult) => void;
 };
@@ -128,8 +129,13 @@ export class LogService {
     }
   }
 
-  private async ensureLogFile(logId: string, selectedOrg?: string, signal?: AbortSignal): Promise<string> {
-    const auth = await getOrgAuth(selectedOrg, undefined, signal);
+  private async ensureLogFile(
+    logId: string,
+    selectedOrg?: string,
+    signal?: AbortSignal,
+    authHint?: OrgAuth
+  ): Promise<string> {
+    const auth = authHint ?? (await getOrgAuth(selectedOrg, undefined, signal));
     const existing = await findExistingLogFile(logId, auth.username);
     if (existing) {
       return existing;
@@ -194,7 +200,14 @@ export class LogService {
     return undefined;
   }
 
-  private async resolveSelectedUsername(selectedOrg?: string, signal?: AbortSignal): Promise<string | undefined> {
+  private async resolveSelectedUsername(
+    selectedOrg?: string,
+    signal?: AbortSignal,
+    authHint?: OrgAuth
+  ): Promise<string | undefined> {
+    if (authHint?.username) {
+      return authHint.username;
+    }
     if (!selectedOrg || signal?.aborted) {
       return undefined;
     }
@@ -315,8 +328,9 @@ export class LogService {
     options?: EnsureLogsSavedOptions
   ): Promise<EnsureLogsSavedSummary> {
     const downloadMissing = options?.downloadMissing !== false;
+    const authHint = options?.authHint;
     const validLogs = logs.filter((log): log is ApexLogRow & { Id: string } => typeof log?.Id === 'string' && log.Id.length > 0);
-    const selectedUsername = await this.resolveSelectedUsername(selectedOrg, signal);
+    const selectedUsername = await this.resolveSelectedUsername(selectedOrg, signal, authHint);
     const summary: EnsureLogsSavedSummary = {
       total: validLogs.length,
       success: 0,
@@ -345,7 +359,7 @@ export class LogService {
                 options?.onItemComplete?.({ logId: log.Id, status: 'existing' });
                 return;
               }
-              await this.ensureLogFile(log.Id, selectedOrg, signal);
+              await this.ensureLogFile(log.Id, selectedOrg, signal, authHint);
               if (signal?.aborted) {
                 summary.cancelled++;
                 options?.onItemComplete?.({ logId: log.Id, status: 'cancelled' });


### PR DESCRIPTION
This PR improves the runtime-backed startup path for Logs and Tail after the monorepo + CLI/daemon migration made those request boundaries easier to observe.

On real startup traces, the Logs panel was serializing too much work before first useful content appeared. The panel could wait for `org/list`, then wait again for `org/auth`, and only then fetch `logs/list`. In parallel, activation preload and the webview bootstrap could ask the runtime for the same org data at the same time, so identical `org/list` and `org/auth` requests were being duplicated instead of shared. On Windows, startup could also spend extra time probing a login-shell PATH even when the current PATH already resolved `sf`.

The user-facing effect was a slower, more confusing first paint: logs arrived later than necessary, org bootstrap work appeared to fan out, and some progress affordances suggested cancellation even though the backend operation was not actually cancellable yet.

This change reduces that startup fan-out and moves non-critical hydration off the first paint path. The Logs panel now starts `sendOrgs()` and `refresh()` together when the webview becomes ready, and `refresh()` fetches `logs/list` before waiting on org auth. Auth-dependent work such as warnings, code-unit hydration, and full-body preload is now continued in the background. The runtime client now coalesces concurrent `org/list` and `org/auth` calls so preload and UI consumers can share the same in-flight request. The log download path reuses an auth hint so runtime auth is not immediately followed by an extra CLI auth round trip during preload. On Windows, the login-shell PATH probe is skipped when the current process PATH already resolves `sf`. Tail also avoids re-running visibility-driven bootstrap work until the webview has actually sent `ready`, and the Logs org-list progress notification no longer advertises cancellation that the backend does not support.

I also added targeted changelog coverage and regression tests around the new startup ordering, runtime request coalescing, auth-hint reuse, Tail ready-state gating, and Windows PATH fast paths.

Validation used:
- `npm run compile`
- `npm run check-types`
- `node scripts/run-tests-cli.js --scope=unit --grep "LogsMessageHandler|runtime client|SfLogsViewProvider behavior|SfLogTailViewProvider|TailService|resolvePATHFromLoginShell|LogService"`
