### PR TITLE
[codex] harden VS Code test isolation

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -22,7 +22,7 @@ Se você preferir rodar e depurar via UI, instale a extensão “Extension Test 
 - VS Code is downloaded via `@vscode/test-electron` and launched with `--extensionDevelopmentPath` and `--extensionTestsPath` (the compiled runner).
 - A temporary workspace is created with a minimal `sfdx-project.json` (including `sourceApiVersion`) and opened during tests.
 - Playwright E2E runs keep the isolated VS Code profile intentionally minimal. Support extensions are installed per scenario instead of pulling the full Salesforce Extension Pack by default. Replay-specific specs opt into `salesforce.salesforcedx-vscode-apex-replay-debugger`, and the harness dismisses visible VS Code notifications during startup to reduce click interception flakiness.
-- By default, Playwright E2E keeps `--extensions-dir` isolated even when a support extension is missing. To intentionally reuse your machine-wide VS Code extensions dir as a fallback, set `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`.
+- Playwright E2E keeps `--extensions-dir` isolated. If a required support extension is missing from that isolated profile, the harness now fails explicitly instead of reusing your machine-wide VS Code extensions.
 - On headless Linux, the script re‑executes under `xvfb-run` if available and sets Electron flags to reduce GPU/DBus issues.
 
 ## Environment variables
@@ -80,7 +80,6 @@ Useful env vars:
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).
 - `SF_E2E_DEBUG_FLAGS_USERNAME`: Optional username for the Debug Flags E2E user. If unset, tests auto-manage `alv.debugflags.<orgid>@example.com` (create if missing, reuse if present). If the org has no spare Salesforce licenses, tests fall back to the authenticated user.
-- `ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1`: Opt-in fallback that points the isolated VS Code run at your machine-wide extensions dir when a required support extension cannot be copied or installed into the temporary E2E profile.
 - `ALV_E2E_TIMING=1`: Prints per-step harness timings for scratch-org setup, VS Code startup, command-palette activation, and webview discovery.
 
 Pool-specific env vars:

--- a/scripts/copy-package-metadata.test.js
+++ b/scripts/copy-package-metadata.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 const modulePath = path.join(
   __dirname,
@@ -14,7 +15,7 @@ const modulePath = path.join(
 );
 
 test('copyPackageMetadata mirrors package docs and telemetry into the extension app root', async () => {
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-copy-package-metadata-'));
   const appRoot = path.join(repoRoot, 'apps', 'vscode-extension');
   fs.mkdirSync(appRoot, { recursive: true });

--- a/scripts/copy-tree-sitter-runtime.test.js
+++ b/scripts/copy-tree-sitter-runtime.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const os = require('node:os');
 const path = require('node:path');
+const { pathToFileURL } = require('node:url');
 
 const modulePath = path.join(
   __dirname,
@@ -14,7 +15,7 @@ const modulePath = path.join(
 );
 
 test('copyTreeSitterRuntime vendors the minimal parser runtime into the extension app', async () => {
-  const mod = await import(modulePath);
+  const mod = await import(pathToFileURL(modulePath).href);
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-copy-tree-sitter-'));
   const sourceRoot = path.join(repoRoot, 'node_modules', 'tree-sitter-sfapex');
 

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,6 +1,6 @@
 const { spawn, execFile, spawnSync } = require('child_process');
 const { platform, tmpdir } = require('os');
-const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require('fs');
+const { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync } = require('fs');
 const { dirname, join, resolve } = require('path');
 const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
 const { build } = require('esbuild');

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,6 +1,6 @@
 const { spawn, execFile, spawnSync } = require('child_process');
 const { platform, tmpdir } = require('os');
-const { mkdtempSync, writeFileSync, mkdirSync, rmSync, existsSync, readdirSync } = require('fs');
+const { mkdtempSync, writeFileSync, mkdirSync, rmSync } = require('fs');
 const { dirname, join, resolve } = require('path');
 const { downloadAndUnzipVSCode, resolveCliArgsFromVSCodeExecutablePath, runTests } = require('@vscode/test-electron');
 const { build } = require('esbuild');
@@ -47,52 +47,6 @@ function addLocalBinToPath() {
   } catch (e) {
     console.warn('Failed to add local bin to PATH:', e && e.message ? e.message : e);
   }
-}
-
-function getExtensionSearchRoots() {
-  return Array.from(
-    new Set(
-      [join(process.env.USERPROFILE || '', '.vscode', 'extensions'), join(process.env.HOME || '', '.vscode', 'extensions')].filter(
-        Boolean
-      )
-    )
-  );
-}
-
-function findExtensionDirectoryInRoot(root, extensionId) {
-  if (!root || !existsSync(root)) {
-    return undefined;
-  }
-
-  const normalizedId = String(extensionId || '').trim().toLowerCase();
-  const prefix = `${normalizedId}-`;
-  const matches = [];
-  try {
-    const entries = readdirSync(root, { withFileTypes: true });
-    for (const entry of entries) {
-      if (!entry.isDirectory()) {
-        continue;
-      }
-      const entryName = entry.name.toLowerCase();
-      if (entryName === normalizedId || entryName.startsWith(prefix)) {
-        matches.push(join(root, entry.name));
-      }
-    }
-  } catch {
-    return undefined;
-  }
-
-  return matches.sort((a, b) => a.localeCompare(b)).at(-1);
-}
-
-function findLocalExtensionsRootForDependencies(extensionIds) {
-  for (const root of getExtensionSearchRoots()) {
-    const allPresent = extensionIds.every(extensionId => !!findExtensionDirectoryInRoot(root, extensionId));
-    if (allPresent) {
-      return root;
-    }
-  }
-  return undefined;
 }
 
 function normalizeForMatch(value) {
@@ -257,6 +211,20 @@ async function killLeakedVSCodeProcesses(markers) {
       }
     }
   }
+}
+
+function resolveMissingExtensionIds(requiredExtensionIds, listOutput) {
+  const installed = new Set(
+    String(listOutput || '')
+      .split(/\r?\n/)
+      .map(line => line.trim())
+      .filter(Boolean)
+      .map(line => line.split('@')[0].trim().toLowerCase())
+  );
+
+  return Array.from(new Set(requiredExtensionIds.map(id => String(id).trim()).filter(Boolean))).filter(
+    extensionId => !installed.has(extensionId.toLowerCase())
+  );
 }
 
 async function whichSf() {
@@ -701,7 +669,6 @@ async function run() {
   const unitExtensionsDir = join(tmpdir(), 'alv-extensions-unit');
   const cachedExtensionsDir = join(vscodeCachePath, 'extensions');
   let resolvedExtensionsDir = cachedExtensionsDir;
-  let sfExtPresent = false;
   if (shouldInstall) {
     const toInstall = (
       process.env.VSCODE_TEST_EXTENSIONS ||
@@ -778,7 +745,8 @@ async function run() {
         console.warn(`[deps] Failed to install ${id}. Continuing; tests may skip/fail.`);
       }
     }
-    // List extensions to aid debugging and flag presence
+    let installedOutput = '';
+    // List extensions to aid debugging and verify the isolated profile contents
     try {
       const list = spawnSync(
         cliPath,
@@ -798,27 +766,17 @@ async function run() {
           env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
         }
       );
-      const out = [list.stdout, list.stderr].filter(Boolean).join('\n').trim();
-      console.log('[deps] Extensions installed in test dir:\n' + out);
-      if (
-        /^salesforce\.salesforcedx-vscode-apex-replay-debugger(?:@|$)/m.test(out) ||
-        /^salesforce\.salesforcedx-vscode(?:@|$)/m.test(out) ||
-        /^salesforce\.salesforcedx-vscode-core(?:@|$)/m.test(out) ||
-        /^salesforce\.salesforcedx-vscode-apex(?:@|$)/m.test(out)
-      ) {
-        sfExtPresent = true;
-      }
+      installedOutput = [list.stdout, list.stderr].filter(Boolean).join('\n').trim();
+      console.log('[deps] Extensions installed in test dir:\n' + installedOutput);
     } catch (e) {
       console.warn('[deps] Failed to list installed extensions:', e && e.message ? e.message : e);
     }
 
-    if (!sfExtPresent) {
-      const localRoot = findLocalExtensionsRootForDependencies(toInstall);
-      if (localRoot) {
-        console.warn(`[deps] Falling back to locally installed VS Code extensions: ${localRoot}`);
-        resolvedExtensionsDir = localRoot;
-        sfExtPresent = true;
-      }
+    const missingExtensions = resolveMissingExtensionIds(toInstall, installedOutput);
+    if (missingExtensions.length) {
+      throw new Error(
+        `[deps] Required VS Code extensions are missing from the isolated test profile: ${missingExtensions.join(', ')}`
+      );
     }
   }
 
@@ -941,9 +899,6 @@ async function run() {
       ...(process.env.VSCODE_TEST_WORKSPACE ? [process.env.VSCODE_TEST_WORKSPACE] : [])
     ];
     const extensionTestsEnv = {};
-    if (sfExtPresent) {
-      extensionTestsEnv.SF_EXT_PRESENT = '1';
-    }
     if (process.env.NODE_V8_COVERAGE) {
       extensionTestsEnv.NODE_V8_COVERAGE = process.env.NODE_V8_COVERAGE;
     }
@@ -996,5 +951,6 @@ module.exports = {
   ensureDefaultScratch,
   ensureDevHub,
   pretestSetup,
+  resolveMissingExtensionIds,
   resolveRequiredDevHubConfig
 };

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -36,6 +36,13 @@ test("VSIX smoke packaging delegates to the monorepo vsce helper", () => {
   assert.match(script, /'--skip-prepublish'/);
 });
 
+test("VSIX smoke validation keeps existsSync available for the packaged VSIX check", () => {
+  const script = fs.readFileSync(path.join(__dirname, "run-tests.js"), "utf8");
+
+  assert.match(script, /\{[^}]*existsSync[^}]*\}\s*=\s*require\('fs'\)/);
+  assert.match(script, /if \(!existsSync\(smokeVsixPath\)\) throw new Error\('\[smoke\] VSIX not found'\);/);
+});
+
 test("resolveMissingExtensionIds reports missing dependencies instead of relying on local user extensions", () => {
   const output = [
     "salesforce.salesforcedx-vscode@58.5.0",

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -2,7 +2,7 @@ const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
 const path = require("node:path");
-const { ensureDevHub, pretestSetup, resolveRequiredDevHubConfig } = require("./run-tests");
+const { ensureDevHub, pretestSetup, resolveMissingExtensionIds, resolveRequiredDevHubConfig } = require("./run-tests");
 
 const originalEnv = { ...process.env };
 
@@ -34,6 +34,21 @@ test("VSIX smoke packaging delegates to the monorepo vsce helper", () => {
 
   assert.match(script, /scripts',\s*'run-vsce\.js'/);
   assert.match(script, /'--skip-prepublish'/);
+});
+
+test("resolveMissingExtensionIds reports missing dependencies instead of relying on local user extensions", () => {
+  const output = [
+    "salesforce.salesforcedx-vscode@58.5.0",
+    "ms-vscode.cpptools@1.24.5"
+  ].join("\n");
+
+  assert.deepEqual(
+    resolveMissingExtensionIds(
+      ["salesforce.salesforcedx-vscode", "salesforce.salesforcedx-vscode-apex-replay-debugger"],
+      output
+    ),
+    ["salesforce.salesforcedx-vscode-apex-replay-debugger"]
+  );
 });
 
 test("resolveRequiredDevHubConfig ignores the legacy SFDX_AUTH_URL fallback", () => {

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -1,13 +1,12 @@
 import path from 'node:path';
 import {
+  createMissingSupportExtensionsError,
   resolveCachedSupportExtensionsDir,
   resolveExtensionDevelopmentPath,
   resolveSupportExtensionsLockPath,
   resolveVscodeCachePath,
   resolveWindowSizeArg,
-  resolveExtensionsDirForMissingDependencies,
-  resolveSupportExtensionIds,
-  shouldAllowLocalExtensionsDirFallback
+  resolveSupportExtensionIds
 } from '../vscode';
 
 describe('resolveSupportExtensionIds', () => {
@@ -27,45 +26,17 @@ describe('resolveSupportExtensionIds', () => {
   });
 });
 
-describe('extensions dir fallback policy', () => {
-  const originalEnv = { ...process.env };
-
-  afterEach(() => {
-    process.env = { ...originalEnv };
-  });
-
-  test('keeps the isolated extensions dir by default when support extensions are still missing', () => {
-    delete process.env.ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR;
-
-    expect(shouldAllowLocalExtensionsDirFallback()).toBe(false);
+describe('missing support extensions', () => {
+  test('fails with an explicit error instead of falling back to local user extensions', () => {
     expect(
-      resolveExtensionsDirForMissingDependencies({
-        isolatedExtensionsDir: '/tmp/alv-e2e-exts',
-        missingExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'],
-        localExtensionsRoot: '/home/test/.vscode/extensions'
-      })
-    ).toEqual({
-      extensionsDir: '/tmp/alv-e2e-exts',
-      warning:
-        '[e2e] Support extensions still missing in isolated profile: salesforce.salesforcedx-vscode-apex-replay-debugger.' +
-        ' Set ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1 to opt into using the local VS Code extensions dir.'
-    });
-  });
-
-  test('allows whole-dir fallback only when explicitly opted in', () => {
-    process.env.ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR = '1';
-
-    expect(shouldAllowLocalExtensionsDirFallback()).toBe(true);
-    expect(
-      resolveExtensionsDirForMissingDependencies({
-        isolatedExtensionsDir: '/tmp/alv-e2e-exts',
-        missingExtensionIds: ['salesforce.salesforcedx-vscode-apex-replay-debugger'],
-        localExtensionsRoot: '/home/test/.vscode/extensions'
-      })
-    ).toEqual({
-      extensionsDir: '/home/test/.vscode/extensions',
-      warning: '[e2e] Falling back to local VS Code extensions dir: /home/test/.vscode/extensions'
-    });
+      createMissingSupportExtensionsError([
+        'salesforce.salesforcedx-vscode-core',
+        'salesforce.salesforcedx-vscode-apex-replay-debugger'
+      ]).message
+    ).toBe(
+      '[e2e] Required VS Code support extensions are missing from the isolated profile: ' +
+        'salesforce.salesforcedx-vscode-core, salesforce.salesforcedx-vscode-apex-replay-debugger'
+    );
   });
 });
 
@@ -76,10 +47,10 @@ describe('VS Code cache paths', () => {
     process.env = { ...originalEnv };
   });
 
-  test('defaults the VS Code cache path to the repo-local .vscode-test directory', () => {
+  test('defaults the VS Code cache path to the monorepo root .vscode-test directory', () => {
     delete process.env.VSCODE_TEST_CACHE_PATH;
 
-    expect(resolveVscodeCachePath('/workspace/alv')).toBe(path.join('/workspace/alv', '.vscode-test'));
+    expect(resolveVscodeCachePath('/workspace/alv/apps/vscode-extension')).toBe(path.join('/workspace/alv', '.vscode-test'));
   });
 
   test('honors VSCODE_TEST_CACHE_PATH when set', () => {

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -390,13 +390,12 @@ export async function launchVsCode(options: {
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'alv-e2e-user-'));
   let extensionsDir = resolveCachedSupportExtensionsDir(vscodeCachePath, vscodeVersion, supportExtensionIds);
   const supportExtensionsLockPath = resolveSupportExtensionsLockPath(extensionsDir);
-  let shouldCleanupExtensionsDir = false;
   await mkdir(extensionsDir, { recursive: true });
 
   // The extension is loaded via --extensionDevelopmentPath. Some E2E scenarios still
   // need support extensions in a reusable test cache (for example Replay Debugger),
   // so install manifest references plus scenario-specific ids.
-  const resolvedExtensionsDir = await timeE2eStep(
+  await timeE2eStep(
     'vscode.ensureSupportExtensions',
     async () =>
       await withFileLock(
@@ -410,11 +409,6 @@ export async function launchVsCode(options: {
           })
       )
   );
-  if (resolvedExtensionsDir !== extensionsDir) {
-    extensionsDir = resolvedExtensionsDir;
-    shouldCleanupExtensionsDir = false;
-  }
-
   const args = [
     options.workspacePath,
     `--extensionDevelopmentPath=${options.extensionDevelopmentPath}`,
@@ -470,9 +464,6 @@ export async function launchVsCode(options: {
       console.warn(`[e2e] Preserving VS Code user-data-dir at ${userDataDir}`);
     } else {
       await removePathBestEffort(userDataDir);
-    }
-    if (shouldCleanupExtensionsDir) {
-      await removePathBestEffort(extensionsDir);
     }
   };
 

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, cp, access, readdir, mkdir, open, stat, unlink, utimes } from 'node:fs/promises';
+import { mkdtemp, readFile, access, readdir, mkdir, open, stat, unlink, utimes } from 'node:fs/promises';
 import path from 'node:path';
 import { tmpdir } from 'node:os';
 import { createHash } from 'node:crypto';
@@ -45,9 +45,16 @@ export function resolveExtensionDevelopmentPath(repoRoot: string): string {
 }
 
 export function resolveVscodeCachePath(extensionDevelopmentPath: string): string {
+  const normalizedPath = path.normalize(extensionDevelopmentPath);
+  const extensionDirName = path.basename(normalizedPath);
+  const parentDirName = path.basename(path.dirname(normalizedPath));
+  const cacheRoot =
+    extensionDirName === 'vscode-extension' && parentDirName === 'apps'
+      ? path.dirname(path.dirname(normalizedPath))
+      : normalizedPath;
   return process.env.VSCODE_TEST_CACHE_PATH
     ? path.resolve(process.env.VSCODE_TEST_CACHE_PATH)
-    : path.join(extensionDevelopmentPath, '.vscode-test');
+    : path.join(cacheRoot, '.vscode-test');
 }
 
 function getSupportExtensionsCacheKey(vscodeVersion: string, extensionIds: string[]): string {
@@ -91,8 +98,10 @@ export function resolveSupportExtensionIds(extensionIds: unknown[] = [], extraEx
   ).sort((a, b) => a.localeCompare(b));
 }
 
-export function shouldAllowLocalExtensionsDirFallback(): boolean {
-  return envFlag('ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR');
+export function createMissingSupportExtensionsError(missingExtensionIds: string[]): Error {
+  return new Error(
+    `[e2e] Required VS Code support extensions are missing from the isolated profile: ${missingExtensionIds.join(', ')}`
+  );
 }
 
 export function resolveWindowSizeArg(windowSize?: Partial<VscodeWindowSize>): string | undefined {
@@ -102,33 +111,6 @@ export function resolveWindowSizeArg(windowSize?: Partial<VscodeWindowSize>): st
     return undefined;
   }
   return `--window-size=${Math.floor(width)},${Math.floor(height)}`;
-}
-
-export function resolveExtensionsDirForMissingDependencies(options: {
-  isolatedExtensionsDir: string;
-  missingExtensionIds: string[];
-  localExtensionsRoot?: string;
-}): { extensionsDir: string; warning?: string } {
-  if (!options.missingExtensionIds.length) {
-    return { extensionsDir: options.isolatedExtensionsDir };
-  }
-
-  const missingList = options.missingExtensionIds.join(', ');
-  if (options.localExtensionsRoot && shouldAllowLocalExtensionsDirFallback()) {
-    return {
-      extensionsDir: options.localExtensionsRoot,
-      warning: `[e2e] Falling back to local VS Code extensions dir: ${options.localExtensionsRoot}`
-    };
-  }
-
-  return {
-    extensionsDir: options.isolatedExtensionsDir,
-    warning:
-      `[e2e] Support extensions still missing in isolated profile: ${missingList}.` +
-      (options.localExtensionsRoot
-        ? ' Set ALV_E2E_ALLOW_LOCAL_EXTENSIONS_DIR=1 to opt into using the local VS Code extensions dir.'
-        : '')
-  };
 }
 
 async function readExtensionReferences(
@@ -227,14 +209,6 @@ async function withFileLock<T>(lockPath: string, action: () => Promise<T>): Prom
   }
 }
 
-function getExtensionSearchRoots(): string[] {
-  const roots = [
-    path.join(process.env.USERPROFILE || '', '.vscode', 'extensions'),
-    path.join(process.env.HOME || '', '.vscode', 'extensions')
-  ];
-  return Array.from(new Set(roots.filter(Boolean)));
-}
-
 async function findExtensionDirectoryInRoot(root: string, extensionId: string): Promise<string | undefined> {
   const normalizedId = extensionId.toLowerCase();
   const prefix = `${normalizedId}-`;
@@ -260,61 +234,6 @@ async function findExtensionDirectoryInRoot(root: string, extensionId: string): 
   }
 
   return matches.sort((a, b) => a.localeCompare(b)).at(-1);
-}
-
-async function findLocalExtensionDirectory(extensionId: string): Promise<string | undefined> {
-  for (const root of getExtensionSearchRoots()) {
-    const match = await findExtensionDirectoryInRoot(root, extensionId);
-    if (match) {
-      return match;
-    }
-  }
-  return undefined;
-}
-
-async function findLocalExtensionsRootForDependencies(extensionIds: string[]): Promise<string | undefined> {
-  for (const root of getExtensionSearchRoots()) {
-    let allPresent = true;
-    for (const extensionId of extensionIds) {
-      const match = await findExtensionDirectoryInRoot(root, extensionId);
-      if (!match) {
-        allPresent = false;
-        break;
-      }
-    }
-    if (allPresent) {
-      return root;
-    }
-  }
-  return undefined;
-}
-
-async function copyLocalExtensionWithDependencies(
-  extensionId: string,
-  extensionsDir: string,
-  seen = new Set<string>()
-): Promise<boolean> {
-  const normalizedId = extensionId.toLowerCase();
-  if (seen.has(normalizedId)) {
-    return false;
-  }
-  seen.add(normalizedId);
-
-  const sourceDir = await findLocalExtensionDirectory(extensionId);
-  if (!sourceDir) {
-    return false;
-  }
-
-  const destDir = path.join(extensionsDir, path.basename(sourceDir));
-  await cp(sourceDir, destDir, { recursive: true, force: true });
-  console.log(`[e2e] Reused locally installed VS Code support extension: ${extensionId}`);
-
-  const nestedDeps = await readExtensionReferences(sourceDir);
-  for (const dep of nestedDeps) {
-    await copyLocalExtensionWithDependencies(dep, extensionsDir, seen);
-  }
-
-  return true;
 }
 
 async function findMissingExtensionIdsInRoot(root: string, extensionIds: string[]): Promise<string[]> {
@@ -376,28 +295,13 @@ async function ensureExtensionDependenciesInstalled(args: {
   const cli = resolveCliArgsFromVSCodeExecutablePath(args.vscodeExecutablePath, { reuseMachineInstall: true });
   const cliPath = cli[0];
   const cliArgs = cli.slice(1);
-  const missingAfterInitialCheck = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
-  for (const dep of missingAfterInitialCheck) {
-    await copyLocalExtensionWithDependencies(dep, args.extensionsDir);
-  }
-
-  let toInstall = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
-  if (!cliPath) {
-    console.warn('[e2e] Could not resolve VS Code CLI path; skipping support extension install into isolated profile.');
-    const localRoot = await findLocalExtensionsRootForDependencies(deps);
-    const decision = resolveExtensionsDirForMissingDependencies({
-      isolatedExtensionsDir: args.extensionsDir,
-      missingExtensionIds: toInstall,
-      localExtensionsRoot: localRoot
-    });
-    if (decision.warning) {
-      console.warn(decision.warning);
-    }
-    return decision.extensionsDir;
-  }
-
+  const toInstall = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
   if (!toInstall.length) {
     return args.extensionsDir;
+  }
+
+  if (!cliPath) {
+    throw new Error('[e2e] Could not resolve VS Code CLI path to install required support extensions.');
   }
 
   installExtensions({
@@ -409,16 +313,10 @@ async function ensureExtensionDependenciesInstalled(args: {
   });
 
   const stillMissing = await findMissingExtensionIdsInRoot(args.extensionsDir, deps);
-  const localRoot = await findLocalExtensionsRootForDependencies(deps);
-  const decision = resolveExtensionsDirForMissingDependencies({
-    isolatedExtensionsDir: args.extensionsDir,
-    missingExtensionIds: stillMissing,
-    localExtensionsRoot: localRoot
-  });
-  if (decision.warning) {
-    console.warn(decision.warning);
+  if (stillMissing.length) {
+    throw createMissingSupportExtensionsError(stillMissing);
   }
-  return decision.extensionsDir;
+  return args.extensionsDir;
 }
 
 async function isAuxiliaryBarOpen(page: Page): Promise<boolean> {
@@ -498,27 +396,23 @@ export async function launchVsCode(options: {
   // The extension is loaded via --extensionDevelopmentPath. Some E2E scenarios still
   // need support extensions in a reusable test cache (for example Replay Debugger),
   // so install manifest references plus scenario-specific ids.
-  try {
-    const resolvedExtensionsDir = await timeE2eStep(
-      'vscode.ensureSupportExtensions',
-      async () =>
-        await withFileLock(
-          supportExtensionsLockPath,
-          async () =>
-            await ensureExtensionDependenciesInstalled({
-              vscodeExecutablePath,
-              userDataDir,
-              extensionsDir,
-              extensionIds: supportExtensionIds
-            })
-        )
-    );
-    if (resolvedExtensionsDir !== extensionsDir) {
-      extensionsDir = resolvedExtensionsDir;
-      shouldCleanupExtensionsDir = false;
-    }
-  } catch (e) {
-    console.warn('[e2e] Failed to ensure VS Code extension dependencies are installed:', e);
+  const resolvedExtensionsDir = await timeE2eStep(
+    'vscode.ensureSupportExtensions',
+    async () =>
+      await withFileLock(
+        supportExtensionsLockPath,
+        async () =>
+          await ensureExtensionDependenciesInstalled({
+            vscodeExecutablePath,
+            userDataDir,
+            extensionsDir,
+            extensionIds: supportExtensionIds
+          })
+      )
+  );
+  if (resolvedExtensionsDir !== extensionsDir) {
+    extensionsDir = resolvedExtensionsDir;
+    shouldCleanupExtensionsDir = false;
   }
 
   const args = [


### PR DESCRIPTION
## Summary
- align the E2E VS Code cache path with the repo-root `.vscode-test` cache used in CI
- remove local-user VS Code extension fallbacks so missing support extensions fail explicitly in isolated test profiles
- fix Windows-only `ERR_UNSUPPORTED_ESM_URL_SCHEME` failures in script tests by importing `.mjs` modules through `pathToFileURL(...)`

## Root Cause
- the Playwright E2E helper defaulted its cache under `apps/vscode-extension/.vscode-test`, while CI restored the root `.vscode-test` cache
- the test harness could silently reuse extensions installed in a developer's local VS Code profile, which hid real isolation problems
- two Node script tests used dynamic `import()` with absolute Windows paths instead of `file://` URLs, which breaks under the Node ESM loader on Windows

## Validation
- `npm.cmd run compile`
- `npm.cmd run test:scripts`
- `npm.cmd run test:e2e:utils`
