### PR TITLE
fix(ci): check out repo before npm publish setup

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -233,6 +233,9 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_DIST_TAG: ${{ needs.validate_tag.outputs.npm_dist_tag }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:
@@ -267,6 +270,9 @@ jobs:
       NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
       NPM_DIST_TAG: ${{ needs.validate_tag.outputs.npm_dist_tag }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@v6
         with:

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -36,6 +36,16 @@ function assertVersionedPathDependency(relativePath, dependencyName, version, de
   );
 }
 
+function readWorkflowJob(relativePath, jobName) {
+  const workflowSource = readFile(relativePath);
+  const match = workflowSource.match(
+    new RegExp(`^  ${jobName}:\\n([\\s\\S]*?)(?=^  [a-z0-9_]+:\\n|\\Z)`, 'mi')
+  );
+
+  assert.ok(match, `expected ${relativePath} to declare the ${jobName} job`);
+  return match[1];
+}
+
 test('package script rebuilds the extension packaging assets that vsce includes', () => {
   const rootPackageJson = JSON.parse(readFile('package.json'));
   const packageScript = String(rootPackageJson.scripts?.package || '');
@@ -151,31 +161,33 @@ test('rust-release workflow preserves per-artifact directories when downloading 
 });
 
 test('rust-release workflow configures the npm registry before publishing packages', () => {
-  const workflowSource = readFile('.github/workflows/rust-release.yml');
+  const nativePublishJob = readWorkflowJob('.github/workflows/rust-release.yml', 'publish_npm_native');
+  const metaPublishJob = readWorkflowJob('.github/workflows/rust-release.yml', 'publish_npm_meta');
 
   assert.match(
-    workflowSource,
-    /publish_npm_native:[\s\S]*?uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
+    nativePublishJob,
+    /uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
     'expected native npm publish job to configure the npm registry before publishing'
   );
   assert.match(
-    workflowSource,
-    /publish_npm_meta:[\s\S]*?uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
+    metaPublishJob,
+    /uses:\s+actions\/setup-node@v6[\s\S]*?registry-url:\s+'https:\/\/registry\.npmjs\.org'/,
     'expected meta npm publish job to configure the npm registry before publishing'
   );
 });
 
 test('rust-release publish jobs check out the repo before reading .nvmrc', () => {
-  const workflowSource = readFile('.github/workflows/rust-release.yml');
+  const nativePublishJob = readWorkflowJob('.github/workflows/rust-release.yml', 'publish_npm_native');
+  const metaPublishJob = readWorkflowJob('.github/workflows/rust-release.yml', 'publish_npm_meta');
 
   assert.match(
-    workflowSource,
-    /publish_npm_native:[\s\S]*?- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
+    nativePublishJob,
+    /- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
     'expected native npm publish job to check out the repo before setup-node reads .nvmrc'
   );
   assert.match(
-    workflowSource,
-    /publish_npm_meta:[\s\S]*?- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
+    metaPublishJob,
+    /- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
     'expected meta npm publish job to check out the repo before setup-node reads .nvmrc'
   );
 });

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -164,3 +164,18 @@ test('rust-release workflow configures the npm registry before publishing packag
     'expected meta npm publish job to configure the npm registry before publishing'
   );
 });
+
+test('rust-release publish jobs check out the repo before reading .nvmrc', () => {
+  const workflowSource = readFile('.github/workflows/rust-release.yml');
+
+  assert.match(
+    workflowSource,
+    /publish_npm_native:[\s\S]*?- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
+    'expected native npm publish job to check out the repo before setup-node reads .nvmrc'
+  );
+  assert.match(
+    workflowSource,
+    /publish_npm_meta:[\s\S]*?- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
+    'expected meta npm publish job to check out the repo before setup-node reads .nvmrc'
+  );
+});


### PR DESCRIPTION
## Summary
- add checkout to the npm publish jobs before setup-node reads `.nvmrc`
- cover the regression in `scripts/packaging-ci.test.js`
- unblock the retagged `rust-v0.1.1` release flow after the publish-job failure

## Verification
- npm run test:scripts