### PR TITLE
fix(cli-npm): expose apex-log-viewer bin alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.
 

--- a/packages/cli-npm/templates/package.meta.json
+++ b/packages/cli-npm/templates/package.meta.json
@@ -3,7 +3,8 @@
   "version": "__VERSION__",
   "type": "module",
   "bin": {
-    "alv": "bin/apex-log-viewer.js"
+    "alv": "bin/apex-log-viewer.js",
+    "apex-log-viewer": "bin/apex-log-viewer.js"
   },
   "optionalDependencies": {
     "@electivus/apex-log-viewer-linux-x64": "__VERSION__",

--- a/scripts/build-cli-npm-packages.test.js
+++ b/scripts/build-cli-npm-packages.test.js
@@ -38,7 +38,8 @@ test('buildCliNpmPackages generates the meta package with all native optionalDep
   assert.equal(metaPackage.name, '@electivus/apex-log-viewer');
   assert.equal(metaPackage.version, '1.2.3');
   assert.deepEqual(metaPackage.bin, {
-    alv: 'bin/apex-log-viewer.js'
+    alv: 'bin/apex-log-viewer.js',
+    'apex-log-viewer': 'bin/apex-log-viewer.js'
   });
   assert.equal(metaPackage.optionalDependencies['@electivus/apex-log-viewer-linux-x64'], '1.2.3');
   assert.equal(metaPackage.optionalDependencies['@electivus/apex-log-viewer-darwin-arm64'], '1.2.3');


### PR DESCRIPTION
## Summary
- publish both `alv` and `apex-log-viewer` from the npm meta package
- keep the existing launcher path so both names resolve to the same runtime entrypoint
- cover the generated `bin` map in the CLI npm packaging test and note the fix in the changelog

## Validation
- node --test scripts/build-cli-npm-packages.test.js
- node --test scripts/packaging-ci.test.js
- smoke install via temp prefix: build meta package, `npm install -g` it locally, verify both `alv --version` and `apex-log-viewer --version` work
