### PR TITLE
[codex] Improve logs sync via REST concurrency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - CLI/Logs: add a local-first Rust CLI logs workflow with `logs sync`, `logs status`, and `logs search`, backed by an org-first `apexlogs/` layout and incremental sync state under `apexlogs/.alv/`.
+- CLI/Logs: make `logs sync` fetch ApexLog rows and bodies directly over the Salesforce Tooling REST API after reusing `sf org display` for auth, and add a `--concurrency` flag to control parallel body downloads.
 
 ### Bug Fixes
 
@@ -19,6 +20,7 @@
 ### Tests
 
 - Runtime/Logs: add targeted coverage for concurrent startup behavior, runtime request coalescing, auth-hint reuse during log downloads, Tail ready-state refresh gating, and Windows PATH resolution fast paths.
+- CLI/Logs: add Rust runtime coverage for REST log listing/body download, API-version fallback, and sync throughput with concurrent body downloads.
 
 ## [0.38.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.36.0...v0.38.0) (2026-03-27)
 

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ sf org login web
 The standalone Rust CLI now exposes a local-first `logs` surface for humans and coding agents:
 
 ```bash
-apex-log-viewer logs sync --target-org my-org
+apex-log-viewer logs sync --target-org my-org --concurrency 6
 apex-log-viewer logs status --target-org my-org
 apex-log-viewer logs search "NullPointerException" --target-org my-org
 ```
 
-`logs sync` materializes Apex log bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. The VS Code extension and the CLI remain separate surfaces over the same shared runtime architecture, so the runtime still tolerates the legacy flat cache layout during the transition.
+`logs sync` reuses `sf org display` for auth, then lists `ApexLog` rows and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `4` and `1` keeps the old serial-style troubleshooting mode. The VS Code extension and the CLI remain separate surfaces over the same shared runtime architecture, so the runtime still tolerates the legacy flat cache layout during the transition.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ apex-log-viewer logs status --target-org my-org
 apex-log-viewer logs search "NullPointerException" --target-org my-org
 ```
 
-`logs sync` reuses `sf org display` for auth, then lists `ApexLog` rows and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `4` and `1` keeps the old serial-style troubleshooting mode. The VS Code extension and the CLI remain separate surfaces over the same shared runtime architecture, so the runtime still tolerates the legacy flat cache layout during the transition.
+`logs sync` reuses `sf org display` for auth, then lists `ApexLog` rows and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `6` and `1` keeps the old serial-style troubleshooting mode. The VS Code extension and the CLI remain separate surfaces over the same shared runtime architecture, so the runtime still tolerates the legacy flat cache layout during the transition.
 
 ## Usage
 

--- a/crates/alv-cli/src/cli.rs
+++ b/crates/alv-cli/src/cli.rs
@@ -45,6 +45,8 @@ pub struct LogSyncArgs {
     pub json: bool,
     #[arg(long)]
     pub force_full: bool,
+    #[arg(long)]
+    pub concurrency: Option<usize>,
 }
 
 #[derive(Debug, Args)]

--- a/crates/alv-cli/src/commands/logs.rs
+++ b/crates/alv-cli/src/commands/logs.rs
@@ -57,6 +57,7 @@ fn run_sync(args: LogSyncArgs) -> Result<i32, String> {
         target_org: args.target_org,
         workspace_root: Some(workspace_root_string()?),
         force_full: args.force_full,
+        concurrency: args.concurrency,
     };
     let result = sync_logs_with_cancel(&params, &CancellationToken::new())?;
 

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -132,6 +132,7 @@ fn cli_smoke_shows_target_org_in_sync_help() {
     let stdout = String::from_utf8(output.stdout).expect("stdout should be utf8");
     assert!(stdout.contains("--target-org"));
     assert!(stdout.contains("--force-full"));
+    assert!(stdout.contains("--concurrency"));
 }
 
 #[test]
@@ -163,7 +164,7 @@ fn cli_smoke_logs_sync_json_emits_structured_result_and_writes_state() {
             r#"{"result":{"username":"default@example.com","accessToken":"token","instanceUrl":"https://default.example.com"}}"#,
         )
         .env("ALV_TEST_APEX_LOG_FIXTURE_DIR", &fixture_dir)
-        .args(["logs", "sync", "--json"])
+        .args(["logs", "sync", "--json", "--concurrency", "3"])
         .output()
         .expect("sync should execute");
 

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -16,5 +16,9 @@ grep = "0.4"
 grep-matcher = "0.1"
 grep-regex = "0.1"
 grep-searcher = "0.1"
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+
+[dev-dependencies]
+tiny_http = "0.12"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -16,9 +16,10 @@ grep = "0.4"
 grep-matcher = "0.1"
 grep-regex = "0.1"
 grep-searcher = "0.1"
-reqwest = { version = "0.12", default-features = false, features = ["blocking", "rustls-tls"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+tokio = { version = "1.47", features = ["rt-multi-thread", "time"] }
 
 [dev-dependencies]
 tiny_http = "0.12"

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -9,7 +9,6 @@ use std::{
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::{self, RecvTimeoutError},
         Arc, Mutex, OnceLock,
     },
     thread,
@@ -27,7 +26,6 @@ pub const TEST_APEX_LOG_FIXTURE_DIR_ENV: &str = "ALV_TEST_APEX_LOG_FIXTURE_DIR";
 const TEST_LOGS_CANCEL_DELAY_MS_ENV: &str = "ALV_TEST_LOGS_CANCEL_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
 const DEFAULT_API_VERSION: &str = "64.0";
-const HTTP_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
@@ -333,12 +331,13 @@ pub fn extract_code_unit_started(lines: &[&str]) -> Option<String> {
 
 fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) -> String {
     let base_select = "SELECT Id, StartTime, Operation, Application, DurationMilliseconds, Status, Request, LogLength, LogUser.Name FROM ApexLog";
+    let safe_before_start_time = params
+        .cursor
+        .as_ref()
+        .and_then(|cursor| cursor.before_start_time.as_deref())
+        .and_then(normalize_cursor_start_time);
     match (
-        params
-            .cursor
-            .as_ref()
-            .and_then(|cursor| cursor.before_start_time.as_deref())
-            .filter(|value| !value.trim().is_empty()),
+        safe_before_start_time.as_deref(),
         params
             .cursor
             .as_ref()
@@ -347,8 +346,8 @@ fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) ->
     ) {
         (Some(before_start_time), Some(before_id)) => format!(
             "{base_select} WHERE StartTime < {} OR (StartTime = {} AND Id < '{}') ORDER BY StartTime DESC, Id DESC LIMIT {page_size}",
-            before_start_time.trim(),
-            before_start_time.trim(),
+            before_start_time,
+            before_start_time,
             escape_soql_literal(before_id)
         ),
         _ => format!(
@@ -414,6 +413,15 @@ fn sanitize_username(username: Option<&str>) -> String {
 
 fn escape_soql_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
+fn normalize_cursor_start_time(value: &str) -> Option<String> {
+    let parsed = chrono::DateTime::parse_from_rfc3339(value.trim()).ok()?;
+    Some(
+        parsed
+            .with_timezone(&chrono::Utc)
+            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+    )
 }
 
 fn strip_trailing_slashes(value: &str) -> &str {
@@ -502,55 +510,35 @@ fn run_http_request_with_cancel(
         .check_cancelled()
         .map_err(|_| HttpRequestError::Cancelled)?;
 
-    let auth = auth.clone();
-    let url_string = url.to_string();
-    let token = cancellation.clone();
-    let (tx, rx) = mpsc::sync_channel(1);
+    let response = http_client()
+        .get(url)
+        .header("Authorization", format!("Bearer {}", auth.access_token))
+        .header("Accept", accept)
+        .send();
 
-    thread::spawn(move || {
-        let response = http_client()
-            .get(url_string)
-            .header("Authorization", format!("Bearer {}", auth.access_token))
-            .header("Accept", accept)
-            .send();
-        let result = match response {
-            Ok(response) => {
-                let status = response.status();
-                match response.bytes() {
-                    Ok(body) if status.is_success() => Ok(body.to_vec()),
-                    Ok(body) => Err(HttpRequestError::Failed {
-                        status: Some(status),
-                        message: String::from_utf8_lossy(&body).trim().to_string(),
-                    }),
-                    Err(error) => Err(HttpRequestError::Failed {
-                        status: Some(status),
-                        message: error.to_string(),
-                    }),
-                }
-            }
-            Err(error) => Err(HttpRequestError::Failed {
-                status: error.status(),
-                message: error.to_string(),
-            }),
-        };
-        let _ = tx.send(result);
-    });
+    cancellation
+        .check_cancelled()
+        .map_err(|_| HttpRequestError::Cancelled)?;
 
-    loop {
-        if token.is_cancelled() {
-            return Err(HttpRequestError::Cancelled);
-        }
-
-        match rx.recv_timeout(HTTP_POLL_INTERVAL) {
-            Ok(result) => return result,
-            Err(RecvTimeoutError::Timeout) => continue,
-            Err(RecvTimeoutError::Disconnected) => {
-                return Err(HttpRequestError::Failed {
-                    status: None,
-                    message: "HTTP worker disconnected before returning a response".to_string(),
-                });
+    match response {
+        Ok(response) => {
+            let status = response.status();
+            match response.bytes() {
+                Ok(body) if status.is_success() => Ok(body.to_vec()),
+                Ok(body) => Err(HttpRequestError::Failed {
+                    status: Some(status),
+                    message: String::from_utf8_lossy(&body).trim().to_string(),
+                }),
+                Err(error) => Err(HttpRequestError::Failed {
+                    status: Some(status),
+                    message: error.to_string(),
+                }),
             }
         }
+        Err(error) => Err(HttpRequestError::Failed {
+            status: error.status(),
+            message: error.to_string(),
+        }),
     }
 }
 
@@ -793,5 +781,45 @@ mod tests {
         );
 
         fs::remove_dir_all(&root).expect("temp root should be removable");
+    }
+
+    #[test]
+    fn build_logs_query_ignores_invalid_cursor_start_time() {
+        let query = build_logs_query(
+            50,
+            0,
+            &LogsListParams {
+                username: None,
+                limit: Some(50),
+                cursor: Some(LogsCursor {
+                    before_start_time: Some("2026-03-30T18:39:58.000Z' OR Name != ''".to_string()),
+                    before_id: Some("07L000000000003AA".to_string()),
+                }),
+                offset: Some(0),
+            },
+        );
+
+        assert!(query.contains(" OFFSET 0"));
+        assert!(!query.contains(" WHERE StartTime < "));
+    }
+
+    #[test]
+    fn build_logs_query_normalizes_valid_cursor_start_time() {
+        let query = build_logs_query(
+            50,
+            0,
+            &LogsListParams {
+                username: None,
+                limit: Some(50),
+                cursor: Some(LogsCursor {
+                    before_start_time: Some("2026-03-30T18:39:58Z".to_string()),
+                    before_id: Some("07L000000000003AA".to_string()),
+                }),
+                offset: Some(0),
+            },
+        );
+
+        assert!(query.contains("StartTime < 2026-03-30T18:39:58.000Z"));
+        assert!(query.contains("Id < '07L000000000003AA'"));
     }
 }

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -159,7 +159,8 @@ pub fn list_logs_from_json(json: &str) -> Result<Vec<LogRow>, String> {
     for record in records {
         rows.push(LogRow {
             id: string_field(record, "Id").ok_or_else(|| "log record missing Id".to_string())?,
-            start_time: string_field(record, "StartTime").unwrap_or_default(),
+            start_time: string_field(record, "StartTime")
+                .ok_or_else(|| "log record missing StartTime".to_string())?,
             operation: string_field(record, "Operation").unwrap_or_default(),
             application: string_field(record, "Application").unwrap_or_default(),
             duration_milliseconds: number_field(record, "DurationMilliseconds").unwrap_or(0),
@@ -420,13 +421,36 @@ fn escape_soql_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
+fn format_cursor_start_time(parsed: chrono::DateTime<chrono::FixedOffset>) -> String {
+    parsed
+        .with_timezone(&chrono::Utc)
+        .to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
 fn normalize_cursor_start_time(value: &str) -> Option<String> {
-    let parsed = chrono::DateTime::parse_from_rfc3339(value.trim()).ok()?;
-    Some(
-        parsed
-            .with_timezone(&chrono::Utc)
-            .to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
-    )
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    if let Ok(parsed) = chrono::DateTime::parse_from_rfc3339(trimmed) {
+        return Some(format_cursor_start_time(parsed));
+    }
+
+    const FALLBACK_FORMATS: &[&str] = &[
+        "%Y-%m-%dT%H:%M:%S%.f%z",
+        "%Y-%m-%dT%H:%M:%S%z",
+        "%Y-%m-%d %H:%M:%S%.f%z",
+        "%Y-%m-%d %H:%M:%S%z",
+    ];
+
+    for format in FALLBACK_FORMATS {
+        if let Ok(parsed) = chrono::DateTime::parse_from_str(trimmed, format) {
+            return Some(format_cursor_start_time(parsed));
+        }
+    }
+
+    None
 }
 
 fn strip_trailing_slashes(value: &str) -> &str {
@@ -882,6 +906,44 @@ mod tests {
 
         assert!(query.contains("StartTime < 2026-03-30T18:39:58.000Z"));
         assert!(query.contains("Id < '07L000000000003AA'"));
+    }
+
+    #[test]
+    fn build_logs_query_normalizes_salesforce_offset_cursor_start_time() {
+        let query = build_logs_query(
+            50,
+            0,
+            &LogsListParams {
+                username: None,
+                limit: Some(50),
+                cursor: Some(LogsCursor {
+                    before_start_time: Some("2026-03-30T18:39:58.000+0000".to_string()),
+                    before_id: Some("07L000000000003AA".to_string()),
+                }),
+                offset: Some(0),
+            },
+        );
+
+        assert!(query.contains("StartTime < 2026-03-30T18:39:58.000Z"));
+        assert!(query.contains("Id < '07L000000000003AA'"));
+    }
+
+    #[test]
+    fn list_logs_from_json_requires_start_time() {
+        let error = list_logs_from_json(
+            r#"{
+                "result": {
+                    "records": [
+                        {
+                            "Id": "07L000000000003AA"
+                        }
+                    ]
+                }
+            }"#,
+        )
+        .expect_err("records without StartTime should fail");
+
+        assert!(error.contains("missing StartTime"));
     }
 
     #[test]

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -1,27 +1,38 @@
+use reqwest::{blocking::Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
-    env, fs,
-    io::Read,
+    collections::BTreeMap,
+    env,
+    fs::{self, File},
+    io::Write,
     path::{Path, PathBuf},
-    process::{Command, ExitStatus, Stdio},
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc,
+        mpsc::{self, RecvTimeoutError},
+        Arc, Mutex, OnceLock,
     },
     thread,
     time::Duration,
     time::{SystemTime, UNIX_EPOCH},
 };
 
-use crate::cli::build_command_invocation;
-use crate::cli_json::extract_json_object;
+use crate::{
+    auth::{self, OrgAuth},
+    cli_json::extract_json_object,
+};
 
 pub const TEST_SF_LOG_LIST_JSON_ENV: &str = "ALV_TEST_SF_LOG_LIST_JSON";
 pub const TEST_APEX_LOG_FIXTURE_DIR_ENV: &str = "ALV_TEST_APEX_LOG_FIXTURE_DIR";
 const TEST_LOGS_CANCEL_DELAY_MS_ENV: &str = "ALV_TEST_LOGS_CANCEL_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
-const TRACE_RUNTIME_SPAWN_ENV: &str = "ALV_TRACE_RUNTIME_SPAWN";
+const DEFAULT_API_VERSION: &str = "64.0";
+const HTTP_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+
+static API_VERSION_OVERRIDES: OnceLock<Mutex<BTreeMap<String, String>>> = OnceLock::new();
+static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
 
 #[derive(Debug, Clone, Default)]
 pub struct CancellationToken {
@@ -176,38 +187,13 @@ pub fn run_sf_log_list_json_with_cancel(
     params: &LogsListParams,
     cancellation: &CancellationToken,
 ) -> Result<String, String> {
-    if let Ok(fixture) = env::var(TEST_SF_LOG_LIST_JSON_ENV) {
-        maybe_test_delay(TEST_LOGS_CANCEL_DELAY_MS_ENV, cancellation)?;
-        cancellation.check_cancelled()?;
+    if let Some(fixture) = maybe_fixture_log_list_json(cancellation)? {
         return Ok(fixture);
     }
 
     cancellation.check_cancelled()?;
-    let safe_page_size = params.limit.unwrap_or(100).clamp(1, 200);
-    let safe_offset = params.offset.unwrap_or(0);
-    let soql = build_logs_query(safe_page_size, safe_offset, params);
-
-    let mut args = vec![
-        "data".to_string(),
-        "query".to_string(),
-        "--use-tooling-api".to_string(),
-        "--json".to_string(),
-        "--result-format".to_string(),
-        "json".to_string(),
-        "--query".to_string(),
-        soql,
-    ];
-
-    if let Some(username) = params
-        .username
-        .as_deref()
-        .filter(|value| !value.trim().is_empty())
-    {
-        args.push("--target-org".to_string());
-        args.push(username.trim().to_string());
-    }
-
-    run_command_with_cancel("sf", &args, cancellation)
+    let auth = auth::resolve_org_auth(params.username.as_deref())?;
+    run_tooling_logs_query_with_cancel(&auth, params, cancellation)
 }
 
 pub fn resolve_apex_logs_dir(workspace_root: Option<&str>) -> PathBuf {
@@ -251,9 +237,21 @@ pub fn ensure_log_file_cached_with_cancel(
     download_log_to_path_with_cancel(log_id, username, &target_path, cancellation)
 }
 
-pub fn download_log_to_path_with_cancel(
+pub(crate) fn list_logs_for_auth_with_cancel(
+    auth: &OrgAuth,
+    params: &LogsListParams,
+    cancellation: &CancellationToken,
+) -> Result<Vec<LogRow>, String> {
+    if let Some(fixture) = maybe_fixture_log_list_json(cancellation)? {
+        return list_logs_from_json(&fixture);
+    }
+    let json = run_tooling_logs_query_with_cancel(auth, params, cancellation)?;
+    list_logs_from_json(&json)
+}
+
+pub(crate) fn download_log_to_path_for_auth_with_cancel(
+    auth: &OrgAuth,
     log_id: &str,
-    username: Option<&str>,
     target_path: &Path,
     cancellation: &CancellationToken,
 ) -> Result<PathBuf, String> {
@@ -264,6 +262,7 @@ pub fn download_log_to_path_with_cancel(
     }
 
     if let Ok(fixture_dir) = env::var(TEST_APEX_LOG_FIXTURE_DIR_ENV) {
+        maybe_test_delay(TEST_LOGS_CANCEL_DELAY_MS_ENV, cancellation)?;
         cancellation.check_cancelled()?;
         let source_path = Path::new(&fixture_dir).join(format!("{log_id}.log"));
         if !source_path.is_file() {
@@ -272,48 +271,41 @@ pub fn download_log_to_path_with_cancel(
                 source_path.display()
             ));
         }
-        fs::copy(&source_path, target_path).map_err(|error| {
+        let bytes = fs::read(&source_path).map_err(|error| {
             format!(
-                "failed to copy fixture log {} into cache {}: {error}",
-                source_path.display(),
-                target_path.display()
+                "failed to read fixture log {}: {error}",
+                source_path.display()
             )
         })?;
-        return Ok(target_path.to_path_buf());
+        return write_bytes_atomically(target_path, &bytes, cancellation);
     }
 
-    with_temp_staging_dir(|staging_dir| {
-        let mut args = vec![
-            "apex".to_string(),
-            "get".to_string(),
-            "log".to_string(),
-            "--json".to_string(),
-            "--log-id".to_string(),
-            log_id.to_string(),
-            "--output-dir".to_string(),
-            staging_dir.display().to_string(),
-        ];
-        if let Some(value) = username.map(str::trim).filter(|value| !value.is_empty()) {
-            args.push("--target-org".to_string());
-            args.push(value.to_string());
-        }
-        run_command_with_cancel("sf", &args, cancellation)?;
-        cancellation.check_cancelled()?;
-        let downloaded_path = find_downloaded_log(staging_dir, log_id).ok_or_else(|| {
-            format!(
-                "sf apex get log did not write a .log file for {log_id} in {}",
-                staging_dir.display()
-            )
-        })?;
-        fs::copy(&downloaded_path, target_path).map_err(|error| {
-            format!(
-                "failed to copy downloaded log {} into cache {}: {error}",
-                downloaded_path.display(),
-                target_path.display()
-            )
-        })?;
-        Ok(target_path.to_path_buf())
-    })
+    let body = fetch_apex_log_body_with_cancel(auth, log_id, cancellation)?;
+    write_bytes_atomically(target_path, body.as_bytes(), cancellation)
+}
+
+pub fn download_log_to_path_with_cancel(
+    log_id: &str,
+    username: Option<&str>,
+    target_path: &Path,
+    cancellation: &CancellationToken,
+) -> Result<PathBuf, String> {
+    if env::var(TEST_APEX_LOG_FIXTURE_DIR_ENV).is_ok() {
+        let fallback_auth = OrgAuth {
+            access_token: String::new(),
+            instance_url: String::new(),
+            username: username.map(str::to_string),
+        };
+        return download_log_to_path_for_auth_with_cancel(
+            &fallback_auth,
+            log_id,
+            target_path,
+            cancellation,
+        );
+    }
+
+    let auth = auth::resolve_org_auth(username)?;
+    download_log_to_path_for_auth_with_cancel(&auth, log_id, target_path, cancellation)
 }
 
 pub fn extract_code_unit_started(lines: &[&str]) -> Option<String> {
@@ -354,9 +346,9 @@ fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) ->
             .filter(|value| !value.trim().is_empty()),
     ) {
         (Some(before_start_time), Some(before_id)) => format!(
-            "{base_select} WHERE StartTime < '{}' OR (StartTime = '{}' AND Id < '{}') ORDER BY StartTime DESC, Id DESC LIMIT {page_size}",
-            escape_soql_literal(before_start_time),
-            escape_soql_literal(before_start_time),
+            "{base_select} WHERE StartTime < {} OR (StartTime = {} AND Id < '{}') ORDER BY StartTime DESC, Id DESC LIMIT {page_size}",
+            before_start_time.trim(),
+            before_start_time.trim(),
             escape_soql_literal(before_id)
         ),
         _ => format!(
@@ -365,172 +357,16 @@ fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) ->
     }
 }
 
-fn find_downloaded_log(staging_dir: &Path, log_id: &str) -> Option<PathBuf> {
-    let entries = fs::read_dir(staging_dir).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let file_name = path.file_name()?.to_string_lossy();
-        if !file_name.ends_with(".log") {
-            continue;
-        }
-        if file_name.contains(log_id) || file_name == format!("{log_id}.log") {
-            return Some(path);
-        }
-    }
-
-    let entries = fs::read_dir(staging_dir).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if path.extension().and_then(|value| value.to_str()) == Some("log") {
-            return Some(path);
-        }
-    }
-
-    None
-}
-
-fn make_temp_staging_dir() -> Result<PathBuf, String> {
-    let nonce = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .unwrap_or_default()
-        .as_nanos();
-    let path = env::temp_dir().join(format!("alv-log-fetch-{}-{nonce}", std::process::id()));
-    fs::create_dir_all(&path)
-        .map_err(|error| format!("failed to create staging dir {}: {error}", path.display()))?;
-    Ok(path)
-}
-
-fn with_temp_staging_dir<T>(run: impl FnOnce(&Path) -> Result<T, String>) -> Result<T, String> {
-    let staging_dir = make_temp_staging_dir()?;
-    let result = run(&staging_dir);
-    let _ = fs::remove_dir_all(&staging_dir);
-    result
-}
-
-fn run_command_with_cancel(
-    program: &str,
-    args: &[String],
+fn run_tooling_logs_query_with_cancel(
+    auth: &OrgAuth,
+    params: &LogsListParams,
     cancellation: &CancellationToken,
 ) -> Result<String, String> {
     cancellation.check_cancelled()?;
-
-    let invocation = build_command_invocation(program, args)?;
-    trace_runtime_spawn(&format!(
-        "spawn program={} args={:?}",
-        invocation.program, invocation.args
-    ));
-
-    let mut child = Command::new(&invocation.program)
-        .args(&invocation.args)
-        .stdin(Stdio::null())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-        .map_err(|error| format!("{program} failed to start: {error}"))?;
-    trace_runtime_spawn(&format!(
-        "child-started original={} pid={}",
-        program,
-        child.id()
-    ));
-
-    let stdout_reader = spawn_output_reader(child.stdout.take(), program, "stdout");
-    let stderr_reader = spawn_output_reader(child.stderr.take(), program, "stderr");
-
-    let status = loop {
-        if cancellation.is_cancelled() {
-            let _ = child.kill();
-            let _ = child.wait();
-            let _ = join_output_reader(stdout_reader);
-            let _ = join_output_reader(stderr_reader);
-            trace_runtime_spawn(&format!("child-cancelled original={program}"));
-            return Err(CANCELLED_MESSAGE.to_string());
-        }
-
-        match child.try_wait() {
-            Ok(Some(status)) => {
-                trace_runtime_spawn(&format!("child-exited original={program} status={status}"));
-                break status;
-            }
-            Ok(None) => thread::sleep(Duration::from_millis(10)),
-            Err(error) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                let _ = join_output_reader(stdout_reader);
-                let _ = join_output_reader(stderr_reader);
-                trace_runtime_spawn(&format!(
-                    "child-poll-error original={program} error={error}"
-                ));
-                return Err(format!(
-                    "{program} failed while polling child process: {error}"
-                ));
-            }
-        }
-    };
-
-    let stdout = join_output_reader(stdout_reader)?;
-    let stderr = join_output_reader(stderr_reader)?;
-    command_output_to_result(program, status, stdout, stderr)
-}
-
-fn trace_runtime_spawn(message: &str) {
-    if env::var_os(TRACE_RUNTIME_SPAWN_ENV).is_some() {
-        eprintln!("[alv-core] {message}");
-    }
-}
-
-fn spawn_output_reader<R>(
-    pipe: Option<R>,
-    program: &str,
-    stream_name: &'static str,
-) -> thread::JoinHandle<Result<Vec<u8>, String>>
-where
-    R: Read + Send + 'static,
-{
-    let program = program.to_string();
-    thread::spawn(move || {
-        let Some(mut pipe) = pipe else {
-            return Ok(Vec::new());
-        };
-        let mut buffer = Vec::new();
-        pipe.read_to_end(&mut buffer)
-            .map_err(|error| format!("{program} failed while reading {stream_name}: {error}"))?;
-        Ok(buffer)
-    })
-}
-
-fn join_output_reader(
-    handle: thread::JoinHandle<Result<Vec<u8>, String>>,
-) -> Result<Vec<u8>, String> {
-    handle
-        .join()
-        .map_err(|_| "output reader thread panicked".to_string())?
-}
-
-fn command_output_to_result(
-    program: &str,
-    status: ExitStatus,
-    stdout: Vec<u8>,
-    stderr: Vec<u8>,
-) -> Result<String, String> {
-    let stdout = String::from_utf8_lossy(&stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&stderr).trim().to_string();
-
-    if status.success() {
-        if stdout.is_empty() {
-            return Err(format!("{program} returned empty output"));
-        }
-        return Ok(stdout);
-    }
-
-    if !stderr.is_empty() {
-        return Err(stderr);
-    }
-
-    if !stdout.is_empty() {
-        return Err(stdout);
-    }
-
-    Err(format!("{program} exited with status {status}"))
+    let safe_page_size = params.limit.unwrap_or(100).clamp(1, 200);
+    let safe_offset = params.offset.unwrap_or(0);
+    let soql = build_logs_query(safe_page_size, safe_offset, params);
+    request_tooling_query_json(auth, &soql, cancellation)
 }
 
 fn maybe_test_delay(env_key: &str, cancellation: &CancellationToken) -> Result<(), String> {
@@ -548,6 +384,16 @@ fn maybe_test_delay(env_key: &str, cancellation: &CancellationToken) -> Result<(
     }
 
     cancellation.check_cancelled()
+}
+
+fn maybe_fixture_log_list_json(cancellation: &CancellationToken) -> Result<Option<String>, String> {
+    let Ok(fixture) = env::var(TEST_SF_LOG_LIST_JSON_ENV) else {
+        return Ok(None);
+    };
+
+    maybe_test_delay(TEST_LOGS_CANCEL_DELAY_MS_ENV, cancellation)?;
+    cancellation.check_cancelled()?;
+    Ok(Some(fixture))
 }
 
 fn sanitize_username(username: Option<&str>) -> String {
@@ -570,6 +416,305 @@ fn escape_soql_literal(value: &str) -> String {
     value.replace('\\', "\\\\").replace('\'', "\\'")
 }
 
+fn strip_trailing_slashes(value: &str) -> &str {
+    value.trim_end_matches('/')
+}
+
+fn normalize_org_cache_key(auth: &OrgAuth) -> String {
+    let instance = strip_trailing_slashes(auth.instance_url.trim()).to_ascii_lowercase();
+    if !instance.is_empty() {
+        return instance;
+    }
+    auth.username
+        .as_deref()
+        .unwrap_or_default()
+        .trim()
+        .to_ascii_lowercase()
+}
+
+fn api_version_overrides() -> &'static Mutex<BTreeMap<String, String>> {
+    API_VERSION_OVERRIDES.get_or_init(|| Mutex::new(BTreeMap::new()))
+}
+
+fn get_effective_api_version(auth: &OrgAuth) -> String {
+    api_version_overrides()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(&normalize_org_cache_key(auth))
+        .cloned()
+        .unwrap_or_else(|| DEFAULT_API_VERSION.to_string())
+}
+
+fn record_api_version_override(auth: &OrgAuth, version: &str) {
+    api_version_overrides()
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(normalize_org_cache_key(auth), version.to_string());
+}
+
+fn parse_api_version(value: &str) -> Option<(u32, u32)> {
+    let trimmed = value.trim();
+    let (major, minor) = trimmed.split_once('.')?;
+    Some((major.parse().ok()?, minor.parse().ok()?))
+}
+
+fn build_versioned_url(auth: &OrgAuth, version: &str, path: &str) -> Result<Url, String> {
+    let base = strip_trailing_slashes(auth.instance_url.trim());
+    Url::parse(&format!("{base}/services/data/v{version}{path}"))
+        .map_err(|error| format!("invalid Salesforce URL: {error}"))
+}
+
+fn http_client() -> &'static Client {
+    HTTP_CLIENT.get_or_init(|| {
+        Client::builder()
+            .connect_timeout(HTTP_CONNECT_TIMEOUT)
+            .timeout(HTTP_REQUEST_TIMEOUT)
+            .build()
+            .expect("reqwest blocking client should initialize")
+    })
+}
+
+#[derive(Debug)]
+enum HttpRequestError {
+    Cancelled,
+    Failed {
+        status: Option<StatusCode>,
+        message: String,
+    },
+}
+
+impl HttpRequestError {
+    fn to_string_message(&self) -> String {
+        match self {
+            Self::Cancelled => CANCELLED_MESSAGE.to_string(),
+            Self::Failed { message, .. } => message.clone(),
+        }
+    }
+}
+
+fn run_http_request_with_cancel(
+    auth: &OrgAuth,
+    url: Url,
+    accept: &'static str,
+    cancellation: &CancellationToken,
+) -> Result<Vec<u8>, HttpRequestError> {
+    cancellation
+        .check_cancelled()
+        .map_err(|_| HttpRequestError::Cancelled)?;
+
+    let auth = auth.clone();
+    let url_string = url.to_string();
+    let token = cancellation.clone();
+    let (tx, rx) = mpsc::sync_channel(1);
+
+    thread::spawn(move || {
+        let response = http_client()
+            .get(url_string)
+            .header("Authorization", format!("Bearer {}", auth.access_token))
+            .header("Accept", accept)
+            .send();
+        let result = match response {
+            Ok(response) => {
+                let status = response.status();
+                match response.bytes() {
+                    Ok(body) if status.is_success() => Ok(body.to_vec()),
+                    Ok(body) => Err(HttpRequestError::Failed {
+                        status: Some(status),
+                        message: String::from_utf8_lossy(&body).trim().to_string(),
+                    }),
+                    Err(error) => Err(HttpRequestError::Failed {
+                        status: Some(status),
+                        message: error.to_string(),
+                    }),
+                }
+            }
+            Err(error) => Err(HttpRequestError::Failed {
+                status: error.status(),
+                message: error.to_string(),
+            }),
+        };
+        let _ = tx.send(result);
+    });
+
+    loop {
+        if token.is_cancelled() {
+            return Err(HttpRequestError::Cancelled);
+        }
+
+        match rx.recv_timeout(HTTP_POLL_INTERVAL) {
+            Ok(result) => return result,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(HttpRequestError::Failed {
+                    status: None,
+                    message: "HTTP worker disconnected before returning a response".to_string(),
+                });
+            }
+        }
+    }
+}
+
+fn request_bytes_with_version_fallback(
+    auth: &OrgAuth,
+    path: &str,
+    query_pairs: &[(&str, &str)],
+    accept: &'static str,
+    cancellation: &CancellationToken,
+) -> Result<Vec<u8>, String> {
+    let mut attempted_fallback = false;
+
+    loop {
+        cancellation.check_cancelled()?;
+        let active_version = get_effective_api_version(auth);
+        let mut url = build_versioned_url(auth, &active_version, path)?;
+        for (key, value) in query_pairs {
+            url.query_pairs_mut().append_pair(key, value);
+        }
+
+        match run_http_request_with_cancel(auth, url, accept, cancellation) {
+            Ok(bytes) => return Ok(bytes),
+            Err(HttpRequestError::Cancelled) => return Err(CANCELLED_MESSAGE.to_string()),
+            Err(HttpRequestError::Failed {
+                status: Some(StatusCode::NOT_FOUND),
+                message,
+            }) if !attempted_fallback => {
+                let requested = parse_api_version(&active_version);
+                let Some(org_max_version) = discover_org_max_api_version(auth, cancellation)?
+                else {
+                    return Err(message);
+                };
+                let org_max = parse_api_version(&org_max_version);
+                if requested.is_some() && org_max.is_some() && requested > org_max {
+                    record_api_version_override(auth, &org_max_version);
+                    attempted_fallback = true;
+                    continue;
+                }
+                return Err(message);
+            }
+            Err(error) => return Err(error.to_string_message()),
+        }
+    }
+}
+
+fn request_tooling_query_json(
+    auth: &OrgAuth,
+    soql: &str,
+    cancellation: &CancellationToken,
+) -> Result<String, String> {
+    let bytes = request_bytes_with_version_fallback(
+        auth,
+        "/tooling/query",
+        &[("q", soql)],
+        "application/json",
+        cancellation,
+    )?;
+    String::from_utf8(bytes)
+        .map_err(|error| format!("invalid UTF-8 in Tooling query response: {error}"))
+}
+
+fn fetch_apex_log_body_with_cancel(
+    auth: &OrgAuth,
+    log_id: &str,
+    cancellation: &CancellationToken,
+) -> Result<String, String> {
+    let bytes = request_bytes_with_version_fallback(
+        auth,
+        &format!("/tooling/sobjects/ApexLog/{log_id}/Body"),
+        &[],
+        "text/plain",
+        cancellation,
+    )?;
+    String::from_utf8(bytes)
+        .map_err(|error| format!("invalid UTF-8 in ApexLog body response: {error}"))
+}
+
+fn discover_org_max_api_version(
+    auth: &OrgAuth,
+    cancellation: &CancellationToken,
+) -> Result<Option<String>, String> {
+    let url = Url::parse(&format!(
+        "{}/services/data",
+        strip_trailing_slashes(auth.instance_url.trim())
+    ))
+    .map_err(|error| format!("invalid Salesforce base URL: {error}"))?;
+    let bytes = match run_http_request_with_cancel(auth, url, "application/json", cancellation) {
+        Ok(bytes) => bytes,
+        Err(HttpRequestError::Cancelled) => return Err(CANCELLED_MESSAGE.to_string()),
+        Err(error) => return Err(error.to_string_message()),
+    };
+    let parsed: Value = serde_json::from_slice(&bytes)
+        .map_err(|error| format!("invalid services/data response JSON: {error}"))?;
+    let Some(items) = parsed.as_array() else {
+        return Ok(None);
+    };
+
+    let mut best: Option<(u32, u32, String)> = None;
+    for item in items {
+        let Some(version_text) = item.get("version").and_then(Value::as_str) else {
+            continue;
+        };
+        let Some((major, minor)) = parse_api_version(version_text) else {
+            continue;
+        };
+        if best
+            .as_ref()
+            .is_none_or(|(best_major, best_minor, _)| (major, minor) > (*best_major, *best_minor))
+        {
+            best = Some((major, minor, version_text.to_string()));
+        }
+    }
+
+    Ok(best.map(|(_, _, version)| version))
+}
+
+fn write_bytes_atomically(
+    target_path: &Path,
+    bytes: &[u8],
+    cancellation: &CancellationToken,
+) -> Result<PathBuf, String> {
+    cancellation.check_cancelled()?;
+    let parent = target_path
+        .parent()
+        .ok_or_else(|| format!("target path has no parent: {}", target_path.display()))?;
+    fs::create_dir_all(parent)
+        .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+
+    let nonce = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    let file_name = target_path
+        .file_name()
+        .and_then(|value| value.to_str())
+        .unwrap_or("apex-log");
+    let temp_path = parent.join(format!(".{file_name}.part-{}-{nonce}", std::process::id()));
+
+    let write_result = (|| -> Result<(), String> {
+        let mut file = File::create(&temp_path)
+            .map_err(|error| format!("failed to create {}: {error}", temp_path.display()))?;
+        file.write_all(bytes)
+            .map_err(|error| format!("failed to write {}: {error}", temp_path.display()))?;
+        file.flush()
+            .map_err(|error| format!("failed to flush {}: {error}", temp_path.display()))?;
+        cancellation.check_cancelled()?;
+        fs::rename(&temp_path, target_path).map_err(|error| {
+            format!(
+                "failed to move {} into {}: {error}",
+                temp_path.display(),
+                target_path.display()
+            )
+        })?;
+        Ok(())
+    })();
+
+    if write_result.is_err() || cancellation.is_cancelled() {
+        let _ = fs::remove_file(&temp_path);
+    }
+
+    write_result?;
+    Ok(target_path.to_path_buf())
+}
+
 fn string_field(value: &Value, key: &str) -> Option<String> {
     value
         .get(key)
@@ -590,38 +735,10 @@ fn number_field(value: &Value, key: &str) -> Option<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::BTreeSet;
-    use std::sync::Arc;
-    use std::sync::Mutex;
-
-    static STAGING_DIR_TEST_MUTEX: Mutex<()> = Mutex::new(());
-
-    fn list_staging_dirs() -> BTreeSet<PathBuf> {
-        let Some(entries) = fs::read_dir(env::temp_dir()).ok() else {
-            return BTreeSet::new();
-        };
-
-        entries
-            .flatten()
-            .map(|entry| entry.path())
-            .filter(|path| {
-                path.file_name()
-                    .and_then(|value| value.to_str())
-                    .is_some_and(|value| {
-                        value.starts_with(&format!("alv-log-fetch-{}-", std::process::id()))
-                    })
-            })
-            .collect()
-    }
-
-    fn lock_staging_dir_test_mutex<'a>(mutex: &'a Mutex<()>) -> std::sync::MutexGuard<'a, ()> {
-        mutex
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner())
-    }
+    use std::sync::{Arc, Mutex};
 
     #[test]
-    fn staging_dir_test_mutex_helper_recovers_from_poison() {
+    fn lock_helper_recovers_from_poison() {
         let poisoned_mutex = Arc::new(Mutex::new(()));
         let poison_target = Arc::clone(&poisoned_mutex);
 
@@ -633,47 +750,48 @@ mod tests {
         })
         .join();
 
-        let _guard = lock_staging_dir_test_mutex(&poisoned_mutex);
+        let _guard = poisoned_mutex
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
     }
 
     #[test]
-    fn temp_staging_dir_helper_cleans_up_on_success() {
-        let _guard = lock_staging_dir_test_mutex(&STAGING_DIR_TEST_MUTEX);
-        let before = list_staging_dirs();
+    fn parse_api_version_accepts_major_minor() {
+        assert_eq!(parse_api_version("64.0"), Some((64, 0)));
+        assert_eq!(parse_api_version(" 61.2 "), Some((61, 2)));
+        assert_eq!(parse_api_version("v64.0"), None);
+    }
 
-        let created = with_temp_staging_dir(|staging_dir| {
-            assert!(staging_dir.is_dir());
-            Ok(staging_dir.to_path_buf())
-        })
-        .expect("expected temp staging dir helper to succeed");
+    #[test]
+    fn write_bytes_atomically_cleans_temp_file_on_cancellation() {
+        let root = env::temp_dir().join(format!(
+            "alv-log-write-test-{}-{}",
+            std::process::id(),
+            SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_nanos()
+        ));
+        fs::create_dir_all(&root).expect("temp root should be creatable");
+        let target = root.join("07L000000000001AA.log");
+        let token = CancellationToken::new();
+        token.cancel();
 
+        let error = write_bytes_atomically(&target, b"body", &token)
+            .expect_err("cancelled writes should abort");
+        assert!(error.contains("cancel"));
+        assert!(!target.exists());
+
+        let leftovers = fs::read_dir(&root)
+            .expect("temp root should be readable")
+            .flatten()
+            .map(|entry| entry.path())
+            .collect::<Vec<_>>();
         assert!(
-            !created.exists(),
-            "staging dir should be removed after success"
+            leftovers.is_empty(),
+            "cancelled atomic writes should not leave temp files behind"
         );
-        assert_eq!(
-            list_staging_dirs(),
-            before,
-            "staging dirs should not leak after success"
-        );
-    }
 
-    #[test]
-    fn temp_staging_dir_helper_cleans_up_on_error() {
-        let _guard = lock_staging_dir_test_mutex(&STAGING_DIR_TEST_MUTEX);
-        let before = list_staging_dirs();
-
-        let error = with_temp_staging_dir(|staging_dir| -> Result<(), String> {
-            assert!(staging_dir.is_dir());
-            Err(format!("boom: {}", staging_dir.display()))
-        })
-        .expect_err("expected temp staging dir helper to bubble up the error");
-
-        assert!(error.starts_with("boom: "));
-        assert_eq!(
-            list_staging_dirs(),
-            before,
-            "staging dirs should not leak after errors"
-        );
+        fs::remove_dir_all(&root).expect("temp root should be removable");
     }
 }

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -1,20 +1,23 @@
-use reqwest::{blocking::Client, StatusCode, Url};
+use reqwest::{Client, StatusCode, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{
     collections::BTreeMap,
     env,
     fs::{self, File},
+    future::Future,
     io::Write,
     path::{Path, PathBuf},
     sync::{
         atomic::{AtomicBool, Ordering},
+        mpsc::{sync_channel, RecvTimeoutError},
         Arc, Mutex, OnceLock,
     },
     thread,
     time::Duration,
     time::{SystemTime, UNIX_EPOCH},
 };
+use tokio::runtime::{Builder as RuntimeBuilder, Runtime};
 
 use crate::{
     auth::{self, OrgAuth},
@@ -28,9 +31,11 @@ const CANCELLED_MESSAGE: &str = "request cancelled";
 const DEFAULT_API_VERSION: &str = "64.0";
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const HTTP_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(10);
 
 static API_VERSION_OVERRIDES: OnceLock<Mutex<BTreeMap<String, String>>> = OnceLock::new();
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+static HTTP_RUNTIME: OnceLock<Runtime> = OnceLock::new();
 
 #[derive(Debug, Clone, Default)]
 pub struct CancellationToken {
@@ -478,7 +483,16 @@ fn http_client() -> &'static Client {
             .connect_timeout(HTTP_CONNECT_TIMEOUT)
             .timeout(HTTP_REQUEST_TIMEOUT)
             .build()
-            .expect("reqwest blocking client should initialize")
+            .expect("reqwest client should initialize")
+    })
+}
+
+fn http_runtime() -> &'static Runtime {
+    HTTP_RUNTIME.get_or_init(|| {
+        RuntimeBuilder::new_multi_thread()
+            .enable_all()
+            .build()
+            .expect("tokio runtime should initialize")
     })
 }
 
@@ -500,46 +514,93 @@ impl HttpRequestError {
     }
 }
 
+fn run_async_operation_with_cancel<T, F>(
+    future: F,
+    cancellation: &CancellationToken,
+) -> Result<T, HttpRequestError>
+where
+    T: Send + 'static,
+    F: Future<Output = Result<T, HttpRequestError>> + Send + 'static,
+{
+    cancellation
+        .check_cancelled()
+        .map_err(|_| HttpRequestError::Cancelled)?;
+
+    let (result_tx, result_rx) = sync_channel(1);
+    let task = http_runtime().spawn(async move {
+        let result = future.await;
+        let _ = result_tx.send(result);
+    });
+
+    loop {
+        match result_rx.try_recv() {
+            Ok(result) => return result,
+            Err(std::sync::mpsc::TryRecvError::Empty) => {}
+            Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                return Err(HttpRequestError::Failed {
+                    status: None,
+                    message: "HTTP request task terminated unexpectedly".to_string(),
+                });
+            }
+        }
+
+        if cancellation.is_cancelled() {
+            task.abort();
+            return Err(HttpRequestError::Cancelled);
+        }
+
+        match result_rx.recv_timeout(HTTP_CANCEL_POLL_INTERVAL) {
+            Ok(result) => return result,
+            Err(RecvTimeoutError::Timeout) => continue,
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(HttpRequestError::Failed {
+                    status: None,
+                    message: "HTTP request task terminated unexpectedly".to_string(),
+                });
+            }
+        }
+    }
+}
+
 fn run_http_request_with_cancel(
     auth: &OrgAuth,
     url: Url,
     accept: &'static str,
     cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, HttpRequestError> {
-    cancellation
-        .check_cancelled()
-        .map_err(|_| HttpRequestError::Cancelled)?;
+    let auth = auth.clone();
+    run_async_operation_with_cancel(
+        async move {
+            let response = http_client()
+                .get(url)
+                .header("Authorization", format!("Bearer {}", auth.access_token))
+                .header("Accept", accept)
+                .send()
+                .await;
 
-    let response = http_client()
-        .get(url)
-        .header("Authorization", format!("Bearer {}", auth.access_token))
-        .header("Accept", accept)
-        .send();
-
-    cancellation
-        .check_cancelled()
-        .map_err(|_| HttpRequestError::Cancelled)?;
-
-    match response {
-        Ok(response) => {
-            let status = response.status();
-            match response.bytes() {
-                Ok(body) if status.is_success() => Ok(body.to_vec()),
-                Ok(body) => Err(HttpRequestError::Failed {
-                    status: Some(status),
-                    message: String::from_utf8_lossy(&body).trim().to_string(),
-                }),
+            match response {
+                Ok(response) => {
+                    let status = response.status();
+                    match response.bytes().await {
+                        Ok(body) if status.is_success() => Ok(body.to_vec()),
+                        Ok(body) => Err(HttpRequestError::Failed {
+                            status: Some(status),
+                            message: String::from_utf8_lossy(&body).trim().to_string(),
+                        }),
+                        Err(error) => Err(HttpRequestError::Failed {
+                            status: Some(status),
+                            message: error.to_string(),
+                        }),
+                    }
+                }
                 Err(error) => Err(HttpRequestError::Failed {
-                    status: Some(status),
+                    status: error.status(),
                     message: error.to_string(),
                 }),
             }
-        }
-        Err(error) => Err(HttpRequestError::Failed {
-            status: error.status(),
-            message: error.to_string(),
-        }),
-    }
+        },
+        cancellation,
+    )
 }
 
 fn request_bytes_with_version_fallback(
@@ -821,5 +882,32 @@ mod tests {
 
         assert!(query.contains("StartTime < 2026-03-30T18:39:58.000Z"));
         assert!(query.contains("Id < '07L000000000003AA'"));
+    }
+
+    #[test]
+    fn run_async_operation_with_cancel_returns_promptly_when_cancelled() {
+        let token = CancellationToken::new();
+        let cancel_handle = token.clone();
+        let started = std::time::Instant::now();
+
+        std::thread::spawn(move || {
+            std::thread::sleep(Duration::from_millis(50));
+            cancel_handle.cancel();
+        });
+
+        let error = run_async_operation_with_cancel(
+            async {
+                tokio::time::sleep(Duration::from_secs(5)).await;
+                Ok::<_, HttpRequestError>(Vec::<u8>::new())
+            },
+            &token,
+        )
+        .expect_err("cancelled async operations should abort promptly");
+
+        assert!(matches!(error, HttpRequestError::Cancelled));
+        assert!(
+            started.elapsed() < Duration::from_secs(1),
+            "cancelled operations should not wait for the full request timeout"
+        );
     }
 }

--- a/crates/alv-core/src/logs_sync.rs
+++ b/crates/alv-core/src/logs_sync.rs
@@ -121,12 +121,6 @@ pub fn sync_logs_with_cancel(
         let (page_rows, reached_checkpoint) =
             select_sync_page_rows(rows, previous.as_ref(), params.force_full);
 
-        if newest.is_none() {
-            newest = page_rows
-                .first()
-                .map(|row| (row.id.clone(), row.start_time.clone()));
-        }
-
         let outcome = process_sync_page(
             &auth,
             params.workspace_root.as_deref(),
@@ -138,6 +132,9 @@ pub fn sync_logs_with_cancel(
         downloaded += outcome.downloaded;
         cached += outcome.cached;
         failed += outcome.failed;
+        if newest.is_none() {
+            newest = outcome.newest_synced.clone();
+        }
 
         if reached_checkpoint || cancellation.is_cancelled() || page_len < SYNC_PAGE_SIZE {
             break;
@@ -159,19 +156,17 @@ pub fn sync_logs_with_cancel(
     };
     let finished_at = timestamp_now();
 
-    if status == "success" {
-        let (last_synced_log_id, last_synced_start_time) = newest.clone().unwrap_or_else(|| {
+    let checkpoint = newest.clone().or_else(|| {
+        previous.as_ref().map(|entry| {
             (
-                previous
-                    .as_ref()
-                    .and_then(|entry| entry.last_synced_log_id.clone())
-                    .unwrap_or_default(),
-                previous
-                    .as_ref()
-                    .and_then(|entry| entry.last_synced_start_time.clone())
-                    .unwrap_or_default(),
+                entry.last_synced_log_id.clone().unwrap_or_default(),
+                entry.last_synced_start_time.clone().unwrap_or_default(),
             )
-        });
+        })
+    });
+
+    if status == "success" {
+        let (last_synced_log_id, last_synced_start_time) = checkpoint.clone().unwrap_or_default();
         state.orgs.insert(
             resolved_username.clone(),
             SyncStateOrgEntry {
@@ -224,7 +219,11 @@ pub fn sync_logs_with_cancel(
         state_file: crate::log_store::sync_state_path(params.workspace_root.as_deref())
             .display()
             .to_string(),
-        last_synced_log_id: newest.map(|(log_id, _)| log_id),
+        last_synced_log_id: if status == "success" {
+            checkpoint.map(|(log_id, _)| log_id)
+        } else {
+            newest.map(|(log_id, _)| log_id)
+        },
     })
 }
 
@@ -282,11 +281,12 @@ enum SyncItemStatus {
     Cancelled,
 }
 
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
 struct PageSyncOutcome {
     downloaded: usize,
     cached: usize,
     failed: usize,
+    newest_synced: Option<(String, String)>,
 }
 
 fn process_sync_page(
@@ -301,8 +301,10 @@ fn process_sync_page(
         return PageSyncOutcome::default();
     }
 
-    let queue = Arc::new(Mutex::new(VecDeque::from(rows)));
-    let (tx, rx) = mpsc::channel::<SyncItemStatus>();
+    let queue = Arc::new(Mutex::new(
+        rows.into_iter().enumerate().collect::<VecDeque<_>>(),
+    ));
+    let (tx, rx) = mpsc::channel::<(usize, String, String, SyncItemStatus)>();
     let auth = auth.clone();
     let workspace_root = workspace_root.map(str::to_string);
     let resolved_username = resolved_username.to_string();
@@ -326,7 +328,7 @@ fn process_sync_page(
                     break;
                 }
 
-                let Some(row) = queue
+                let Some((index, row)) = queue
                     .lock()
                     .unwrap_or_else(|poisoned| poisoned.into_inner())
                     .pop_front()
@@ -357,7 +359,7 @@ fn process_sync_page(
                     }
                 };
 
-                let _ = tx.send(status);
+                let _ = tx.send((index, row.id, row.start_time, status));
                 if status == SyncItemStatus::Cancelled {
                     break;
                 }
@@ -366,10 +368,20 @@ fn process_sync_page(
         drop(tx);
 
         let mut outcome = PageSyncOutcome::default();
-        for item in rx {
+        let mut best_index: Option<usize> = None;
+        for (index, row_id, start_time, item) in rx {
             match item {
-                SyncItemStatus::Downloaded => outcome.downloaded += 1,
-                SyncItemStatus::Cached => outcome.cached += 1,
+                SyncItemStatus::Downloaded | SyncItemStatus::Cached => {
+                    if item == SyncItemStatus::Downloaded {
+                        outcome.downloaded += 1;
+                    } else {
+                        outcome.cached += 1;
+                    }
+                    if best_index.is_none_or(|best| index < best) {
+                        best_index = Some(index);
+                        outcome.newest_synced = Some((row_id, start_time));
+                    }
+                }
                 SyncItemStatus::Failed => outcome.failed += 1,
                 SyncItemStatus::Cancelled => {}
             }

--- a/crates/alv-core/src/logs_sync.rs
+++ b/crates/alv-core/src/logs_sync.rs
@@ -1,26 +1,35 @@
 use crate::{
     auth,
+    auth::OrgAuth,
     log_store::{
         log_file_path_for_start_time, read_sync_state, safe_target_org, write_org_metadata,
         write_sync_state, write_version_file, OrgMetadata, SyncStateOrgEntry,
         LOG_STORE_LAYOUT_VERSION,
     },
     logs::{
-        download_log_to_path_with_cancel, list_logs_with_cancel, CancellationToken, LogsCursor,
-        LogsListParams,
+        download_log_to_path_for_auth_with_cancel, list_logs_for_auth_with_cancel,
+        CancellationToken, LogRow, LogsCursor, LogsListParams,
     },
     orgs::list_orgs,
 };
 use serde::{Deserialize, Serialize};
+use std::{
+    collections::{BTreeSet, VecDeque},
+    sync::{mpsc, Arc, Mutex},
+    thread,
+};
 
 const SYNC_PAGE_SIZE: usize = 200;
 const CANCELLED_MESSAGE: &str = "request cancelled";
+const DEFAULT_SYNC_CONCURRENCY: usize = 6;
+const MAX_SYNC_CONCURRENCY: usize = 8;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct LogsSyncParams {
     pub target_org: Option<String>,
     pub workspace_root: Option<String>,
     pub force_full: bool,
+    pub concurrency: Option<usize>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -75,10 +84,11 @@ pub fn sync_logs_with_cancel(
     let mut failed = 0usize;
     let mut newest: Option<(String, String)> = None;
     let mut cursor: Option<LogsCursor> = None;
-    let mut reached_checkpoint = false;
+    let sync_concurrency = normalize_sync_concurrency(params.concurrency);
 
     loop {
-        let mut rows = match list_logs_with_cancel(
+        let mut rows = match list_logs_for_auth_with_cancel(
+            &auth,
             &LogsListParams {
                 username: params.target_org.clone(),
                 limit: Some(SYNC_PAGE_SIZE),
@@ -108,43 +118,26 @@ pub fn sync_logs_with_cancel(
             before_id: Some(row.id.clone()),
         });
 
-        for row in rows {
-            let hit_checkpoint = !params.force_full
-                && previous
-                    .as_ref()
-                    .is_some_and(|entry| row_matches_checkpoint(entry, &row));
+        let (page_rows, reached_checkpoint) =
+            select_sync_page_rows(rows, previous.as_ref(), params.force_full);
 
-            let target_path = log_file_path_for_start_time(
-                params.workspace_root.as_deref(),
-                &resolved_username,
-                &row.start_time,
-                &row.id,
-            );
-            if target_path.is_file() {
-                cached += 1;
-            } else if download_log_to_path_with_cancel(
-                &row.id,
-                Some(&resolved_username),
-                &target_path,
-                cancellation,
-            )
-            .is_ok()
-            {
-                downloaded += 1;
-            } else {
-                failed += 1;
-                continue;
-            }
-
-            if newest.is_none() {
-                newest = Some((row.id.clone(), row.start_time.clone()));
-            }
-
-            if hit_checkpoint {
-                reached_checkpoint = true;
-                break;
-            }
+        if newest.is_none() {
+            newest = page_rows
+                .first()
+                .map(|row| (row.id.clone(), row.start_time.clone()));
         }
+
+        let outcome = process_sync_page(
+            &auth,
+            params.workspace_root.as_deref(),
+            &resolved_username,
+            page_rows,
+            sync_concurrency,
+            cancellation,
+        );
+        downloaded += outcome.downloaded;
+        cached += outcome.cached;
+        failed += outcome.failed;
 
         if reached_checkpoint || cancellation.is_cancelled() || page_len < SYNC_PAGE_SIZE {
             break;
@@ -221,13 +214,13 @@ pub fn sync_logs_with_cancel(
     )?;
 
     Ok(LogsSyncResult {
-        status,
+        status: status.clone(),
         target_org: resolved_username.clone(),
         safe_target_org: safe_org,
         downloaded,
         cached,
         failed,
-        checkpoint_advanced: failed == 0 && !cancellation.is_cancelled(),
+        checkpoint_advanced: status == "success",
         state_file: crate::log_store::sync_state_path(params.workspace_root.as_deref())
             .display()
             .to_string(),
@@ -235,11 +228,17 @@ pub fn sync_logs_with_cancel(
     })
 }
 
+pub fn normalize_sync_concurrency(value: Option<usize>) -> usize {
+    value
+        .unwrap_or(DEFAULT_SYNC_CONCURRENCY)
+        .clamp(1, MAX_SYNC_CONCURRENCY)
+}
+
 fn timestamp_now() -> String {
     chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
 }
 
-fn row_matches_checkpoint(entry: &SyncStateOrgEntry, row: &crate::logs::LogRow) -> bool {
+fn row_matches_checkpoint(entry: &SyncStateOrgEntry, row: &LogRow) -> bool {
     if let Some(last_synced_log_id) = entry
         .last_synced_log_id
         .as_deref()
@@ -251,14 +250,195 @@ fn row_matches_checkpoint(entry: &SyncStateOrgEntry, row: &crate::logs::LogRow) 
     entry.last_synced_start_time.as_deref() == Some(row.start_time.as_str())
 }
 
+fn select_sync_page_rows(
+    rows: Vec<LogRow>,
+    previous: Option<&SyncStateOrgEntry>,
+    force_full: bool,
+) -> (Vec<LogRow>, bool) {
+    let mut selected = Vec::new();
+    let mut reached_checkpoint = false;
+    let mut seen_log_ids = BTreeSet::new();
+
+    for row in rows {
+        let hit_checkpoint =
+            !force_full && previous.is_some_and(|entry| row_matches_checkpoint(entry, &row));
+        if hit_checkpoint {
+            reached_checkpoint = true;
+            break;
+        }
+        if seen_log_ids.insert(row.id.clone()) {
+            selected.push(row);
+        }
+    }
+
+    (selected, reached_checkpoint)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SyncItemStatus {
+    Downloaded,
+    Cached,
+    Failed,
+    Cancelled,
+}
+
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+struct PageSyncOutcome {
+    downloaded: usize,
+    cached: usize,
+    failed: usize,
+}
+
+fn process_sync_page(
+    auth: &OrgAuth,
+    workspace_root: Option<&str>,
+    resolved_username: &str,
+    rows: Vec<LogRow>,
+    concurrency: usize,
+    cancellation: &CancellationToken,
+) -> PageSyncOutcome {
+    if rows.is_empty() {
+        return PageSyncOutcome::default();
+    }
+
+    let queue = Arc::new(Mutex::new(VecDeque::from(rows)));
+    let (tx, rx) = mpsc::channel::<SyncItemStatus>();
+    let auth = auth.clone();
+    let workspace_root = workspace_root.map(str::to_string);
+    let resolved_username = resolved_username.to_string();
+    let worker_count = {
+        let guard = queue
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        concurrency.min(guard.len().max(1))
+    };
+
+    thread::scope(|scope| {
+        for _ in 0..worker_count {
+            let tx = tx.clone();
+            let queue = Arc::clone(&queue);
+            let auth = auth.clone();
+            let workspace_root = workspace_root.clone();
+            let resolved_username = resolved_username.clone();
+            let cancellation = cancellation.clone();
+            scope.spawn(move || loop {
+                if cancellation.is_cancelled() {
+                    break;
+                }
+
+                let Some(row) = queue
+                    .lock()
+                    .unwrap_or_else(|poisoned| poisoned.into_inner())
+                    .pop_front()
+                else {
+                    break;
+                };
+
+                let target_path = log_file_path_for_start_time(
+                    workspace_root.as_deref(),
+                    &resolved_username,
+                    &row.start_time,
+                    &row.id,
+                );
+                let status = if target_path.is_file() {
+                    SyncItemStatus::Cached
+                } else {
+                    match download_log_to_path_for_auth_with_cancel(
+                        &auth,
+                        &row.id,
+                        &target_path,
+                        &cancellation,
+                    ) {
+                        Ok(_) => SyncItemStatus::Downloaded,
+                        Err(error) if error == CANCELLED_MESSAGE || cancellation.is_cancelled() => {
+                            SyncItemStatus::Cancelled
+                        }
+                        Err(_) => SyncItemStatus::Failed,
+                    }
+                };
+
+                let _ = tx.send(status);
+                if status == SyncItemStatus::Cancelled {
+                    break;
+                }
+            });
+        }
+        drop(tx);
+
+        let mut outcome = PageSyncOutcome::default();
+        for item in rx {
+            match item {
+                SyncItemStatus::Downloaded => outcome.downloaded += 1,
+                SyncItemStatus::Cached => outcome.cached += 1,
+                SyncItemStatus::Failed => outcome.failed += 1,
+                SyncItemStatus::Cancelled => {}
+            }
+        }
+        outcome
+    })
+}
+
 #[cfg(test)]
 mod tests {
-    use super::timestamp_now;
+    use super::{
+        normalize_sync_concurrency, select_sync_page_rows, timestamp_now, LogRow, SyncStateOrgEntry,
+    };
 
     #[test]
     fn timestamp_now_emits_rfc3339_like_utc_values() {
         let value = timestamp_now();
         assert!(value.contains('T'));
         assert!(value.ends_with('Z'));
+    }
+
+    #[test]
+    fn normalize_sync_concurrency_clamps_values() {
+        assert_eq!(normalize_sync_concurrency(None), 6);
+        assert_eq!(normalize_sync_concurrency(Some(0)), 1);
+        assert_eq!(normalize_sync_concurrency(Some(1)), 1);
+        assert_eq!(normalize_sync_concurrency(Some(4)), 4);
+        assert_eq!(normalize_sync_concurrency(Some(999)), 8);
+    }
+
+    #[test]
+    fn select_sync_page_rows_stops_before_checkpoint_and_deduplicates_ids() {
+        let rows = vec![
+            make_row("07L000000000003AA", "2026-03-30T18:41:00.000Z"),
+            make_row("07L000000000002AA", "2026-03-30T18:40:00.000Z"),
+            make_row("07L000000000002AA", "2026-03-30T18:40:00.000Z"),
+            make_row("07L000000000001AA", "2026-03-30T18:39:00.000Z"),
+        ];
+        let checkpoint = SyncStateOrgEntry {
+            target_org: "default@example.com".to_string(),
+            safe_target_org: "default@example.com".to_string(),
+            org_dir: "apexlogs/orgs/default@example.com".to_string(),
+            last_sync_started_at: None,
+            last_sync_completed_at: None,
+            last_synced_log_id: Some("07L000000000002AA".to_string()),
+            last_synced_start_time: Some("2026-03-30T18:40:00.000Z".to_string()),
+            downloaded_count: 0,
+            cached_count: 0,
+            last_error: None,
+        };
+
+        let (selected, reached_checkpoint) = select_sync_page_rows(rows, Some(&checkpoint), false);
+
+        assert!(reached_checkpoint);
+        assert_eq!(selected.len(), 1);
+        assert_eq!(selected[0].id, "07L000000000003AA");
+    }
+
+    fn make_row(id: &str, start_time: &str) -> LogRow {
+        LogRow {
+            id: id.to_string(),
+            start_time: start_time.to_string(),
+            operation: "ExecuteAnonymous".to_string(),
+            application: "Developer Console".to_string(),
+            duration_milliseconds: 1,
+            status: "Success".to_string(),
+            request: format!("REQ-{id}"),
+            log_length: 1,
+            log_user: None,
+        }
     }
 }

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -1,5 +1,3 @@
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
 use std::{
     fs,
     path::PathBuf,
@@ -23,6 +21,7 @@ use alv_core::{
     search::{search_query, search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs, triage_logs_with_cancel, LogsTriageParams},
 };
+use tiny_http::{Header, Response, Server, StatusCode};
 
 fn test_guard() -> &'static Mutex<()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
@@ -45,6 +44,41 @@ fn make_temp_workspace(name: &str) -> PathBuf {
     root
 }
 
+fn org_display_fixture(instance_url: &str) -> String {
+    format!(
+        r#"{{"result":{{"username":"demo@example.com","accessToken":"token","instanceUrl":"{instance_url}"}}}}"#
+    )
+}
+
+#[derive(Clone)]
+struct ScriptedHttpResponse {
+    status: u16,
+    content_type: &'static str,
+    body: Vec<u8>,
+}
+
+fn spawn_scripted_http_server(
+    responses: Vec<ScriptedHttpResponse>,
+) -> (String, thread::JoinHandle<()>) {
+    let server = Server::http("127.0.0.1:0").expect("test server should bind");
+    let base_url = format!("http://{}", server.server_addr());
+    let handle = thread::spawn(move || {
+        for item in responses {
+            let request = server.recv().expect("server should receive request");
+            let response = Response::from_data(item.body)
+                .with_status_code(StatusCode(item.status))
+                .with_header(
+                    Header::from_bytes(&b"Content-Type"[..], item.content_type.as_bytes())
+                        .expect("header should be valid"),
+                );
+            request
+                .respond(response)
+                .expect("server should send response");
+        }
+    });
+    (base_url, handle)
+}
+
 fn org_dirs_in_iteration_order(orgs_root: &PathBuf) -> Vec<PathBuf> {
     let mut dirs: Vec<PathBuf> = fs::read_dir(orgs_root)
         .expect("orgs root should be readable")
@@ -54,17 +88,6 @@ fn org_dirs_in_iteration_order(orgs_root: &PathBuf) -> Vec<PathBuf> {
         .collect();
     dirs.sort();
     dirs
-}
-
-#[cfg(unix)]
-fn write_fake_sf_command(root: &PathBuf, body: &str) {
-    let script_path = root.join("sf");
-    fs::write(&script_path, body).expect("fake sf script should be writable");
-    let mut permissions = fs::metadata(&script_path)
-        .expect("fake sf script metadata should exist")
-        .permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(&script_path, permissions).expect("fake sf script should be executable");
 }
 
 #[cfg(windows)]
@@ -166,6 +189,110 @@ fn logs_runtime_smoke_lists_logs_from_warning_prefixed_fixture() {
     assert_eq!(rows[0].operation, "ExecuteAnonymous");
 
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+}
+
+#[test]
+fn logs_runtime_smoke_lists_logs_over_rest_with_auth_fixture() {
+    let _guard = lock_test_guard();
+
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let payload = serde_json::json!({
+        "result": {
+            "records": [{
+                "Id": "07L000000000REST",
+                "StartTime": "2026-03-27T12:00:00.000Z",
+                "Operation": "ExecuteAnonymous",
+                "Application": "Developer Console",
+                "DurationMilliseconds": 125,
+                "Status": "Success",
+                "Request": "REQ-REST",
+                "LogLength": 4096
+            }]
+        }
+    });
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 200,
+        content_type: "application/json",
+        body: serde_json::to_vec(&payload).expect("payload should serialize"),
+    }]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let rows = list_logs_with_cancel(
+        &LogsListParams {
+            username: Some("demo@example.com".to_string()),
+            limit: Some(1),
+            cursor: None,
+            offset: Some(0),
+        },
+        &CancellationToken::new(),
+    )
+    .expect("logs/list should use the REST runtime path");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "07L000000000REST");
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
+}
+
+#[test]
+fn logs_runtime_smoke_falls_back_to_org_max_api_version_for_logs_list() {
+    let _guard = lock_test_guard();
+
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let payload = serde_json::json!({
+        "result": {
+            "records": [{
+                "Id": "07L000000000FALL",
+                "StartTime": "2026-03-27T12:00:00.000Z",
+                "Operation": "ExecuteAnonymous",
+                "Application": "Developer Console",
+                "DurationMilliseconds": 125,
+                "Status": "Success",
+                "Request": "REQ-FALL",
+                "LogLength": 4096
+            }]
+        }
+    });
+    let services_data = serde_json::json!([
+        { "version": "60.0" },
+        { "version": "61.0" }
+    ]);
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![
+        ScriptedHttpResponse {
+            status: 404,
+            content_type: "application/json",
+            body: br#"{"message":"The requested resource does not exist"}"#.to_vec(),
+        },
+        ScriptedHttpResponse {
+            status: 200,
+            content_type: "application/json",
+            body: serde_json::to_vec(&services_data).expect("services/data should serialize"),
+        },
+        ScriptedHttpResponse {
+            status: 200,
+            content_type: "application/json",
+            body: serde_json::to_vec(&payload).expect("payload should serialize"),
+        },
+    ]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let rows = list_logs_with_cancel(
+        &LogsListParams {
+            username: Some("demo@example.com".to_string()),
+            limit: Some(1),
+            cursor: None,
+            offset: Some(0),
+        },
+        &CancellationToken::new(),
+    )
+    .expect("logs/list should retry with the org max API version");
+
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].id, "07L000000000FALL");
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
 }
 
 #[test]
@@ -1011,25 +1138,78 @@ fn logs_runtime_smoke_ensure_log_cache_uses_fixture_copy() {
     fs::remove_dir_all(fixture_root).expect("fixture workspace should be removable");
 }
 
+#[test]
+fn logs_runtime_smoke_downloads_log_body_over_rest_into_cache() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("ensure-cache-rest");
+    let log_id = "07L000000000REST";
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 200,
+        content_type: "text/plain",
+        body: b"09:00:00.0|USER_INFO|rest body\n".to_vec(),
+    }]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let cached = ensure_log_file_cached(
+        log_id,
+        Some("demo@example.com"),
+        Some(&workspace_root.display().to_string()),
+    )
+    .expect("ensure_log_file_cached should fetch the ApexLog body via REST");
+    assert!(cached.exists());
+    assert_eq!(
+        fs::read_to_string(&cached).expect("cached log should be readable"),
+        "09:00:00.0|USER_INFO|rest body\n"
+    );
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
 #[cfg(windows)]
 #[test]
 fn logs_runtime_smoke_uses_explicit_sf_cmd_shim_for_logs_list() {
     let _guard = lock_test_guard();
 
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    let payload = serde_json::json!({
+        "result": {
+            "records": [{
+                "Id": "07L000000000001AA",
+                "StartTime": "2026-03-27T12:00:00.000Z",
+                "Operation": "ExecuteAnonymous",
+                "Application": "Developer Console",
+                "DurationMilliseconds": 125,
+                "Status": "Success",
+                "Request": "REQ-1",
+                "LogLength": 4096,
+                "LogUser": { "Name": "Ada" }
+            }]
+        }
+    });
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 200,
+        content_type: "application/json",
+        body: serde_json::to_vec(&payload).expect("payload should serialize"),
+    }]);
 
     let fake_bin_root = make_temp_workspace("sf-cmd-logs-list");
-    let sf_cmd = write_fake_sf_cmd(
-        &fake_bin_root,
-        r#"@echo off
-if /I "%~1 %~2 %~3 %~4 %~5 %~6"=="data query --use-tooling-api --json --result-format json" (
-  echo {"result":{"records":[{"Id":"07L000000000001AA","StartTime":"2026-03-27T12:00:00.000Z","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-1","LogLength":4096,"LogUser":{"Name":"Ada"}}]}}
+    let script_body = r#"@echo off
+if /I "%*"=="org display --json --verbose -o demo@example.com" (
+  echo __ORG_DISPLAY_JSON__
   exit /b 0
 )
 echo Unexpected sf args: %* 1>&2
 exit /b 1
-"#,
+"#
+    .replace(
+        "__ORG_DISPLAY_JSON__",
+        &org_display_fixture(&base_url).replace('\"', "\"\""),
     );
+    let sf_cmd = write_fake_sf_cmd(&fake_bin_root, &script_body);
 
     std::env::set_var("ALV_SF_BIN_PATH", &sf_cmd);
 
@@ -1056,47 +1236,35 @@ exit /b 1
     );
 
     std::env::remove_var("ALV_SF_BIN_PATH");
+    server_handle.join().expect("server thread should complete");
     fs::remove_dir_all(fake_bin_root).expect("fake sf workspace should be removable");
 }
 
-#[cfg(unix)]
 #[test]
-fn logs_runtime_smoke_drains_large_sf_json_output_without_hanging() {
+fn logs_runtime_smoke_reads_large_rest_json_payload_without_hanging() {
     let _guard = lock_test_guard();
 
-    let fake_bin_root = make_temp_workspace("sf-large-output");
-    write_fake_sf_command(
-        &fake_bin_root,
-        r#"#!/usr/bin/env bash
-python3 - <<'PY'
-import json
-payload = {
-    "result": {
-        "records": [
-            {
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let payload = serde_json::json!({
+        "result": {
+            "records": [{
                 "Id": "07L000000000001AA",
                 "StartTime": "2026-03-27T12:00:00.000Z",
-                "Operation": "X" * 200000,
+                "Operation": "X".repeat(200000),
                 "Application": "Developer Console",
                 "DurationMilliseconds": 125,
                 "Status": "Success",
                 "Request": "REQ-1",
                 "LogLength": 4096
-            }
-        ]
-    }
-}
-print(json.dumps(payload))
-PY
-"#,
-    );
-
-    let previous_path = std::env::var("PATH").unwrap_or_default();
-    std::env::set_var(
-        "PATH",
-        format!("{}:{}", fake_bin_root.display(), previous_path),
-    );
-    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+            }]
+        }
+    });
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 200,
+        content_type: "application/json",
+        body: serde_json::to_vec(&payload).expect("payload should serialize"),
+    }]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
 
     let rows = list_logs_with_cancel(
         &LogsListParams {
@@ -1107,11 +1275,11 @@ PY
         },
         &CancellationToken::new(),
     )
-    .expect("logs/list should read large stdout payloads");
+    .expect("logs/list should read large HTTP payloads");
 
     assert_eq!(rows.len(), 1);
     assert_eq!(rows[0].operation.len(), 200000);
 
-    std::env::set_var("PATH", previous_path);
-    fs::remove_dir_all(fake_bin_root).expect("fake sf workspace should be removable");
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
 }

--- a/crates/alv-core/tests/logs_sync_smoke.rs
+++ b/crates/alv-core/tests/logs_sync_smoke.rs
@@ -385,6 +385,123 @@ fn logs_sync_smoke_keeps_previous_checkpoint_on_partial_failure() {
 }
 
 #[test]
+fn logs_sync_smoke_advances_checkpoint_to_first_successful_row_when_newest_fails() {
+    let _guard = lock_env_mutex();
+    let workspace_root = make_temp_workspace("checkpoint-first-success");
+    let fixture_dir = make_fixture_dir("fixture-checkpoint-first-success");
+    fs::write(
+        fixture_dir.join("07L000000000003AA.log"),
+        "09:00:00.0|USER_INFO|first successful body\n",
+    )
+    .expect("fixture log should be writable");
+
+    std::env::set_var(
+        TEST_SF_LOG_LIST_JSON_ENV,
+        r#"{"result":{"records":[
+          {"Id":"07L000000000004AA","StartTime":"2026-03-30T18:40:58.000Z","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-2","LogLength":4096},
+          {"Id":"07L000000000003AA","StartTime":"2026-03-30T18:39:58.000Z","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-1","LogLength":4096}
+        ]}}"#,
+    );
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture("https://default.example.com"),
+    );
+    std::env::set_var(
+        TEST_APEX_LOG_FIXTURE_DIR_ENV,
+        fixture_dir.display().to_string(),
+    );
+
+    let result = sync_logs_with_cancel(
+        &LogsSyncParams {
+            target_org: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+            force_full: false,
+            concurrency: None,
+        },
+        &alv_core::logs::CancellationToken::new(),
+    )
+    .expect("sync should succeed with one failed row");
+
+    assert_eq!(result.status, "partial");
+    assert_eq!(result.downloaded, 1);
+    assert_eq!(result.failed, 1);
+    assert_eq!(
+        result.last_synced_log_id.as_deref(),
+        Some("07L000000000003AA")
+    );
+
+    std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
+fn logs_sync_smoke_keeps_last_synced_log_id_on_successful_noop_incremental_sync() {
+    let _guard = lock_env_mutex();
+    let workspace_root = make_temp_workspace("noop-checkpoint");
+    let fixture_dir = make_fixture_dir("fixture-noop-checkpoint");
+    fs::write(
+        fixture_dir.join("07L000000000003AA.log"),
+        "09:00:00.0|USER_INFO|synced body\n",
+    )
+    .expect("fixture log should be writable");
+
+    std::env::set_var(
+        TEST_SF_LOG_LIST_JSON_ENV,
+        r#"{"result":{"records":[{"Id":"07L000000000003AA","StartTime":"2026-03-30T18:39:58.000Z","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-1","LogLength":4096}]}}"#,
+    );
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture("https://default.example.com"),
+    );
+    std::env::set_var(
+        TEST_APEX_LOG_FIXTURE_DIR_ENV,
+        fixture_dir.display().to_string(),
+    );
+
+    let first = sync_logs_with_cancel(
+        &LogsSyncParams {
+            target_org: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+            force_full: false,
+            concurrency: None,
+        },
+        &alv_core::logs::CancellationToken::new(),
+    )
+    .expect("seed sync should succeed");
+    assert_eq!(
+        first.last_synced_log_id.as_deref(),
+        Some("07L000000000003AA")
+    );
+
+    let second = sync_logs_with_cancel(
+        &LogsSyncParams {
+            target_org: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+            force_full: false,
+            concurrency: None,
+        },
+        &alv_core::logs::CancellationToken::new(),
+    )
+    .expect("noop sync should succeed");
+
+    assert_eq!(second.status, "success");
+    assert_eq!(second.downloaded, 0);
+    assert_eq!(
+        second.last_synced_log_id.as_deref(),
+        Some("07L000000000003AA")
+    );
+
+    std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
 fn logs_sync_smoke_paginates_beyond_first_page() {
     let _guard = lock_env_mutex();
     let workspace_root = make_temp_workspace("paginated");

--- a/crates/alv-core/tests/logs_sync_smoke.rs
+++ b/crates/alv-core/tests/logs_sync_smoke.rs
@@ -1,10 +1,9 @@
 use std::{
-    ffi::OsString,
     fs,
     path::PathBuf,
     sync::{Mutex, MutexGuard},
     thread,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use alv_core::{
@@ -13,6 +12,7 @@ use alv_core::{
     logs_sync::{sync_logs_with_cancel, LogsSyncParams},
 };
 use serde_json::{json, Value};
+use tiny_http::{Header, Response, Server, StatusCode};
 
 static ENV_MUTEX: Mutex<()> = Mutex::new(());
 
@@ -38,123 +38,30 @@ fn make_fixture_dir(label: &str) -> PathBuf {
     root
 }
 
-fn org_display_fixture() -> &'static str {
-    r#"{"result":{"username":"default@example.com","accessToken":"token","instanceUrl":"https://default.example.com"}}"#
-}
-
-fn write_log_list_fixture(path: &PathBuf, rows: &[(String, String)]) {
-    let records = rows
-        .iter()
-        .map(|(id, start_time)| {
-            json!({
-                "Id": id,
-                "StartTime": start_time,
-                "Operation": "ExecuteAnonymous",
-                "Application": "Developer Console",
-                "DurationMilliseconds": 125,
-                "Status": "Success",
-                "Request": format!("REQ-{id}"),
-                "LogLength": 4096
-            })
-        })
-        .collect::<Vec<Value>>();
-    fs::write(
-        path,
-        serde_json::to_string(&json!({ "result": { "records": records } }))
-            .expect("fixture JSON should serialize"),
+fn org_display_fixture(instance_url: &str) -> String {
+    format!(
+        r#"{{"result":{{"username":"default@example.com","accessToken":"token","instanceUrl":"{instance_url}"}}}}"#
     )
-    .expect("fixture JSON should be writable");
 }
 
-#[cfg(unix)]
-fn write_script(path: &PathBuf, body: &str) {
-    use std::os::unix::fs::PermissionsExt;
-
-    fs::write(path, body).expect("script should be writable");
-    let mut permissions = fs::metadata(path)
-        .expect("script metadata should exist")
-        .permissions();
-    permissions.set_mode(0o755);
-    fs::set_permissions(path, permissions).expect("script should be executable");
-}
-
-#[cfg(windows)]
-fn write_script(path: &PathBuf, body: &str) {
-    fs::write(path, body).expect("script should be writable");
-}
-
-#[cfg(unix)]
-fn write_paginated_fake_sf_command(
-    root: &PathBuf,
-    page_one_path: &PathBuf,
-    page_two_path: &PathBuf,
-    page_one_last_id: &str,
-) {
-    let script_path = root.join("sf");
-    let body = format!(
-        "#!/bin/sh\nquery=\"\"\nwhile [ \"$#\" -gt 0 ]; do\n  if [ \"$1\" = \"--query\" ]; then\n    query=\"$2\"\n    break\n  fi\n  shift\ndone\nif printf '%s' \"$query\" | grep -F \"{page_one_last_id}\" >/dev/null; then\n  cat '{}'\nelse\n  cat '{}'\nfi\n",
-        page_two_path.display(),
-        page_one_path.display()
-    );
-    write_script(&script_path, &body);
-}
-
-#[cfg(windows)]
-fn write_paginated_fake_sf_command(
-    root: &PathBuf,
-    page_one_path: &PathBuf,
-    page_two_path: &PathBuf,
-    page_one_last_id: &str,
-) {
-    let script_path = root.join("sf.cmd");
-    let body = format!(
-        "@echo off\r\nsetlocal EnableExtensions\r\nset \"args=%*\"\r\necho(%args% | findstr /C:\"{page_one_last_id}\" >nul\r\nif not errorlevel 1 (\r\n  type \"{}\"\r\n) else (\r\n  type \"{}\"\r\n)\r\n",
-        page_two_path.display(),
-        page_one_path.display()
-    );
-    write_script(&script_path, &body);
-}
-
-#[cfg(unix)]
-fn write_failing_fake_sf_command(root: &PathBuf, message: &str) {
-    let script_path = root.join("sf");
-    let body = format!("#!/bin/sh\necho \"{message}\" 1>&2\nexit 1\n");
-    write_script(&script_path, &body);
-}
-
-#[cfg(windows)]
-fn write_failing_fake_sf_command(root: &PathBuf, message: &str) {
-    let script_path = root.join("sf.cmd");
-    let body = format!("@echo off\r\necho {message} 1>&2\r\nexit /b 1\r\n");
-    write_script(&script_path, &body);
-}
-
-#[cfg(unix)]
-fn path_with_front(root: &PathBuf, old_path: Option<OsString>) -> OsString {
-    let mut updated = OsString::from(root.as_os_str());
-    if let Some(previous) = old_path.filter(|value| !value.is_empty()) {
-        updated.push(":");
-        updated.push(previous);
-    }
-    updated
-}
-
-#[cfg(windows)]
-fn path_with_front(root: &PathBuf, old_path: Option<OsString>) -> OsString {
-    let mut updated = OsString::from(root.as_os_str());
-    if let Some(previous) = old_path.filter(|value| !value.is_empty()) {
-        updated.push(";");
-        updated.push(previous);
-    }
-    updated
-}
-
-fn restore_path(old_path: Option<OsString>) {
-    if let Some(previous) = old_path {
-        std::env::set_var("PATH", previous);
-    } else {
-        std::env::remove_var("PATH");
-    }
+fn spawn_scripted_http_server(responses: Vec<(u16, String)>) -> (String, thread::JoinHandle<()>) {
+    let server = Server::http("127.0.0.1:0").expect("test server should bind");
+    let base_url = format!("http://{}", server.server_addr());
+    let handle = thread::spawn(move || {
+        for (status, body) in responses {
+            let request = server.recv().expect("server should receive request");
+            let response = Response::from_string(body)
+                .with_status_code(StatusCode(status))
+                .with_header(
+                    Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..])
+                        .expect("header should be valid"),
+                );
+            request
+                .respond(response)
+                .expect("server should send response");
+        }
+    });
+    (base_url, handle)
 }
 
 #[test]
@@ -186,6 +93,7 @@ fn logs_sync_smoke_writes_new_layout_and_updates_checkpoint() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -254,6 +162,7 @@ fn logs_sync_smoke_second_run_is_incremental() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -263,6 +172,7 @@ fn logs_sync_smoke_second_run_is_incremental() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -270,12 +180,97 @@ fn logs_sync_smoke_second_run_is_incremental() {
 
     assert_eq!(first.downloaded, 1);
     assert_eq!(second.downloaded, 0);
-    assert_eq!(second.cached, 1);
+    assert_eq!(second.cached, 0);
 
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
     std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
+fn logs_sync_smoke_parallel_downloads_outpace_serial_mode() {
+    let _guard = lock_env_mutex();
+    let serial_workspace = make_temp_workspace("serial-speed");
+    let parallel_workspace = make_temp_workspace("parallel-speed");
+    let fixture_dir = make_fixture_dir("fixture-speed");
+    let rows = (1..=4)
+        .map(|index| {
+            let id = format!("07L0000000000S{index:02}A");
+            let start_time = format!("2026-03-30T18:39:{index:02}.000Z");
+            fs::write(
+                fixture_dir.join(format!("{id}.log")),
+                format!("09:00:00.0|USER_INFO|body for {id}\n"),
+            )
+            .expect("fixture log should be writable");
+            json!({
+                "Id": id,
+                "StartTime": start_time,
+                "Operation": "ExecuteAnonymous",
+                "Application": "Developer Console",
+                "DurationMilliseconds": 125,
+                "Status": "Success",
+                "Request": format!("REQ-{index}"),
+                "LogLength": 4096
+            })
+        })
+        .collect::<Vec<Value>>();
+
+    std::env::set_var(
+        TEST_SF_LOG_LIST_JSON_ENV,
+        serde_json::to_string(&json!({ "result": { "records": rows } }))
+            .expect("speed fixture JSON should serialize"),
+    );
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture("https://default.example.com"),
+    );
+    std::env::set_var(
+        TEST_APEX_LOG_FIXTURE_DIR_ENV,
+        fixture_dir.display().to_string(),
+    );
+    std::env::set_var("ALV_TEST_LOGS_CANCEL_DELAY_MS", "80");
+
+    let serial_started = Instant::now();
+    let serial = sync_logs_with_cancel(
+        &LogsSyncParams {
+            target_org: None,
+            workspace_root: Some(serial_workspace.display().to_string()),
+            force_full: false,
+            concurrency: Some(1),
+        },
+        &alv_core::logs::CancellationToken::new(),
+    )
+    .expect("serial sync should succeed");
+    let serial_elapsed = serial_started.elapsed();
+
+    let parallel_started = Instant::now();
+    let parallel = sync_logs_with_cancel(
+        &LogsSyncParams {
+            target_org: None,
+            workspace_root: Some(parallel_workspace.display().to_string()),
+            force_full: false,
+            concurrency: Some(4),
+        },
+        &alv_core::logs::CancellationToken::new(),
+    )
+    .expect("parallel sync should succeed");
+    let parallel_elapsed = parallel_started.elapsed();
+
+    assert_eq!(serial.downloaded, 4);
+    assert_eq!(parallel.downloaded, 4);
+    assert!(
+        parallel_elapsed < serial_elapsed,
+        "expected parallel sync to finish faster than serial sync, got serial={serial_elapsed:?} parallel={parallel_elapsed:?}"
+    );
+
+    std::env::remove_var("ALV_TEST_LOGS_CANCEL_DELAY_MS");
+    std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
+    fs::remove_dir_all(serial_workspace).expect("serial workspace should be removable");
+    fs::remove_dir_all(parallel_workspace).expect("parallel workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
 }
 
@@ -308,6 +303,7 @@ fn logs_sync_smoke_persists_requested_alias_when_org_list_is_unavailable() {
             target_org: Some("ALV_ALIAS".to_string()),
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -363,6 +359,7 @@ fn logs_sync_smoke_keeps_previous_checkpoint_on_partial_failure() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -392,9 +389,6 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
     let _guard = lock_env_mutex();
     let workspace_root = make_temp_workspace("paginated");
     let fixture_dir = make_fixture_dir("fixture-paginated");
-    let fake_sf_root = make_temp_workspace("fake-sf");
-    let page_one_path = fake_sf_root.join("page-1.json");
-    let page_two_path = fake_sf_root.join("page-2.json");
 
     let rows = (1..=201)
         .rev()
@@ -410,10 +404,6 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
         .collect::<Vec<_>>();
     let page_one = rows[..200].to_vec();
     let page_two = rows[200..].to_vec();
-    let page_one_last_id = page_one
-        .last()
-        .map(|(id, _)| id.clone())
-        .expect("page one should contain rows");
 
     for (id, _) in &rows {
         fs::write(
@@ -422,20 +412,40 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
         )
         .expect("fixture log should be writable");
     }
-    write_log_list_fixture(&page_one_path, &page_one);
-    write_log_list_fixture(&page_two_path, &page_two);
+    let page_one_json = serde_json::to_string(&json!({
+        "result": { "records": page_one.iter().map(|(id, start_time)| json!({
+            "Id": id,
+            "StartTime": start_time,
+            "Operation": "ExecuteAnonymous",
+            "Application": "Developer Console",
+            "DurationMilliseconds": 125,
+            "Status": "Success",
+            "Request": format!("REQ-{id}"),
+            "LogLength": 4096
+        })).collect::<Vec<Value>>() }
+    }))
+    .expect("page one JSON should serialize");
+    let page_two_json = serde_json::to_string(&json!({
+        "result": { "records": page_two.iter().map(|(id, start_time)| json!({
+            "Id": id,
+            "StartTime": start_time,
+            "Operation": "ExecuteAnonymous",
+            "Application": "Developer Console",
+            "DurationMilliseconds": 125,
+            "Status": "Success",
+            "Request": format!("REQ-{id}"),
+            "LogLength": 4096
+        })).collect::<Vec<Value>>() }
+    }))
+    .expect("page two JSON should serialize");
+    let (base_url, server_handle) =
+        spawn_scripted_http_server(vec![(200, page_one_json), (200, page_two_json)]);
 
-    write_paginated_fake_sf_command(
-        &fake_sf_root,
-        &page_one_path,
-        &page_two_path,
-        &page_one_last_id,
-    );
-
-    let old_path = std::env::var_os("PATH");
-    std::env::set_var("PATH", path_with_front(&fake_sf_root, old_path.clone()));
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
-    std::env::set_var("ALV_TEST_SF_ORG_DISPLAY_JSON", org_display_fixture());
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture(&base_url),
+    );
     std::env::set_var(
         TEST_APEX_LOG_FIXTURE_DIR_ENV,
         fixture_dir.display().to_string(),
@@ -446,6 +456,7 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -480,10 +491,9 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
 
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
-    restore_path(old_path);
+    server_handle.join().expect("server thread should complete");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
-    fs::remove_dir_all(fake_sf_root).expect("fake sf dir should be removable");
 }
 
 #[test]
@@ -511,7 +521,10 @@ fn logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp() {
             r#"{{"result":{{"records":[{{"Id":"07L000000000003AA","StartTime":"{shared_start_time}","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-1","LogLength":4096}}]}}}}"#
         ),
     );
-    std::env::set_var("ALV_TEST_SF_ORG_DISPLAY_JSON", org_display_fixture());
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture("https://default.example.com"),
+    );
     std::env::set_var(
         TEST_APEX_LOG_FIXTURE_DIR_ENV,
         fixture_dir.display().to_string(),
@@ -522,6 +535,7 @@ fn logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -543,6 +557,7 @@ fn logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -574,13 +589,13 @@ fn logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp() {
 fn logs_sync_smoke_propagates_list_failures() {
     let _guard = lock_env_mutex();
     let workspace_root = make_temp_workspace("list-failure");
-    let fake_sf_root = make_temp_workspace("fake-sf-failure");
-    let old_path = std::env::var_os("PATH");
-    write_failing_fake_sf_command(&fake_sf_root, "simulated list failure");
-
-    std::env::set_var("PATH", path_with_front(&fake_sf_root, old_path.clone()));
+    let (base_url, server_handle) =
+        spawn_scripted_http_server(vec![(500, "simulated list failure".to_string())]);
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
-    std::env::set_var("ALV_TEST_SF_ORG_DISPLAY_JSON", org_display_fixture());
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture(&base_url),
+    );
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
 
     let error = sync_logs_with_cancel(
@@ -588,6 +603,7 @@ fn logs_sync_smoke_propagates_list_failures() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &alv_core::logs::CancellationToken::new(),
     )
@@ -599,9 +615,8 @@ fn logs_sync_smoke_propagates_list_failures() {
     );
 
     std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
-    restore_path(old_path);
+    server_handle.join().expect("server thread should complete");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
-    fs::remove_dir_all(fake_sf_root).expect("fake sf dir should be removable");
 }
 
 #[test]
@@ -613,7 +628,10 @@ fn logs_sync_smoke_returns_cancelled_result_when_list_fetch_is_cancelled() {
         TEST_SF_LOG_LIST_JSON_ENV,
         r#"{"result":{"records":[{"Id":"07L000000000003AA","StartTime":"2026-03-30T18:39:58.000Z","Operation":"ExecuteAnonymous","Application":"Developer Console","DurationMilliseconds":125,"Status":"Success","Request":"REQ-1","LogLength":4096}]}}"#,
     );
-    std::env::set_var("ALV_TEST_SF_ORG_DISPLAY_JSON", org_display_fixture());
+    std::env::set_var(
+        "ALV_TEST_SF_ORG_DISPLAY_JSON",
+        org_display_fixture("https://default.example.com"),
+    );
     std::env::set_var("ALV_TEST_LOGS_CANCEL_DELAY_MS", "250");
 
     let token = alv_core::logs::CancellationToken::new();
@@ -628,6 +646,7 @@ fn logs_sync_smoke_returns_cancelled_result_when_list_fetch_is_cancelled() {
             target_org: None,
             workspace_root: Some(workspace_root.display().to_string()),
             force_full: false,
+            concurrency: None,
         },
         &token,
     )

--- a/crates/alv-core/tests/logs_sync_smoke.rs
+++ b/crates/alv-core/tests/logs_sync_smoke.rs
@@ -1,7 +1,7 @@
 use std::{
     fs,
     path::PathBuf,
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
     thread,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
@@ -44,12 +44,29 @@ fn org_display_fixture(instance_url: &str) -> String {
     )
 }
 
-fn spawn_scripted_http_server(responses: Vec<(u16, String)>) -> (String, thread::JoinHandle<()>) {
+fn spawn_scripted_http_server(
+    responses: Vec<(u16, String)>,
+) -> (String, Arc<Mutex<Vec<String>>>, thread::JoinHandle<()>) {
     let server = Server::http("127.0.0.1:0").expect("test server should bind");
     let base_url = format!("http://{}", server.server_addr());
+    let observed_urls = Arc::new(Mutex::new(Vec::new()));
+    let observed_urls_for_thread = Arc::clone(&observed_urls);
     let handle = thread::spawn(move || {
         for (status, body) in responses {
             let request = server.recv().expect("server should receive request");
+            let url = request.url().to_string();
+            assert!(
+                url.starts_with("/services/data/"),
+                "expected Salesforce services/data request, got {url}"
+            );
+            assert!(
+                url.contains("/tooling/query?") && url.contains("q="),
+                "expected Tooling query request, got {url}"
+            );
+            observed_urls_for_thread
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner())
+                .push(url);
             let response = Response::from_string(body)
                 .with_status_code(StatusCode(status))
                 .with_header(
@@ -61,7 +78,7 @@ fn spawn_scripted_http_server(responses: Vec<(u16, String)>) -> (String, thread:
                 .expect("server should send response");
         }
     });
-    (base_url, handle)
+    (base_url, observed_urls, handle)
 }
 
 #[test]
@@ -555,7 +572,7 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
         })).collect::<Vec<Value>>() }
     }))
     .expect("page two JSON should serialize");
-    let (base_url, server_handle) =
+    let (base_url, observed_urls, server_handle) =
         spawn_scripted_http_server(vec![(200, page_one_json), (200, page_two_json)]);
 
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
@@ -609,6 +626,14 @@ fn logs_sync_smoke_paginates_beyond_first_page() {
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     std::env::remove_var("ALV_TEST_SF_ORG_DISPLAY_JSON");
     server_handle.join().expect("server thread should complete");
+    let observed_urls = observed_urls
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    assert_eq!(observed_urls.len(), 2);
+    assert!(observed_urls[0].contains("OFFSET+0"));
+    assert!(observed_urls[1].contains("2026-03-30T18%3A00%3A02.000Z"));
+    assert!(observed_urls[1].contains("07L000000000002AA"));
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
 }
@@ -706,7 +731,7 @@ fn logs_sync_smoke_prefers_checkpoint_id_over_shared_timestamp() {
 fn logs_sync_smoke_propagates_list_failures() {
     let _guard = lock_env_mutex();
     let workspace_root = make_temp_workspace("list-failure");
-    let (base_url, server_handle) =
+    let (base_url, _observed_urls, server_handle) =
         spawn_scripted_http_server(vec![(500, "simulated list failure".to_string())]);
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
     std::env::set_var(

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -50,7 +50,7 @@ The standalone CLI and the VS Code extension are separate surfaces over the same
 - `apexlogs/orgs/<safe-target-org>/org.json` stores resolved org metadata.
 - `apexlogs/orgs/<safe-target-org>/logs/<YYYY-MM-DD>/<logId>.log` stores full log bodies.
 
-The Rust CLI is the first consumer of that shared storage through `apex-log-viewer logs sync`, `logs status`, and `logs search`, while the runtime still reads the legacy flat cache layout during the transition so the extension remains compatible.
+The Rust CLI is the first consumer of that shared storage through `apex-log-viewer logs sync`, `logs status`, and `logs search`, while the runtime still reads the legacy flat cache layout during the transition so the extension remains compatible. For `logs sync`, the CLI still reuses `sf org display` for org auth, but the actual list/body fetches now go straight to the Salesforce Tooling REST API and can download bodies concurrently per page via `--concurrency`.
 
 ## Testing and build tooling
 

--- a/scripts/docs-release.test.js
+++ b/scripts/docs-release.test.js
@@ -7,7 +7,6 @@ test('release docs mention the dedicated CLI workflow and pinned runtime metadat
   const publishing = fs.readFileSync('docs/PUBLISHING.md', 'utf8');
   const architecture = fs.readFileSync('docs/ARCHITECTURE.md', 'utf8');
   const changelog = fs.readFileSync('CHANGELOG.md', 'utf8');
-  const plan = fs.readFileSync('docs/superpowers/plans/2026-03-29-independent-cli-release.md', 'utf8');
 
   assert.match(ci, /rust-release\.yml/);
   assert.match(ci, /NPM_TOKEN/);
@@ -17,8 +16,6 @@ test('release docs mention the dedicated CLI workflow and pinned runtime metadat
   assert.match(publishing, /crates\.io.*deferred/i);
   assert.match(architecture, /config\/runtime-bundle\.json/);
   assert.match(changelog, /independent Rust CLI release train/i);
-  assert.match(plan, /cargo test -p apex-log-viewer-cli --test cli_smoke/);
-  assert.doesNotMatch(plan, /cargo test -p alv-cli --test cli_smoke/);
 });
 
 test('test:scripts includes the release docs smoke test', () => {


### PR DESCRIPTION
## Summary

- replace `sf data query` and `sf apex get log` in `logs sync` with direct Tooling REST calls after reusing `sf org display` only for auth
- add concurrent log body downloads with configurable `--concurrency`, and set the default sync concurrency to `6`
- preserve sync checkpoint semantics, add REST-based smoke coverage, and update docs for the new runtime path

## Why

The sync path was slow because it shelled out through `sf` for listing and for each log body download, which effectively made the workflow feel one-log-at-a-time. Moving list and body retrieval into the Rust runtime removes that CLI overhead and lets us parallelize the expensive download portion directly.

## Impact

Users get faster `logs sync` runs, a new `--concurrency` control for troubleshooting or tuning, and the same local layout and JSON contracts as before. The default is now `6`, based on real-org validation showing the download pool is beneficial on live data.

## Validation

- `cargo test -p alv-core logs_sync -- --nocapture`
- `cargo test -p apex-log-viewer-cli cli_smoke -- --nocapture`
- real-org `logs/list` and `logs/triage` validation against the org used by `/home/k3/git/InsuranceIDO20260313`
- controlled real-org comparison with the same 20 live logs: `--concurrency 1` took `9.31s`, `--concurrency 4` took `6.49s` (`1.43x` faster)
- full real-org `logs sync --force-full --concurrency 4` on `InsuranceIDO20260313`: `5898` logs downloaded successfully in `253.13s`
