### PR TITLE
fix(logs): align cached log lookup across runtime and extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 - CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
+- Runtime/Logs: stop repeated recursive cached-log scans by resolving saved log paths through the shared Rust lookup first, caching runtime hits in-process, and limiting the extension's local fallback to the supported `orgs/<org>/logs/<day>/` layout plus legacy flat files.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.
 
 ### Chores

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -7,6 +7,8 @@ import type {
   JsonRpcSuccessResponse,
   InitializeResult,
   LogsListParams,
+  ResolveCachedLogPathParams,
+  ResolveCachedLogPathResult,
   LogsTriageEntry,
   LogsTriageParams,
   RuntimeLogRow,
@@ -201,6 +203,16 @@ export class RuntimeClient extends EventEmitter {
       await this.initialize();
     }
     return this.request<LogsTriageEntry[]>('logs/triage', params, signal);
+  }
+
+  async resolveCachedLogPath(
+    params: ResolveCachedLogPathParams,
+    signal?: AbortSignal
+  ): Promise<ResolveCachedLogPathResult> {
+    if (!this.requestHandler) {
+      await this.initialize();
+    }
+    return this.request<ResolveCachedLogPathResult>('logs/resolveCachedPath', params, signal);
   }
 
   scheduleRestart(): void {

--- a/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
+++ b/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
@@ -4,6 +4,14 @@ import proxyquire from 'proxyquire';
 
 const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
 
+function directoryEntry(name: string) {
+  return {
+    name,
+    isDirectory: () => true,
+    isFile: () => false
+  };
+}
+
 suite('findExistingLogFile runtime lookup', () => {
   test('prefers the runtime-resolved cached path', async () => {
     const resolveCalls: Array<{ logId: string; username?: string; workspaceRoot?: string }> = [];
@@ -87,5 +95,54 @@ suite('findExistingLogFile runtime lookup', () => {
     const result = await workspaceModule.findExistingLogFile('07L000000000002AA', 'demo');
 
     assert.equal(result, localPath);
+  });
+
+  test('ignores unsupported local log subdirectories when the runtime request fails', async () => {
+    const logId = '07L000000000003AA';
+    const offLayout = path.join('/tmp/alv-workspace', 'apexlogs', 'orgs', 'demo', 'logs', 'archive', `${logId}.log`);
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict(
+      '../../../../src/utils/workspace',
+      {
+        vscode: {
+          workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }]
+          }
+        },
+        '../../apps/vscode-extension/src/runtime/runtimeClient': {
+          runtimeClient: {
+            resolveCachedLogPath: async () => {
+              throw new Error('daemon unavailable');
+            }
+          }
+        },
+        fs: {
+          promises: {
+            readdir: async (target: string, options?: { withFileTypes?: boolean }) => {
+              if (options?.withFileTypes && target.endsWith(path.join('orgs', 'demo', 'logs'))) {
+                return [directoryEntry('archive')];
+              }
+              if (options?.withFileTypes) {
+                return [];
+              }
+              return [];
+            },
+            stat: async (target: string) => {
+              if (target === offLayout) {
+                return { isFile: () => true };
+              }
+              throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+            }
+          }
+        },
+        './logger': {
+          logInfo: () => undefined,
+          logWarn: () => undefined
+        }
+      }
+    );
+
+    const result = await workspaceModule.findExistingLogFile(logId, 'demo');
+
+    assert.equal(result, undefined);
   });
 });

--- a/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
+++ b/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
@@ -1,0 +1,91 @@
+import assert from 'assert/strict';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+suite('findExistingLogFile runtime lookup', () => {
+  test('prefers the runtime-resolved cached path', async () => {
+    const resolveCalls: Array<{ logId: string; username?: string; workspaceRoot?: string }> = [];
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict(
+      '../../../../src/utils/workspace',
+      {
+        vscode: {
+          workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }]
+          }
+        },
+        '../../apps/vscode-extension/src/runtime/runtimeClient': {
+          runtimeClient: {
+            resolveCachedLogPath: async (params: { logId: string; username?: string; workspaceRoot?: string }) => {
+              resolveCalls.push(params);
+              return {
+                path: '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+              };
+            }
+          }
+        },
+        './logger': {
+          logInfo: () => undefined,
+          logWarn: () => undefined
+        }
+      }
+    );
+
+    const result = await workspaceModule.findExistingLogFile('07L000000000001AA', 'demo@example.com');
+
+    assert.equal(
+      result,
+      '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+    );
+    assert.deepEqual(resolveCalls, [
+      {
+        logId: '07L000000000001AA',
+        username: 'demo@example.com',
+        workspaceRoot: '/tmp/alv-workspace'
+      }
+    ]);
+  });
+
+  test('falls back to local lookup when the runtime request fails', async () => {
+    const localPath = path.join('/tmp/alv-workspace', 'apexlogs', 'demo_07L000000000002AA.log');
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict(
+      '../../../../src/utils/workspace',
+      {
+        vscode: {
+          workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }]
+          }
+        },
+        '../../apps/vscode-extension/src/runtime/runtimeClient': {
+          runtimeClient: {
+            resolveCachedLogPath: async () => {
+              throw new Error('daemon unavailable');
+            }
+          }
+        },
+        fs: {
+          promises: {
+            readdir: async (target: string, options?: { withFileTypes?: boolean }) => {
+              if (target.endsWith(path.join('orgs', 'demo', 'logs'))) {
+                return [];
+              }
+              if (options?.withFileTypes) {
+                return [];
+              }
+              return ['demo_07L000000000002AA.log'];
+            }
+          }
+        },
+        './logger': {
+          logInfo: () => undefined,
+          logWarn: () => undefined
+        }
+      }
+    );
+
+    const result = await workspaceModule.findExistingLogFile('07L000000000002AA', 'demo');
+
+    assert.equal(result, localPath);
+  });
+});

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -224,6 +224,36 @@ suite('runtime client', () => {
     assert.equal(auth.username, 'demo@example.com');
   });
 
+  test('resolveCachedLogPath uses the runtime request method', async () => {
+    const methods: string[] = [];
+    const client = new RuntimeClient({
+      requestHandler: async (method, params) => {
+        methods.push(method);
+        assert.equal(method, 'logs/resolveCachedPath');
+        assert.deepEqual(params, {
+          logId: '07L000000000001AA',
+          username: 'demo@example.com',
+          workspaceRoot: '/tmp/alv-workspace'
+        });
+        return {
+          path: '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+        } as never;
+      }
+    });
+
+    const result = await client.resolveCachedLogPath({
+      logId: '07L000000000001AA',
+      username: 'demo@example.com',
+      workspaceRoot: '/tmp/alv-workspace'
+    });
+
+    assert.deepEqual(methods, ['logs/resolveCachedPath']);
+    assert.equal(
+      result.path,
+      '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+    );
+  });
+
   test('coalesces concurrent orgList requests with identical params', async () => {
     let orgListCalls = 0;
     let resolveOrgList: ((value: OrgListItem[]) => void) | undefined;

--- a/crates/alv-app-server/src/handlers/logs.rs
+++ b/crates/alv-app-server/src/handlers/logs.rs
@@ -3,6 +3,21 @@ use alv_core::{
     search::{search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs_with_cancel, LogsTriageParams},
 };
+use serde::Serialize;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveCachedLogPathParams {
+    pub log_id: String,
+    pub username: Option<String>,
+    pub workspace_root: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveCachedLogPathResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
 
 pub fn handle_logs_list_with_cancel(
     params: LogsListParams,
@@ -29,4 +44,15 @@ pub fn handle_logs_triage_with_cancel(
     let items = triage_logs_with_cancel(&params, cancellation)?;
     serde_json::to_string(&items)
         .map_err(|error| format!("failed to serialize logs/triage response: {error}"))
+}
+
+pub fn handle_resolve_cached_path(params: ResolveCachedLogPathParams) -> Result<String, String> {
+    let path = crate::log_lookup_cache::resolve_cached_log_path(
+        params.workspace_root.as_deref(),
+        &params.log_id,
+        params.username.as_deref(),
+    );
+
+    serde_json::to_string(&ResolveCachedLogPathResult { path })
+        .map_err(|error| format!("failed to serialize logs/resolveCachedPath response: {error}"))
 }

--- a/crates/alv-app-server/src/lib.rs
+++ b/crates/alv-app-server/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod log_lookup_cache;
 pub mod server;
 pub mod transport_stdio;

--- a/crates/alv-app-server/src/log_lookup_cache.rs
+++ b/crates/alv-app-server/src/log_lookup_cache.rs
@@ -1,5 +1,6 @@
 use std::{
     collections::HashMap,
+    path::Path,
     sync::{Mutex, OnceLock},
 };
 
@@ -34,9 +35,13 @@ pub fn resolve_cached_log_path(
     }
 
     let cache = LOG_PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
-    if let Ok(guard) = cache.lock() {
-        if let Some(existing) = guard.get(&key) {
-            return Some(existing.clone());
+    if let Ok(mut guard) = cache.lock() {
+        if let Some(existing) = guard.get(&key).cloned() {
+            if Path::new(&existing).is_file() {
+                return Some(existing);
+            }
+
+            guard.remove(&key);
         }
     }
 

--- a/crates/alv-app-server/src/log_lookup_cache.rs
+++ b/crates/alv-app-server/src/log_lookup_cache.rs
@@ -1,0 +1,56 @@
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    workspace_root: Option<String>,
+    username: Option<String>,
+    log_id: String,
+}
+
+static LOG_PATH_CACHE: OnceLock<Mutex<HashMap<CacheKey, String>>> = OnceLock::new();
+
+pub fn resolve_cached_log_path(
+    workspace_root: Option<&str>,
+    log_id: &str,
+    username: Option<&str>,
+) -> Option<String> {
+    let key = CacheKey {
+        workspace_root: workspace_root
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        username: username
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string),
+        log_id: log_id.trim().to_string(),
+    };
+
+    if key.log_id.is_empty() {
+        return None;
+    }
+
+    let cache = LOG_PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock() {
+        if let Some(existing) = guard.get(&key) {
+            return Some(existing.clone());
+        }
+    }
+
+    let resolved = alv_core::log_store::find_cached_log_path(
+        key.workspace_root.as_deref(),
+        &key.log_id,
+        key.username.as_deref(),
+    )?
+    .to_string_lossy()
+    .into_owned();
+
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(key, resolved.clone());
+    }
+
+    Some(resolved)
+}

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -43,6 +43,7 @@ enum ServerOperation {
     LogsList(LogsListParams),
     SearchQuery(SearchQueryParams),
     LogsTriage(LogsTriageParams),
+    ResolveCachedPath(logs_handler::ResolveCachedLogPathParams),
     Unknown(String),
 }
 
@@ -257,6 +258,10 @@ fn execute_call(call: ServerCall, cancellation: &CancellationToken) -> Result<St
             let payload = logs_handler::handle_logs_triage_with_cancel(params, cancellation)?;
             Ok(jsonrpc_result(&call.id, &payload))
         }
+        ServerOperation::ResolveCachedPath(params) => {
+            let payload = logs_handler::handle_resolve_cached_path(params)?;
+            Ok(jsonrpc_result(&call.id, &payload))
+        }
         ServerOperation::Unknown(method) => Ok(jsonrpc_error(
             &call.id,
             -32601,
@@ -396,6 +401,24 @@ fn parse_request_line(request: &str) -> Result<ParsedRequest, String> {
                 .or_else(|| params.get("workspace_root").and_then(Value::as_str))
                 .map(str::to_string),
         }),
+        "logs/resolveCachedPath" => {
+            ServerOperation::ResolveCachedPath(logs_handler::ResolveCachedLogPathParams {
+                log_id: params
+                    .get("logId")
+                    .and_then(Value::as_str)
+                    .unwrap_or_default()
+                    .to_string(),
+                username: params
+                    .get("username")
+                    .and_then(Value::as_str)
+                    .map(str::to_string),
+                workspace_root: params
+                    .get("workspaceRoot")
+                    .and_then(Value::as_str)
+                    .or_else(|| params.get("workspace_root").and_then(Value::as_str))
+                    .map(str::to_string),
+            })
+        }
         _ => ServerOperation::Unknown(method.to_string()),
     };
 

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -188,6 +188,38 @@ fn app_server_smoke_routes_logs_search_and_triage_requests() {
 }
 
 #[test]
+fn app_server_smoke_resolves_cached_log_paths() {
+    let workspace_root = make_temp_dir("resolve-cache");
+    let cached_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("demo@example.com")
+        .join("logs")
+        .join("2026-03-30")
+        .join("07L000000000001AA.log");
+    fs::create_dir_all(
+        cached_path
+            .parent()
+            .expect("cached log parent should exist"),
+    )
+    .expect("cached log dir should be creatable");
+    fs::write(&cached_path, "body").expect("cached log should be writable");
+
+    let response = handle_request_line(&format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:1\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000001AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
+        workspace_root.display()
+    ))
+    .expect("resolve request should succeed")
+    .expect("resolve request should emit a response");
+
+    assert!(response.contains("\"id\":\"resolve:1\""));
+    assert!(response.contains("\"path\":\""));
+    assert!(response.contains("07L000000000001AA.log"));
+
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
+}
+
+#[test]
 fn app_server_smoke_cancels_in_flight_request_and_keeps_processing_stdio() {
     let _guard = test_guard().lock().expect("test guard should lock");
 

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -220,6 +220,49 @@ fn app_server_smoke_resolves_cached_log_paths() {
 }
 
 #[test]
+fn app_server_smoke_drops_stale_cached_log_path_hits() {
+    let workspace_root = make_temp_dir("resolve-cache-stale");
+    let cached_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("demo@example.com")
+        .join("logs")
+        .join("2026-03-30")
+        .join("07L000000000009AA.log");
+    fs::create_dir_all(
+        cached_path
+            .parent()
+            .expect("cached log parent should exist"),
+    )
+    .expect("cached log dir should be creatable");
+    fs::write(&cached_path, "body").expect("cached log should be writable");
+
+    let first_response = handle_request_line(&format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:stale-1\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000009AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
+        workspace_root.display()
+    ))
+    .expect("first resolve request should succeed")
+    .expect("first resolve request should emit a response");
+    assert!(first_response.contains("07L000000000009AA.log"));
+
+    fs::remove_file(&cached_path).expect("cached log should be removable");
+
+    let second_response = handle_request_line(&format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:stale-2\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000009AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
+        workspace_root.display()
+    ))
+    .expect("second resolve request should succeed")
+    .expect("second resolve request should emit a response");
+
+    assert!(
+        !second_response.contains("\"path\":\""),
+        "stale cache hits should not keep returning a removed file path"
+    );
+
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
+}
+
+#[test]
 fn app_server_smoke_cancels_in_flight_request_and_keeps_processing_stdio() {
     let _guard = test_guard().lock().expect("test guard should lock");
 

--- a/crates/alv-core/src/log_store.rs
+++ b/crates/alv-core/src/log_store.rs
@@ -238,7 +238,7 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
 
     for entry in fs::read_dir(logs_root).ok()?.flatten() {
         let day_dir = entry.path();
-        if !day_dir.is_dir() {
+        if !day_dir.is_dir() || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref()) {
             continue;
         }
 
@@ -249,6 +249,22 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
     }
 
     None
+}
+
+fn is_supported_log_day_dir_name(name: &str) -> bool {
+    name == "unknown-date"
+        || matches!(
+            name.as_bytes(),
+            [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
+                if y1.is_ascii_digit()
+                    && y2.is_ascii_digit()
+                    && y3.is_ascii_digit()
+                    && y4.is_ascii_digit()
+                    && m1.is_ascii_digit()
+                    && m2.is_ascii_digit()
+                    && d1.is_ascii_digit()
+                    && d2.is_ascii_digit()
+        )
 }
 
 fn find_log_in_orgs_root(orgs_root: &Path, log_id: &str) -> Option<PathBuf> {

--- a/crates/alv-core/src/log_store.rs
+++ b/crates/alv-core/src/log_store.rs
@@ -197,7 +197,7 @@ pub fn find_cached_log_path(
 
     if let Some(username) = resolved_username.filter(|value| !value.trim().is_empty()) {
         let scoped_root = org_dir(workspace_root, username).join("logs");
-        if let Some(found) = find_log_in_tree(&scoped_root, log_id) {
+        if let Some(found) = find_log_in_logs_dir(&scoped_root, log_id) {
             return Some(found);
         }
 
@@ -215,7 +215,7 @@ pub fn find_cached_log_path(
     }
 
     let orgs_root = root.join("orgs");
-    if let Some(found) = find_log_in_tree(&orgs_root, log_id) {
+    if let Some(found) = find_log_in_orgs_root(&orgs_root, log_id) {
         return Some(found);
     }
 
@@ -231,22 +231,35 @@ pub fn find_cached_log_path(
     None
 }
 
-fn find_log_in_tree(root: &Path, log_id: &str) -> Option<PathBuf> {
-    if !root.exists() {
+fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !logs_root.is_dir() {
         return None;
     }
 
-    for entry in fs::read_dir(root).ok()?.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            if let Some(found) = find_log_in_tree(&path, log_id) {
-                return Some(found);
-            }
+    for entry in fs::read_dir(logs_root).ok()?.flatten() {
+        let day_dir = entry.path();
+        if !day_dir.is_dir() {
             continue;
         }
 
-        if path.file_name()?.to_string_lossy() == format!("{log_id}.log") {
-            return Some(path);
+        let candidate = day_dir.join(format!("{log_id}.log"));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn find_log_in_orgs_root(orgs_root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !orgs_root.is_dir() {
+        return None;
+    }
+
+    for entry in fs::read_dir(orgs_root).ok()?.flatten() {
+        let found = find_log_in_logs_dir(&entry.path().join("logs"), log_id);
+        if found.is_some() {
+            return found;
         }
     }
 

--- a/crates/alv-core/tests/log_store_layout.rs
+++ b/crates/alv-core/tests/log_store_layout.rs
@@ -182,6 +182,67 @@ fn log_store_scoped_lookup_does_not_scan_other_org_trees_when_scope_misses() {
 }
 
 #[test]
+fn log_store_ignores_matching_files_outside_logs_day_directories() {
+    let workspace_root = make_temp_workspace("bounded-layout");
+    let off_layout = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("archive")
+        .join("2026-03-30");
+    fs::create_dir_all(&off_layout).expect("archive dir should be creatable");
+    fs::write(off_layout.join("07L0000000000BAD.log"), "off-layout")
+        .expect("off-layout file should be writable");
+
+    let found = find_cached_log_path(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "07L0000000000BAD",
+        Some("default@example.com"),
+    );
+
+    assert!(
+        found.is_none(),
+        "lookup should ignore files outside logs/<day>/"
+    );
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn log_store_unscoped_lookup_ignores_matching_files_outside_logs_day_directories() {
+    let workspace_root = make_temp_workspace("bounded-unscoped");
+    let off_layout = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("other@example.com")
+        .join("tmp")
+        .join("2026-03-30");
+    fs::create_dir_all(&off_layout).expect("tmp dir should be creatable");
+    fs::write(off_layout.join("07L0000000000OFF.log"), "off-layout")
+        .expect("off-layout file should be writable");
+
+    let found = find_cached_log_path(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "07L0000000000OFF",
+        None,
+    );
+
+    assert!(
+        found.is_none(),
+        "unscoped lookup should still respect the supported layout"
+    );
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn log_store_ignores_empty_log_ids() {
     let workspace_root = make_temp_workspace("empty-log-id");
     let workspace_text = workspace_root

--- a/crates/alv-core/tests/log_store_layout.rs
+++ b/crates/alv-core/tests/log_store_layout.rs
@@ -213,6 +213,36 @@ fn log_store_ignores_matching_files_outside_logs_day_directories() {
 }
 
 #[test]
+fn log_store_ignores_matching_files_in_unsupported_logs_subdirectories() {
+    let workspace_root = make_temp_workspace("unsupported-log-dir");
+    let off_layout = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("archive");
+    fs::create_dir_all(&off_layout).expect("archive dir should be creatable");
+    fs::write(off_layout.join("07L0000000000ARC.log"), "off-layout")
+        .expect("off-layout file should be writable");
+
+    let found = find_cached_log_path(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "07L0000000000ARC",
+        Some("default@example.com"),
+    );
+
+    assert!(
+        found.is_none(),
+        "lookup should ignore unsupported logs subdirectories like archive/"
+    );
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn log_store_unscoped_lookup_ignores_matching_files_outside_logs_day_directories() {
     let workspace_root = make_temp_workspace("bounded-unscoped");
     let off_layout = workspace_root
@@ -239,6 +269,39 @@ fn log_store_unscoped_lookup_ignores_matching_files_outside_logs_day_directories
         found.is_none(),
         "unscoped lookup should still respect the supported layout"
     );
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn log_store_finds_unknown_date_layout_files() {
+    let workspace_root = make_temp_workspace("unknown-date");
+    let unknown_date = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("unknown-date")
+        .join("07L0000000000UNK.log");
+    fs::create_dir_all(
+        unknown_date
+            .parent()
+            .expect("unknown-date parent should exist"),
+    )
+    .expect("unknown-date dir should be creatable");
+    fs::write(&unknown_date, "unknown-date").expect("unknown-date log should be writable");
+
+    let found = find_cached_log_path(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "07L0000000000UNK",
+        Some("default@example.com"),
+    )
+    .expect("lookup should find unknown-date layout");
+
+    assert_eq!(found, unknown_date);
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 

--- a/docs/superpowers/plans/2026-04-04-issue-692-runtime-lookup.md
+++ b/docs/superpowers/plans/2026-04-04-issue-692-runtime-lookup.md
@@ -1,0 +1,771 @@
+# Issue 692 Runtime Lookup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the extension’s repeated recursive cached-log lookup with a runtime-backed shared resolver, while tightening the shared Rust lookup so repeated local log opens no longer rescan arbitrary `apexlogs/` subtrees.
+
+**Architecture:** Keep `alv-core` as the source of truth for lookup semantics, add a narrow `logs/resolveCachedPath` RPC in `alv-app-server`, and make `src/utils/workspace.ts` call that RPC before a bounded local fallback. Cache only successful runtime lookups in the app-server process so the extension benefits from repeated hits without keeping stale negative entries after new files are written locally.
+
+**Tech Stack:** TypeScript, VS Code extension host tests, JSON-RPC runtime client, Rust (`alv-core`, `alv-app-server`), Cargo tests
+
+---
+
+## File Map
+
+- `packages/app-server-client-ts/src/index.ts`
+  Adds the TypeScript request/response types for `logs/resolveCachedPath`.
+- `apps/vscode-extension/src/runtime/runtimeClient.ts`
+  Adds the typed `resolveCachedLogPath()` wrapper over the new RPC method.
+- `apps/vscode-extension/src/test/runtime/runtimeClient.test.ts`
+  Verifies the runtime client sends the new method and returns the typed payload.
+- `crates/alv-core/src/log_store.rs`
+  Replaces the arbitrary recursive walk with a bounded org-first traversal that only inspects `logs/<day>/`.
+- `crates/alv-core/tests/log_store_layout.rs`
+  Proves the shared lookup ignores matching files outside the supported org-first layout and still preserves legacy fallbacks.
+- `crates/alv-app-server/src/log_lookup_cache.rs`
+  New process-lifetime cache module for resolved hit paths.
+- `crates/alv-app-server/src/lib.rs`
+  Registers the cache module.
+- `crates/alv-app-server/src/handlers/logs.rs`
+  Adds the handler that serializes `logs/resolveCachedPath`.
+- `crates/alv-app-server/src/server.rs`
+  Parses the new method and dispatches it to the logs handler.
+- `crates/alv-app-server/tests/app_server_smoke.rs`
+  Covers the new JSON-RPC route.
+- `src/utils/workspace.ts`
+  Makes `findExistingLogFile()` runtime-first, with a bounded local fallback.
+- `apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts`
+  New focused extension-host unit tests for runtime preference and local fallback.
+- `apps/vscode-extension/src/test/findExistingLogFile.test.ts`
+  Existing integration suite that continues to exercise the helper under the real extension test runner.
+- `CHANGELOG.md`
+  Adds the user-facing note under `Unreleased`.
+
+### Task 1: Add the Typed Runtime Client Contract
+
+**Files:**
+- Modify: `packages/app-server-client-ts/src/index.ts`
+- Modify: `apps/vscode-extension/src/runtime/runtimeClient.ts`
+- Test: `apps/vscode-extension/src/test/runtime/runtimeClient.test.ts`
+
+- [ ] **Step 1: Write the failing runtime-client test**
+
+```ts
+  test('resolveCachedLogPath uses the runtime request method', async () => {
+    const methods: string[] = [];
+    const client = new RuntimeClient({
+      requestHandler: async (method, params) => {
+        methods.push(method);
+        assert.deepEqual(params, {
+          logId: '07L000000000001AA',
+          username: 'demo@example.com',
+          workspaceRoot: '/tmp/alv-workspace'
+        });
+        return {
+          path: '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+        } as never;
+      }
+    });
+
+    const result = await client.resolveCachedLogPath({
+      logId: '07L000000000001AA',
+      username: 'demo@example.com',
+      workspaceRoot: '/tmp/alv-workspace'
+    });
+
+    assert.deepEqual(methods, ['logs/resolveCachedPath']);
+    assert.equal(
+      result.path,
+      '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log'
+    );
+  });
+```
+
+- [ ] **Step 2: Run the extension-host unit suite to confirm the new API is missing**
+
+Run:
+
+```bash
+npm run pretest
+node scripts/run-tests-cli.js --scope=unit --vscode=stable
+```
+
+Expected:
+
+```text
+FAIL runtime client
+TypeError: client.resolveCachedLogPath is not a function
+```
+
+- [ ] **Step 3: Add the shared TypeScript RPC types**
+
+```ts
+export type ResolveCachedLogPathParams = {
+  logId: string;
+  username?: string;
+  workspaceRoot?: string;
+};
+
+export type ResolveCachedLogPathResult = {
+  path?: string;
+};
+```
+
+- [ ] **Step 4: Add the `RuntimeClient.resolveCachedLogPath()` method**
+
+```ts
+  async resolveCachedLogPath(
+    params: ResolveCachedLogPathParams,
+    signal?: AbortSignal
+  ): Promise<ResolveCachedLogPathResult> {
+    if (!this.requestHandler) {
+      await this.initialize();
+    }
+    return this.request<ResolveCachedLogPathResult>('logs/resolveCachedPath', params, signal);
+  }
+```
+
+- [ ] **Step 5: Re-run typecheck and the unit suite**
+
+Run:
+
+```bash
+npm run check-types
+node scripts/run-tests-cli.js --scope=unit --vscode=stable
+```
+
+Expected:
+
+```text
+TypeScript compilation succeeds
+unit suite passes, including "runtime client"
+```
+
+- [ ] **Step 6: Commit the contract and client wrapper**
+
+```bash
+git add packages/app-server-client-ts/src/index.ts \
+  apps/vscode-extension/src/runtime/runtimeClient.ts \
+  apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+git commit -m "feat(runtime): add cached log path client method"
+```
+
+### Task 2: Tighten the Shared `alv-core` Lookup
+
+**Files:**
+- Modify: `crates/alv-core/src/log_store.rs`
+- Test: `crates/alv-core/tests/log_store_layout.rs`
+
+- [ ] **Step 1: Add failing Rust tests for bounded org-first traversal**
+
+```rust
+#[test]
+fn log_store_ignores_matching_files_outside_logs_day_directories() {
+    let workspace_root = make_temp_workspace("bounded-layout");
+    let off_layout = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("archive")
+        .join("2026-03-30");
+    fs::create_dir_all(&off_layout).expect("archive dir should be creatable");
+    fs::write(
+        off_layout.join("07L0000000000BAD.log"),
+        "off-layout",
+    )
+    .expect("off-layout file should be writable");
+
+    let found = find_cached_log_path(
+        Some(workspace_root.to_str().expect("workspace path should be utf8")),
+        "07L0000000000BAD",
+        Some("default@example.com"),
+    );
+
+    assert!(found.is_none(), "lookup should ignore files outside logs/<day>/");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn log_store_unscoped_lookup_ignores_matching_files_outside_logs_day_directories() {
+    let workspace_root = make_temp_workspace("bounded-unscoped");
+    let off_layout = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("other@example.com")
+        .join("tmp")
+        .join("2026-03-30");
+    fs::create_dir_all(&off_layout).expect("tmp dir should be creatable");
+    fs::write(
+        off_layout.join("07L0000000000OFF.log"),
+        "off-layout",
+    )
+    .expect("off-layout file should be writable");
+
+    let found = find_cached_log_path(
+        Some(workspace_root.to_str().expect("workspace path should be utf8")),
+        "07L0000000000OFF",
+        None,
+    );
+
+    assert!(found.is_none(), "unscoped lookup should still respect the supported layout");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+```
+
+- [ ] **Step 2: Run the focused Rust test to verify the current recursive lookup fails**
+
+Run:
+
+```bash
+cargo test -p alv-core --test log_store_layout
+```
+
+Expected:
+
+```text
+FAILED log_store_ignores_matching_files_outside_logs_day_directories
+FAILED log_store_unscoped_lookup_ignores_matching_files_outside_logs_day_directories
+```
+
+- [ ] **Step 3: Replace the recursive tree walk with bounded helpers**
+
+```rust
+fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !logs_root.is_dir() {
+        return None;
+    }
+
+    for entry in fs::read_dir(logs_root).ok()?.flatten() {
+        let day_dir = entry.path();
+        if !day_dir.is_dir() {
+            continue;
+        }
+
+        let candidate = day_dir.join(format!("{log_id}.log"));
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+
+    None
+}
+
+fn find_log_in_orgs_root(orgs_root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !orgs_root.is_dir() {
+        return None;
+    }
+
+    for entry in fs::read_dir(orgs_root).ok()?.flatten() {
+        let found = find_log_in_logs_dir(&entry.path().join("logs"), log_id);
+        if found.is_some() {
+            return found;
+        }
+    }
+
+    None
+}
+```
+
+- [ ] **Step 4: Wire the new helpers into `find_cached_log_path()`**
+
+```rust
+    if let Some(username) = resolved_username.filter(|value| !value.trim().is_empty()) {
+        let scoped_root = org_dir(workspace_root, username).join("logs");
+        if let Some(found) = find_log_in_logs_dir(&scoped_root, log_id) {
+            return Some(found);
+        }
+        // legacy fallback stays unchanged
+    }
+
+    let orgs_root = root.join("orgs");
+    if let Some(found) = find_log_in_orgs_root(&orgs_root, log_id) {
+        return Some(found);
+    }
+```
+
+- [ ] **Step 5: Re-run the focused Rust test**
+
+Run:
+
+```bash
+cargo test -p alv-core --test log_store_layout
+```
+
+Expected:
+
+```text
+test result: ok.
+10 passed; 0 failed
+```
+
+- [ ] **Step 6: Commit the shared lookup optimization**
+
+```bash
+git add crates/alv-core/src/log_store.rs crates/alv-core/tests/log_store_layout.rs
+git commit -m "perf(logs): bound shared cached log lookup"
+```
+
+### Task 3: Add `logs/resolveCachedPath` to the App Server
+
+**Files:**
+- Create: `crates/alv-app-server/src/log_lookup_cache.rs`
+- Modify: `crates/alv-app-server/src/lib.rs`
+- Modify: `crates/alv-app-server/src/handlers/logs.rs`
+- Modify: `crates/alv-app-server/src/server.rs`
+- Test: `crates/alv-app-server/tests/app_server_smoke.rs`
+
+- [ ] **Step 1: Add the failing app-server smoke test for the new RPC route**
+
+```rust
+#[test]
+fn app_server_smoke_resolves_cached_log_paths() {
+    let workspace_root = make_temp_dir("resolve-cache");
+    let cached_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("demo@example.com")
+        .join("logs")
+        .join("2026-03-30")
+        .join("07L000000000001AA.log");
+    fs::create_dir_all(cached_path.parent().expect("cached log parent should exist"))
+        .expect("cached log dir should be creatable");
+    fs::write(&cached_path, "body").expect("cached log should be writable");
+
+    let response = handle_request_line(&format!(
+        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:1\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000001AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
+        workspace_root.display()
+    ))
+    .expect("resolve request should succeed")
+    .expect("resolve request should emit a response");
+
+    assert!(response.contains("\"id\":\"resolve:1\""));
+    assert!(response.contains("\"path\":\""));
+    assert!(response.contains("07L000000000001AA.log"));
+
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
+}
+```
+
+- [ ] **Step 2: Run the focused app-server smoke test and confirm the route does not exist yet**
+
+Run:
+
+```bash
+cargo test -p alv-app-server app_server_smoke_resolves_cached_log_paths -- --exact
+```
+
+Expected:
+
+```text
+FAILED app_server_smoke_resolves_cached_log_paths
+method not found: logs/resolveCachedPath
+```
+
+- [ ] **Step 3: Create the hit-cache module**
+
+```rust
+use std::{
+    collections::HashMap,
+    sync::{Mutex, OnceLock},
+};
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct CacheKey {
+    workspace_root: Option<String>,
+    username: Option<String>,
+    log_id: String,
+}
+
+static LOG_PATH_CACHE: OnceLock<Mutex<HashMap<CacheKey, String>>> = OnceLock::new();
+
+pub fn resolve_cached_log_path(
+    workspace_root: Option<&str>,
+    log_id: &str,
+    username: Option<&str>,
+) -> Option<String> {
+    let key = CacheKey {
+        workspace_root: workspace_root.map(str::trim).filter(|value| !value.is_empty()).map(str::to_string),
+        username: username.map(str::trim).filter(|value| !value.is_empty()).map(str::to_string),
+        log_id: log_id.trim().to_string(),
+    };
+
+    if key.log_id.is_empty() {
+        return None;
+    }
+
+    let cache = LOG_PATH_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock() {
+        if let Some(existing) = guard.get(&key) {
+            return Some(existing.clone());
+        }
+    }
+
+    let resolved = alv_core::log_store::find_cached_log_path(
+        key.workspace_root.as_deref(),
+        &key.log_id,
+        key.username.as_deref(),
+    )?
+    .to_string_lossy()
+    .into_owned();
+
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(key, resolved.clone());
+    }
+
+    Some(resolved)
+}
+```
+
+- [ ] **Step 4: Add the new request parsing and handler dispatch**
+
+```rust
+"logs/resolveCachedPath" => ServerOperation::ResolveCachedPath(logs_handler::ResolveCachedLogPathParams {
+    log_id: params
+        .get("logId")
+        .and_then(Value::as_str)
+        .unwrap_or_default()
+        .to_string(),
+    username: params.get("username").and_then(Value::as_str).map(str::to_string),
+    workspace_root: params
+        .get("workspaceRoot")
+        .and_then(Value::as_str)
+        .or_else(|| params.get("workspace_root").and_then(Value::as_str))
+        .map(str::to_string),
+}),
+```
+
+```rust
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolveCachedLogPathParams {
+    pub log_id: String,
+    pub username: Option<String>,
+    pub workspace_root: Option<String>,
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolveCachedLogPathResult {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+}
+
+pub fn handle_resolve_cached_path(params: ResolveCachedLogPathParams) -> Result<String, String> {
+    let path = crate::log_lookup_cache::resolve_cached_log_path(
+        params.workspace_root.as_deref(),
+        &params.log_id,
+        params.username.as_deref(),
+    );
+
+    serde_json::to_string(&ResolveCachedLogPathResult { path })
+        .map_err(|error| format!("failed to serialize logs/resolveCachedPath response: {error}"))
+}
+```
+
+```rust
+enum ServerOperation {
+    // ...
+    ResolveCachedPath(logs_handler::ResolveCachedLogPathParams),
+}
+```
+
+- [ ] **Step 5: Re-run the focused app-server tests**
+
+Run:
+
+```bash
+cargo test -p alv-app-server app_server_smoke_resolves_cached_log_paths -- --exact
+cargo test -p alv-app-server app_server_smoke_routes_logs_search_and_triage_requests -- --exact
+```
+
+Expected:
+
+```text
+test app_server_smoke_resolves_cached_log_paths ... ok
+test app_server_smoke_routes_logs_search_and_triage_requests ... ok
+```
+
+- [ ] **Step 6: Commit the runtime route**
+
+```bash
+git add crates/alv-app-server/src/log_lookup_cache.rs \
+  crates/alv-app-server/src/lib.rs \
+  crates/alv-app-server/src/handlers/logs.rs \
+  crates/alv-app-server/src/server.rs \
+  crates/alv-app-server/tests/app_server_smoke.rs
+git commit -m "feat(runtime): add cached log path resolver route"
+```
+
+### Task 4: Make `findExistingLogFile()` Runtime-First with Bounded Fallback
+
+**Files:**
+- Modify: `src/utils/workspace.ts`
+- Create: `apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts`
+- Test: `apps/vscode-extension/src/test/findExistingLogFile.test.ts`
+
+- [ ] **Step 1: Add failing extension-host unit tests for runtime preference and fallback**
+
+```ts
+import assert from 'assert/strict';
+import * as path from 'path';
+import proxyquire from 'proxyquire';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+suite('findExistingLogFile runtime lookup', () => {
+  test('prefers the runtime-resolved cached path', async () => {
+    const resolveCalls: any[] = [];
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      vscode: { workspace: { workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }] } },
+      '../../apps/vscode-extension/src/runtime/runtimeClient': {
+        runtimeClient: {
+          resolveCachedLogPath: async (params: any) => {
+            resolveCalls.push(params);
+            return { path: '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log' };
+          }
+        }
+      },
+      './logger': { logInfo: () => undefined, logWarn: () => undefined }
+    });
+
+    const result = await workspaceModule.findExistingLogFile('07L000000000001AA', 'demo@example.com');
+
+    assert.equal(result, '/tmp/alv-workspace/apexlogs/orgs/demo@example.com/logs/2026-03-30/07L000000000001AA.log');
+    assert.deepEqual(resolveCalls, [{
+      logId: '07L000000000001AA',
+      username: 'demo@example.com',
+      workspaceRoot: '/tmp/alv-workspace'
+    }]);
+  });
+
+  test('falls back to local lookup when the runtime request fails', async () => {
+    const localPath = path.join('/tmp/alv-workspace', 'apexlogs', 'demo_07L000000000002AA.log');
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      vscode: { workspace: { workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }] } },
+      '../../apps/vscode-extension/src/runtime/runtimeClient': {
+        runtimeClient: {
+          resolveCachedLogPath: async () => {
+            throw new Error('daemon unavailable');
+          }
+        }
+      },
+      fs: {
+        promises: {
+          readdir: async (target: string, options?: { withFileTypes?: boolean }) => {
+            if (target.endsWith(path.join('orgs', 'demo', 'logs'))) {
+              return [];
+            }
+            if (options?.withFileTypes) {
+              return [];
+            }
+            return ['demo_07L000000000002AA.log'];
+          }
+        }
+      },
+      './logger': { logInfo: () => undefined, logWarn: () => undefined }
+    });
+
+    const result = await workspaceModule.findExistingLogFile('07L000000000002AA', 'demo');
+    assert.equal(result, localPath);
+  });
+});
+```
+
+- [ ] **Step 2: Run the unit suite to verify the helper still uses only local filesystem logic**
+
+Run:
+
+```bash
+npm run pretest
+node scripts/run-tests-cli.js --scope=unit --vscode=stable
+```
+
+Expected:
+
+```text
+FAIL findExistingLogFile runtime lookup
+AssertionError or TypeError because workspace.ts never calls runtimeClient.resolveCachedLogPath
+```
+
+- [ ] **Step 3: Add a bounded local fallback helper and runtime-first lookup**
+
+```ts
+import { runtimeClient } from '../../apps/vscode-extension/src/runtime/runtimeClient';
+
+async function findExistingOrgFirstLogFile(logsRoot: string, logId: string): Promise<string | undefined> {
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(logsRoot, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+    const candidate = path.join(logsRoot, entry.name, `${logId}.log`);
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) {
+        return candidate;
+      }
+    } catch {
+      // continue
+    }
+  }
+
+  return undefined;
+}
+
+async function findExistingLogFileLocally(logId: string, username?: string): Promise<string | undefined> {
+  const dir = getApexLogsDir();
+  if (username) {
+    const orgFirst = await findExistingOrgFirstLogFile(
+      path.join(dir, 'orgs', toSafeLogUserName(username), 'logs'),
+      logId
+    );
+    if (orgFirst) {
+      return orgFirst;
+    }
+  } else {
+    const orgsDir = path.join(dir, 'orgs');
+    let orgEntries: import('fs').Dirent[];
+    try {
+      orgEntries = await fs.readdir(orgsDir, { withFileTypes: true });
+    } catch {
+      orgEntries = [];
+    }
+  for (const entry of orgEntries) {
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      const orgFirst = await findExistingOrgFirstLogFile(path.join(orgsDir, entry.name, 'logs'), logId);
+      if (orgFirst) {
+        return orgFirst;
+      }
+    }
+  }
+
+  const entries = await fs.readdir(dir);
+  if (username) {
+    const exact = `${toSafeLogUserName(username)}_${logId}.log`;
+    if (entries.includes(exact)) {
+      return path.join(dir, exact);
+    }
+  }
+  const legacy = entries.find(name => name === `${logId}.log`);
+  if (legacy) {
+    return path.join(dir, legacy);
+  }
+  if (!username) {
+    const preferred = entries.find(name => name.endsWith(`_${logId}.log`));
+    if (preferred) {
+      return path.join(dir, preferred);
+    }
+  }
+
+  return undefined;
+}
+
+export async function findExistingLogFile(logId: string, username?: string): Promise<string | undefined> {
+  const workspaceRoot = getWorkspaceRoot();
+  try {
+    const result = await runtimeClient.resolveCachedLogPath({ logId, username, workspaceRoot });
+    if (typeof result.path === 'string' && result.path.trim().length > 0) {
+      return result.path;
+    }
+  } catch (error) {
+    logWarn('Could not resolve cached log path via runtime ->', getErrorMessage(error));
+  }
+
+  return findExistingLogFileLocally(logId, username);
+}
+```
+
+- [ ] **Step 4: Re-run the unit and integration suites**
+
+Run:
+
+```bash
+node scripts/run-tests-cli.js --scope=unit --vscode=stable
+node scripts/run-tests-cli.js --scope=integration --vscode=stable
+```
+
+Expected:
+
+```text
+unit suite passes, including "findExistingLogFile runtime lookup"
+integration suite passes, including "integration: findExistingLogFile"
+```
+
+- [ ] **Step 5: Commit the extension helper switch**
+
+```bash
+git add src/utils/workspace.ts \
+  apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts \
+  apps/vscode-extension/src/test/findExistingLogFile.test.ts
+git commit -m "fix(logs): resolve cached log paths through runtime"
+```
+
+### Task 5: Update Changelog and Run Final Verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md`
+
+- [ ] **Step 1: Add the unreleased changelog note**
+
+```md
+### Bug Fixes
+
+- Runtime/Logs: route extension cached-log lookup through the shared runtime, bound org-first cache traversal to the supported `logs/<day>/` layout, and avoid repeated full-tree scans when reopening locally cached logs.
+```
+
+- [ ] **Step 2: Keep the approved spec aligned with the safe cache behavior**
+
+```md
+- The app server caches resolved hits for the daemon session.
+- Misses stay uncached so the extension can create a new file locally without leaving a stale negative cache entry behind.
+```
+
+- [ ] **Step 3: Install Linux Electron dependencies if this environment does not already have them**
+
+Run:
+
+```bash
+INSTALL_LINUX_DEPS=true npm run test:linux-deps
+```
+
+Expected:
+
+```text
+[deps] Libraries installed successfully.
+```
+
+- [ ] **Step 4: Run the final verification sweep**
+
+Run:
+
+```bash
+cargo test -p alv-core --test log_store_layout
+cargo test -p alv-app-server
+npm run compile
+node scripts/run-tests-cli.js --scope=unit --vscode=stable
+node scripts/run-tests-cli.js --scope=integration --vscode=stable
+```
+
+Expected:
+
+```text
+All Rust tests pass
+npm run compile exits 0
+unit suite passes
+integration suite passes
+```
+
+- [ ] **Step 5: Commit the docs and verification-ready state**
+
+```bash
+git add CHANGELOG.md docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md
+git commit -m "docs(changelog): note runtime cached log lookup"
+```

--- a/docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md
@@ -72,12 +72,11 @@ The app server will normalize the lookup key as:
 - normalized username scope
 - log id
 
-The server process will cache both hits and misses for the lifetime of the daemon:
+The server process will cache resolved hits for the lifetime of the daemon:
 
 - hit: resolved absolute file path
-- miss: explicit negative cache entry
 
-This keeps repeated extension lookups cheap without introducing persistent shared state into `alv-core`.
+Misses will still use the bounded shared lookup, but they will not be memoized because the extension can create a log file locally later in the same daemon session. This keeps repeated successful lookups cheap without introducing stale negative entries.
 
 ### 3. Extension integration
 
@@ -118,7 +117,7 @@ Fallback rules:
 - Empty or whitespace `logId` returns no path.
 - Username-scoped requests do not leak into another org tree.
 - Runtime transport errors do not block the user; they trigger the local fallback path.
-- Negative cache entries live only for the daemon session, so restarting the runtime naturally invalidates stale misses.
+- Cached hits live only for the daemon session, so restarting the runtime naturally invalidates stale paths.
 
 ## Testing Strategy
 
@@ -131,7 +130,7 @@ Fallback rules:
 ### `alv-app-server`
 
 - Add a JSON-RPC smoke test for `logs/resolveCachedPath`.
-- Add coverage that repeated identical requests can reuse cached hit/miss results without changing behavior.
+- Add coverage that repeated identical requests can reuse cached hits without changing behavior.
 
 ### Extension
 

--- a/docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md
+++ b/docs/superpowers/specs/2026-04-04-issue-692-runtime-lookup-design.md
@@ -1,0 +1,169 @@
+# Issue 692 Design: Shared Runtime Cached-Log Lookup
+
+## Summary
+
+Issue [#692](https://github.com/Electivus/Apex-Log-Viewer/issues/692) is still open because the extension-side `findExistingLogFile()` helper performs a recursive tree walk to locate a single `<logId>.log` file. That work happens on a hot path and repeats across bulk log operations. The chosen design is to move extension log-path resolution onto the shared runtime path through a new JSON-RPC endpoint, while also tightening the underlying `alv-core` lookup algorithm so the shared resolver no longer scans arbitrary subtrees on every request.
+
+## Goals
+
+- Stop repeated whole-tree scans for single-log lookups.
+- Keep lookup behavior compatible with both org-first and legacy flat cache layouts.
+- Make the extension reuse the shared runtime lookup instead of maintaining a separate primary implementation.
+- Preserve scoped lookup semantics so a username-scoped request does not leak into another org tree.
+- Keep the public extension behavior unchanged for log open/download workflows.
+
+## Non-Goals
+
+- No persistent on-disk index for cached logs in this change.
+- No change to the canonical cache layout under `apexlogs/orgs/<safe-org>/logs/<YYYY-MM-DD>/<logId>.log`.
+- No refactor of runtime search/triage beyond reusing the same optimized lookup primitives where it is already a fit.
+- No requirement that the extension shell out to CLI commands for local cache lookups.
+
+## Chosen Approach
+
+We will implement a new runtime JSON-RPC method, `logs/resolveCachedPath`, and make the extension call that method whenever it needs to locate an already cached log file.
+
+The runtime path will be split into two responsibilities:
+
+- `alv-core` remains the source of truth for lookup semantics and path-resolution rules.
+- `alv-app-server` owns a process-lifetime in-memory cache keyed by normalized lookup scope so repeated calls do not keep traversing the filesystem.
+
+The extension will keep the existing `findExistingLogFile(logId, username?)` interface, but the implementation will become:
+
+1. Attempt runtime lookup through `runtimeClient`.
+2. Return the resolved path when present.
+3. Fall back to the existing local TypeScript lookup only if the runtime is unavailable or the RPC call fails.
+
+This preserves extension resilience while making the shared runtime path the default behavior.
+
+## Architecture
+
+### 1. `alv-core` shared lookup
+
+`alv-core` already exposes `find_cached_log_path(workspace_root, log_id, resolved_username)`. That function will stay as the semantic source of truth, but its internal traversal will be tightened to the known cache layout instead of recursively scanning arbitrary subtrees.
+
+Expected lookup behavior:
+
+- If `resolved_username` is provided:
+  - Check `apexlogs/orgs/<safe-username>/logs/<date>/<logId>.log` using a bounded org-first traversal.
+  - Fall back to legacy flat files under `apexlogs/`, first `<safe-username>_<logId>.log`, then `<logId>.log`.
+  - Never scan other org trees.
+- If `resolved_username` is not provided:
+  - Search org-first logs across all org directories using the bounded layout.
+  - Fall back to legacy flat files under `apexlogs/`, including both bare and username-prefixed files.
+
+The key optimization is that org-first lookup will only inspect the known `logs/<day>/` depth instead of recursively descending unrelated directories.
+
+### 2. `alv-app-server` runtime cache and RPC
+
+`alv-app-server` will add a new operation:
+
+- Method: `logs/resolveCachedPath`
+- Params:
+  - `logId: string`
+  - `username?: string`
+  - `workspaceRoot?: string`
+- Result:
+  - `{ path?: string }`
+
+The app server will normalize the lookup key as:
+
+- effective workspace root
+- normalized username scope
+- log id
+
+The server process will cache both hits and misses for the lifetime of the daemon:
+
+- hit: resolved absolute file path
+- miss: explicit negative cache entry
+
+This keeps repeated extension lookups cheap without introducing persistent shared state into `alv-core`.
+
+### 3. Extension integration
+
+`RuntimeClient` will gain a typed helper, for example `resolveCachedLogPath(params, signal?)`.
+
+Extension consumers that need a local cached log path will move to the runtime contract:
+
+- `src/utils/workspace.ts`
+- `src/services/logService.ts`
+- any other direct callers of `findExistingLogFile()` that currently depend on local filesystem walking
+
+`findExistingLogFile()` will remain the compatibility surface for extension callers, but its primary implementation path will be runtime-backed.
+
+### 4. Fallback behavior
+
+If the runtime is unavailable, restarting, or returns an error, the extension will fall back to its local TypeScript lookup logic.
+
+Fallback rules:
+
+- Preserve the current no-side-effects behavior: lookup must not create `apexlogs/`.
+- Preserve username-scoped isolation.
+- Keep the fallback conservative and semantically aligned, but it does not need its own in-memory session cache because it is now the exception path.
+
+## Data Flow
+
+### Cached log lookup from the extension
+
+1. Extension code asks for `findExistingLogFile(logId, username?)`.
+2. `findExistingLogFile()` calls `runtimeClient.resolveCachedLogPath({ logId, username, workspaceRoot })`.
+3. `RuntimeClient` sends `logs/resolveCachedPath` to the daemon.
+4. `alv-app-server` checks its session cache.
+5. On cache miss, `alv-app-server` delegates to `alv-core::find_cached_log_path(...)`.
+6. The daemon returns `{ path }` or `{}`.
+7. The extension uses the returned path, or falls back locally if the RPC path was unavailable.
+
+## Error Handling
+
+- Empty or whitespace `logId` returns no path.
+- Username-scoped requests do not leak into another org tree.
+- Runtime transport errors do not block the user; they trigger the local fallback path.
+- Negative cache entries live only for the daemon session, so restarting the runtime naturally invalidates stale misses.
+
+## Testing Strategy
+
+### `alv-core`
+
+- Extend `log_store_layout` coverage for the optimized bounded traversal.
+- Add tests that confirm scoped lookups do not traverse unrelated org directories.
+- Add tests for legacy flat fallback after org-first miss.
+
+### `alv-app-server`
+
+- Add a JSON-RPC smoke test for `logs/resolveCachedPath`.
+- Add coverage that repeated identical requests can reuse cached hit/miss results without changing behavior.
+
+### Extension
+
+- Update or add tests so `findExistingLogFile()` prefers the runtime-backed path.
+- Add coverage for runtime failure fallback to local lookup.
+- Update `logService` and related tests where the lookup dependency changes from local-first to runtime-first.
+
+## Verification Plan
+
+Before implementation is considered complete, the change must be verified with at least:
+
+- focused Rust tests for `alv-core` log-store lookup
+- focused app-server smoke coverage for the new RPC route
+- extension integration coverage including `integration: findExistingLogFile`
+- repository typecheck/build commands required by the touched code paths
+
+## Alternatives Considered
+
+### Keep two optimized implementations
+
+This would optimize the extension and `alv-core` separately, but it keeps two primary lookup implementations alive. It improves performance, but not alignment.
+
+### Build a persistent log index
+
+This could further reduce lookup cost in very large caches, but it adds invalidation, persistence, and migration complexity that is not required to resolve issue `#692`.
+
+### Force all log lookup through user-facing CLI commands
+
+This would move logic out of the extension, but it conflicts with the repository’s runtime strategy and adds avoidable coupling to shell execution.
+
+## Implementation Notes
+
+- Prefer adding the new RPC shape to `packages/app-server-client-ts` first so both sides share the contract.
+- Keep the new runtime method narrowly scoped to path resolution only; downloading missing logs remains a separate concern.
+- Preserve the existing TypeScript function signatures where possible so the migration is mostly internal.

--- a/packages/app-server-client-ts/src/index.ts
+++ b/packages/app-server-client-ts/src/index.ts
@@ -91,6 +91,16 @@ export type LogsTriageEntry = {
   summary: RuntimeLogTriageSummary;
 };
 
+export type ResolveCachedLogPathParams = {
+  logId: string;
+  username?: string;
+  workspaceRoot?: string;
+};
+
+export type ResolveCachedLogPathResult = {
+  path?: string;
+};
+
 export type JsonRpcRequest = {
   jsonrpc: '2.0';
   id: string;

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as os from 'os';
 import * as path from 'path';
 import { promises as fs } from 'fs';
+import { runtimeClient } from '../../apps/vscode-extension/src/runtime/runtimeClient';
 import { logInfo, logWarn } from './logger';
 
 export interface SalesforceProjectInfo {
@@ -132,26 +133,49 @@ function toSafeLogUserName(username: string | undefined): string {
   return (username || 'default').replace(/[^a-zA-Z0-9_.@-]+/g, '_');
 }
 
-async function findExistingLogFileInTree(rootDir: string, logId: string): Promise<string | undefined> {
+async function findExistingLogFileInLogsDir(logsDir: string, logId: string): Promise<string | undefined> {
   let entries: import('fs').Dirent[];
   try {
-    entries = await fs.readdir(rootDir, { withFileTypes: true });
+    entries = await fs.readdir(logsDir, { withFileTypes: true });
   } catch {
     return undefined;
   }
 
   for (const entry of entries) {
-    const filePath = path.join(rootDir, entry.name);
-    if (entry.isDirectory()) {
-      const nested = await findExistingLogFileInTree(filePath, logId);
-      if (nested) {
-        return nested;
-      }
+    if (!entry.isDirectory()) {
       continue;
     }
 
-    if (entry.isFile() && entry.name === `${logId}.log`) {
-      return filePath;
+    const candidate = path.join(logsDir, entry.name, `${logId}.log`);
+    try {
+      const stat = await fs.stat(candidate);
+      if (stat.isFile()) {
+        return candidate;
+      }
+    } catch {
+      // ignore missing or unreadable candidates
+    }
+  }
+
+  return undefined;
+}
+
+async function findExistingLogFileInOrgsDir(orgsDir: string, logId: string): Promise<string | undefined> {
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(orgsDir, { withFileTypes: true });
+  } catch {
+    return undefined;
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    const found = await findExistingLogFileInLogsDir(path.join(orgsDir, entry.name, 'logs'), logId);
+    if (found) {
+      return found;
     }
   }
 
@@ -163,14 +187,29 @@ async function findExistingLogFileInTree(rootDir: string, logId: string): Promis
  */
 export async function findExistingLogFile(logId: string, username?: string): Promise<string | undefined> {
   const dir = getApexLogsDir();
+  const workspaceRoot = getWorkspaceRoot();
+
+  try {
+    const resolved = await runtimeClient.resolveCachedLogPath({
+      logId,
+      username,
+      workspaceRoot
+    });
+    if (typeof resolved.path === 'string' && resolved.path.trim().length > 0) {
+      return resolved.path;
+    }
+  } catch (error) {
+    logWarn('Workspace: runtime cached log lookup failed ->', getErrorMessage(error));
+  }
+
   try {
     if (username) {
-      const orgFirst = await findExistingLogFileInTree(path.join(dir, 'orgs', toSafeLogUserName(username), 'logs'), logId);
+      const orgFirst = await findExistingLogFileInLogsDir(path.join(dir, 'orgs', toSafeLogUserName(username), 'logs'), logId);
       if (orgFirst) {
         return orgFirst;
       }
     } else {
-      const orgFirst = await findExistingLogFileInTree(path.join(dir, 'orgs'), logId);
+      const orgFirst = await findExistingLogFileInOrgsDir(path.join(dir, 'orgs'), logId);
       if (orgFirst) {
         return orgFirst;
       }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -133,6 +133,10 @@ function toSafeLogUserName(username: string | undefined): string {
   return (username || 'default').replace(/[^a-zA-Z0-9_.@-]+/g, '_');
 }
 
+function isSupportedLogDayDirName(name: string): boolean {
+  return name === 'unknown-date' || /^\d{4}-\d{2}-\d{2}$/.test(name);
+}
+
 async function findExistingLogFileInLogsDir(logsDir: string, logId: string): Promise<string | undefined> {
   let entries: import('fs').Dirent[];
   try {
@@ -142,7 +146,7 @@ async function findExistingLogFileInLogsDir(logsDir: string, logId: string): Pro
   }
 
   for (const entry of entries) {
-    if (!entry.isDirectory()) {
+    if (!entry.isDirectory() || !isSupportedLogDayDirName(entry.name)) {
       continue;
     }
 


### PR DESCRIPTION
## Summary
- add a shared `logs/resolveCachedPath` runtime path that reuses the Rust `alv-core` lookup and caches successful hits in-process
- bound both the shared Rust lookup and the extension fallback to the supported `orgs/<org>/logs/<day>/` layout while preserving legacy flat-file compatibility
- add regression coverage for the runtime client, app server, shared log-store layout, and extension runtime-first lookup; update the changelog

Closes #692

## Test Plan
- [x] cargo test -p alv-core --test log_store_layout
- [x] cargo test -p alv-app-server
- [x] npm run compile
- [x] xvfb-run -a -s '-screen 0 1280x1024x24' node scripts/run-tests-cli.js --scope=unit --vscode=stable
- [x] node scripts/run-tests-cli.js --scope=integration --vscode=stable