### PR TITLE
[codex] chore(dependabot): group related dependency stacks

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,13 @@ updates:
           - 'react-dom'
           - '@types/react'
           - '@types/react-dom'
+      radix-ui:
+        applies-to: version-updates
+        update-types:
+          - 'minor'
+          - 'patch'
+        patterns:
+          - '@radix-ui/*'
       tailwind:
         applies-to: version-updates
         patterns:
@@ -41,10 +48,18 @@ updates:
           - 'ts-jest'
           - 'jsdom'
           - '@types/jsdom'
-      typescript-eslint:
+      typescript-tooling:
         applies-to: version-updates
         patterns:
+          - 'typescript'
           - '@typescript-eslint/*'
+      vscode-extension-tooling:
+        applies-to: version-updates
+        patterns:
+          - '@vscode/test-electron'
+          - '@vscode/vsce'
+          - 'vscode-nls'
+          - 'vscode-nls-dev'
       nx:
         applies-to: version-updates
         patterns:

--- a/apps/vscode-extension/src/test/dependabotConfig.test.ts
+++ b/apps/vscode-extension/src/test/dependabotConfig.test.ts
@@ -165,19 +165,64 @@ updates:
     );
   });
 
-  test('keeps TypeScript ESLint majors grouped for the coupled plugin and parser', async () => {
+  test('keeps TypeScript majors grouped with the TypeScript ESLint stack', async () => {
     const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
     const raw = await readFile(path.join(repoRoot, '.github', 'dependabot.yml'), 'utf8');
-    const typescriptEslintGroup = getNpmGroupConfig(raw, 'typescript-eslint');
+    const typescriptToolingGroup = getNpmGroupConfig(raw, 'typescript-tooling');
 
     assert.ok(
-      typescriptEslintGroup.patterns?.includes('@typescript-eslint/*'),
-      'typescript-eslint group should include the full @typescript-eslint family'
+      typescriptToolingGroup.patterns?.includes('typescript'),
+      'typescript-tooling group should include typescript'
+    );
+    assert.ok(
+      typescriptToolingGroup.patterns?.includes('@typescript-eslint/*'),
+      'typescript-tooling group should include the full @typescript-eslint family'
     );
     assert.equal(
-      typescriptEslintGroup['update-types'],
+      typescriptToolingGroup['update-types'],
       undefined,
-      'typescript-eslint group should not exclude major updates because plugin and parser majors are coupled'
+      'typescript-tooling group should not exclude major updates because typescript and typescript-eslint need coordinated majors'
+    );
+  });
+
+  test('keeps Radix UI updates grouped as a low-risk minor and patch stack', async () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const raw = await readFile(path.join(repoRoot, '.github', 'dependabot.yml'), 'utf8');
+    const radixGroup = getNpmGroupConfig(raw, 'radix-ui');
+
+    assert.ok(radixGroup.patterns?.includes('@radix-ui/*'), 'radix-ui group should include the full @radix-ui family');
+    assert.deepEqual(
+      radixGroup['update-types'],
+      ['minor', 'patch'],
+      'radix-ui group should keep majors separate while bundling routine updates'
+    );
+  });
+
+  test('keeps VS Code extension packaging and test tooling grouped', async () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const raw = await readFile(path.join(repoRoot, '.github', 'dependabot.yml'), 'utf8');
+    const vscodeToolingGroup = getNpmGroupConfig(raw, 'vscode-extension-tooling');
+
+    assert.ok(
+      vscodeToolingGroup.patterns?.includes('@vscode/test-electron'),
+      'vscode-extension-tooling group should include @vscode/test-electron'
+    );
+    assert.ok(
+      vscodeToolingGroup.patterns?.includes('@vscode/vsce'),
+      'vscode-extension-tooling group should include @vscode/vsce'
+    );
+    assert.ok(
+      vscodeToolingGroup.patterns?.includes('vscode-nls'),
+      'vscode-extension-tooling group should include vscode-nls'
+    );
+    assert.ok(
+      vscodeToolingGroup.patterns?.includes('vscode-nls-dev'),
+      'vscode-extension-tooling group should include vscode-nls-dev'
+    );
+    assert.equal(
+      vscodeToolingGroup['update-types'],
+      undefined,
+      'vscode-extension-tooling group should not exclude majors because these tools support the same extension toolchain'
     );
   });
 


### PR DESCRIPTION
## What changed

- renamed the existing `typescript-eslint` Dependabot group to `typescript-tooling`
- added `typescript` to that group so TypeScript and `@typescript-eslint/*` update together
- added a `radix-ui` group for `@radix-ui/*` minor/patch updates
- added a `vscode-extension-tooling` group for VS Code extension packaging/testing dependencies

## Why

Dependabot was already grouping `@typescript-eslint/*`, but leaving `typescript` outside that family. That produced a broken standalone PR for `typescript@6` when the peer dependency range in the TypeScript ESLint stack was still behind. Grouping the stack makes those updates arrive coherently instead of as mismatched PRs.

The Radix UI and VS Code extension tooling groups are lower-risk review-noise reductions for dependency families that are already used together in this repository.

## Validation

- `python -c "import yaml; yaml.safe_load(open('.github/dependabot.yml', 'r', encoding='utf-8')); print('YAML_OK')"`
