### PR TITLE
fix(ci): checkout release publish jobs before setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -343,6 +343,9 @@ jobs:
     timeout-minutes: 15
     environment: marketplace
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
@@ -390,6 +393,9 @@ jobs:
     timeout-minutes: 15
     environment: marketplace
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -245,3 +245,20 @@ test('rust-release release job checks out the repo before running gh release com
     'expected release job to check out the repo before running gh release commands'
   );
 });
+
+for (const [workflowPath, jobName, description] of [
+  ['.github/workflows/release.yml', 'publish_marketplace', 'Marketplace publish'],
+  ['.github/workflows/release.yml', 'publish_open_vsx', 'Open VSX publish'],
+  ['.github/workflows/prerelease.yml', 'publish_marketplace', 'pre-release Marketplace publish'],
+  ['.github/workflows/prerelease.yml', 'publish_open_vsx', 'pre-release Open VSX publish']
+]) {
+  test(`${description} job checks out the repo before setup-node reads .nvmrc`, () => {
+    const publishJob = readWorkflowJob(workflowPath, jobName);
+
+    assert.match(
+      publishJob,
+      /- name:\s+Checkout[\s\S]*?uses:\s+actions\/checkout@[0-9a-f]{40}[\s\S]*?- name:\s+Setup Node\.js from \.nvmrc/,
+      `expected ${workflowPath} ${jobName} to check out the repo before setup-node reads .nvmrc`
+    );
+  });
+}


### PR DESCRIPTION
## Summary
- add `actions/checkout` to the stable release publish jobs before `actions/setup-node` reads `.nvmrc`
- keep the publish steps unchanged otherwise so the recovery path stays fully CI-driven
- add a packaging CI regression test that guards the checkout-before-setup-node contract for release and prerelease publish jobs

## Root cause
The `v0.40.0` `Release (tags)` workflow failed in both publish jobs before any publish attempt because `actions/setup-node` was configured with `node-version-file: .nvmrc`, but those jobs never checked out the repository. On a fresh runner, `.nvmrc` was therefore missing.

## Verification
- `PATH="$HOME/.nvm/versions/node/v22.15.1/bin:$PATH" node --test scripts/packaging-ci.test.js`
