### PR TITLE
fix(runtime): align cli initialize version contract

### DIFF
--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -164,6 +164,7 @@ suite('runtime client', () => {
       requestHandler: async <TResult>(method: string): Promise<TResult> => {
         assert.equal(method, 'initialize');
         return {
+          runtime_version: '0.1.0',
           cli_version: '0.1.0',
           protocol_version: '1',
           channel: 'stable',
@@ -301,6 +302,7 @@ suite('runtime client', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
+                runtime_version: '0.1.0',
                 cli_version: '0.1.0',
                 protocol_version: '1',
                 channel: 'stable',
@@ -525,6 +527,7 @@ suite('runtime client', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
+                runtime_version: '0.1.0',
                 cli_version: '0.1.0',
                 protocol_version: '1',
                 channel: 'stable',
@@ -641,6 +644,7 @@ suite('runtime client', () => {
             jsonrpc: '2.0',
             id: message.id,
             result: {
+              runtime_version: '0.1.0',
               cli_version: '0.1.0',
               protocol_version: '1',
               channel: 'stable',
@@ -803,6 +807,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
+                    runtime_version: '0.1.0',
                     cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
@@ -835,6 +840,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
+                  runtime_version: '0.1.0',
                   cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
@@ -900,6 +906,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
+                    runtime_version: '0.1.0',
                     cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
@@ -932,6 +939,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
+                  runtime_version: '0.1.0',
                   cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
@@ -996,6 +1004,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
+                    runtime_version: '0.1.0',
                     cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
@@ -1031,6 +1040,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
+                  runtime_version: '0.1.0',
                   cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
@@ -1094,6 +1104,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
+                  runtime_version: '0.1.0',
                   cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
@@ -1147,6 +1158,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
+                    runtime_version: '0.1.0',
                     cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
@@ -1182,6 +1194,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
+                  runtime_version: '0.1.0',
                   cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -164,7 +164,7 @@ suite('runtime client', () => {
       requestHandler: async <TResult>(method: string): Promise<TResult> => {
         assert.equal(method, 'initialize');
         return {
-          runtime_version: '0.1.0',
+          cli_version: '0.1.0',
           protocol_version: '1',
           channel: 'stable',
           platform: 'linux',
@@ -185,6 +185,7 @@ suite('runtime client', () => {
     const result = await client.initialize();
 
     assert.equal(result.protocol_version, '1');
+    assert.equal(result.cli_version, '0.1.0');
     assert.equal(result.channel, 'stable');
     assert.equal(result.capabilities.orgs, true);
   });
@@ -300,7 +301,7 @@ suite('runtime client', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
-                runtime_version: '0.1.0',
+                cli_version: '0.1.0',
                 protocol_version: '1',
                 channel: 'stable',
                 platform: 'linux',
@@ -524,7 +525,7 @@ suite('runtime client', () => {
               jsonrpc: '2.0',
               id: message.id,
               result: {
-                runtime_version: '0.1.0',
+                cli_version: '0.1.0',
                 protocol_version: '1',
                 channel: 'stable',
                 platform: 'linux',
@@ -640,7 +641,7 @@ suite('runtime client', () => {
             jsonrpc: '2.0',
             id: message.id,
             result: {
-              runtime_version: '0.1.0',
+              cli_version: '0.1.0',
               protocol_version: '1',
               channel: 'stable',
               platform: 'win32',
@@ -802,7 +803,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
-                    runtime_version: '0.1.0',
+                    cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
                     platform: 'linux',
@@ -834,7 +835,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  runtime_version: '0.1.0',
+                  cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
                   platform: 'linux',
@@ -899,7 +900,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
-                    runtime_version: '0.1.0',
+                    cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
                     platform: 'linux',
@@ -931,7 +932,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  runtime_version: '0.1.0',
+                  cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
                   platform: 'linux',
@@ -995,7 +996,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
-                    runtime_version: '0.1.0',
+                    cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
                     platform: 'linux',
@@ -1030,7 +1031,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  runtime_version: '0.1.0',
+                  cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
                   platform: 'linux',
@@ -1093,7 +1094,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  runtime_version: '0.1.0',
+                  cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
                   platform: 'linux',
@@ -1146,7 +1147,7 @@ suite('runtime client', () => {
                   jsonrpc: '2.0',
                   id: message.id,
                   result: {
-                    runtime_version: '0.1.0',
+                    cli_version: '0.1.0',
                     protocol_version: '1',
                     channel: 'stable',
                     platform: 'linux',
@@ -1181,7 +1182,7 @@ suite('runtime client', () => {
                 jsonrpc: '2.0',
                 id: message.id,
                 result: {
-                  runtime_version: '0.1.0',
+                  cli_version: '0.1.0',
                   protocol_version: '1',
                   channel: 'stable',
                   platform: 'linux',

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.1", path = "../alv-core" }
-alv-protocol = { version = "0.1.1", path = "../alv-protocol" }
+alv-core = { version = "0.1.2", path = "../alv-core" }
+alv-protocol = { version = "0.1.2", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -59,11 +59,11 @@ fn release_channel_for_version(version: &str) -> &'static str {
 }
 
 pub fn handle_initialize(_params: InitializeParams) -> InitializeResult {
-    let runtime_version = env!("CARGO_PKG_VERSION").to_string();
-    let channel = release_channel_for_version(&runtime_version).to_string();
+    let cli_version = env!("CARGO_PKG_VERSION").to_string();
+    let channel = release_channel_for_version(&cli_version).to_string();
 
     InitializeResult {
-        runtime_version,
+        cli_version,
         protocol_version: "1".to_string(),
         channel,
         platform: std::env::consts::OS.to_string(),
@@ -408,8 +408,8 @@ fn jsonrpc_error(id: &str, code: i32, message: &str) -> String {
 
 fn serialize_initialize_result(result: &InitializeResult) -> String {
     format!(
-        "{{\"runtime_version\":\"{}\",\"protocol_version\":\"{}\",\"channel\":\"{}\",\"platform\":\"{}\",\"arch\":\"{}\",\"capabilities\":{{\"orgs\":{},\"logs\":{},\"search\":{},\"tail\":{},\"debug_flags\":{},\"doctor\":{}}},\"state_dir\":\"{}\",\"cache_dir\":\"{}\"}}",
-        escape_json(&result.runtime_version),
+        "{{\"cli_version\":\"{}\",\"protocol_version\":\"{}\",\"channel\":\"{}\",\"platform\":\"{}\",\"arch\":\"{}\",\"capabilities\":{{\"orgs\":{},\"logs\":{},\"search\":{},\"tail\":{},\"debug_flags\":{},\"doctor\":{}}},\"state_dir\":\"{}\",\"cache_dir\":\"{}\"}}",
+        escape_json(&result.cli_version),
         escape_json(&result.protocol_version),
         escape_json(&result.channel),
         escape_json(&result.platform),

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -24,6 +24,7 @@ mod orgs_handler;
 
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const JSONRPC_SERVER_ERROR: i32 = -32000;
+pub const CLI_VERSION_ENV: &str = "ALV_CLI_VERSION";
 
 enum ParsedRequest {
     Cancel { request_id: String },
@@ -59,10 +60,15 @@ fn release_channel_for_version(version: &str) -> &'static str {
 }
 
 pub fn handle_initialize(_params: InitializeParams) -> InitializeResult {
-    let cli_version = env!("CARGO_PKG_VERSION").to_string();
+    let cli_version = std::env::var(CLI_VERSION_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_string());
     let channel = release_channel_for_version(&cli_version).to_string();
 
     InitializeResult {
+        runtime_version: cli_version.clone(),
         cli_version,
         protocol_version: "1".to_string(),
         channel,
@@ -408,7 +414,8 @@ fn jsonrpc_error(id: &str, code: i32, message: &str) -> String {
 
 fn serialize_initialize_result(result: &InitializeResult) -> String {
     format!(
-        "{{\"cli_version\":\"{}\",\"protocol_version\":\"{}\",\"channel\":\"{}\",\"platform\":\"{}\",\"arch\":\"{}\",\"capabilities\":{{\"orgs\":{},\"logs\":{},\"search\":{},\"tail\":{},\"debug_flags\":{},\"doctor\":{}}},\"state_dir\":\"{}\",\"cache_dir\":\"{}\"}}",
+        "{{\"runtime_version\":\"{}\",\"cli_version\":\"{}\",\"protocol_version\":\"{}\",\"channel\":\"{}\",\"platform\":\"{}\",\"arch\":\"{}\",\"capabilities\":{{\"orgs\":{},\"logs\":{},\"search\":{},\"tail\":{},\"debug_flags\":{},\"doctor\":{}}},\"state_dir\":\"{}\",\"cache_dir\":\"{}\"}}",
+        escape_json(&result.runtime_version),
         escape_json(&result.cli_version),
         escape_json(&result.protocol_version),
         escape_json(&result.channel),

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -71,7 +71,7 @@ fn app_server_smoke_reports_initialize_handshake() {
         client_version: "0.1.0".to_string(),
     });
 
-    assert_eq!(result.runtime_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(result.cli_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(result.protocol_version, "1");
     assert_eq!(result.channel, expected_channel);
     assert_eq!(result.platform, std::env::consts::OS);

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -71,6 +71,7 @@ fn app_server_smoke_reports_initialize_handshake() {
         client_version: "0.1.0".to_string(),
     });
 
+    assert_eq!(result.runtime_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(result.cli_version, env!("CARGO_PKG_VERSION"));
     assert_eq!(result.protocol_version, "1");
     assert_eq!(result.channel, expected_channel);

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -12,7 +12,7 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.1", path = "../alv-app-server" }
+alv-app-server = { version = "0.1.2", path = "../alv-app-server" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/alv-cli/src/main.rs
+++ b/crates/alv-cli/src/main.rs
@@ -4,6 +4,7 @@ fn main() {
     let args: Vec<String> = env::args().skip(1).collect();
 
     if args.len() == 2 && args[0] == "app-server" && args[1] == "--stdio" {
+        env::set_var(alv_app_server::server::CLI_VERSION_ENV, env!("CARGO_PKG_VERSION"));
         alv_app_server::server::run_stdio().expect("app-server failed");
         return;
     }

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -138,9 +138,14 @@ fn cli_smoke_routes_initialize_and_logs_list_over_stdio() {
         r#"{"jsonrpc":"2.0","id":"initialize:1","method":"initialize","params":{"client_name":"cli-smoke","client_version":"0.1.0"}}"#,
     );
     let initialize = harness.recv_json();
+    let runtime_version = initialize["result"]["runtime_version"]
+        .as_str()
+        .expect("initialize result should include runtime_version");
     let cli_version = initialize["result"]["cli_version"]
         .as_str()
         .expect("initialize result should include cli_version");
+    assert_eq!(runtime_version, env!("CARGO_PKG_VERSION"));
+    assert_eq!(cli_version, env!("CARGO_PKG_VERSION"));
     let expected_channel = if cli_version.contains('-') {
         "pre-release"
     } else {

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -1,5 +1,4 @@
 use std::{
-    fs,
     io::{BufRead, BufReader, Write},
     process::{Child, ChildStdin, Command, Stdio},
     sync::{
@@ -7,10 +6,13 @@ use std::{
         Mutex, OnceLock,
     },
     thread,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 
 use serde_json::Value;
+
+#[cfg(windows)]
+use std::{fs, time::{SystemTime, UNIX_EPOCH}};
 
 fn test_guard() -> &'static Mutex<()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
@@ -136,10 +138,10 @@ fn cli_smoke_routes_initialize_and_logs_list_over_stdio() {
         r#"{"jsonrpc":"2.0","id":"initialize:1","method":"initialize","params":{"client_name":"cli-smoke","client_version":"0.1.0"}}"#,
     );
     let initialize = harness.recv_json();
-    let runtime_version = initialize["result"]["runtime_version"]
+    let cli_version = initialize["result"]["cli_version"]
         .as_str()
-        .expect("initialize result should include runtime_version");
-    let expected_channel = if runtime_version.contains('-') {
+        .expect("initialize result should include cli_version");
+    let expected_channel = if cli_version.contains('-') {
         "pre-release"
     } else {
         "stable"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/crates/alv-protocol/src/codegen.rs
+++ b/crates/alv-protocol/src/codegen.rs
@@ -14,6 +14,7 @@ export type RuntimeCapabilities = {
 };
 
 export type InitializeResult = {
+  runtime_version: string;
   cli_version: string;
   protocol_version: string;
   channel: string;

--- a/crates/alv-protocol/src/codegen.rs
+++ b/crates/alv-protocol/src/codegen.rs
@@ -14,7 +14,7 @@ export type RuntimeCapabilities = {
 };
 
 export type InitializeResult = {
-  runtime_version: string;
+  cli_version: string;
   protocol_version: string;
   channel: string;
   platform: string;

--- a/crates/alv-protocol/src/messages.rs
+++ b/crates/alv-protocol/src/messages.rs
@@ -18,6 +18,7 @@ pub struct RuntimeCapabilities {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InitializeResult {
+    pub runtime_version: String,
     pub cli_version: String,
     pub protocol_version: String,
     pub channel: String,

--- a/crates/alv-protocol/src/messages.rs
+++ b/crates/alv-protocol/src/messages.rs
@@ -18,7 +18,7 @@ pub struct RuntimeCapabilities {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct InitializeResult {
-    pub runtime_version: String,
+    pub cli_version: String,
     pub protocol_version: String,
     pub channel: String,
     pub platform: String,

--- a/crates/alv-protocol/tests/protocol_schema.rs
+++ b/crates/alv-protocol/tests/protocol_schema.rs
@@ -10,6 +10,7 @@ fn protocol_schema_serializes_initialize_contract() {
     };
 
     let result = InitializeResult {
+        runtime_version: "0.1.0".to_string(),
         cli_version: "0.1.0".to_string(),
         protocol_version: "1".to_string(),
         channel: "stable".to_string(),
@@ -37,6 +38,7 @@ fn protocol_schema_serializes_initialize_contract() {
     assert_eq!(
         serde_json::to_value(result).expect("result should serialize"),
         json!({
+            "runtime_version": "0.1.0",
             "cli_version": "0.1.0",
             "protocol_version": "1",
             "channel": "stable",
@@ -63,6 +65,7 @@ fn protocol_schema_prints_generated_typescript_surface() {
     assert!(generated.contains("export type InitializeParams"));
     assert!(generated.contains("export type InitializeResult"));
     assert!(generated.contains("channel: string;"));
+    assert!(generated.contains("runtime_version: string;"));
     assert!(generated.contains("cli_version: string;"));
     assert!(generated.contains("debug_flags: boolean;"));
 

--- a/crates/alv-protocol/tests/protocol_schema.rs
+++ b/crates/alv-protocol/tests/protocol_schema.rs
@@ -10,7 +10,7 @@ fn protocol_schema_serializes_initialize_contract() {
     };
 
     let result = InitializeResult {
-        runtime_version: "0.1.0".to_string(),
+        cli_version: "0.1.0".to_string(),
         protocol_version: "1".to_string(),
         channel: "stable".to_string(),
         platform: "linux".to_string(),
@@ -37,7 +37,7 @@ fn protocol_schema_serializes_initialize_contract() {
     assert_eq!(
         serde_json::to_value(result).expect("result should serialize"),
         json!({
-            "runtime_version": "0.1.0",
+            "cli_version": "0.1.0",
             "protocol_version": "1",
             "channel": "stable",
             "platform": "linux",
@@ -63,6 +63,7 @@ fn protocol_schema_prints_generated_typescript_surface() {
     assert!(generated.contains("export type InitializeParams"));
     assert!(generated.contains("export type InitializeResult"));
     assert!(generated.contains("channel: string;"));
+    assert!(generated.contains("cli_version: string;"));
     assert!(generated.contains("debug_flags: boolean;"));
 
     println!("{generated}");

--- a/packages/app-server-client-ts/src/generated/index.ts
+++ b/packages/app-server-client-ts/src/generated/index.ts
@@ -13,7 +13,7 @@ export type RuntimeCapabilities = {
 };
 
 export type InitializeResult = {
-  runtime_version: string;
+  cli_version: string;
   protocol_version: string;
   channel: string;
   platform: string;

--- a/packages/app-server-client-ts/src/generated/index.ts
+++ b/packages/app-server-client-ts/src/generated/index.ts
@@ -13,6 +13,7 @@ export type RuntimeCapabilities = {
 };
 
 export type InitializeResult = {
+  runtime_version: string;
   cli_version: string;
   protocol_version: string;
   channel: string;

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -115,6 +115,7 @@ test('rust-release workflow bootstrap skips crates.io publishing', () => {
 test('published Rust manifests keep versioned local dependencies so cargo publish is valid', () => {
   const appServerVersion = readCargoVersion('crates/alv-app-server/Cargo.toml');
   const coreVersion = readCargoVersion('crates/alv-core/Cargo.toml');
+  const mcpVersion = readCargoVersion('crates/alv-mcp/Cargo.toml');
   const protocolVersion = readCargoVersion('crates/alv-protocol/Cargo.toml');
   const cliVersion = readCargoVersion('crates/alv-cli/Cargo.toml');
 
@@ -131,6 +132,18 @@ test('published Rust manifests keep versioned local dependencies so cargo publis
     appServerVersion,
     '../alv-app-server'
   );
+  assert.equal(
+    appServerVersion,
+    cliVersion,
+    'expected the app-server crate version to stay aligned with the distributed CLI crate version'
+  );
+  assert.equal(coreVersion, cliVersion, 'expected alv-core to stay aligned with the CLI crate version');
+  assert.equal(
+    protocolVersion,
+    cliVersion,
+    'expected alv-protocol to stay aligned with the CLI crate version'
+  );
+  assert.equal(mcpVersion, cliVersion, 'expected alv-mcp to stay aligned with the CLI crate version');
   assert.ok(cliVersion.length > 0, 'expected the CLI crate version to remain readable');
 });
 


### PR DESCRIPTION
## Summary
- rename the initialize handshake field from `runtime_version` to `cli_version`
- align the internal Rust crates to `0.1.2` so the app-server reports the distributed CLI version
- update Rust and extension tests plus generated TypeScript protocol types to the new contract

## Verification
- `cargo test -p alv-protocol --test protocol_schema`
- `cargo test -p alv-app-server --test app_server_smoke`
- `cargo test -p apex-log-viewer-cli --test cli_smoke`
- `npm run test:rust`
- `npm run compile-tests`
- `npm run pretest`
- `node scripts/run-tests-cli.js --scope=unit`
- real handshake validation in `/home/k3/git/InsuranceIDO20260313` with `target/debug/apex-log-viewer app-server --stdio`, confirming `cli_version: 0.1.2`
