### PR TITLE
perf(logs): index cached paths for search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
+- Runtime/Logs: avoid repeated recursive cache walks during CLI log search by indexing candidate local log paths once per request while preserving org-first and legacy-layout fallback behavior.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Runtime/Logs: stop repeated recursive cached-log scans by resolving saved log paths through the shared Rust lookup first, caching runtime hits in-process, and limiting the extension's local fallback to the supported `orgs/<org>/logs/<day>/` layout plus legacy flat files.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -12,6 +12,7 @@ use std::{
 };
 
 const TEST_SEARCH_LINE_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_LINE_DELAY_MS";
+const TEST_SEARCH_ROOT_INDEX_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
 type CachedLogPathIndex = BTreeMap<String, Vec<PathBuf>>;
 
@@ -61,6 +62,10 @@ pub fn search_query_with_cancel(
         .case_insensitive(true)
         .build(query)
         .map_err(|error| format!("failed to build search matcher: {error}"))?;
+    let log_ids = dedup_ids(&params.log_ids);
+    if log_ids.is_empty() {
+        return Ok(SearchQueryResult::default());
+    }
 
     let mut result = SearchQueryResult::default();
     let canonical_username = resolve_canonical_username(params.username.as_deref())
@@ -74,10 +79,11 @@ pub fn search_query_with_cancel(
         params.workspace_root.as_deref(),
         raw_username_hint,
         canonical_username.as_deref(),
+        &log_ids,
         cancellation,
     )?;
 
-    for log_id in dedup_ids(&params.log_ids) {
+    for log_id in log_ids {
         cancellation.check_cancelled()?;
         let Some(paths) = path_index.get(&log_id) else {
             result.pending_log_ids.push(log_id);
@@ -123,7 +129,15 @@ pub fn search_query_with_cancel(
 }
 
 fn maybe_test_delay(cancellation: &CancellationToken) -> io::Result<()> {
-    let Some(delay_ms) = std::env::var(TEST_SEARCH_LINE_DELAY_MS_ENV)
+    maybe_test_delay_for_env(TEST_SEARCH_LINE_DELAY_MS_ENV, cancellation)
+}
+
+fn maybe_test_root_index_delay(cancellation: &CancellationToken) -> io::Result<()> {
+    maybe_test_delay_for_env(TEST_SEARCH_ROOT_INDEX_DELAY_MS_ENV, cancellation)
+}
+
+fn maybe_test_delay_for_env(env_name: &str, cancellation: &CancellationToken) -> io::Result<()> {
+    let Some(delay_ms) = std::env::var(env_name)
         .ok()
         .and_then(|value| value.trim().parse::<u64>().ok())
     else {
@@ -249,6 +263,7 @@ fn build_cached_log_path_index(
     workspace_root: Option<&str>,
     raw_username_hint: Option<&str>,
     canonical_username: Option<&str>,
+    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
     match canonical_username {
@@ -256,6 +271,7 @@ fn build_cached_log_path_index(
             workspace_root,
             raw_username_hint,
             username,
+            requested_log_ids,
             cancellation,
         ),
         None => {
@@ -263,7 +279,12 @@ fn build_cached_log_path_index(
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
             {
-                build_raw_scoped_cached_log_path_index(workspace_root, raw_username, cancellation)
+                build_raw_scoped_cached_log_path_index(
+                    workspace_root,
+                    raw_username,
+                    requested_log_ids,
+                    cancellation,
+                )
             } else {
                 build_unscoped_cached_log_path_index(workspace_root, cancellation)
             }
@@ -289,6 +310,7 @@ fn build_scoped_cached_log_path_index(
     workspace_root: Option<&str>,
     raw_username: Option<&str>,
     canonical_username: &str,
+    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
     let root = log_store::resolve_apexlogs_root(workspace_root);
@@ -312,7 +334,14 @@ fn build_scoped_cached_log_path_index(
         }
     }
 
-    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
+    collect_requested_root_log_paths(
+        &root,
+        requested_log_ids,
+        &allowed_prefixes,
+        true,
+        cancellation,
+        &mut index,
+    )?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)
@@ -321,6 +350,7 @@ fn build_scoped_cached_log_path_index(
 fn build_raw_scoped_cached_log_path_index(
     workspace_root: Option<&str>,
     raw_username: &str,
+    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
     let root = log_store::resolve_apexlogs_root(workspace_root);
@@ -334,7 +364,14 @@ fn build_raw_scoped_cached_log_path_index(
 
     let raw_safe = log_store::safe_target_org(raw_username);
     let allowed_prefixes = vec![raw_safe];
-    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
+    collect_requested_root_log_paths(
+        &root,
+        requested_log_ids,
+        &allowed_prefixes,
+        true,
+        cancellation,
+        &mut index,
+    )?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)
@@ -365,8 +402,8 @@ fn collect_log_path_index_in_tree(
         let Some(file_name) = path.file_name() else {
             continue;
         };
-        let file_name = file_name.to_string_lossy();
-        let Some(log_id) = file_name.strip_suffix(".log").map(str::to_string) else {
+        let file_name = file_name.to_string_lossy().into_owned();
+        let Some(log_id) = file_name.strip_suffix(".log") else {
             continue;
         };
         if log_id.trim().is_empty() {
@@ -374,6 +411,27 @@ fn collect_log_path_index_in_tree(
         }
 
         push_index_path(index, &log_id, path);
+    }
+
+    Ok(())
+}
+
+fn collect_requested_root_log_paths(
+    root: &Path,
+    requested_log_ids: &[String],
+    allowed_prefixes: &[String],
+    include_bare_log: bool,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
+    for log_id in requested_log_ids {
+        cancellation.check_cancelled()?;
+
+        for candidate in root_log_candidates(root, log_id, allowed_prefixes, include_bare_log) {
+            if candidate.is_file() {
+                push_index_path(index, log_id, candidate);
+            }
+        }
     }
 
     Ok(())
@@ -392,6 +450,7 @@ fn collect_root_log_path_index(
 
     for entry in entries.flatten() {
         cancellation.check_cancelled()?;
+        maybe_test_root_index_delay(cancellation).map_err(|error| error.to_string())?;
 
         let path = entry.path();
         if !path.is_file() {
@@ -401,11 +460,10 @@ fn collect_root_log_path_index(
         let Some(file_name) = path.file_name() else {
             continue;
         };
-        let file_name = file_name.to_string_lossy();
+        let file_name = file_name.to_string_lossy().into_owned();
         let Some((prefix, log_id)) = parse_root_log_file_name(&file_name) else {
             continue;
         };
-        let log_id = log_id.to_string();
 
         if let Some(prefix) = prefix {
             let include_prefixed = include_all_prefixed_paths
@@ -424,6 +482,22 @@ fn collect_root_log_path_index(
     }
 
     Ok(())
+}
+
+fn root_log_candidates(
+    root: &Path,
+    log_id: &str,
+    allowed_prefixes: &[String],
+    include_bare_log: bool,
+) -> Vec<PathBuf> {
+    let mut candidates = Vec::new();
+    for prefix in allowed_prefixes {
+        candidates.push(root.join(format!("{prefix}_{log_id}.log")));
+    }
+    if include_bare_log {
+        candidates.push(root.join(format!("{log_id}.log")));
+    }
+    candidates
 }
 
 fn parse_root_log_file_name(file_name: &str) -> Option<(Option<&str>, &str)> {

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -312,7 +312,7 @@ fn build_scoped_cached_log_path_index(
         }
     }
 
-    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)
@@ -334,7 +334,7 @@ fn build_raw_scoped_cached_log_path_index(
 
     let raw_safe = log_store::safe_target_org(raw_username);
     let allowed_prefixes = vec![raw_safe];
-    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &allowed_prefixes, false, cancellation, &mut index)?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -13,6 +13,7 @@ use std::{
 
 const TEST_SEARCH_LINE_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_LINE_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
+type CachedLogPathIndex = BTreeMap<String, Vec<PathBuf>>;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SearchQueryParams {
@@ -69,35 +70,19 @@ pub fn search_query_with_cancel(
         .raw_username
         .as_deref()
         .or(params.username.as_deref());
+    let path_index = build_cached_log_path_index(
+        params.workspace_root.as_deref(),
+        raw_username_hint,
+        canonical_username.as_deref(),
+        cancellation,
+    )?;
 
     for log_id in dedup_ids(&params.log_ids) {
         cancellation.check_cancelled()?;
-        let paths = match canonical_username.as_deref() {
-            Some(username) => find_scoped_cached_log_paths(
-                params.workspace_root.as_deref(),
-                &log_id,
-                raw_username_hint,
-                username,
-            ),
-            None => {
-                if let Some(raw_username) = raw_username_hint
-                    .map(str::trim)
-                    .filter(|value| !value.is_empty())
-                {
-                    find_raw_scoped_cached_log_paths(
-                        params.workspace_root.as_deref(),
-                        &log_id,
-                        raw_username,
-                    )
-                } else {
-                    find_cached_log_paths(params.workspace_root.as_deref(), &log_id)
-                }
-            }
-        };
-        if paths.is_empty() {
+        let Some(paths) = path_index.get(&log_id) else {
             result.pending_log_ids.push(log_id);
             continue;
-        }
+        };
 
         let mut matched_line = None::<String>;
         for path in paths {
@@ -260,142 +245,205 @@ fn resolve_canonical_username(username: Option<&str>) -> Result<Option<String>, 
     ))
 }
 
-fn find_cached_log_paths(workspace_root: Option<&str>, log_id: &str) -> Vec<PathBuf> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
-
-    collect_log_paths_in_tree(&root.join("orgs"), log_id, &mut paths);
-
-    if let Ok(entries) = fs::read_dir(&root) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            let Some(file_name) = path.file_name() else {
-                continue;
-            };
-            let file_name = file_name.to_string_lossy();
-            if file_name == format!("{log_id}.log")
-                || file_name.ends_with(&format!("_{log_id}.log"))
+fn build_cached_log_path_index(
+    workspace_root: Option<&str>,
+    raw_username_hint: Option<&str>,
+    canonical_username: Option<&str>,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    match canonical_username {
+        Some(username) => build_scoped_cached_log_path_index(
+            workspace_root,
+            raw_username_hint,
+            username,
+            cancellation,
+        ),
+        None => {
+            if let Some(raw_username) = raw_username_hint
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
             {
-                paths.push(path);
+                build_raw_scoped_cached_log_path_index(workspace_root, raw_username, cancellation)
+            } else {
+                build_unscoped_cached_log_path_index(workspace_root, cancellation)
             }
         }
     }
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
 }
 
-fn find_scoped_cached_log_paths(
+fn build_unscoped_cached_log_path_index(
     workspace_root: Option<&str>,
-    log_id: &str,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    let root = log_store::resolve_apexlogs_root(workspace_root);
+    let mut index = CachedLogPathIndex::new();
+
+    collect_log_path_index_in_tree(&root.join("orgs"), cancellation, &mut index)?;
+    collect_root_log_path_index(&root, &[], true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
+}
+
+fn build_scoped_cached_log_path_index(
+    workspace_root: Option<&str>,
     raw_username: Option<&str>,
     canonical_username: &str,
-) -> Vec<PathBuf> {
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
     let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
+    let mut index = CachedLogPathIndex::new();
 
-    collect_log_paths_in_tree(
+    collect_log_path_index_in_tree(
         &log_store::org_dir(workspace_root, canonical_username).join("logs"),
-        log_id,
-        &mut paths,
-    );
+        cancellation,
+        &mut index,
+    )?;
 
-    push_legacy_scoped_paths(&mut paths, &root, log_id, raw_username, canonical_username);
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
-}
-
-fn find_raw_scoped_cached_log_paths(
-    workspace_root: Option<&str>,
-    log_id: &str,
-    raw_username: &str,
-) -> Vec<PathBuf> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut paths = Vec::new();
-
-    collect_log_paths_in_tree(
-        &log_store::org_dir(workspace_root, raw_username).join("logs"),
-        log_id,
-        &mut paths,
-    );
-
-    let raw_safe = log_store::safe_target_org(raw_username);
-    for candidate in [
-        root.join(format!("{raw_safe}_{log_id}.log")),
-        root.join(format!("{log_id}.log")),
-    ] {
-        if candidate.is_file() {
-            paths.push(candidate);
-        }
-    }
-
-    paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
-    paths.dedup();
-    paths
-}
-
-fn push_legacy_scoped_paths(
-    paths: &mut Vec<PathBuf>,
-    root: &Path,
-    log_id: &str,
-    raw_username: Option<&str>,
-    canonical_username: &str,
-) {
-    for candidate in legacy_scoped_paths(root, log_id, raw_username, canonical_username) {
-        if candidate.is_file() {
-            paths.push(candidate);
-        }
-    }
-}
-
-fn legacy_scoped_paths(
-    root: &Path,
-    log_id: &str,
-    raw_username: Option<&str>,
-    canonical_username: &str,
-) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
     let canonical_safe = log_store::safe_target_org(canonical_username);
-    candidates.push(root.join(format!("{canonical_safe}_{log_id}.log")));
-
+    let mut allowed_prefixes = vec![canonical_safe];
     if let Some(raw_username) = raw_username
         .map(str::trim)
         .filter(|value| !value.is_empty())
     {
         let raw_safe = log_store::safe_target_org(raw_username);
-        if raw_safe != canonical_safe {
-            candidates.push(root.join(format!("{raw_safe}_{log_id}.log")));
+        if raw_safe != allowed_prefixes[0] {
+            allowed_prefixes.push(raw_safe);
         }
     }
 
-    candidates.push(root.join(format!("{log_id}.log")));
-    candidates
+    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
 }
 
-fn collect_log_paths_in_tree(root: &Path, log_id: &str, paths: &mut Vec<PathBuf>) {
+fn build_raw_scoped_cached_log_path_index(
+    workspace_root: Option<&str>,
+    raw_username: &str,
+    cancellation: &CancellationToken,
+) -> Result<CachedLogPathIndex, String> {
+    let root = log_store::resolve_apexlogs_root(workspace_root);
+    let mut index = CachedLogPathIndex::new();
+
+    collect_log_path_index_in_tree(
+        &log_store::org_dir(workspace_root, raw_username).join("logs"),
+        cancellation,
+        &mut index,
+    )?;
+
+    let raw_safe = log_store::safe_target_org(raw_username);
+    let allowed_prefixes = vec![raw_safe];
+    collect_root_log_path_index(&root, &allowed_prefixes, true, cancellation, &mut index)?;
+    sort_and_dedup_path_index(&mut index);
+
+    Ok(index)
+}
+
+fn collect_log_path_index_in_tree(
+    root: &Path,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
     if !root.exists() {
-        return;
+        return Ok(());
     }
 
     let Ok(entries) = fs::read_dir(root) else {
-        return;
+        return Ok(());
     };
 
     for entry in entries.flatten() {
+        cancellation.check_cancelled()?;
+
         let path = entry.path();
         if path.is_dir() {
-            collect_log_paths_in_tree(&path, log_id, paths);
+            collect_log_path_index_in_tree(&path, cancellation, index)?;
             continue;
         }
 
-        if path
-            .file_name()
-            .is_some_and(|file_name| file_name.to_string_lossy() == format!("{log_id}.log"))
-        {
-            paths.push(path);
+        let Some(file_name) = path.file_name() else {
+            continue;
+        };
+        let file_name = file_name.to_string_lossy();
+        let Some(log_id) = file_name.strip_suffix(".log").map(str::to_string) else {
+            continue;
+        };
+        if log_id.trim().is_empty() {
+            continue;
         }
+
+        push_index_path(index, &log_id, path);
+    }
+
+    Ok(())
+}
+
+fn collect_root_log_path_index(
+    root: &Path,
+    allowed_prefixes: &[String],
+    include_all_prefixed_paths: bool,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
+    let Ok(entries) = fs::read_dir(root) else {
+        return Ok(());
+    };
+
+    for entry in entries.flatten() {
+        cancellation.check_cancelled()?;
+
+        let path = entry.path();
+        if !path.is_file() {
+            continue;
+        }
+
+        let Some(file_name) = path.file_name() else {
+            continue;
+        };
+        let file_name = file_name.to_string_lossy();
+        let Some((prefix, log_id)) = parse_root_log_file_name(&file_name) else {
+            continue;
+        };
+        let log_id = log_id.to_string();
+
+        if let Some(prefix) = prefix {
+            let include_prefixed = include_all_prefixed_paths
+                || allowed_prefixes
+                    .iter()
+                    .any(|allowed_prefix| allowed_prefix == prefix);
+            if !include_prefixed {
+                continue;
+            }
+        }
+
+        if log_id.trim().is_empty() {
+            continue;
+        }
+        push_index_path(index, &log_id, path);
+    }
+
+    Ok(())
+}
+
+fn parse_root_log_file_name(file_name: &str) -> Option<(Option<&str>, &str)> {
+    let stem = file_name.strip_suffix(".log")?;
+    match stem.rsplit_once('_') {
+        Some((prefix, log_id)) if !prefix.is_empty() && !log_id.is_empty() => {
+            Some((Some(prefix), log_id))
+        }
+        _ if !stem.is_empty() => Some((None, stem)),
+        _ => None,
+    }
+}
+
+fn push_index_path(index: &mut CachedLogPathIndex, log_id: &str, path: PathBuf) {
+    index.entry(log_id.to_string()).or_default().push(path);
+}
+
+fn sort_and_dedup_path_index(index: &mut CachedLogPathIndex) {
+    for paths in index.values_mut() {
+        paths.sort_by(|left, right| left.to_string_lossy().cmp(&right.to_string_lossy()));
+        paths.dedup();
     }
 }

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -90,6 +90,13 @@ fn org_dirs_in_iteration_order(orgs_root: &PathBuf) -> Vec<PathBuf> {
     dirs
 }
 
+fn write_legacy_root_noise_logs(apexlogs_dir: &PathBuf, prefix: &str, count: usize) {
+    for index in 0..count {
+        fs::write(apexlogs_dir.join(format!("{prefix}_{index:05}.log")), "")
+            .expect("noise log should be writable");
+    }
+}
+
 #[cfg(windows)]
 fn write_fake_sf_cmd(root: &PathBuf, body: &str) -> PathBuf {
     let script_path = root.join("sf.cmd");
@@ -423,6 +430,43 @@ fn logs_runtime_smoke_search_reads_org_first_cache_layout() {
 }
 
 #[test]
+fn logs_runtime_smoke_search_with_blank_log_ids_short_circuits_before_cache_indexing() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-empty-log-ids");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    write_legacy_root_noise_logs(&apexlogs_dir, "noise", 64);
+    std::env::set_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS", "2");
+
+    let token = CancellationToken::new();
+    let cancel_handle = token.clone();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        cancel_handle.cancel();
+    });
+
+    let result = search_query_with_cancel(
+        &SearchQueryParams {
+            query: "needle".to_string(),
+            log_ids: vec!["   ".to_string()],
+            username: None,
+            raw_username: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+        },
+        &token,
+    )
+    .expect("blank log ids should return before indexing cache paths");
+
+    assert!(result.log_ids.is_empty());
+    assert!(result.pending_log_ids.is_empty());
+    assert!(result.snippets.is_empty());
+
+    std::env::remove_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS");
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_search_checks_duplicate_log_ids_across_org_trees() {
     let _guard = lock_test_guard();
 
@@ -587,6 +631,57 @@ fn logs_runtime_smoke_search_scoped_to_selected_org_uses_legacy_bare_log_fallbac
     assert_eq!(result.log_ids, vec!["07L00000000000LB1".to_string()]);
     assert!(result.pending_log_ids.is_empty());
 
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_search_scoped_hit_skips_unrelated_legacy_root_scan() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-scoped-skip-legacy-root-scan");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    let selected_org_dir = apexlogs_dir
+        .join("orgs")
+        .join("selected@example.com")
+        .join("logs")
+        .join("2026-03-30");
+    fs::create_dir_all(&selected_org_dir).expect("selected org log dir should exist");
+    let log_id = "07L00000000000SX1";
+    fs::write(
+        selected_org_dir.join(format!("{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|ScopedIndexedNeedle\n",
+    )
+    .expect("selected org cached log should be writable");
+    write_legacy_root_noise_logs(&apexlogs_dir, "otherorg", 64);
+    std::env::set_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS", "2");
+
+    let token = CancellationToken::new();
+    let cancel_handle = token.clone();
+    thread::spawn(move || {
+        thread::sleep(Duration::from_millis(50));
+        cancel_handle.cancel();
+    });
+
+    let result = search_query_with_cancel(
+        &SearchQueryParams {
+            query: "ScopedIndexedNeedle".to_string(),
+            log_ids: vec![log_id.to_string()],
+            username: Some("selected@example.com".to_string()),
+            raw_username: None,
+            workspace_root: Some(workspace_root.display().to_string()),
+        },
+        &token,
+    )
+    .expect("scoped search should not scan unrelated legacy root entries");
+
+    assert_eq!(result.log_ids, vec![log_id.to_string()]);
+    let snippet = result
+        .snippets
+        .get(log_id)
+        .expect("matched log should include snippet");
+    assert!(snippet.text.contains("ScopedIndexedNeedle"));
+
+    std::env::remove_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -528,6 +528,41 @@ fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_org_duplicate_
 }
 
 #[test]
+fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_legacy_root_match() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-scoped-ignore-other-legacy-root");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L00000000000SR1";
+    fs::write(
+        apexlogs_dir.join(format!("selected@example.com_{log_id}.log")),
+        "09:00:00.0|USER_INFO|selected root cache does not contain the needle\n",
+    )
+    .expect("selected-org legacy root log should be writable");
+    fs::write(
+        apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|ScopedLegacyRootNeedle\n",
+    )
+    .expect("other-org legacy root log should be writable");
+
+    let result = search_query(&SearchQueryParams {
+        query: "ScopedLegacyRootNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("selected@example.com".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should ignore other-org legacy flat cache files");
+
+    assert!(result.log_ids.is_empty());
+    assert!(result.pending_log_ids.is_empty());
+    assert!(!result.snippets.contains_key(log_id));
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_search_scoped_to_selected_org_uses_legacy_bare_log_fallback() {
     let _guard = lock_test_guard();
 
@@ -595,6 +630,41 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
         .get(log_id)
         .expect("matched log should include snippet");
     assert!(snippet.text.contains("AliasScopedNeedle"));
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_search_raw_alias_scope_ignores_other_legacy_root_match() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-alias-offline-legacy-root");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L0000000000AR1";
+    fs::write(
+        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        "09:00:00.0|USER_INFO|alias root cache does not contain the needle\n",
+    )
+    .expect("alias-scoped legacy root log should be writable");
+    fs::write(
+        apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|AliasRootScopeNeedle\n",
+    )
+    .expect("other-org legacy root log should be writable");
+
+    let result = search_query(&SearchQueryParams {
+        query: "AliasRootScopeNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("Alias Org".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should ignore unrelated legacy root files during raw alias fallback");
+
+    assert!(result.log_ids.is_empty());
+    assert!(result.pending_log_ids.is_empty());
+    assert!(!result.snippets.contains_key(log_id));
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -600,6 +600,53 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
 }
 
 #[test]
+fn logs_runtime_smoke_search_uses_legacy_alias_scoped_cache_when_alias_resolves() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-alias-canonical-legacy");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let log_id = "07L0000000000AC1";
+    fs::write(
+        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        "09:00:00.0|FATAL_ERROR|AliasCanonicalLegacyNeedle\n",
+    )
+    .expect("legacy alias-scoped log should be writable");
+
+    std::env::set_var(
+        TEST_ORG_DISPLAY_JSON_ENV,
+        r#"{
+            "status": 0,
+            "result": {
+                "username": "canonical@example.com",
+                "accessToken": "00D-token",
+                "instanceUrl": "https://example.my.salesforce.com"
+            }
+        }"#,
+    );
+
+    let result = search_query(&SearchQueryParams {
+        query: "AliasCanonicalLegacyNeedle".to_string(),
+        log_ids: vec![log_id.to_string()],
+        username: Some("Alias Org".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should keep the alias-scoped legacy fallback after alias resolution");
+
+    assert_eq!(result.log_ids, vec![log_id.to_string()]);
+    assert!(result.pending_log_ids.is_empty());
+    let snippet = result
+        .snippets
+        .get(log_id)
+        .expect("matched log should include snippet");
+    assert!(snippet.text.contains("AliasCanonicalLegacyNeedle"));
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory() {
     let _guard = lock_test_guard();
 


### PR DESCRIPTION
## Summary
- build a single cached `logId -> paths` index per `search_query_with_cancel` request instead of recursively walking the cache tree for every log id
- preserve scoped org-first, alias, and legacy flat-file fallback behavior while filtering unrelated legacy root matches
- add regression coverage for alias-scoped and selected-org legacy-root search fallbacks, and note the runtime search optimization in the changelog

Closes #690.

## Test Plan
- [x] `cargo test -p alv-core logs_runtime_smoke_search`
- [x] `cargo test -p alv-core`
- [x] `npm test`
