### PR TITLE
fix(runtime): ship linux-x64 sidecar with musl

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -82,7 +82,7 @@ jobs:
         include:
           - os: ubuntu-latest
             target: linux-x64
-            cargo_target: x86_64-unknown-linux-gnu
+            cargo_target: x86_64-unknown-linux-musl
           - os: ubuntu-latest
             target: linux-arm64
             cargo_target: aarch64-unknown-linux-gnu
@@ -119,6 +119,14 @@ jobs:
 
       - name: Install Rust target
         run: rustup target add ${{ matrix.cargo_target }}
+
+      - name: Install Linux x64 musl toolchain
+        if: matrix.target == 'linux-x64'
+        shell: bash
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
 
       - name: Install Linux arm64 linker
         if: matrix.target == 'linux-arm64'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Runtime/Logs: stop repeated recursive cached-log scans by resolving saved log paths through the shared Rust lookup first, caching runtime hits in-process, and limiting the extension's local fallback to the supported `orgs/<org>/logs/<day>/` layout plus legacy flat files.
 - Tail/Logs: keep Tail webviews from re-running bootstrap work before the webview is ready, and stop advertising cancellation for Logs org listing when the backend work is not actually cancellable yet.
+- Runtime/Packaging: publish the bundled `linux-x64` sidecar from `x86_64-unknown-linux-musl` so the extension runtime works in older-glibc environments such as Agentforce Vibes IDE / Salesforce Code Builder.
 
 ### Chores
 

--- a/apps/vscode-extension/scripts/copy-runtime-binary.mjs
+++ b/apps/vscode-extension/scripts/copy-runtime-binary.mjs
@@ -3,7 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const CARGO_TARGETS = {
-  'linux-x64': 'x86_64-unknown-linux-gnu',
+  'linux-x64': 'x86_64-unknown-linux-musl',
   'linux-arm64': 'aarch64-unknown-linux-gnu',
   'win32-x64': 'x86_64-pc-windows-msvc',
   'win32-arm64': 'aarch64-pc-windows-msvc',

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -8,6 +8,8 @@ This repository uses GitHub Actions to build, test, package, and publish the ext
 - Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 - Workflow Rust CLI Release (`.github/workflows/rust-release.yml`): runs on `rust-v*` tags, publishes the npm meta/native packages and GitHub release assets built from the tested CLI release bundle, and intentionally keeps `crates.io` out of the bootstrap path for now. Required repository secret for the initial CLI publish path is `NPM_TOKEN`.
+- The `linux-x64` runtime artifact in that workflow is built from `x86_64-unknown-linux-musl`, which avoids binding the shipped sidecar to the GitHub runner's host `glibc`.
+- That workflow installs Ubuntu `musl-tools` and drives Cargo through `musl-gcc`; local Linux maintainers need the equivalent musl compiler package for their distro when they run `npm run package:runtime:local`.
 - Workflow Rust Supply Chain (`.github/workflows/rust-supply-chain.yml`): runs `cargo deny check advisories bans licenses sources` on pull requests and pushes to `main`.
 
 Build & Test basics:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -9,7 +9,7 @@ This repository uses GitHub Actions to build, test, package, and publish the ext
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 - Workflow Rust CLI Release (`.github/workflows/rust-release.yml`): runs on `rust-v*` tags, publishes the npm meta/native packages and GitHub release assets built from the tested CLI release bundle, and intentionally keeps `crates.io` out of the bootstrap path for now. Required repository secret for the initial CLI publish path is `NPM_TOKEN`.
 - The `linux-x64` runtime artifact in that workflow is built from `x86_64-unknown-linux-musl`, which avoids binding the shipped sidecar to the GitHub runner's host `glibc`.
-- That workflow installs Ubuntu `musl-tools` and drives Cargo through `musl-gcc`; local Linux maintainers need the equivalent musl compiler package for their distro when they run `npm run package:runtime:local`.
+- That workflow installs Ubuntu `musl-tools` and drives Cargo through `musl-gcc`; local Linux maintainers need the equivalent musl compiler package for their distro when building the `linux-x64` runtime with `npm run package:runtime:local`.
 - Workflow Rust Supply Chain (`.github/workflows/rust-supply-chain.yml`): runs `cargo deny check advisories bans licenses sources` on pull requests and pushes to `main`.
 
 Build & Test basics:

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -34,6 +34,7 @@ How it works
 - If `OVSX_PAT` is present, it publishes the same VSIX artifacts to Open VSX.
 - Tags matching `rust-v*` trigger the CLI packaging workflow (`.github/workflows/rust-release.yml`).
 - The CLI workflow uploads GitHub release assets and publishes the generated npm native and meta packages.
+- The canonical `linux-x64` CLI/runtime artifact is built from `x86_64-unknown-linux-musl` so the extension sidecar remains compatible with older-glibc Linux environments.
 - `crates.io` publication is intentionally deferred until the internal crate surface is ready to be maintained as a public registry contract.
 - The extension build consumes the pinned runtime metadata in `config/runtime-bundle.json`, so the extension release channel can stay separate from the CLI release train.
 
@@ -66,3 +67,4 @@ Notes
 - `CHANGELOG.md` is manual. Keep entries concise; document breaking changes clearly.
 - Versions must be unique between stable and pre‑releases; do not re‑use the same `major.minor.patch` for both channels.
 - The Marketplace listing for this extension will show a “Pre‑Release” tab for users who opt in to pre‑releases.
+- Local Linux packaging that rebuilds the bundled runtime (`npm run package:runtime:local`) now expects a musl toolchain with `musl-gcc` on `PATH`; on Ubuntu the workflow installs `musl-tools`, while Arch users typically need the `musl` package.

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -67,4 +67,4 @@ Notes
 - `CHANGELOG.md` is manual. Keep entries concise; document breaking changes clearly.
 - Versions must be unique between stable and pre‑releases; do not re‑use the same `major.minor.patch` for both channels.
 - The Marketplace listing for this extension will show a “Pre‑Release” tab for users who opt in to pre‑releases.
-- Local Linux packaging that rebuilds the bundled runtime (`npm run package:runtime:local`) now expects a musl toolchain with `musl-gcc` on `PATH`; on Ubuntu the workflow installs `musl-tools`, while Arch users typically need the `musl` package.
+- When rebuilding the bundled `linux-x64` runtime on Linux with `npm run package:runtime:local`, the workflow expects a musl toolchain with `musl-gcc` on `PATH`; on Ubuntu it installs `musl-tools`, while Arch users typically need the `musl` package.

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "watch:webview": "npm-run-all -p tailwind:watch watch:webview:bundle",
     "build:runtime": "cargo build -p apex-log-viewer-cli --bin apex-log-viewer && node apps/vscode-extension/scripts/copy-runtime-binary.mjs",
     "package:runtime": "node scripts/fetch-runtime-release.mjs",
-    "package:runtime:local": "cargo build -p apex-log-viewer-cli --bin apex-log-viewer --release && node apps/vscode-extension/scripts/copy-runtime-binary.mjs release",
+    "package:runtime:local": "node scripts/build-runtime-target.mjs release",
     "build:cli:npm": "node scripts/build-cli-npm-packages.mjs",
     "build:tree-sitter-runtime": "node apps/vscode-extension/scripts/copy-tree-sitter-runtime.mjs",
     "build:package-metadata": "node apps/vscode-extension/scripts/copy-package-metadata.mjs",

--- a/scripts/build-runtime-target.mjs
+++ b/scripts/build-runtime-target.mjs
@@ -13,13 +13,17 @@ const CARGO_TARGETS = {
   'darwin-arm64': 'aarch64-apple-darwin'
 };
 
+export function resolveCargoTarget(target) {
+  return CARGO_TARGETS[target];
+}
+
 export function resolveCargoBuildArgs(target, profile = 'release') {
   const args = ['build', '-p', 'apex-log-viewer-cli', '--bin', 'apex-log-viewer'];
   if (profile === 'release') {
     args.push('--release');
   }
 
-  const cargoTarget = CARGO_TARGETS[target];
+  const cargoTarget = resolveCargoTarget(target);
   if (cargoTarget) {
     args.push('--target', cargoTarget);
   }
@@ -38,13 +42,62 @@ export function resolveCargoBuildEnv(target, inheritedEnv = process.env) {
   return env;
 }
 
+export function ensureBootstrapCargoTargetInstalled({
+  repoRoot,
+  target,
+  spawnSyncImpl = spawnSync
+}) {
+  const cargoTarget = resolveCargoTarget(target);
+  if (!cargoTarget || target !== 'linux-x64') {
+    return;
+  }
+
+  const installedTargets = spawnSyncImpl('rustup', ['target', 'list', '--installed'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+
+  if (installedTargets.error) {
+    throw installedTargets.error;
+  }
+  if ((installedTargets.status ?? 0) !== 0) {
+    throw new Error(
+      `rustup target list --installed failed with exit code ${installedTargets.status ?? 'unknown'}`
+    );
+  }
+
+  const installed = new Set(
+    String(installedTargets.stdout ?? '')
+      .split(/\r?\n/u)
+      .map(value => value.trim())
+      .filter(Boolean)
+  );
+  if (installed.has(cargoTarget)) {
+    return;
+  }
+
+  const addTarget = spawnSyncImpl('rustup', ['target', 'add', cargoTarget], {
+    cwd: repoRoot,
+    stdio: 'inherit'
+  });
+
+  if (addTarget.error) {
+    throw addTarget.error;
+  }
+  if ((addTarget.status ?? 0) !== 0) {
+    throw new Error(`rustup target add ${cargoTarget} failed with exit code ${addTarget.status ?? 'unknown'}`);
+  }
+}
+
 export function buildRuntimeTarget({
   repoRoot,
   target,
   profile = 'release',
   spawnSyncImpl = spawnSync,
-  copyRuntimeBinaryImpl = copyRuntimeBinary
+  copyRuntimeBinaryImpl = copyRuntimeBinary,
+  ensureBootstrapCargoTargetInstalledImpl = ensureBootstrapCargoTargetInstalled
 }) {
+  ensureBootstrapCargoTargetInstalledImpl({ repoRoot, target, spawnSyncImpl });
   const args = resolveCargoBuildArgs(target, profile);
   const env = resolveCargoBuildEnv(target);
   const result = spawnSyncImpl('cargo', args, {

--- a/scripts/build-runtime-target.mjs
+++ b/scripts/build-runtime-target.mjs
@@ -58,6 +58,9 @@ export function ensureBootstrapCargoTargetInstalled({
   });
 
   if (installedTargets.error) {
+    if (installedTargets.error.code === 'ENOENT') {
+      return;
+    }
     throw installedTargets.error;
   }
   if ((installedTargets.status ?? 0) !== 0) {
@@ -82,6 +85,9 @@ export function ensureBootstrapCargoTargetInstalled({
   });
 
   if (addTarget.error) {
+    if (addTarget.error.code === 'ENOENT') {
+      return;
+    }
     throw addTarget.error;
   }
   if ((addTarget.status ?? 0) !== 0) {

--- a/scripts/build-runtime-target.mjs
+++ b/scripts/build-runtime-target.mjs
@@ -5,7 +5,7 @@ import { fileURLToPath } from 'node:url';
 import { copyRuntimeBinary } from '../apps/vscode-extension/scripts/copy-runtime-binary.mjs';
 
 const CARGO_TARGETS = {
-  'linux-x64': 'x86_64-unknown-linux-gnu',
+  'linux-x64': 'x86_64-unknown-linux-musl',
   'linux-arm64': 'aarch64-unknown-linux-gnu',
   'win32-x64': 'x86_64-pc-windows-msvc',
   'win32-arm64': 'aarch64-pc-windows-msvc',
@@ -27,6 +27,17 @@ export function resolveCargoBuildArgs(target, profile = 'release') {
   return args;
 }
 
+export function resolveCargoBuildEnv(target, inheritedEnv = process.env) {
+  const env = { ...inheritedEnv };
+
+  if (target === 'linux-x64') {
+    env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER =
+      env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER || 'musl-gcc';
+  }
+
+  return env;
+}
+
 export function buildRuntimeTarget({
   repoRoot,
   target,
@@ -35,8 +46,10 @@ export function buildRuntimeTarget({
   copyRuntimeBinaryImpl = copyRuntimeBinary
 }) {
   const args = resolveCargoBuildArgs(target, profile);
+  const env = resolveCargoBuildEnv(target);
   const result = spawnSyncImpl('cargo', args, {
     cwd: repoRoot,
+    env,
     stdio: 'inherit'
   });
 
@@ -50,15 +63,31 @@ export function buildRuntimeTarget({
   return copyRuntimeBinaryImpl({ repoRoot, target, profile });
 }
 
+export function resolveBuildArguments(argv, currentTarget) {
+  let target = currentTarget;
+  let profile = 'release';
+
+  if (argv[0]) {
+    if (argv[0] === 'debug' || argv[0] === 'release') {
+      profile = argv[0];
+    } else {
+      target = argv[0];
+    }
+  }
+
+  if (argv[1]) {
+    profile = argv[1];
+  }
+
+  return { target, profile };
+}
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const repoRoot = path.resolve(__dirname, '..');
 
 if (process.argv[1] === __filename) {
-  const target = process.argv[2];
-  const profile = process.argv[3] ?? 'release';
-  if (!target) {
-    throw new Error('usage: node scripts/build-runtime-target.mjs <target> [profile]');
-  }
+  const currentTarget = `${process.platform}-${process.arch}`;
+  const { target, profile } = resolveBuildArguments(process.argv.slice(2), currentTarget);
   buildRuntimeTarget({ repoRoot, target, profile });
 }

--- a/scripts/copy-runtime-binary.test.js
+++ b/scripts/copy-runtime-binary.test.js
@@ -61,9 +61,70 @@ test('resolveCargoBuildArgs includes the packaged runtime target triple', async 
   );
 });
 
+test('ensureBootstrapCargoTargetInstalled adds the linux-x64 musl target when it is missing', async () => {
+  const mod = await import(pathToFileURL(buildModulePath).href);
+  const spawnCalls = [];
+
+  mod.ensureBootstrapCargoTargetInstalled({
+    repoRoot: '/repo',
+    target: 'linux-x64',
+    spawnSyncImpl(command, args, options) {
+      spawnCalls.push({ command, args, options });
+      if (args[1] === 'list') {
+        return { status: 0, stdout: 'x86_64-unknown-linux-gnu\n' };
+      }
+      return { status: 0 };
+    }
+  });
+
+  assert.deepEqual(spawnCalls, [
+    {
+      command: 'rustup',
+      args: ['target', 'list', '--installed'],
+      options: { cwd: '/repo', encoding: 'utf8' }
+    },
+    {
+      command: 'rustup',
+      args: ['target', 'add', 'x86_64-unknown-linux-musl'],
+      options: { cwd: '/repo', stdio: 'inherit' }
+    }
+  ]);
+});
+
+test('ensureBootstrapCargoTargetInstalled skips work when linux-x64 musl is already installed or the target is unrelated', async () => {
+  const mod = await import(pathToFileURL(buildModulePath).href);
+  const spawnCalls = [];
+
+  mod.ensureBootstrapCargoTargetInstalled({
+    repoRoot: '/repo',
+    target: 'linux-x64',
+    spawnSyncImpl(command, args, options) {
+      spawnCalls.push({ command, args, options });
+      return { status: 0, stdout: 'x86_64-unknown-linux-musl\n' };
+    }
+  });
+  mod.ensureBootstrapCargoTargetInstalled({
+    repoRoot: '/repo',
+    target: 'win32-x64',
+    spawnSyncImpl(command, args, options) {
+      spawnCalls.push({ command, args, options });
+      return { status: 0 };
+    }
+  });
+
+  assert.deepEqual(spawnCalls, [
+    {
+      command: 'rustup',
+      args: ['target', 'list', '--installed'],
+      options: { cwd: '/repo', encoding: 'utf8' }
+    }
+  ]);
+});
+
 test('buildRuntimeTarget runs cargo for the requested target before copying the runtime', async () => {
   const mod = await import(pathToFileURL(buildModulePath).href);
   const spawnCalls = [];
+  const bootstrapCalls = [];
 
   const result = mod.buildRuntimeTarget({
     repoRoot: '/repo',
@@ -75,9 +136,19 @@ test('buildRuntimeTarget runs cargo for the requested target before copying the 
     },
     copyRuntimeBinaryImpl(args) {
       return { copied: true, ...args };
+    },
+    ensureBootstrapCargoTargetInstalledImpl(args) {
+      bootstrapCalls.push(args);
     }
   });
 
+  assert.deepEqual(bootstrapCalls, [
+    {
+      repoRoot: '/repo',
+      spawnSyncImpl: bootstrapCalls[0].spawnSyncImpl,
+      target: 'win32-arm64'
+    }
+  ]);
   assert.equal(spawnCalls.length, 1);
   assert.deepEqual(spawnCalls[0].args, [
     'build',
@@ -92,7 +163,6 @@ test('buildRuntimeTarget runs cargo for the requested target before copying the 
   assert.equal(spawnCalls[0].command, 'cargo');
   assert.equal(spawnCalls[0].options.cwd, '/repo');
   assert.equal(spawnCalls[0].options.stdio, 'inherit');
-  assert.equal(spawnCalls[0].options.env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER, undefined);
   assert.deepEqual(result, {
     copied: true,
     profile: 'release',
@@ -108,7 +178,12 @@ test('resolveCargoBuildEnv pins the musl linker for linux-x64 while leaving othe
     mod.resolveCargoBuildEnv('linux-x64', {}).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
     'musl-gcc'
   );
-  assert.equal(mod.resolveCargoBuildEnv('win32-x64', {}).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER, undefined);
+  assert.equal(
+    mod.resolveCargoBuildEnv('win32-x64', {
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: '/inherited/musl-gcc'
+    }).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
+    '/inherited/musl-gcc'
+  );
   assert.equal(
     mod.resolveCargoBuildEnv('linux-x64', {
       CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: '/custom/musl-gcc'

--- a/scripts/copy-runtime-binary.test.js
+++ b/scripts/copy-runtime-binary.test.js
@@ -121,6 +121,22 @@ test('ensureBootstrapCargoTargetInstalled skips work when linux-x64 musl is alre
   ]);
 });
 
+test('ensureBootstrapCargoTargetInstalled tolerates missing rustup so distro-managed toolchains can still rely on cargo directly', async () => {
+  const mod = await import(pathToFileURL(buildModulePath).href);
+
+  assert.doesNotThrow(() =>
+    mod.ensureBootstrapCargoTargetInstalled({
+      repoRoot: '/repo',
+      target: 'linux-x64',
+      spawnSyncImpl() {
+        return {
+          error: Object.assign(new Error('spawn rustup ENOENT'), { code: 'ENOENT' })
+        };
+      }
+    })
+  );
+});
+
 test('buildRuntimeTarget runs cargo for the requested target before copying the runtime', async () => {
   const mod = await import(pathToFileURL(buildModulePath).href);
   const spawnCalls = [];

--- a/scripts/copy-runtime-binary.test.js
+++ b/scripts/copy-runtime-binary.test.js
@@ -12,9 +12,9 @@ test('resolveSourceCandidates prefers target-specific cargo output before host f
   const mod = await import(pathToFileURL(modulePath).href);
 
   assert.deepEqual(
-    mod.resolveSourceCandidates('/repo', 'linux-arm64', 'release'),
+    mod.resolveSourceCandidates('/repo', 'linux-x64', 'release'),
     [
-      path.join('/repo', 'target', 'aarch64-unknown-linux-gnu', 'release', 'apex-log-viewer'),
+      path.join('/repo', 'target', 'x86_64-unknown-linux-musl', 'release', 'apex-log-viewer'),
       path.join('/repo', 'target', 'release', 'apex-log-viewer')
     ]
   );
@@ -47,7 +47,7 @@ test('resolveCargoBuildArgs includes the packaged runtime target triple', async 
   const mod = await import(pathToFileURL(buildModulePath).href);
 
   assert.deepEqual(
-    mod.resolveCargoBuildArgs('linux-arm64', 'release'),
+    mod.resolveCargoBuildArgs('linux-x64', 'release'),
     [
       'build',
       '-p',
@@ -56,7 +56,7 @@ test('resolveCargoBuildArgs includes the packaged runtime target triple', async 
       'apex-log-viewer',
       '--release',
       '--target',
-      'aarch64-unknown-linux-gnu'
+      'x86_64-unknown-linux-musl'
     ]
   );
 });
@@ -78,26 +78,62 @@ test('buildRuntimeTarget runs cargo for the requested target before copying the 
     }
   });
 
-  assert.deepEqual(spawnCalls, [
-    {
-      command: 'cargo',
-      args: [
-        'build',
-        '-p',
-        'apex-log-viewer-cli',
-        '--bin',
-        'apex-log-viewer',
-        '--release',
-        '--target',
-        'aarch64-pc-windows-msvc'
-      ],
-      options: { cwd: '/repo', stdio: 'inherit' }
-    }
+  assert.equal(spawnCalls.length, 1);
+  assert.deepEqual(spawnCalls[0].args, [
+    'build',
+    '-p',
+    'apex-log-viewer-cli',
+    '--bin',
+    'apex-log-viewer',
+    '--release',
+    '--target',
+    'aarch64-pc-windows-msvc'
   ]);
+  assert.equal(spawnCalls[0].command, 'cargo');
+  assert.equal(spawnCalls[0].options.cwd, '/repo');
+  assert.equal(spawnCalls[0].options.stdio, 'inherit');
+  assert.equal(spawnCalls[0].options.env.CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER, undefined);
   assert.deepEqual(result, {
     copied: true,
     profile: 'release',
     repoRoot: '/repo',
     target: 'win32-arm64'
+  });
+});
+
+test('resolveCargoBuildEnv pins the musl linker for linux-x64 while leaving other targets untouched', async () => {
+  const mod = await import(pathToFileURL(buildModulePath).href);
+
+  assert.equal(
+    mod.resolveCargoBuildEnv('linux-x64', {}).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
+    'musl-gcc'
+  );
+  assert.equal(mod.resolveCargoBuildEnv('win32-x64', {}).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER, undefined);
+  assert.equal(
+    mod.resolveCargoBuildEnv('linux-x64', {
+      CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER: '/custom/musl-gcc'
+    }).CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER,
+    '/custom/musl-gcc'
+  );
+});
+
+test('resolveBuildArguments defaults to the current target and treats a lone profile argument as release mode selection', async () => {
+  const mod = await import(pathToFileURL(buildModulePath).href);
+
+  assert.deepEqual(mod.resolveBuildArguments([], 'linux-x64'), {
+    target: 'linux-x64',
+    profile: 'release'
+  });
+  assert.deepEqual(mod.resolveBuildArguments(['release'], 'linux-x64'), {
+    target: 'linux-x64',
+    profile: 'release'
+  });
+  assert.deepEqual(mod.resolveBuildArguments(['linux-arm64'], 'linux-x64'), {
+    target: 'linux-arm64',
+    profile: 'release'
+  });
+  assert.deepEqual(mod.resolveBuildArguments(['linux-arm64', 'debug'], 'linux-x64'), {
+    target: 'linux-arm64',
+    profile: 'debug'
   });
 });

--- a/scripts/package-cli-release.mjs
+++ b/scripts/package-cli-release.mjs
@@ -5,7 +5,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const CARGO_TARGETS = {
-  'linux-x64': 'x86_64-unknown-linux-gnu',
+  'linux-x64': 'x86_64-unknown-linux-musl',
   'linux-arm64': 'aarch64-unknown-linux-gnu',
   'win32-x64': 'x86_64-pc-windows-msvc',
   'win32-arm64': 'aarch64-pc-windows-msvc',

--- a/scripts/package-cli-release.test.js
+++ b/scripts/package-cli-release.test.js
@@ -66,3 +66,18 @@ test('packageCliRelease requires all requested release targets to be present', a
 
   fs.rmSync(repoRoot, { recursive: true, force: true });
 });
+
+test('discoverReleaseBinaries finds linux-x64 musl cargo output before the generic host fallback', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cli-release-repo-'));
+  const linuxBinary = path.join(repoRoot, 'target', 'x86_64-unknown-linux-musl', 'release', 'apex-log-viewer');
+
+  fs.mkdirSync(path.dirname(linuxBinary), { recursive: true });
+  fs.writeFileSync(linuxBinary, 'linux-binary');
+
+  assert.deepEqual(mod.discoverReleaseBinaries(repoRoot, ['linux-x64']), {
+    'linux-x64': linuxBinary
+  });
+
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+});

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -55,13 +55,13 @@ test('package script rebuilds the extension packaging assets that vsce includes'
   assert.match(packageScript, /\bbuild:package-metadata\b/);
 });
 
-test('package:runtime fetches the pinned CLI release asset and package:runtime:local keeps the local cargo fallback', () => {
+test('package:runtime fetches the pinned CLI release asset and package:runtime:local builds the canonical host target locally', () => {
   const rootPackageJson = JSON.parse(readFile('package.json'));
 
   assert.equal(rootPackageJson.scripts?.['package:runtime'], 'node scripts/fetch-runtime-release.mjs');
-  assert.match(
-    String(rootPackageJson.scripts?.['package:runtime:local'] || ''),
-    /cargo build -p apex-log-viewer-cli --bin apex-log-viewer --release && node apps\/vscode-extension\/scripts\/copy-runtime-binary\.mjs release/
+  assert.equal(
+    rootPackageJson.scripts?.['package:runtime:local'],
+    'node scripts/build-runtime-target.mjs release'
   );
 });
 
@@ -156,6 +156,21 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
     channel: 'stable',
     protocolVersion: '1'
   });
+});
+
+test('rust-release workflow builds linux-x64 with musl to avoid coupling the shipped runtime to the host glibc', () => {
+  const workflowSource = readFile('.github/workflows/rust-release.yml');
+
+  assert.match(
+    workflowSource,
+    /target:\s+linux-x64[\s\S]*?cargo_target:\s+x86_64-unknown-linux-musl/,
+    'expected linux-x64 runtime releases to use the musl Rust target'
+  );
+  assert.match(
+    workflowSource,
+    /Install Linux x64 musl toolchain[\s\S]*?musl-tools/,
+    'expected the rust-release workflow to install musl build tools for linux-x64 packaging'
+  );
 });
 
 test('rust-release workflow preserves per-artifact directories when downloading runtime binaries', () => {


### PR DESCRIPTION
This change fixes a Linux runtime compatibility regression that breaks Apex Log Viewer inside Agentforce Vibes IDE / Salesforce Code Builder.

In the failing environment, the bundled `linux-x64` runtime exits immediately during extension activation with `/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.39' not found`. The result is that the runtime daemon never starts, org preloading fails, and Logs/Tail features cannot talk to the Rust sidecar at all.

The root cause is that our published `linux-x64` runtime artifact was being built against the GitHub runner's GNU libc toolchain, which allowed the generated binary to pick up a newer glibc requirement than older hosted IDE environments provide. Because the extension packaging flow consumes a pinned CLI runtime release, that incompatible binary then shipped directly inside the VSIX.

This patch changes the canonical published `linux-x64` runtime build to `x86_64-unknown-linux-musl` while preserving the external target name and asset naming used by the extension packaging flow. The Rust release workflow now installs the musl toolchain for the Ubuntu runner, the runtime build/copy/package scripts all resolve `linux-x64` to the musl target, and the local `package:runtime:local` path now goes through the same target-aware build script instead of relying on a generic host build fallback. I also wired the build script to set `CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=musl-gcc` for the musl build so dependencies like `ring` can compile cleanly in CI.

The test coverage was updated alongside the packaging changes. Script and workflow tests now assert that `linux-x64` resolves to the musl target, that the local runtime packaging path uses the canonical host target flow, and that the Rust release workflow installs the expected musl build tools. Documentation and changelog entries were updated to explain the new Linux compatibility contract and the local requirement for `musl-gcc` when maintainers rebuild the packaged runtime on Linux.

Validation performed for this branch:

- `node --test scripts/copy-runtime-binary.test.js scripts/package-cli-release.test.js scripts/packaging-ci.test.js scripts/docs-release.test.js`

One local limitation remains outside the code change itself: on this Arch host, I could not complete a full musl binary build because `musl-gcc` is not installed locally. The workflow change explicitly installs the Ubuntu equivalent (`musl-tools`), and the build script now expects an equivalent musl compiler package to be present on local Linux machines.
