### PR TITLE
perf(logs): index cached paths for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Bug Fixes
 
 - CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
+- Runtime/Logs: avoid repeated recursive cache walks during CLI log search by indexing candidate local log paths once per request while preserving org-first and legacy-layout fallback behavior.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.
 

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -312,7 +312,7 @@ fn build_scoped_cached_log_path_index(
         }
     }
 
-    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)
@@ -334,7 +334,7 @@ fn build_raw_scoped_cached_log_path_index(
 
     let raw_safe = log_store::safe_target_org(raw_username);
     let allowed_prefixes = vec![raw_safe];
-    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -13,6 +13,7 @@ use std::{
 
 const TEST_SEARCH_LINE_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_LINE_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
+type CachedLogPathIndex = BTreeMap<String, Vec<PathBuf>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SearchQueryParams {
@@ -69,35 +70,19 @@ pub fn search_query_with_cancel(
         .raw_username
         .as_deref()
         .or(params.username.as_deref());
+    let path_index = build_cached_log_path_index(
+        params.workspace_root.as_deref(),
+        raw_username_hint,
+        canonical_username.as_deref(),
+        cancellation,
+    )?;
 
     for log_id in dedup_ids(&params.log_ids) {
         cancellation.check_cancelled()?;
-        let paths = match canonical_username.as_deref() {
-            Some(username) => find_scoped_cached_log_paths(
-                params.workspace_root.as_deref(),
-                &log_id,
-                raw_username_hint,
-                username,
-            ),
-            None => {
-                if let Some(raw_username) = raw_username_hint
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                {
-                    find_raw_scoped_cached_log_paths(
-                        params.workspace_root.as_deref(),
-                        &log_id,
-                        raw_username,
-                    )
-                } else {
-                    find_cached_log_paths(params.workspace_root.as_deref(), &log_id)
-                }
-            }
-        };
-        if paths.is_empty() {
+        let Some(paths) = path_index.get(&log_id) else {
             result.pending_log_ids.push(log_id);
             continue;
-        }
+        };
 
         let mut matched_line = None::<String>;
         for path in paths {
@@ -260,142 +245,205 @@ fn resolve_canonical_username(username: Option<&str>) -> Result<Option<String>, 
     ))
 }
 
-fn find_cached_log_paths(workspace_root: Option<&str>, log_id: &str) -> Vec<PathBuf> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
-
-    collect_log_paths_in_tree(&root.join("orgs"), log_id, &mut paths);
-
-    if let Ok(entries) = fs::read_dir(&root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(file_name) = path.file_name() else {
-                continue;
-            };
-            let file_name = file_name.to_string_lossy();
-            if file_name == format!("{log_id}.log")
-                || file_name.ends_with(&format!("_{log_id}.log"))
+fn build_cached_log_path_index(
+    workspace_root: Option<&str>,
+    raw_username_hint: Option<&str>,
+    canonical_username: Option<&str>,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    match canonical_username {
+        Some(username) => build_scoped_cached_log_path_index(
+            workspace_root,
+            raw_username_hint,
+            username,
+            cancellation,
+        ),
+        None => {
+            if let Some(raw_username) = raw_username_hint
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
             {
-                paths.push(path);
+                build_raw_scoped_cached_log_path_index(workspace_root, raw_username, cancellation)
+            } else {
+                build_unscoped_cached_log_path_index(workspace_root, cancellation)
             }
         }
     }
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
 }
 
-fn find_scoped_cached_log_paths(
+fn build_unscoped_cached_log_path_index(
     workspace_root: Option<&str>,
-    log_id: &str,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    let root = log_store::resolve_apexlogs_root(workspace_root);
+    let mut index = CachedLogPathIndex::new();
+
+    collect_log_path_index_in_tree(&root.join("orgs"), cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &[], true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
+}
+
+fn build_scoped_cached_log_path_index(
+    workspace_root: Option<&str>,
     raw_username: Option<&str>,
     canonical_username: &str,
-) -> Vec<PathBuf> {
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
     let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
+    let mut index = CachedLogPathIndex::new();
 
-    collect_log_paths_in_tree(
+    collect_log_path_index_in_tree(
         &log_store::org_dir(workspace_root, canonical_username).join("logs"),
-        log_id,
-        &mut paths,
-    );
+        cancellation,
+        &mut index,
+    )?;
 
-    push_legacy_scoped_paths(&mut paths, &root, log_id, raw_username, canonical_username);
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
-}
-
-fn find_raw_scoped_cached_log_paths(
-    workspace_root: Option<&str>,
-    log_id: &str,
-    raw_username: &str,
-) -> Vec<PathBuf> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
-
-    collect_log_paths_in_tree(
-        &log_store::org_dir(workspace_root, raw_username).join("logs"),
-        log_id,
-        &mut paths,
-    );
-
-    let raw_safe = log_store::safe_target_org(raw_username);
-    for candidate in [
-        root.join(format!("{raw_safe}_{log_id}.log")),
-        root.join(format!("{log_id}.log")),
-    ] {
-        if candidate.is_file() {
-            paths.push(candidate);
-        }
-    }
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
-}
-
-fn push_legacy_scoped_paths(
-    paths: &mut Vec<PathBuf>,
-    root: &Path,
-    log_id: &str,
-    raw_username: Option<&str>,
-    canonical_username: &str,
-) {
-    for candidate in legacy_scoped_paths(root, log_id, raw_username, canonical_username) {
-        if candidate.is_file() {
-            paths.push(candidate);
-        }
-    }
-}
-
-fn legacy_scoped_paths(
-    root: &Path,
-    log_id: &str,
-    raw_username: Option<&str>,
-    canonical_username: &str,
-) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
     let canonical_safe = log_store::safe_target_org(canonical_username);
-    candidates.push(root.join(format!("{canonical_safe}_{log_id}.log")));
-
+    let mut allowed_prefixes = vec![canonical_safe];
     if let Some(raw_username) = raw_username
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
         let raw_safe = log_store::safe_target_org(raw_username);
-        if raw_safe != canonical_safe {
-            candidates.push(root.join(format!("{raw_safe}_{log_id}.log")));
+        if raw_safe != allowed_prefixes[0] {
+            allowed_prefixes.push(raw_safe);
         }
     }
 
-    candidates.push(root.join(format!("{log_id}.log")));
-    candidates
+    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
 }
 
-fn collect_log_paths_in_tree(root: &Path, log_id: &str, paths: &mut Vec<PathBuf>) {
+fn build_raw_scoped_cached_log_path_index(
+    workspace_root: Option<&str>,
+    raw_username: &str,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    let root = log_store::resolve_apexlogs_root(workspace_root);
+    let mut index = CachedLogPathIndex::new();
+
+    collect_log_path_index_in_tree(
+        &log_store::org_dir(workspace_root, raw_username).join("logs"),
+        cancellation,
+        &mut index,
+    )?;
+
+    let raw_safe = log_store::safe_target_org(raw_username);
+    let allowed_prefixes = vec![raw_safe];
+    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
+}
+
+fn collect_log_path_index_in_tree(
+    root: &Path,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
     if !root.exists() {
-        return;
+        return Ok(());
     }
 
     let Ok(entries) = fs::read_dir(root) else {
-        return;
+        return Ok(());
     };
 
     for entry in entries.flatten() {
+        cancellation.check_cancelled()?;
+
         let path = entry.path();
         if path.is_dir() {
-            collect_log_paths_in_tree(&path, log_id, paths);
+            collect_log_path_index_in_tree(&path, cancellation, index)?;
             continue;
         }
 
-        if path
-            .file_name()
-            .is_some_and(|file_name| file_name.to_string_lossy() == format!("{log_id}.log"))
-        {
-            paths.push(path);
+        let Some(file_name) = path.file_name() else {
+            continue;
+        };
+        let file_name = file_name.to_string_lossy();
+        let Some(log_id) = file_name.strip_suffix(".log").map(str::to_string) else {
+            continue;
+        };
+        if log_id.trim().is_empty() {
+            continue;
         }
+
+        push_index_path(index, &log_id, path);
+    }
+
+    Ok(())
+}
+
+fn collect_root_log_path_index(
+    root: &Path,
+    allowed_prefixes: &[String],
+    include_all_prefixed_paths: bool,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
+    let Ok(entries) = fs::read_dir(root) else {
+        return Ok(());
+    };
+
+    for entry in entries.flatten() {
+        cancellation.check_cancelled()?;
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name() else {
+            continue;
+        };
+        let file_name = file_name.to_string_lossy();
+        let Some((prefix, log_id)) = parse_root_log_file_name(&file_name) else {
+            continue;
+        };
+        let log_id = log_id.to_string();
+
+        if let Some(prefix) = prefix {
+            let include_prefixed = include_all_prefixed_paths
+                || allowed_prefixes
+                    .iter()
+                    .any(|allowed_prefix| allowed_prefix == prefix);
+            if !include_prefixed {
+                continue;
+            }
+        }
+
+        if log_id.trim().is_empty() {
+            continue;
+        }
+        push_index_path(index, &log_id, path);
+    }
+
+    Ok(())
+}
+
+fn parse_root_log_file_name(file_name: &str) -> Option<(Option<&str>, &str)> {
+    let stem = file_name.strip_suffix(".log")?;
+    match stem.rsplit_once('_') {
+        Some((prefix, log_id)) if !prefix.is_empty() && !log_id.is_empty() => {
+            Some((Some(prefix), log_id))
+        }
+        _ if !stem.is_empty() => Some((None, stem)),
+        _ => None,
+    }
+}
+
+fn push_index_path(index: &mut CachedLogPathIndex, log_id: &str, path: PathBuf) {
+    index.entry(log_id.to_string()).or_default().push(path);
+}
+
+fn sort_and_dedup_path_index(index: &mut CachedLogPathIndex) {
+    for paths in index.values_mut() {
+        paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+        paths.dedup();
     }
 }

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -401,6 +401,41 @@ fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_org_duplicate_
 }
 
 #[test]
+fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_legacy_root_match() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-scoped-ignore-other-legacy-root");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L00000000000SR1";
+    fs::write(
+        apexlogs_dir.join(format!("selected@example.com_{log_id}.log")),
+        "09:00:00.0|USER_INFO|selected root cache does not contain the needle\n",
+    )
+    .expect("selected-org legacy root log should be writable");
+    fs::write(
+        apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|ScopedLegacyRootNeedle\n",
+    )
+    .expect("other-org legacy root log should be writable");
+
+    let result = search_query(&SearchQueryParams {
+        query: "ScopedLegacyRootNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("selected@example.com".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should ignore other-org legacy flat cache files");
+
+    assert!(result.log_ids.is_empty());
+    assert!(result.pending_log_ids.is_empty());
+    assert!(!result.snippets.contains_key(log_id));
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_search_scoped_to_selected_org_uses_legacy_bare_log_fallback() {
     let _guard = lock_test_guard();
 
@@ -468,6 +503,41 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
         .get(log_id)
         .expect("matched log should include snippet");
     assert!(snippet.text.contains("AliasScopedNeedle"));
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_search_raw_alias_scope_ignores_other_legacy_root_match() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-alias-offline-legacy-root");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L0000000000AR1";
+    fs::write(
+        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        "09:00:00.0|USER_INFO|alias root cache does not contain the needle\n",
+    )
+    .expect("alias-scoped legacy root log should be writable");
+    fs::write(
+        apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|AliasRootScopeNeedle\n",
+    )
+    .expect("other-org legacy root log should be writable");
+
+    let result = search_query(&SearchQueryParams {
+        query: "AliasRootScopeNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("Alias Org".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should ignore unrelated legacy root files during raw alias fallback");
+
+    assert!(result.log_ids.is_empty());
+    assert!(result.pending_log_ids.is_empty());
+    assert!(!result.snippets.contains_key(log_id));
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -473,6 +473,53 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
 }
 
 #[test]
+fn logs_runtime_smoke_search_uses_legacy_alias_scoped_cache_when_alias_resolves() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-alias-canonical-legacy");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L0000000000AC1";
+    fs::write(
+        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|AliasCanonicalLegacyNeedle\n",
+    )
+    .expect("legacy alias-scoped log should be writable");
+
+    std::env::set_var(
+        TEST_ORG_DISPLAY_JSON_ENV,
+        r#"{
+            "status": 0,
+            "result": {
+                "username": "canonical@example.com",
+                "accessToken": "00D-token",
+                "instanceUrl": "https://example.my.salesforce.com"
+            }
+        }"#,
+    );
+
+    let result = search_query(&SearchQueryParams {
+        query: "AliasCanonicalLegacyNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("Alias Org".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should keep the alias-scoped legacy fallback after alias resolution");
+
+    assert_eq!(result.log_ids, vec![log_id.to_string()]);
+    assert!(result.pending_log_ids.is_empty());
+    let snippet = result
+        .snippets
+        .get(log_id)
+        .expect("matched log should include snippet");
+    assert!(snippet.text.contains("AliasCanonicalLegacyNeedle"));
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory() {
     let _guard = lock_test_guard();
 


### PR DESCRIPTION
## Summary
- build a single cached `logId -> paths` index per `search_query_with_cancel` request instead of recursively scanning the cache tree for every log id
- preserve existing org-first, raw alias, canonical alias, and legacy flat-layout fallback behavior while reusing the indexed candidates
- add a regression test for canonical alias resolution still finding legacy alias-scoped cached logs and note the change in `CHANGELOG.md`

Closes #690.

## Testing
- `cargo fmt --all`
- `cargo test -p alv-core logs_runtime_smoke_search`
- `cargo test -p alv-core` *(timed out locally after 5 minutes; not included as a passing result)*
