### PR TITLE
fix(cli-npm): restore global alv entrypoint

### DIFF
--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"

--- a/packages/cli-npm/bin/apex-log-viewer.js
+++ b/packages/cli-npm/bin/apex-log-viewer.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { createRequire } from 'node:module';
@@ -44,7 +45,16 @@ export function main(argv = process.argv.slice(2)) {
   process.exit(resolveExitCode(result));
 }
 
-const entryPath = process.argv[1] ? path.resolve(process.argv[1]) : '';
-if (entryPath && entryPath === fileURLToPath(import.meta.url)) {
+export function isDirectExecution(entryArgv1 = process.argv[1], moduleUrl = import.meta.url) {
+  if (!entryArgv1) {
+    return false;
+  }
+
+  const entryPath = path.resolve(entryArgv1);
+  const resolvedEntryPath = fs.existsSync(entryPath) ? fs.realpathSync.native(entryPath) : entryPath;
+  return resolvedEntryPath === fileURLToPath(moduleUrl);
+}
+
+if (isDirectExecution()) {
   main();
 }

--- a/scripts/build-cli-npm-packages.test.js
+++ b/scripts/build-cli-npm-packages.test.js
@@ -120,6 +120,25 @@ test('resolveExitCode falls back to 1 when the native binary exits via signal', 
   assert.equal(launcher.resolveExitCode({ status: null, signal: 'SIGTERM' }), 1);
 });
 
+test('isDirectExecution treats npm-style symlink entrypoints as direct execution', async () => {
+  const launcher = await import(pathToFileURL(launcherPath).href);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cli-symlink-'));
+  const symlinkPath = path.join(tempDir, 'alv');
+
+  try {
+    fs.symlinkSync(launcherPath, symlinkPath);
+
+    assert.equal(typeof launcher.isDirectExecution, 'function');
+    assert.equal(launcher.isDirectExecution(symlinkPath, pathToFileURL(launcherPath).href), true);
+    assert.equal(
+      launcher.isDirectExecution(path.join(tempDir, 'different-entry.js'), pathToFileURL(launcherPath).href),
+      false
+    );
+  } finally {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});
+
 test('discoverBinaries finds packaged runtime binaries under apps/vscode-extension/bin', async () => {
   const mod = await import(pathToFileURL(modulePath).href);
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cli-discover-'));

--- a/scripts/build-cli-npm-packages.test.js
+++ b/scripts/build-cli-npm-packages.test.js
@@ -120,13 +120,24 @@ test('resolveExitCode falls back to 1 when the native binary exits via signal', 
   assert.equal(launcher.resolveExitCode({ status: null, signal: 'SIGTERM' }), 1);
 });
 
-test('isDirectExecution treats npm-style symlink entrypoints as direct execution', async () => {
+test('isDirectExecution treats npm-style symlink entrypoints as direct execution', async (t) => {
   const launcher = await import(pathToFileURL(launcherPath).href);
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cli-symlink-'));
   const symlinkPath = path.join(tempDir, 'alv');
 
   try {
-    fs.symlinkSync(launcherPath, symlinkPath);
+    if (process.platform === 'win32') {
+      t.skip('Windows symlink creation may require Developer Mode or elevated privileges');
+    }
+
+    try {
+      fs.symlinkSync(launcherPath, symlinkPath);
+    } catch (error) {
+      if (error && (error.code === 'EPERM' || error.code === 'EACCES')) {
+        t.skip('Symlink creation is not permitted in this environment');
+      }
+      throw error;
+    }
 
     assert.equal(typeof launcher.isDirectExecution, 'function');
     assert.equal(launcher.isDirectExecution(symlinkPath, pathToFileURL(launcherPath).href), true);


### PR DESCRIPTION
## Summary
- resolve npm global symlink entrypoints before deciding whether to invoke the CLI launcher
- add a regression test that reproduces the npm-installed `alv` symlink case
- bump the standalone CLI release version to `0.1.2` for the npm republish

## Root cause
`@electivus/apex-log-viewer@0.1.1` installed successfully from npm, but the published `alv` command was a no-op when invoked through the global npm symlink. The launcher compared `process.argv[1]` to `import.meta.url` without resolving symlinks, so `main()` never ran in the real installed layout.

## Verification
- `node --test scripts/build-cli-npm-packages.test.js`
- `npm run test:scripts`
- `npm install -g @electivus/apex-log-viewer@0.1.1`
- `node /home/k3/.nvm/versions/node/v24.14.1/lib/node_modules/@electivus/apex-log-viewer/bin/apex-log-viewer.js --version`
- `alv --version` on `0.1.1` reproduced the no-output bug before this fix
