### PR TITLE
chore(release): prepare rust cli 0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.6"
+version = "0.1.7"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.6"
+version = "0.1.7"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.6",
-  "tag": "rust-v0.1.6",
+  "cliVersion": "0.1.7",
+  "tag": "rust-v0.1.7",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.6", path = "../alv-core" }
-alv-protocol = { version = "0.1.6", path = "../alv-protocol" }
+alv-core = { version = "0.1.7", path = "../alv-core" }
+alv-protocol = { version = "0.1.7", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.6", path = "../alv-app-server" }
-alv-core = { version = "0.1.6", path = "../alv-core" }
+alv-app-server = { version = "0.1.7", path = "../alv-app-server" }
+alv-core = { version = "0.1.7", path = "../alv-core" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.6"
+version = "0.1.7"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -151,8 +151,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.6',
-    tag: 'rust-v0.1.6',
+    cliVersion: '0.1.7',
+    tag: 'rust-v0.1.7',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
This PR prepares the next standalone Rust CLI/runtime release as `0.1.7`.

The change bumps every versioned Rust workspace crate from `0.1.6` to `0.1.7`, keeps the internal path dependencies aligned, updates the matching entries in `Cargo.lock`, and advances the pinned runtime metadata in `config/runtime-bundle.json` to `rust-v0.1.7`. That keeps the repository in the release-ready state expected by the Rust CLI workflow and by the packaging regression tests.

The intent is to publish the new CLI/runtime first via the `rust-v0.1.7` tag, then cut the next extension pre-release against this same commit so the pre-release VSIX fetches the tested `0.1.7` runtime asset. This follows the existing repository pattern where the runtime bundle is pinned forward in the release-prep commit before the extension channel consumes it.

Validation performed for this branch:

- `node --test scripts/packaging-ci.test.js scripts/docs-release.test.js`
- `cargo check -p apex-log-viewer-cli --locked`
