### PR TITLE
[codex] chore(dependabot): group related dependency stacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
+      radix-ui:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+        patterns:
+          - '@radix-ui/*'
       tailwind:
         applies-to: version-updates
         patterns:
@@ -41,10 +48,18 @@ updates:
           - 'ts-jest'
           - 'jsdom'
           - '@types/jsdom'
-      typescript-eslint:
+      typescript-tooling:
         applies-to: version-updates
         patterns:
+          - 'typescript'
           - '@typescript-eslint/*'
+      vscode-extension-tooling:
+        applies-to: version-updates
+        patterns:
+          - '@vscode/test-electron'
+          - '@vscode/vsce'
+          - 'vscode-nls'
+          - 'vscode-nls-dev'
       nx:
         applies-to: version-updates
         patterns:


### PR DESCRIPTION
## What changed

- renamed the existing `typescript-eslint` Dependabot group to `typescript-tooling`
- added `typescript` to that group so TypeScript and `@typescript-eslint/*` update together
- added a `radix-ui` group for `@radix-ui/*` minor/patch updates
- added a `vscode-extension-tooling` group for VS Code extension packaging/testing dependencies

## Why

Dependabot was already grouping `@typescript-eslint/*`, but leaving `typescript` outside that family. That produced a broken standalone PR for `typescript@6` when the peer dependency range in the TypeScript ESLint stack was still behind. Grouping the stack makes those updates arrive coherently instead of as mismatched PRs.

The Radix UI and VS Code extension tooling groups are lower-risk review-noise reductions for dependency families that are already used together in this repository.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', 'r', encoding='utf-8')); print('YAML_OK')"`
