### PR TITLE
chore(cli): prepare 0.1.3 release

### DIFF
--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.2", path = "../alv-core" }
-alv-protocol = { version = "0.1.2", path = "../alv-protocol" }
+alv-core = { version = "0.1.3", path = "../alv-core" }
+alv-protocol = { version = "0.1.3", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,7 +12,7 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.2", path = "../alv-app-server" }
+alv-app-server = { version = "0.1.3", path = "../alv-app-server" }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"


### PR DESCRIPTION
## Summary
- bump the Rust CLI workspace crates from 0.1.2 to 0.1.3 in lockstep
- keep the extension runtime pin unchanged for now
- prepare the next CLI publish to distribute the initialize version-contract fix

## Verification
- npm run test:rust
- node --test scripts/packaging-ci.test.js