### PR TITLE
fix(ci): configure npm registry for CLI publish

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -233,6 +233,12 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_DIST_TAG: ${{ needs.validate_tag.outputs.npm_dist_tag }}
     steps:
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Download staged npm packages
         uses: actions/download-artifact@v8
         with:
@@ -261,6 +267,12 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_DIST_TAG: ${{ needs.validate_tag.outputs.npm_dist_tag }}
     steps:
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+
       - name: Download staged npm packages
         uses: actions/download-artifact@v8
         with:

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -149,3 +149,18 @@ test('rust-release workflow preserves per-artifact directories when downloading 
     'expected the release packaging job to normalize binaries from per-target artifact directories'
   );
 });
+
+test('rust-release workflow configures the npm registry before publishing packages', () => {
+  const workflowSource = readFile('.github/workflows/rust-release.yml');
+
+  assert.match(
+    workflowSource,
+    /publish_npm_native:[\s\S]*?uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
+    'expected native npm publish job to configure the npm registry before publishing'
+  );
+  assert.match(
+    workflowSource,
+    /publish_npm_meta:[\s\S]*?uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
+    'expected meta npm publish job to configure the npm registry before publishing'
+  );
+});


### PR DESCRIPTION
## Summary
- configure the npm registry in both CLI publish jobs before running `npm publish`
- add a regression test to keep the release workflow wired for npm auth
- fix the failure we hit rerunning `rust-v0.1.1` after adding `NPM_TOKEN`

## Verification
- npm run test:scripts