### PR TITLE
fix(ci): extract Windows runtime zips without powershell args

### DIFF
--- a/scripts/fetch-runtime-release.mjs
+++ b/scripts/fetch-runtime-release.mjs
@@ -58,6 +58,10 @@ function assertSpawnSucceeded(result, description) {
   }
 }
 
+function quotePowerShellLiteral(value) {
+  return `'${String(value).replaceAll("'", "''")}'`;
+}
+
 export function extractArchive({
   archivePath,
   destinationDir,
@@ -74,9 +78,7 @@ export function extractArchive({
         '-NoLogo',
         '-NoProfile',
         '-Command',
-        'Expand-Archive -LiteralPath $args[0] -DestinationPath $args[1] -Force',
-        archivePath,
-        destinationDir
+        `Expand-Archive -LiteralPath ${quotePowerShellLiteral(archivePath)} -DestinationPath ${quotePowerShellLiteral(destinationDir)} -Force`
       ],
       { stdio: 'inherit' }
     );

--- a/scripts/fetch-runtime-release.test.js
+++ b/scripts/fetch-runtime-release.test.js
@@ -88,3 +88,37 @@ test('fetchRuntimeRelease reads config/runtime-bundle.json and installs the chos
 
   fs.rmSync(repoRoot, { recursive: true, force: true });
 });
+
+test('extractArchive embeds Windows paths directly in the PowerShell command', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-fetch-runtime-win-'));
+  const calls = [];
+  const archivePath = String.raw`C:\temp\O'Brien\apex-log-viewer.zip`;
+  const destinationDir = String.raw`D:\runtime\O'Brien`;
+
+  try {
+    mod.extractArchive({
+      archivePath,
+      destinationDir,
+      target: 'win32-x64',
+      spawnSyncImpl(command, args) {
+        calls.push({ command, args });
+        return { status: 0 };
+      }
+    });
+
+    assert.deepEqual(calls, [
+      {
+        command: 'powershell.exe',
+        args: [
+          '-NoLogo',
+          '-NoProfile',
+          '-Command',
+          `Expand-Archive -LiteralPath 'C:\\temp\\O''Brien\\apex-log-viewer.zip' -DestinationPath 'D:\\runtime\\O''Brien' -Force`
+        ]
+      }
+    ]);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/scripts/fetch-runtime-release.test.js
+++ b/scripts/fetch-runtime-release.test.js
@@ -91,12 +91,23 @@ test('fetchRuntimeRelease reads config/runtime-bundle.json and installs the chos
 
 test('extractArchive embeds Windows paths directly in the PowerShell command', async () => {
   const mod = await import(pathToFileURL(modulePath).href);
-  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-fetch-runtime-win-'));
   const calls = [];
   const archivePath = String.raw`C:\temp\O'Brien\apex-log-viewer.zip`;
   const destinationDir = String.raw`D:\runtime\O'Brien`;
+  const rmSyncCalls = [];
+  const mkdirSyncCalls = [];
+  const originalRmSync = fs.rmSync;
+  const originalMkdirSync = fs.mkdirSync;
 
   try {
+    fs.rmSync = (dir, options) => {
+      rmSyncCalls.push({ dir, options });
+    };
+    fs.mkdirSync = (dir, options) => {
+      mkdirSyncCalls.push({ dir, options });
+      return dir;
+    };
+
     mod.extractArchive({
       archivePath,
       destinationDir,
@@ -118,7 +129,20 @@ test('extractArchive embeds Windows paths directly in the PowerShell command', a
         ]
       }
     ]);
+    assert.deepEqual(rmSyncCalls, [
+      {
+        dir: destinationDir,
+        options: { recursive: true, force: true }
+      }
+    ]);
+    assert.deepEqual(mkdirSyncCalls, [
+      {
+        dir: destinationDir,
+        options: { recursive: true }
+      }
+    ]);
   } finally {
-    fs.rmSync(repoRoot, { recursive: true, force: true });
+    fs.rmSync = originalRmSync;
+    fs.mkdirSync = originalMkdirSync;
   }
 });


### PR DESCRIPTION
## Summary
- stop relying on PowerShell `$args` when extracting Windows runtime zip assets
- quote Windows archive and destination paths directly in the Expand-Archive command
- cover the Windows extraction branch in fetch-runtime-release tests

## Testing
- node --test scripts/fetch-runtime-release.test.js
- npm run test:scripts