### PR TITLE
[codex] Finish runtime client org/auth migration

### DIFF
--- a/apps/vscode-extension/src/panel/DebugFlagsPanel.ts
+++ b/apps/vscode-extension/src/panel/DebugFlagsPanel.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { getOrgAuth, listOrgs } from '../../../../src/salesforce/cli';
 import {
   createDebugLevel,
   deleteDebugLevel,
@@ -22,6 +21,7 @@ import { localize } from '../../../../src/utils/localize';
 import { getErrorMessage } from '../../../../src/utils/error';
 import { logInfo, logWarn } from '../../../../src/utils/logger';
 import { buildWebviewHtml } from '../../../../src/utils/webviewHtml';
+import { runtimeClient } from '../runtime/runtimeClient';
 
 interface ShowOptions {
   selectedOrg?: string;
@@ -164,7 +164,7 @@ export class DebugFlagsPanel {
     const token = ++this.orgBootstrapToken;
     this.post({ type: 'debugFlagsLoading', scope: 'orgs', value: true });
     try {
-      const orgs = await listOrgs();
+      const orgs = await runtimeClient.orgList();
       if (token !== this.orgBootstrapToken || this.disposed) {
         return;
       }
@@ -808,7 +808,18 @@ export class DebugFlagsPanel {
     if (!selected) {
       throw new Error(localize('debugFlags.noOrg', 'No Salesforce org is selected.'));
     }
-    return getOrgAuth(selected, undefined, signal);
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const auth = await runtimeClient.getOrgAuth({ username: selected });
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    return auth;
   }
 
   private dispose(): void {

--- a/apps/vscode-extension/src/panel/DebugFlagsPanel.ts
+++ b/apps/vscode-extension/src/panel/DebugFlagsPanel.ts
@@ -813,7 +813,7 @@ export class DebugFlagsPanel {
       error.name = 'AbortError';
       throw error;
     }
-    const auth = await runtimeClient.getOrgAuth({ username: selected });
+    const auth = await runtimeClient.getOrgAuth({ username: selected }, signal);
     if (signal?.aborted) {
       const error = new Error('Request aborted');
       error.name = 'AbortError';

--- a/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
@@ -351,7 +351,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         safeSendEvent('logs.replay', { view: 'tail', outcome: 'ok' }, { durationMs });
       } catch {}
     } catch (e) {
-      if (e instanceof Error && e.message === 'aborted') {
+      if (this.isAbortLikeError(e)) {
         // cancellation; no error message
       } else {
         const msg = getErrorMessage(e);
@@ -363,6 +363,15 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         } catch {}
       }
     }
+  }
+
+  private isAbortLikeError(err: unknown, message?: string): boolean {
+    if ((err as { name?: string } | undefined)?.name === 'AbortError') {
+      return true;
+    }
+
+    const normalized = String(message ?? getErrorMessage(err) ?? '').toLowerCase();
+    return normalized.includes('abort') || normalized.includes('canceled') || normalized.includes('cancelled');
   }
 
   private bindHost(host: BoundWebviewHost): void {

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -39,6 +39,7 @@ type PendingRequest = {
 type InFlightRequest<TResult> = {
   activeObservers: number;
   controller: AbortController;
+  evict: () => void;
   promise: Promise<TResult>;
   settled: boolean;
 };
@@ -229,15 +230,18 @@ export class RuntimeClient extends EventEmitter {
     const entry: InFlightRequest<TResult> = {
       activeObservers: 0,
       controller,
+      evict: () => {
+        if (store.get(key) === entry) {
+          store.delete(key);
+        }
+      },
       promise: Promise.resolve(undefined as TResult),
       settled: false
     };
     const request = start(controller.signal);
     entry.promise = request.finally(() => {
       entry.settled = true;
-      if (store.get(key) === entry) {
-        store.delete(key);
-      }
+      entry.evict();
     });
     store.set(key, entry);
     return entry;
@@ -252,6 +256,7 @@ export class RuntimeClient extends EventEmitter {
     const release = () => {
       entry.activeObservers = Math.max(0, entry.activeObservers - 1);
       if (!entry.settled && entry.activeObservers === 0) {
+        entry.evict();
         entry.controller.abort();
       }
     };

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -36,6 +36,12 @@ type PendingRequest = {
   reject: (error: Error) => void;
   cleanup?: () => void;
 };
+type InFlightRequest<TResult> = {
+  activeObservers: number;
+  controller: AbortController;
+  promise: Promise<TResult>;
+  settled: boolean;
+};
 
 export type RuntimeRequestHandler = <TResult>(
   method: string,
@@ -58,8 +64,8 @@ export class RuntimeClient extends EventEmitter {
   private initializePromise: Promise<InitializeResult> | undefined;
   private nextRequestId = 0;
   private readonly pendingRequests = new Map<string, PendingRequest>();
-  private readonly inFlightOrgLists = new Map<string, Promise<OrgListItem[]>>();
-  private readonly inFlightOrgAuth = new Map<string, Promise<OrgAuth>>();
+  private readonly inFlightOrgLists = new Map<string, InFlightRequest<OrgListItem[]>>();
+  private readonly inFlightOrgAuth = new Map<string, InFlightRequest<OrgAuth>>();
   private restartDelayMs = 250;
   private restartPromise: Promise<void> | undefined;
   private readonly clientName: string;
@@ -125,23 +131,19 @@ export class RuntimeClient extends EventEmitter {
     return this.initializePromise;
   }
 
-  async orgList(params: OrgListParams = {}): Promise<OrgListItem[]> {
+  async orgList(params: OrgListParams = {}, signal?: AbortSignal): Promise<OrgListItem[]> {
     if (!this.requestHandler) {
       await this.initialize();
     }
     const key = JSON.stringify({ forceRefresh: params.forceRefresh === true });
     const pending = this.inFlightOrgLists.get(key);
     if (pending) {
-      return pending;
+      return this.observeInFlightRequest(pending, signal);
     }
-    const request = this.request<OrgListItem[]>('org/list', params);
-    const tracked = request.finally(() => {
-      if (this.inFlightOrgLists.get(key) === tracked) {
-        this.inFlightOrgLists.delete(key);
-      }
-    });
-    this.inFlightOrgLists.set(key, tracked);
-    return tracked;
+    const tracked = this.createInFlightRequest(this.inFlightOrgLists, key, requestSignal =>
+      this.request<OrgListItem[]>('org/list', params, requestSignal)
+    );
+    return this.observeInFlightRequest(tracked, signal);
   }
 
   async getOrgAuth(params: OrgAuthParams = {}, signal?: AbortSignal): Promise<OrgAuth> {
@@ -151,19 +153,12 @@ export class RuntimeClient extends EventEmitter {
     const key = JSON.stringify({ username: typeof params.username === 'string' ? params.username.trim() : '' });
     const pending = this.inFlightOrgAuth.get(key);
     if (pending) {
-      return this.observeWithSignal(pending, signal);
+      return this.observeInFlightRequest(pending, signal);
     }
-    const request = this.request<OrgAuth>('org/auth', params, signal);
-    if (signal) {
-      return request;
-    }
-    const tracked = request.finally(() => {
-      if (this.inFlightOrgAuth.get(key) === tracked) {
-        this.inFlightOrgAuth.delete(key);
-      }
-    });
-    this.inFlightOrgAuth.set(key, tracked);
-    return tracked;
+    const tracked = this.createInFlightRequest(this.inFlightOrgAuth, key, requestSignal =>
+      this.request<OrgAuth>('org/auth', params, requestSignal)
+    );
+    return this.observeInFlightRequest(tracked, signal);
   }
 
   async logsList(params: LogsListParams = {}, signal?: AbortSignal): Promise<RuntimeLogRow[]> {
@@ -219,34 +214,64 @@ export class RuntimeClient extends EventEmitter {
     this.emit(RUNTIME_CANCEL_EVENT, { requestId } satisfies RuntimeCancelEvent);
   }
 
-  private observeWithSignal<TResult>(underlying: Promise<TResult>, signal?: AbortSignal): Promise<TResult> {
-    if (!signal) {
-      return underlying;
-    }
-    if (signal.aborted) {
+  private createInFlightRequest<TResult>(
+    store: Map<string, InFlightRequest<TResult>>,
+    key: string,
+    start: (signal: AbortSignal) => Promise<TResult>
+  ): InFlightRequest<TResult> {
+    const controller = new AbortController();
+    const entry: InFlightRequest<TResult> = {
+      activeObservers: 0,
+      controller,
+      promise: Promise.resolve(undefined as TResult),
+      settled: false
+    };
+    const request = start(controller.signal);
+    entry.promise = request.finally(() => {
+      entry.settled = true;
+      if (store.get(key) === entry) {
+        store.delete(key);
+      }
+    });
+    store.set(key, entry);
+    return entry;
+  }
+
+  private observeInFlightRequest<TResult>(entry: InFlightRequest<TResult>, signal?: AbortSignal): Promise<TResult> {
+    if (signal?.aborted) {
       return Promise.reject(this.createAbortError());
     }
+
+    entry.activeObservers += 1;
+    const release = () => {
+      entry.activeObservers = Math.max(0, entry.activeObservers - 1);
+      if (!entry.settled && entry.activeObservers === 0) {
+        entry.controller.abort();
+      }
+    };
+
+    if (!signal) {
+      return entry.promise.finally(release);
+    }
+
     return new Promise<TResult>((resolve, reject) => {
-      let aborted = false;
-      const onAbort = () => {
-        aborted = true;
+      let finished = false;
+      const finish = (callback: () => void) => {
+        if (finished) {
+          return;
+        }
+        finished = true;
         signal.removeEventListener('abort', onAbort);
-        reject(this.createAbortError());
+        release();
+        callback();
+      };
+      const onAbort = () => {
+        finish(() => reject(this.createAbortError()));
       };
       signal.addEventListener('abort', onAbort, { once: true });
-      underlying.then(
-        value => {
-          signal.removeEventListener('abort', onAbort);
-          if (!aborted) {
-            resolve(value);
-          }
-        },
-        error => {
-          signal.removeEventListener('abort', onAbort);
-          if (!aborted) {
-            reject(error);
-          }
-        }
+      entry.promise.then(
+        value => finish(() => resolve(value)),
+        error => finish(() => reject(error))
       );
     });
   }

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -135,6 +135,9 @@ export class RuntimeClient extends EventEmitter {
     if (!this.requestHandler) {
       await this.initialize();
     }
+    if (signal?.aborted) {
+      throw this.createAbortError();
+    }
     const key = JSON.stringify({ forceRefresh: params.forceRefresh === true });
     const pending = this.inFlightOrgLists.get(key);
     if (pending) {
@@ -149,6 +152,9 @@ export class RuntimeClient extends EventEmitter {
   async getOrgAuth(params: OrgAuthParams = {}, signal?: AbortSignal): Promise<OrgAuth> {
     if (!this.requestHandler) {
       await this.initialize();
+    }
+    if (signal?.aborted) {
+      throw this.createAbortError();
     }
     const key = JSON.stringify({ username: typeof params.username === 'string' ? params.username.trim() : '' });
     const pending = this.inFlightOrgAuth.get(key);

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -144,16 +144,19 @@ export class RuntimeClient extends EventEmitter {
     return tracked;
   }
 
-  async getOrgAuth(params: OrgAuthParams = {}): Promise<OrgAuth> {
+  async getOrgAuth(params: OrgAuthParams = {}, signal?: AbortSignal): Promise<OrgAuth> {
     if (!this.requestHandler) {
       await this.initialize();
     }
     const key = JSON.stringify({ username: typeof params.username === 'string' ? params.username.trim() : '' });
     const pending = this.inFlightOrgAuth.get(key);
     if (pending) {
-      return pending;
+      return this.observeWithSignal(pending, signal);
     }
-    const request = this.request<OrgAuth>('org/auth', params);
+    const request = this.request<OrgAuth>('org/auth', params, signal);
+    if (signal) {
+      return request;
+    }
     const tracked = request.finally(() => {
       if (this.inFlightOrgAuth.get(key) === tracked) {
         this.inFlightOrgAuth.delete(key);
@@ -214,6 +217,38 @@ export class RuntimeClient extends EventEmitter {
       }
     }
     this.emit(RUNTIME_CANCEL_EVENT, { requestId } satisfies RuntimeCancelEvent);
+  }
+
+  private observeWithSignal<TResult>(underlying: Promise<TResult>, signal?: AbortSignal): Promise<TResult> {
+    if (!signal) {
+      return underlying;
+    }
+    if (signal.aborted) {
+      return Promise.reject(this.createAbortError());
+    }
+    return new Promise<TResult>((resolve, reject) => {
+      let aborted = false;
+      const onAbort = () => {
+        aborted = true;
+        signal.removeEventListener('abort', onAbort);
+        reject(this.createAbortError());
+      };
+      signal.addEventListener('abort', onAbort, { once: true });
+      underlying.then(
+        value => {
+          signal.removeEventListener('abort', onAbort);
+          if (!aborted) {
+            resolve(value);
+          }
+        },
+        error => {
+          signal.removeEventListener('abort', onAbort);
+          if (!aborted) {
+            reject(error);
+          }
+        }
+      );
+    });
   }
 
   private async request<TResult>(method: string, params?: unknown, signal?: AbortSignal): Promise<TResult> {

--- a/apps/vscode-extension/src/test/debugFlagsPanel.test.ts
+++ b/apps/vscode-extension/src/test/debugFlagsPanel.test.ts
@@ -7,10 +7,14 @@ const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
 function loadDebugFlagsPanel(stubs?: {
   traceflags?: Record<string, unknown>;
   telemetry?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
+  cli?: Record<string, unknown>;
 }) {
   return proxyquireStrict('../panel/DebugFlagsPanel', {
     '../../../../src/salesforce/traceflags': stubs?.traceflags ?? {},
-    '../shared/telemetry': stubs?.telemetry ?? {}
+    '../shared/telemetry': stubs?.telemetry ?? {},
+    '../runtime/runtimeClient': stubs?.runtime ?? {},
+    '../../../../src/salesforce/cli': stubs?.cli ?? {}
   }) as typeof import('../panel/DebugFlagsPanel');
 }
 
@@ -106,6 +110,76 @@ suite('DebugFlagsPanel', () => {
     assert.equal(panelLike.selectedOrg, 'new@example.com');
     assert.equal(panelLike.selectedTarget, undefined);
     assert.equal(bootstrapped, 1);
+  });
+
+  test('bootstrapData loads orgs and auth through runtime client', async () => {
+    const runtimeAuth = {
+      username: 'runtime@example.com',
+      instanceUrl: 'https://example.com',
+      accessToken: 'token'
+    };
+
+    const { DebugFlagsPanel } = loadDebugFlagsPanel({
+      runtime: {
+        runtimeClient: {
+          orgList: async () => [
+            {
+              username: 'runtime@example.com',
+              alias: 'Runtime',
+              isDefaultUsername: true
+            }
+          ],
+          getOrgAuth: async ({ username }: { username?: string } = {}) => ({
+            ...runtimeAuth,
+            username: username ?? runtimeAuth.username
+          })
+        }
+      },
+      cli: {
+        listOrgs: async () => {
+          throw new Error('should not call cli listOrgs');
+        },
+        getOrgAuth: async () => {
+          throw new Error('should not call cli getOrgAuth');
+        }
+      }
+    });
+
+    const posted: any[] = [];
+    const debugLevelCalls: Array<{ auth: typeof runtimeAuth; token?: number }> = [];
+    let searchUsersCalls = 0;
+    const panelLike = {
+      disposed: false,
+      orgBootstrapToken: 0,
+      selectedOrg: 'runtime@example.com',
+      post: (message: any) => {
+        posted.push(message);
+      },
+      getSelectedAuth: (DebugFlagsPanel as any).prototype.getSelectedAuth,
+      sendDebugLevelData: async (auth: typeof runtimeAuth, _selectedId?: string, token?: number) => {
+        debugLevelCalls.push({ auth, token });
+      },
+      searchUsers: async () => {
+        searchUsersCalls += 1;
+      }
+    };
+
+    await (DebugFlagsPanel as any).prototype.bootstrapData.call(panelLike);
+
+    assert.deepEqual(posted.find(message => message.type === 'debugFlagsOrgs'), {
+      type: 'debugFlagsOrgs',
+      data: [
+        {
+          username: 'runtime@example.com',
+          alias: 'Runtime',
+          isDefaultUsername: true
+        }
+      ],
+      selected: 'runtime@example.com'
+    });
+    assert.deepEqual(debugLevelCalls, [{ auth: runtimeAuth, token: 1 }]);
+    assert.equal(searchUsersCalls, 1);
+    assert.equal(posted.some(message => message.type === 'debugFlagsError'), false);
   });
 
   test('searchUsers emits sanitized telemetry on success', async () => {

--- a/apps/vscode-extension/src/test/logIdToPath.test.ts
+++ b/apps/vscode-extension/src/test/logIdToPath.test.ts
@@ -11,11 +11,24 @@ function loadTailService(stubs?: {
   cli?: Record<string, unknown>;
   http?: Record<string, unknown>;
   workspace?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
 }) {
   return proxyquireStrict('../../../../src/utils/tailService', {
     '../salesforce/cli': stubs?.cli ?? {},
     '../salesforce/http': stubs?.http ?? {},
-    './workspace': stubs?.workspace ?? {}
+    './workspace': stubs?.workspace ?? {},
+    '../../apps/vscode-extension/src/runtime/runtimeClient':
+      stubs?.runtime ?? {
+        runtimeClient: {
+          getOrgAuth:
+            stubs?.cli?.getOrgAuth ??
+            (async ({ username }: { username?: string } = {}) => ({
+              username,
+              instanceUrl: 'https://example.com',
+              accessToken: 'token'
+            }))
+        }
+      }
   }) as typeof import('../../../../src/utils/tailService');
 }
 

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -97,6 +97,7 @@ suite('LogService', () => {
 
   test('openLog resolves auth through runtime client instead of salesforce cli', async () => {
     const calls: any[] = [];
+    const authCalls: Array<{ username?: string }> = [];
     const vscodeMock = createVscodeLogServiceStub([]);
     const { LogService } = proxyquireStrict('../../../../src/services/logService', {
       vscode: vscodeMock,
@@ -113,11 +114,14 @@ suite('LogService', () => {
       },
       '../../apps/vscode-extension/src/runtime/runtimeClient': {
         runtimeClient: {
-          getOrgAuth: async ({ username }: { username?: string } = {}) => ({
-            username,
-            accessToken: 't',
-            instanceUrl: 'url'
-          })
+          getOrgAuth: async ({ username }: { username?: string } = {}) => {
+            authCalls.push({ username });
+            return {
+              username,
+              accessToken: 't',
+              instanceUrl: 'url'
+            };
+          }
         }
       },
       '../utils/workspace': {
@@ -138,6 +142,7 @@ suite('LogService', () => {
     await svc.openLog('abc', 'runtime@example.com');
 
     assert.equal(calls.length, 1);
+    assert.deepEqual(authCalls, [{ username: 'runtime@example.com' }]);
     assert.equal(calls[0]?.logId, 'abc');
     assert.equal(calls[0]?.filePath, '/tmp/runtime.log');
   });

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -37,6 +37,21 @@ function createVscodeLogServiceStub(commandCalls: Array<{ command: string; uri: 
   };
 }
 
+function createRuntimeClientStub(auth: Partial<OrgAuth> = {}) {
+  return {
+    '../../apps/vscode-extension/src/runtime/runtimeClient': {
+      runtimeClient: {
+        getOrgAuth: async ({ username }: { username?: string } = {}) => ({
+          accessToken: 't',
+          instanceUrl: 'url',
+          username: username ?? auth.username,
+          ...auth
+        })
+      }
+    }
+  };
+}
+
 suite('LogService', () => {
   async function waitForCondition(
     predicate: () => boolean,
@@ -78,6 +93,53 @@ suite('LogService', () => {
     assert.equal(res.length, 1);
     assert.equal(calls.length, 1);
     assert.deepEqual(calls[0], { auth, limit: 2, offset: 0 });
+  });
+
+  test('openLog resolves auth through runtime client instead of salesforce cli', async () => {
+    const calls: any[] = [];
+    const vscodeMock = createVscodeLogServiceStub([]);
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      vscode: vscodeMock,
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        fetchApexLogHead: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => ''
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => {
+          throw new Error('should not call cli getOrgAuth');
+        }
+      },
+      '../../apps/vscode-extension/src/runtime/runtimeClient': {
+        runtimeClient: {
+          getOrgAuth: async ({ username }: { username?: string } = {}) => ({
+            username,
+            accessToken: 't',
+            instanceUrl: 'url'
+          })
+        }
+      },
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async () => ({ dir: '', filePath: '/tmp/should-not-write.log' }),
+        findExistingLogFile: async (_logId: string, username?: string) =>
+          username === 'runtime@example.com' ? '/tmp/runtime.log' : undefined
+      },
+      '../../apps/vscode-extension/src/panel/LogViewerPanel': {
+        LogViewerPanel: class {
+          static async show(opts: any) {
+            calls.push(opts);
+          }
+        }
+      }
+    });
+
+    const svc = new LogService();
+    await svc.openLog('abc', 'runtime@example.com');
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.logId, 'abc');
+    assert.equal(calls[0]?.filePath, '/tmp/runtime.log');
   });
 
   test('loadLogHeads skips uncached logs instead of downloading full bodies', async () => {
@@ -226,12 +288,13 @@ suite('LogService', () => {
           extractCodeUnitStartedFromLines: () => undefined,
           fetchApexLogBody: async () => ''
         },
-        '../salesforce/cli': {
-          getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
-        },
-        '../utils/workspace': {
-          getLogFilePathWithUsername: async () => ({ dir: '', filePath: '/tmp/test.log' }),
-          findExistingLogFile: async (_logId: string, username?: string) =>
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async () => ({ dir: '', filePath: '/tmp/test.log' }),
+        findExistingLogFile: async (_logId: string, username?: string) =>
             username === 'user@example.com' ? '/tmp/test.log' : undefined
         },
         '../../apps/vscode-extension/src/panel/LogViewerPanel': {
@@ -304,6 +367,7 @@ suite('LogService', () => {
         '../salesforce/cli': {
           getOrgAuth: async () => ({ username: 'user', accessToken: 'token', instanceUrl: 'url' })
         },
+        ...createRuntimeClientStub({ username: 'user', accessToken: 'token', instanceUrl: 'url' }),
         '../utils/workspace': {
           getLogFilePathWithUsername: async () => ({ dir: path.dirname(filePath), filePath }),
           findExistingLogFile: async () => storedPath
@@ -344,6 +408,7 @@ suite('LogService', () => {
       '../salesforce/cli': {
         getOrgAuth: async () => ({ username: 'u', accessToken: 't', instanceUrl: 'url' })
       },
+      ...createRuntimeClientStub({ username: 'u', accessToken: 't', instanceUrl: 'url' }),
       '../utils/workspace': {
         getLogFilePathWithUsername: async (_username: string | undefined, logId: string) => ({
           dir: '/tmp',

--- a/apps/vscode-extension/src/test/orgManager.test.ts
+++ b/apps/vscode-extension/src/test/orgManager.test.ts
@@ -94,4 +94,36 @@ suite('OrgManager', () => {
       rmSync(tmp, { recursive: true, force: true });
     }
   });
+
+  test('list does not mutate selection after cancellation', async () => {
+    const controller = new AbortController();
+    const { OrgManager } = proxyquire('../utils/orgManager', {
+      '../../../../src/utils/orgs': {
+        pickSelectedOrg: () => 'u1',
+        '@noCallThru': true
+      },
+      '../runtime/runtimeClient': {
+        runtimeClient: {
+          orgList: async (_params: unknown, signal?: AbortSignal) => {
+            controller.abort();
+            if (signal?.aborted) {
+              const error = new Error('Request aborted');
+              error.name = 'AbortError';
+              throw error;
+            }
+            return [{ username: 'u1' }];
+          }
+        },
+        '@noCallThru': true
+      }
+    });
+    const mgr = new OrgManager({} as any);
+    mgr.setSelectedOrg('existing');
+
+    await assert.rejects(
+      mgr.list(false, controller.signal),
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    assert.equal(mgr.getSelectedOrg(), 'existing');
+  });
 });

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -209,6 +209,67 @@ suite('runtime client', () => {
     assert.ok(seenSignal, 'orgList should provide an abortable signal to the runtime request');
   });
 
+  test('does not dispatch orgList after cancellation during initialize', async () => {
+    let orgListCalls = 0;
+    let releaseInitialize: (() => void) | undefined;
+    const daemon = createFakeDaemon({
+      onWrite(message, helpers) {
+        if (message.method === 'initialize') {
+          releaseInitialize = () => {
+            helpers.emitMessage({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                runtime_version: '0.1.0',
+                protocol_version: '1',
+                platform: 'linux',
+                arch: 'x64',
+                capabilities: {
+                  orgs: true,
+                  logs: true,
+                  search: true,
+                  tail: true,
+                  debug_flags: true,
+                  doctor: true
+                },
+                state_dir: '.alv/state',
+                cache_dir: '.alv/cache'
+              }
+            });
+          };
+          return;
+        }
+        if (message.method === 'org/list') {
+          orgListCalls++;
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: []
+          });
+          return;
+        }
+        throw new Error(`unexpected method: ${message.method}`);
+      }
+    });
+
+    const client = new RuntimeClient({
+      createProcess: () => daemon,
+      prepareProcessEnv: async () => undefined
+    });
+
+    const controller = new AbortController();
+    const pending = client.orgList({ forceRefresh: true }, controller.signal);
+    await new Promise(resolve => setImmediate(resolve));
+    controller.abort();
+    releaseInitialize?.();
+
+    await assert.rejects(
+      pending,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    assert.equal(orgListCalls, 0);
+  });
+
   test('coalesces concurrent getOrgAuth requests for the same username', async () => {
     let authCalls = 0;
     let resolveAuth: ((value: OrgAuth) => void) | undefined;
@@ -316,6 +377,71 @@ suite('runtime client', () => {
       (error: unknown) => error instanceof Error && error.name === 'AbortError'
     );
     assert.ok(seenSignal, 'getOrgAuth should provide an abortable signal to the runtime request');
+  });
+
+  test('does not dispatch getOrgAuth after cancellation during initialize', async () => {
+    let authCalls = 0;
+    let releaseInitialize: (() => void) | undefined;
+    const daemon = createFakeDaemon({
+      onWrite(message, helpers) {
+        if (message.method === 'initialize') {
+          releaseInitialize = () => {
+            helpers.emitMessage({
+              jsonrpc: '2.0',
+              id: message.id,
+              result: {
+                runtime_version: '0.1.0',
+                protocol_version: '1',
+                platform: 'linux',
+                arch: 'x64',
+                capabilities: {
+                  orgs: true,
+                  logs: true,
+                  search: true,
+                  tail: true,
+                  debug_flags: true,
+                  doctor: true
+                },
+                state_dir: '.alv/state',
+                cache_dir: '.alv/cache'
+              }
+            });
+          };
+          return;
+        }
+        if (message.method === 'org/auth') {
+          authCalls++;
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              username: 'demo@example.com',
+              instanceUrl: 'https://example.my.salesforce.com',
+              accessToken: 'token'
+            }
+          });
+          return;
+        }
+        throw new Error(`unexpected method: ${message.method}`);
+      }
+    });
+
+    const client = new RuntimeClient({
+      createProcess: () => daemon,
+      prepareProcessEnv: async () => undefined
+    });
+
+    const controller = new AbortController();
+    const pending = client.getOrgAuth({ username: 'demo@example.com' }, controller.signal);
+    await new Promise(resolve => setImmediate(resolve));
+    controller.abort();
+    releaseInitialize?.();
+
+    await assert.rejects(
+      pending,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    assert.equal(authCalls, 0);
   });
 
   test('prepares daemon env before starting the runtime process', async () => {

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -173,6 +173,42 @@ suite('runtime client', () => {
     assert.deepEqual(left, right);
   });
 
+  test('forwards abort signals to orgList request handling', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async <TResult>(method: string, params: unknown, signal?: AbortSignal) => {
+        assert.equal(method, 'org/list');
+        assert.deepEqual(params, { forceRefresh: true });
+        seenSignal = signal;
+        return (await new Promise<OrgListItem[]>((_resolve, reject) => {
+          if (!signal) {
+            reject(new Error('missing signal'));
+            return;
+          }
+          signal.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('Request aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true }
+          );
+        })) as TResult;
+      }
+    });
+
+    const controller = new AbortController();
+    const pending = client.orgList({ forceRefresh: true }, controller.signal);
+    controller.abort();
+
+    await assert.rejects(
+      pending,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    assert.ok(seenSignal, 'orgList should provide an abortable signal to the runtime request');
+  });
+
   test('coalesces concurrent getOrgAuth requests for the same username', async () => {
     let authCalls = 0;
     let resolveAuth: ((value: OrgAuth) => void) | undefined;
@@ -200,6 +236,50 @@ suite('runtime client', () => {
     const [left, right] = await Promise.all([first, second]);
     assert.equal(authCalls, 1);
     assert.deepEqual(left, right);
+  });
+
+  test('coalesces concurrent signaled getOrgAuth requests for the same username', async () => {
+    let authCalls = 0;
+    let resolveAuth: ((value: OrgAuth) => void) | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async <TResult>(method: string, params: unknown, signal?: AbortSignal) => {
+        assert.equal(method, 'org/auth');
+        assert.deepEqual(params, { username: 'demo@example.com' });
+        authCalls++;
+        return (await new Promise<OrgAuth>((resolve, reject) => {
+          resolveAuth = resolve;
+          signal?.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('Request aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true }
+          );
+        })) as TResult;
+      }
+    });
+
+    const firstController = new AbortController();
+    const secondController = new AbortController();
+    const first = client.getOrgAuth({ username: 'demo@example.com' }, firstController.signal);
+    const second = client.getOrgAuth({ username: 'demo@example.com' }, secondController.signal);
+
+    assert.equal(authCalls, 1);
+    firstController.abort();
+    resolveAuth?.({
+      username: 'demo@example.com',
+      instanceUrl: 'https://example.my.salesforce.com',
+      accessToken: 'token'
+    });
+
+    await assert.rejects(
+      first,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    await assert.doesNotReject(second);
+    assert.equal(authCalls, 1);
   });
 
   test('forwards abort signals to getOrgAuth request handling', async () => {
@@ -235,7 +315,7 @@ suite('runtime client', () => {
       pending,
       (error: unknown) => error instanceof Error && error.name === 'AbortError'
     );
-    assert.equal(seenSignal, controller.signal);
+    assert.ok(seenSignal, 'getOrgAuth should provide an abortable signal to the runtime request');
   });
 
   test('prepares daemon env before starting the runtime process', async () => {

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -202,6 +202,42 @@ suite('runtime client', () => {
     assert.deepEqual(left, right);
   });
 
+  test('forwards abort signals to getOrgAuth request handling', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async <TResult>(method: string, params: unknown, signal?: AbortSignal) => {
+        assert.equal(method, 'org/auth');
+        assert.deepEqual(params, { username: 'demo@example.com' });
+        seenSignal = signal;
+        return (await new Promise<OrgAuth>((_resolve, reject) => {
+          if (!signal) {
+            reject(new Error('missing signal'));
+            return;
+          }
+          signal.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('Request aborted');
+              error.name = 'AbortError';
+              reject(error);
+            },
+            { once: true }
+          );
+        })) as TResult;
+      }
+    });
+
+    const controller = new AbortController();
+    const pending = client.getOrgAuth({ username: 'demo@example.com' }, controller.signal);
+    controller.abort();
+
+    await assert.rejects(
+      pending,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    assert.equal(seenSignal, controller.signal);
+  });
+
   test('prepares daemon env before starting the runtime process', async () => {
     let prepareCalls = 0;
     let seenEnv: NodeJS.ProcessEnv | undefined;

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -270,6 +270,59 @@ suite('runtime client', () => {
     assert.equal(orgListCalls, 0);
   });
 
+  test('starts a fresh orgList request after a cancelled shared request aborts', async () => {
+    let orgListCalls = 0;
+    let rejectAbortedRequest: (() => void) | undefined;
+    let resolveRetriedRequest: ((value: OrgListItem[]) => void) | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async <TResult>(method: string, params: unknown, signal?: AbortSignal) => {
+        assert.equal(method, 'org/list');
+        assert.deepEqual(params, { forceRefresh: false });
+        orgListCalls++;
+        return (await new Promise<OrgListItem[]>((resolve, reject) => {
+          if (orgListCalls === 1) {
+            signal?.addEventListener(
+              'abort',
+              () => {
+                rejectAbortedRequest = () => {
+                  const error = new Error('Request aborted');
+                  error.name = 'AbortError';
+                  reject(error);
+                };
+              },
+              { once: true }
+            );
+            return;
+          }
+
+          resolveRetriedRequest = resolve;
+        })) as TResult;
+      }
+    });
+
+    const controller = new AbortController();
+    const first = client.orgList({ forceRefresh: false }, controller.signal);
+    controller.abort();
+
+    const second = client.orgList({ forceRefresh: false });
+
+    assert.equal(orgListCalls, 2);
+    rejectAbortedRequest?.();
+    resolveRetriedRequest?.([
+      {
+        username: 'demo@example.com',
+        alias: 'Demo',
+        isDefaultUsername: true
+      }
+    ]);
+
+    await assert.rejects(
+      first,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    await assert.doesNotReject(second);
+  });
+
   test('coalesces concurrent getOrgAuth requests for the same username', async () => {
     let authCalls = 0;
     let resolveAuth: ((value: OrgAuth) => void) | undefined;
@@ -442,6 +495,57 @@ suite('runtime client', () => {
       (error: unknown) => error instanceof Error && error.name === 'AbortError'
     );
     assert.equal(authCalls, 0);
+  });
+
+  test('starts a fresh getOrgAuth request after a cancelled shared request aborts', async () => {
+    let authCalls = 0;
+    let rejectAbortedRequest: (() => void) | undefined;
+    let resolveRetriedRequest: ((value: OrgAuth) => void) | undefined;
+    const client = new RuntimeClient({
+      requestHandler: async <TResult>(method: string, params: unknown, signal?: AbortSignal) => {
+        assert.equal(method, 'org/auth');
+        assert.deepEqual(params, { username: 'demo@example.com' });
+        authCalls++;
+        return (await new Promise<OrgAuth>((resolve, reject) => {
+          if (authCalls === 1) {
+            signal?.addEventListener(
+              'abort',
+              () => {
+                rejectAbortedRequest = () => {
+                  const error = new Error('Request aborted');
+                  error.name = 'AbortError';
+                  reject(error);
+                };
+              },
+              { once: true }
+            );
+            return;
+          }
+
+          resolveRetriedRequest = resolve;
+        })) as TResult;
+      }
+    });
+
+    const controller = new AbortController();
+    const first = client.getOrgAuth({ username: 'demo@example.com' }, controller.signal);
+    controller.abort();
+
+    const second = client.getOrgAuth({ username: 'demo@example.com' });
+
+    assert.equal(authCalls, 2);
+    rejectAbortedRequest?.();
+    resolveRetriedRequest?.({
+      username: 'demo@example.com',
+      instanceUrl: 'https://example.my.salesforce.com',
+      accessToken: 'token'
+    });
+
+    await assert.rejects(
+      first,
+      (error: unknown) => error instanceof Error && error.name === 'AbortError'
+    );
+    await assert.doesNotReject(second);
   });
 
   test('prepares daemon env before starting the runtime process', async () => {

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -563,11 +563,20 @@ suite('TailService', () => {
 
   test('replay treats AbortError from ensureLogSaved as cancellation', async () => {
     const originalExecuteCommand = vscode.commands.executeCommand;
+    const originalWithProgress = vscode.window.withProgress;
     const executed: Array<{ command: string; args: any[] }> = [];
     (vscode.commands as any).executeCommand = async (command: string, ...args: any[]) => {
       executed.push({ command, args });
       return undefined;
     };
+    (vscode.window as any).withProgress = async (_options: any, task: any) =>
+      task(
+        { report() {} },
+        {
+          isCancellationRequested: false,
+          onCancellationRequested: () => new MockDisposable()
+        }
+      );
 
     try {
       const { SfLogTailViewProvider } = loadTailProvider();
@@ -611,6 +620,7 @@ suite('TailService', () => {
       );
     } finally {
       (vscode.commands as any).executeCommand = originalExecuteCommand;
+      (vscode.window as any).withProgress = originalWithProgress;
     }
   });
 

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -21,13 +21,26 @@ function loadTailService(stubs?: {
   traceflags?: Record<string, unknown>;
   streaming?: Record<string, unknown>;
   jsforce?: Record<string, unknown>;
+  runtime?: Record<string, unknown>;
 }) {
   return proxyquireStrict('../../../../src/utils/tailService', {
     '../salesforce/cli': stubs?.cli ?? {},
     '../salesforce/http': stubs?.http ?? {},
     '../salesforce/traceflags': stubs?.traceflags ?? {},
     '../salesforce/streaming': stubs?.streaming ?? {},
-    '../salesforce/jsforce': stubs?.jsforce ?? {}
+    '../salesforce/jsforce': stubs?.jsforce ?? {},
+    '../../apps/vscode-extension/src/runtime/runtimeClient':
+      stubs?.runtime ?? {
+        runtimeClient: {
+          getOrgAuth:
+            stubs?.cli?.getOrgAuth ??
+            (async ({ username }: { username?: string } = {}) => ({
+              username,
+              instanceUrl: 'https://example.com',
+              accessToken: 'token'
+            }))
+        }
+      }
   }) as typeof import('../../../../src/utils/tailService');
 }
 
@@ -210,6 +223,62 @@ suite('TailService', () => {
     (cli as any).getOrgAuth = origGetAuth;
     (traceflags as any).ensureUserTraceFlag = origEnsure;
     (http as any).fetchApexLogs = origFetch;
+    service.stop();
+  });
+
+  test('start resolves auth through runtime client instead of salesforce cli', async () => {
+    const { TailService } = loadTailService({
+      cli: {
+        getOrgAuth: async () => {
+          throw new Error('should not call cli getOrgAuth');
+        }
+      },
+      runtime: {
+        runtimeClient: {
+          getOrgAuth: async ({ username }: { username?: string } = {}) => ({
+            username,
+            instanceUrl: 'https://example.com',
+            accessToken: 'token'
+          })
+        }
+      },
+      traceflags: {
+        ensureUserTraceFlag: async () => false
+      },
+      http: {
+        fetchApexLogs: async () => [],
+        getEffectiveApiVersion: () => '64.0'
+      },
+      streaming: {
+        createConnectionFromAuth: async (auth: any, apiVersion: string) => ({
+          version: apiVersion,
+          instanceUrl: auth.instanceUrl,
+          accessToken: auth.accessToken,
+          request: async () => '',
+          query: async () => ({ records: [] }),
+          queryMore: async () => ({ records: [] }),
+          tooling: {
+            query: async () => ({ records: [] }),
+            create: async () => ({ success: true, id: '1', errors: [] }),
+            update: async () => ({ success: true, id: '1', errors: [] }),
+            destroy: async () => ({ success: true, id: '1', errors: [] })
+          },
+          streaming: {} as any
+        }),
+        createLoggingStreamingClient: async () => ({
+          handshake: async () => {},
+          replay: () => {},
+          subscribe: async () => {},
+          disconnect: () => {}
+        })
+      }
+    });
+    const service = new TailService(() => {});
+    service.setOrg('runtime-user@example.com');
+
+    await service.start('DEBUG');
+
+    assert.equal((service as any).currentAuth?.username, 'runtime-user@example.com');
     service.stop();
   });
 

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -74,6 +74,9 @@ function loadTailProvider(stubs?: {
           }))
       }
     },
+    '../../../../src/utils/replayDebugger': {
+      ensureReplayDebuggerAvailable: async () => true
+    },
     '../../../../src/salesforce/traceflags': stubs?.traceflags ?? {},
     '../../../../src/utils/tailService': { TailService: TailServiceStub }
   }) as typeof import('../provider/SfLogTailViewProvider');
@@ -556,6 +559,59 @@ suite('TailService', () => {
 
     await assert.rejects(pending, /aborted/i);
     assert.equal(destroyed, true);
+  });
+
+  test('replay treats AbortError from ensureLogSaved as cancellation', async () => {
+    const originalExecuteCommand = vscode.commands.executeCommand;
+    const executed: Array<{ command: string; args: any[] }> = [];
+    (vscode.commands as any).executeCommand = async (command: string, ...args: any[]) => {
+      executed.push({ command, args });
+      return undefined;
+    };
+
+    try {
+      const { SfLogTailViewProvider } = loadTailProvider();
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const posted: any[] = [];
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+
+      (provider as any).post = (message: any) => {
+        posted.push(message);
+      };
+      (provider as any).sendOrgs = async () => {};
+      (provider as any).sendDebugLevels = async () => {};
+      await provider.resolveWebviewView(view);
+
+      (provider as any).tailService.ensureLogSaved = async () => {
+        const error = new Error('Request aborted');
+        error.name = 'AbortError';
+        throw error;
+      };
+
+      await webview.emit({ type: 'replay', logId: '07Lxx0000000001' });
+
+      assert.equal(
+        posted.some(message => message?.type === 'error'),
+        false,
+        'AbortError should be treated as cancellation'
+      );
+      assert.equal(
+        executed.some(
+          entry =>
+            entry.command === 'sf.launch.replay.debugger.logfile' ||
+            entry.command === 'sfdx.launch.replay.debugger.logfile'
+        ),
+        false,
+        'replay debugger should not launch after cancellation'
+      );
+    } finally {
+      (vscode.commands as any).executeCommand = originalExecuteCommand;
+    }
   });
 
   test('openDebugFlags opens debug flags panel from tail view', async () => {

--- a/apps/vscode-extension/src/utils/orgManager.ts
+++ b/apps/vscode-extension/src/utils/orgManager.ts
@@ -26,8 +26,18 @@ export class OrgManager {
     this.selectedOrg = org;
   }
 
-  async list(forceRefresh = false): Promise<{ orgs: OrgItem[]; selected?: string }> {
-    const orgs = await runtimeClient.orgList({ forceRefresh });
+  async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const orgs = await runtimeClient.orgList({ forceRefresh }, signal);
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
     await this.ensureProjectDefaultSelected(orgs);
     const selected = pickSelectedOrg(orgs, this.selectedOrg);
     this.selectedOrg = selected;

--- a/docs/SCRATCH_ORG_POOL.md
+++ b/docs/SCRATCH_ORG_POOL.md
@@ -26,6 +26,11 @@ Create or update the pool records:
 npm run scratch-pool:bootstrap -- --target-org DevHubElectivus --pool-key alv-e2e --target-size 21
 ```
 
+Notes:
+
+- When invoking these scripts through `npm run`, keep the extra `--` before the script arguments. Without it, `npm` consumes flags like `--pool-key`, and the script fails with errors such as `Missing required --pool-key for bootstrap.`
+- If your shell already exports `SF_DEVHUB_ALIAS`, you can omit `--target-org` and run `npm run scratch-pool:bootstrap -- --pool-key alv-e2e --target-size 21`.
+
 Useful bootstrap overrides:
 
 - `--scratch-duration-days 30`

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import { promises as fs } from 'fs';
 import { createLimiter, type Limiter } from '../utils/limiter';
-import { getOrgAuth } from '../salesforce/cli';
 import { fetchApexLogBody, extractCodeUnitStartedFromLines } from '../salesforce/http';
 import type { ApexLogCursor } from '../salesforce/http';
 import type { OrgAuth } from '../salesforce/types';
@@ -12,6 +11,7 @@ import { getErrorMessage } from '../utils/error';
 import { logWarn, logInfo } from '../utils/logger';
 import { localize } from '../utils/localize';
 import { LogViewerPanel } from '../../apps/vscode-extension/src/panel/LogViewerPanel';
+import { runtimeClient } from '../../apps/vscode-extension/src/runtime/runtimeClient';
 import { fetchApexLogs } from '../salesforce/http';
 import { createUnreadableLogSummary, summarizeLogFile } from './logTriage';
 import type { LogTriageSummary } from '../../apps/vscode-extension/src/shared/logTriage';
@@ -135,7 +135,7 @@ export class LogService {
     signal?: AbortSignal,
     authHint?: OrgAuth
   ): Promise<string> {
-    const auth = authHint ?? (await getOrgAuth(selectedOrg, undefined, signal));
+    const auth = authHint ?? (await this.getOrgAuth(selectedOrg, signal));
     const existing = await findExistingLogFile(logId, auth.username);
     if (existing) {
       return existing;
@@ -212,10 +212,25 @@ export class LogService {
       return undefined;
     }
     try {
-      return (await getOrgAuth(selectedOrg, undefined, signal)).username;
+      return (await this.getOrgAuth(selectedOrg, signal)).username;
     } catch {
       return undefined;
     }
+  }
+
+  private async getOrgAuth(selectedOrg?: string, signal?: AbortSignal): Promise<OrgAuth> {
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const auth = await runtimeClient.getOrgAuth({ username: selectedOrg });
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    return auth;
   }
 
   async classifyLogsForErrors(

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -224,7 +224,7 @@ export class LogService {
       error.name = 'AbortError';
       throw error;
     }
-    const auth = await runtimeClient.getOrgAuth({ username: selectedOrg });
+    const auth = await runtimeClient.getOrgAuth({ username: selectedOrg }, signal);
     if (signal?.aborted) {
       const error = new Error('Request aborted');
       error.name = 'AbortError';

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -31,7 +31,12 @@ export class OrgManager {
       error.name = 'AbortError';
       throw error;
     }
-    const orgs = await runtimeClient.orgList({ forceRefresh });
+    const orgs = await runtimeClient.orgList({ forceRefresh }, signal);
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
     await this.ensureProjectDefaultSelected(orgs);
     const selected = pickSelectedOrg(orgs, this.selectedOrg);
     this.selectedOrg = selected;

--- a/src/utils/orgManager.ts
+++ b/src/utils/orgManager.ts
@@ -2,7 +2,7 @@ import type * as vscode from 'vscode';
 import * as path from 'path';
 import { promises as fs } from 'fs';
 import { pickSelectedOrg } from './orgs';
-import { listOrgs } from '../salesforce/cli';
+import { runtimeClient } from '../../apps/vscode-extension/src/runtime/runtimeClient';
 import type { OrgItem } from '../../apps/vscode-extension/src/shared/types';
 import { getWorkspaceRoot } from './workspace';
 import { logWarn } from './logger';
@@ -26,7 +26,12 @@ export class OrgManager {
   }
 
   async list(forceRefresh = false, signal?: AbortSignal): Promise<{ orgs: OrgItem[]; selected?: string }> {
-    const orgs = await listOrgs(forceRefresh, signal);
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const orgs = await runtimeClient.orgList({ forceRefresh });
     await this.ensureProjectDefaultSelected(orgs);
     const selected = pickSelectedOrg(orgs, this.selectedOrg);
     this.selectedOrg = selected;

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -1,9 +1,9 @@
 import { promises as fs } from 'fs';
 import { fetchApexLogs, fetchApexLogBody, getEffectiveApiVersion } from '../salesforce/http';
-import { getOrgAuth } from '../salesforce/cli';
 import { ensureUserTraceFlag } from '../salesforce/traceflags';
 import type { OrgAuth } from '../salesforce/types';
 import type { ExtensionToWebviewMessage } from '../../apps/vscode-extension/src/shared/messages';
+import { runtimeClient } from '../../apps/vscode-extension/src/runtime/runtimeClient';
 import { logInfo, logWarn, logError, showOutput } from './logger';
 import { localize } from './localize';
 import { getErrorMessage } from './error';
@@ -78,7 +78,7 @@ export class TailService {
     this.logIdToPath.clear();
     this.currentDebugLevel = debugLevel;
     try {
-      const auth = await getOrgAuth(this.selectedOrg);
+      const auth = await this.getOrgAuth();
       if (!this.tailRunning || this.disposed) {
         logWarn('Tail: start aborted while awaiting auth');
         return;
@@ -285,7 +285,7 @@ export class TailService {
     }
     this.seenLogIds.add(id);
     try {
-      const auth = this.currentAuth ?? (await getOrgAuth(this.selectedOrg));
+      const auth = this.currentAuth ?? (await this.getOrgAuth());
       this.currentAuth = auth;
       const conn =
         this.connection
@@ -364,7 +364,7 @@ export class TailService {
     if (existing) {
       return existing;
     }
-    const auth = this.currentAuth ?? (await getOrgAuth(this.selectedOrg, undefined, signal));
+    const auth = this.currentAuth ?? (await this.getOrgAuth(signal));
     this.currentAuth = auth;
     const connection =
       this.connection && !signal?.aborted
@@ -422,6 +422,21 @@ export class TailService {
       this.connection = await createConnectionFromAuth(auth, effectiveVersion);
     }
     return this.connection;
+  }
+
+  private async getOrgAuth(signal?: AbortSignal): Promise<OrgAuth> {
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    const auth = await runtimeClient.getOrgAuth({ username: this.selectedOrg });
+    if (signal?.aborted) {
+      const error = new Error('Request aborted');
+      error.name = 'AbortError';
+      throw error;
+    }
+    return auth;
   }
 
   private getWorkspaceRoot(): string | undefined {

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -430,7 +430,7 @@ export class TailService {
       error.name = 'AbortError';
       throw error;
     }
-    const auth = await runtimeClient.getOrgAuth({ username: this.selectedOrg });
+    const auth = await runtimeClient.getOrgAuth({ username: this.selectedOrg }, signal);
     if (signal?.aborted) {
       const error = new Error('Request aborted');
       error.name = 'AbortError';


### PR DESCRIPTION
## Summary
- route debug flag, log, tail, and org bootstrap auth resolution through `runtimeClient` instead of `salesforce/cli`
- add coverage proving the VS Code extension paths now use the runtime client for org/auth resolution
- clarify the scratch pool bootstrap docs around `npm run ... --` argument forwarding and `SF_DEVHUB_ALIAS`

## Why
The migration goal is to stop using the Salesforce CLI directly from the TypeScript side of the extension runtime. This change removes the remaining production imports in the affected TS flows and locks the new runtime-backed behavior with tests.

## Validation
- `node scripts/run-tests-cli.js --scope=unit` (`293 passing`)
- `npm run test:e2e` (`7 passed (3.9m)`)
