### PR TITLE
fix(docs): restore marketplace screenshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Bug Fixes
 
 - CLI/npm: publish the global meta package with both `alv` and `apex-log-viewer` shims so Windows and other npm installs expose the familiar long command name too.
+- Docs/Marketplace: point README banner and screenshot images at the actual published extension asset paths so GitHub and the VS Code Marketplace render them instead of broken placeholders.
 - Runtime/Logs: avoid repeated recursive cache walks during CLI log search by indexing candidate local log paths once per request while preserving org-first and legacy-layout fallback behavior.
 - Runtime/Logs: reduce startup request fan-out by letting the Logs panel fetch rows without waiting for org bootstrap/auth hydration, coalescing concurrent runtime `org/list` and `org/auth` requests, reusing auth during log-body preload, and avoiding redundant login-shell PATH probes when the current Windows PATH already resolves `sf`.
 - Runtime/Logs: stop repeated recursive cached-log scans by resolving saved log paths through the shared Rust lookup first, caching runtime hits in-process, and limiting the extension's local fallback to the supported `orgs/<org>/logs/<day>/` layout plus legacy flat files.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Apex Log Viewer banner](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/media/banner.png)
+![Apex Log Viewer banner](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/apps/vscode-extension/media/banner.png)
 
 # Electivus Apex Log Viewer
 
@@ -24,7 +24,7 @@ Search downloaded Salesforce Apex logs inside VS Code, jump straight to the righ
 
 ## Screenshots
 
-![Search, snippets, triage, and local log search](media/docs/hero.png)
+![Search, snippets, triage, and local log search](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/apps/vscode-extension/media/docs/hero.png)
 
 Search in the logs panel is optimized for locally saved log bodies, so the most effective flow is:
 
@@ -34,11 +34,11 @@ Search in the logs panel is optimized for locally saved log bodies, so the most 
 4. Use **Download all logs** when the refreshed and scrolled set still did not surface what you need, or when you want to pull the whole org backlog into the workspace in one shot.
 5. Open the best candidate in the dedicated viewer.
 
-![Dedicated Apex Log Viewer with diagnostics](media/docs/log-viewer.png)
+![Dedicated Apex Log Viewer with diagnostics](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/apps/vscode-extension/media/docs/log-viewer.png)
 
-![Apex Debug Flags editor](media/docs/debug-flags.png)
+![Apex Debug Flags editor](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/apps/vscode-extension/media/docs/debug-flags.png)
 
-![Real-time Apex log tail](media/docs/tail.png)
+![Real-time Apex log tail](https://raw.githubusercontent.com/Electivus/Apex-Log-Viewer/main/apps/vscode-extension/media/docs/tail.png)
 
 ## Requirements
 

--- a/scripts/docs-release.test.js
+++ b/scripts/docs-release.test.js
@@ -2,6 +2,10 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 test('release docs mention the dedicated CLI workflow and pinned runtime metadata', () => {
   const ci = fs.readFileSync('docs/CI.md', 'utf8');
   const publishing = fs.readFileSync('docs/PUBLISHING.md', 'utf8');
@@ -16,6 +20,25 @@ test('release docs mention the dedicated CLI workflow and pinned runtime metadat
   assert.match(publishing, /crates\.io.*deferred/i);
   assert.match(architecture, /config\/runtime-bundle\.json/);
   assert.match(changelog, /independent Rust CLI release train/i);
+});
+
+test('README screenshot assets point at the published extension media paths', () => {
+  const readme = fs.readFileSync('README.md', 'utf8');
+  const assetPaths = [
+    'apps/vscode-extension/media/banner.png',
+    'apps/vscode-extension/media/docs/hero.png',
+    'apps/vscode-extension/media/docs/log-viewer.png',
+    'apps/vscode-extension/media/docs/debug-flags.png',
+    'apps/vscode-extension/media/docs/tail.png'
+  ];
+
+  for (const assetPath of assetPaths) {
+    assert.equal(fs.existsSync(assetPath), true, `expected ${assetPath} to exist`);
+    assert.match(readme, new RegExp(escapeRegExp(assetPath)));
+  }
+
+  assert.doesNotMatch(readme, /raw\.githubusercontent\.com\/Electivus\/Apex-Log-Viewer\/main\/media\//);
+  assert.doesNotMatch(readme, /!\[[^\]]*\]\(media\//);
 });
 
 test('test:scripts includes the release docs smoke test', () => {


### PR DESCRIPTION
## Summary
- point the README banner and screenshot links at the actual published extension assets under `apps/vscode-extension/media`
- stop the VS Code Marketplace from resolving screenshots to broken `.../raw/HEAD/media/...` URLs
- add a regression test that fails if the README drifts back to repo-root `media/...` paths

## Testing
- `node --test scripts/docs-release.test.js`
