### PR TITLE
[codex] fix logs sync StartTime cursor quoting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Bug Fixes
 
+- CLI/Logs: stop emitting quoted SOQL `dateTime` cursor literals during incremental `logs sync`, so Salesforce accepts `StartTime` checkpoint filters again.
 - CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -354,9 +354,9 @@ fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) ->
             .filter(|value| !value.trim().is_empty()),
     ) {
         (Some(before_start_time), Some(before_id)) => format!(
-            "{base_select} WHERE StartTime < '{}' OR (StartTime = '{}' AND Id < '{}') ORDER BY StartTime DESC, Id DESC LIMIT {page_size}",
-            escape_soql_literal(before_start_time),
-            escape_soql_literal(before_start_time),
+            "{base_select} WHERE StartTime < {} OR (StartTime = {} AND Id < '{}') ORDER BY StartTime DESC, Id DESC LIMIT {page_size}",
+            before_start_time,
+            before_start_time,
             escape_soql_literal(before_id)
         ),
         _ => format!(
@@ -675,5 +675,28 @@ mod tests {
             before,
             "staging dirs should not leak after errors"
         );
+    }
+
+    #[test]
+    fn build_logs_query_keeps_datetime_cursor_unquoted() {
+        let query = build_logs_query(
+            200,
+            0,
+            &LogsListParams {
+                username: Some("demo@example.com".to_string()),
+                limit: Some(200),
+                cursor: Some(LogsCursor {
+                    before_start_time: Some("2026-03-29T00:44:00.000+0000".to_string()),
+                    before_id: Some("07L000000000003AA".to_string()),
+                }),
+                offset: Some(0),
+            },
+        );
+
+        assert!(query.contains("StartTime < 2026-03-29T00:44:00.000+0000"));
+        assert!(query.contains("StartTime = 2026-03-29T00:44:00.000+0000"));
+        assert!(query.contains("Id < '07L000000000003AA'"));
+        assert!(!query.contains("StartTime < '2026-03-29T00:44:00.000+0000'"));
+        assert!(!query.contains("StartTime = '2026-03-29T00:44:00.000+0000'"));
     }
 }


### PR DESCRIPTION
## Summary

- stop quoting `StartTime` datetime cursor literals in the SOQL built for incremental `alv logs sync`
- keep `Id` cursor comparisons quoted/escaped and add a regression test for the query builder
- document the user-facing fix in `CHANGELOG.md`

## Root Cause

`logs sync` paginates by building a SOQL cursor filter on `ApexLog.StartTime`. The generated query was wrapping the `dateTime` literal in single quotes, which Salesforce rejects with `INVALID_FIELD` for `StartTime` filter criteria.

## Validation

- `cargo test -p alv-core build_logs_query_keeps_datetime_cursor_unquoted -- --nocapture`
- `cargo test -p alv-core logs_sync_smoke_paginates_beyond_first_page -- --nocapture`
- `cargo test -p alv-core logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp -- --nocapture`
