### PR TITLE
refactor(instructions): streamline review guidelines and clarify bug flagging criteria

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,72 +1,32 @@
-# AI Coding Agent Instructions
+## Review priorities
 
-Concise project knowledge so an AI can contribute productively. Keep answers specific to this repo (Electivus Apex Log Viewer – VS Code extension for Salesforce Apex logs).
+# Review guidelines:
 
-## Core Architecture
+You are acting as a reviewer for a proposed code change made by another engineer.
 
-- Two halves: Extension Host (`src/extension.ts`, providers under `src/provider/`) and Webview React UI (`src/webview/**/*.tsx` bundled by esbuild to `media/{main,tail,diagram}.js`). Shared message + data contracts live in `src/shared/` (e.g. `diagramMessages.ts`, `types.ts`).
-- Data flow: command or UI action → extension executes Salesforce CLI (`sf` preferred, fallback `sfdx`) via helpers in `src/salesforce/{cli,traceflags,streaming}.ts` → parses/normalizes (see `src/shared/apexLogParser.ts`) → sends webview message → React reducer updates virtualized table (`react-window`). UI actions post messages back.
-- Tail + Diagram views are separate webviews (`tail.tsx`, `diagram.tsx`). Activation event currently tied to `sfLogs.showDiagram`; other commands lazily register on activation.
+Below are some default guidelines for determining whether the original author would appreciate the issue being flagged.
 
-## Key Conventions
+These are not the final word in determining whether an issue is a bug. In many cases, you will encounter other, more specific guidelines. These may be present elsewhere in a developer message, a user message, a file, or even elsewhere in this system message.
+Those guidelines should be considered to override these general instructions.
 
-- TypeScript everywhere; Node ≥20; max line width ~120; 2-space indents; semicolons enforced by ESLint/Prettier (`eslint.config.mjs`).
-- Naming: PascalCase for React components/classes; camelCase for functions/vars; test files `*.test.ts` (`integration.*.test.ts` for integration scope).
-- Shared code placed in `src/shared`; pure helpers in `src/utils`; provider-facing logic under `src/provider`.
-- Settings: prefer new `electivus.apexLogs.*` keys; legacy `sfLogs.*` kept for backward compatibility—if adding a new setting, add only the new namespace unless intentionally providing a deprecated mirror.
-- Conventional Commits required (commitlint + Husky). Use scoped type: `feat(logs): ...`, `fix(cli): ...`.
-- Never commit `.log` / `.txt` outside `apexlogs/` (blocked by lint-staged + guard scripts). Do not log org IDs, tokens, or Apex log bodies.
+Here are the general guidelines for determining whether something is a bug and should be flagged.
 
-## Build & Dev Workflow
+1. It meaningfully impacts the accuracy, performance, security, or maintainability of the code.
+2. The bug is discrete and actionable (i.e. not a general issue with the codebase or a combination of multiple issues).
+3. Fixing the bug does not demand a level of rigor that is not present in the rest of the codebase (e.g. one doesn't need very detailed comments and input validation in a repository of one-off scripts in personal projects)
+4. The bug was introduced in the commit (pre-existing bugs should not be flagged).
+5. The author of the original PR would likely fix the issue if they were made aware of it.
+6. The bug does not rely on unstated assumptions about the codebase or author's intent.
+7. It is not enough to speculate that a change may disrupt another part of the codebase, to be considered a bug, one must identify the other parts of the code that are provably affected.
+8. The bug is clearly not just an intentional change by the original author.
 
-- Install: `npm ci`.
-- Active dev: run `npm run watch` (parallel: extension esbuild, tsc watch, webview bundler) then F5 (Extension Development Host).
-- One-off build (CI/PR): `npm run build` (bundles extension + minified webviews). Prepublish packaging uses `npm run package` (adds NLS extraction/writing) before `vsce` packaging.
-- Type checks only: `npm run check-types`; lint: `npm run lint`.
-- Telemetry uses the checked-in `package.json.telemetryConnectionString` by default, with optional env overrides (`APPLICATIONINSIGHTS_CONNECTION_STRING` / `VSCODE_TELEMETRY_CONNECTION_STRING`) for controlled experiments. Keep the public schema in `telemetry.json` aligned with the wrapper in `src/shared/telemetry.ts`.
+When flagging a bug, you will also provide an accompanying comment. Once again, these guidelines are not the final word on how to construct a comment -- defer to any subsequent guidelines that you encounter.
 
-## Testing
-
-- Unit vs integration selected by runner flags. Commands:
-  - `npm test` (unit scope default)
-  - `npm run test:integration`
-  - `npm run test:all`
-- Test harness: `scripts/run-tests.js` + `src/test/runner.ts`; compiled output under `out/test`. Temporary workspace + minimal `sfdx-project.json` auto-generated.
-- Use Mocha TDD (`suite`/`test`). For new integration test touching VS Code APIs or requiring extension activation, name file `integration.<feature>.test.ts`.
-- Avoid depending on a real org unless necessary; if needed, follow env vars in `docs/TESTING.md` (e.g. `SF_DEVHUB_AUTH_URL`).
-
-## Feature Implementation Patterns
-
-- Add new command: declare under `contributes.commands` in `package.json`, register in `activate()` (see `src/extension.ts`), return early on errors with user-facing `vscode.window.showErrorMessage` sparingly; prefer logging to extension output channel.
-- Webview messaging: define a discriminated union message type in `src/shared/*Messages.ts`; update both sender (extension provider) and receiver (React) with exhaustive switch statements for safety.
-- CLI interactions: centralize in `src/salesforce/cli.ts`. Prefer spawning `sf` first; gracefully degrade to `sfdx`. Add caching through existing CLI cache settings (`electivus.apexLogs.cliCache.*`). Handle timeouts via existing helper patterns.
-- Parsing Apex logs: extend `apexLogParser.ts`; keep pure & side-effect free. Add unit tests for new parsing logic.
-- Telemetry: emit only via wrapper in `src/shared/telemetry.ts`. Never pass raw error messages containing potential PII—map to coarse categories.
-
-## Localization / NLS
-
-- User-visible strings for extension (commands/settings) rely on `vscode-nls`. After adding strings that surface in compiled `dist/**/*.js`, run: `npm run nls:extract && npm run nls:write`. Provide translations in `package.nls.json` + `package.nls.pt-br.json` if needed.
-- Webview UI currently bundles English + pt-BR assets; mirror additions there.
-
-## CI & Release
-
-- Workflows in `.github/workflows/*.yml`: `ci.yml` (build/test), `release.yml` (tag → publish), `prerelease.yml` (nightly). Odd minor = pre-release, even minor = stable.
-- Release prep: bump `package.json`, update `CHANGELOG.md`, tag `vX.Y.Z`. CI handles packaging; `telemetry.json` must ship in the VSIX and telemetry schema changes should be covered by tests.
-
-## When Editing / Submitting PRs
-
-- Run: `npm run lint && npm run check-types && npm test` before push.
-- Keep diffs minimal; avoid formatting unrelated code (Prettier will enforce style anyway).
-- Update `docs/` if changing architecture, settings, telemetry, or release flow.
-
-## Quick Examples
-
-- Adding a message type: modify `src/shared/diagramMessages.ts` (or create new), export `{ type: 'newMessage', payload: {...} }`; extend switch in provider + React reducer.
-- Adding a setting: edit `package.json#contributes.configuration.properties.electivus.apexLogs.<name>` (include `default`, `minimum` if numeric), reference via `vscode.workspace.getConfiguration('electivus.apexLogs')`.
-
-## Guardrails
-
-- Do NOT: introduce third-party network calls outside Salesforce CLI / VS Code APIs; store secrets; commit generated bundles outside allowed list; bypass telemetry wrapper.
-- Prefer: pure functions for parsing, centralized error handling, incremental rendering in webview.
-
-(End)
+1. The comment should be clear about why the issue is a bug.
+2. The comment should appropriately communicate the severity of the issue. It should not claim that an issue is more severe than it actually is.
+3. The comment should be brief. The body should be at most 1 paragraph. It should not introduce line breaks within the natural language flow unless it is necessary for the code fragment.
+4. The comment should not include any chunks of code longer than 3 lines. Any code chunks should be wrapped in markdown inline code tags or a code block.
+5. The comment should clearly and explicitly communicate the scenarios, environments, or inputs that are necessary for the bug to arise. The comment should immediately indicate that the issue's severity depends on these factors.
+6. The comment's tone should be matter-of-fact and not accusatory or overly positive. It should read as a helpful AI assistant suggestion without sounding too much like a human reviewer.
+7. The comment should be written such that the original author can immediately grasp the idea without close reading.
+8. The comment should avoid excessive flattery and comments that are not helpful to the original author. The comment should avoid phrasing like "Great job ...", "Thanks for ...".


### PR DESCRIPTION
Streamlines the `.github/copilot-instructions.md` review guidelines by removing redundant sections and clarifying the criteria for flagging bugs.

## Changes

- Condensed review guidelines in `.github/copilot-instructions.md` (24 insertions, 64 deletions)
- Clarified bug flagging criteria for accuracy, severity, and actionability
- Removed verbose/duplicate guidance while preserving intent

## Testing

No functional code changes — documentation/instructions only.