### PR TITLE
fix(ci): checkout repo before creating CLI releases

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -297,6 +297,9 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       PRE_RELEASE: ${{ needs.validate_tag.outputs.pre_release }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
       - name: Download packaged release assets
         uses: actions/download-artifact@v8
         with:

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -39,7 +39,7 @@ function assertVersionedPathDependency(relativePath, dependencyName, version, de
 function readWorkflowJob(relativePath, jobName) {
   const workflowSource = readFile(relativePath);
   const match = workflowSource.match(
-    new RegExp(`^  ${jobName}:\\n([\\s\\S]*?)(?=^  [a-z0-9_]+:\\n|\\Z)`, 'mi')
+    new RegExp(`^  ${jobName}:\\n([\\s\\S]*?)(?=^  [a-z0-9_]+:\\n|(?![\\s\\S]))`, 'mi')
   );
 
   assert.ok(match, `expected ${relativePath} to declare the ${jobName} job`);
@@ -189,5 +189,15 @@ test('rust-release publish jobs check out the repo before reading .nvmrc', () =>
     metaPublishJob,
     /- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
     'expected meta npm publish job to check out the repo before setup-node reads .nvmrc'
+  );
+});
+
+test('rust-release release job checks out the repo before running gh release commands', () => {
+  const releaseJob = readWorkflowJob('.github/workflows/rust-release.yml', 'release');
+
+  assert.match(
+    releaseJob,
+    /- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@v6[\s\S]*?- name:\s+Create or update GitHub release/,
+    'expected release job to check out the repo before running gh release commands'
   );
 });


### PR DESCRIPTION
## Summary
- add a checkout step to the Rust CLI release job before invoking gh release commands
- cover the release job ordering in packaging CI tests
- fix the workflow job test helper so it can read the last job in a workflow file

## Testing
- node --test scripts/packaging-ci.test.js
- npm run test:scripts