### PR TITLE
[codex] fix cargo-deny rustls-webpki advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
## Summary
- update `rustls-webpki` in `Cargo.lock` from `0.103.10` to `0.103.12`
- keep the change limited to the lockfile so the existing `reqwest` -> `rustls` resolution stays intact

## Root cause
`Rust Supply Chain` started failing on `main` and PRs because `cargo deny check advisories bans licenses sources` flagged `RUSTSEC-2026-0098` and `RUSTSEC-2026-0099` against `rustls-webpki 0.103.10`, pulled in through `reqwest` -> `rustls` -> `rustls-webpki`.

## Validation
- `cargo deny check advisories bans licenses sources`
- `cargo tree -i rustls-webpki -p alv-core`
- `npm run test:rust` still fails locally on Windows in existing `alv-app-server` smoke tests because they interpolate backslash paths into JSON without escaping; latest `CI` on `main` is green on `ubuntu-latest`, so that issue is separate from this cargo-deny fix
