### PR TITLE
[codex] fix e2e support extension install on Windows

### DIFF
--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -62,7 +62,6 @@ describe('resolveCliSpawnInvocation', () => {
       command: process.env.ComSpec || 'cmd.exe',
       args: [
         '/d',
-        '/s',
         '/c',
         'C:\\VS Code\\bin\\code.cmd',
         '--extensions-dir',

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -54,15 +54,17 @@ describe('resolveCliSpawnInvocation', () => {
   test('wraps Windows .cmd CLIs through cmd.exe with separate arguments', () => {
     expect(
       resolveCliSpawnInvocation(
-      'C:\\VS Code\\bin\\code.cmd',
-      ['--extensions-dir', 'C:\\Temp\\support extensions', '--install-extension', 'publisher.extension'],
-      'win32'
+        'C:\\VS Code\\bin\\code.cmd',
+        ['--extensions-dir', 'C:\\Temp\\support extensions', '--install-extension', 'publisher.extension'],
+        'win32'
       )
     ).toEqual({
       command: process.env.ComSpec || 'cmd.exe',
       args: [
         '/d',
+        '/s',
         '/c',
+        'call',
         'C:\\VS Code\\bin\\code.cmd',
         '--extensions-dir',
         'C:\\Temp\\support extensions',

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -51,19 +51,26 @@ describe('resolveCliSpawnInvocation', () => {
     );
   });
 
-  test('wraps Windows .cmd CLIs through cmd.exe with quoted arguments', () => {
-    const invocation = resolveCliSpawnInvocation(
+  test('wraps Windows .cmd CLIs through cmd.exe with separate arguments', () => {
+    expect(
+      resolveCliSpawnInvocation(
       'C:\\VS Code\\bin\\code.cmd',
       ['--extensions-dir', 'C:\\Temp\\support extensions', '--install-extension', 'publisher.extension'],
       'win32'
-    );
-
-    expect(invocation.command).toBe(process.env.ComSpec || 'cmd.exe');
-    expect(invocation.args.slice(0, 3)).toEqual(['/d', '/s', '/c']);
-    expect(invocation.args[3]).toContain('"C:\\VS Code\\bin\\code.cmd"');
-    expect(invocation.args[3]).toContain('--extensions-dir');
-    expect(invocation.args[3]).toContain('"C:\\Temp\\support extensions"');
-    expect(invocation.args[3]).toContain('publisher.extension');
+      )
+    ).toEqual({
+      command: process.env.ComSpec || 'cmd.exe',
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        'C:\\VS Code\\bin\\code.cmd',
+        '--extensions-dir',
+        'C:\\Temp\\support extensions',
+        '--install-extension',
+        'publisher.extension'
+      ]
+    });
   });
 });
 

--- a/test/e2e/utils/__tests__/vscode.test.ts
+++ b/test/e2e/utils/__tests__/vscode.test.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import {
   createMissingSupportExtensionsError,
   resolveCachedSupportExtensionsDir,
+  resolveCliSpawnInvocation,
   resolveExtensionDevelopmentPath,
   resolveSupportExtensionsLockPath,
   resolveVscodeCachePath,
@@ -37,6 +38,32 @@ describe('missing support extensions', () => {
       '[e2e] Required VS Code support extensions are missing from the isolated profile: ' +
         'salesforce.salesforcedx-vscode-core, salesforce.salesforcedx-vscode-apex-replay-debugger'
     );
+  });
+});
+
+describe('resolveCliSpawnInvocation', () => {
+  test('keeps direct CLI execution on non-Windows platforms', () => {
+    expect(resolveCliSpawnInvocation('/usr/local/bin/code', ['--install-extension', 'publisher.extension'], 'linux')).toEqual(
+      {
+        command: '/usr/local/bin/code',
+        args: ['--install-extension', 'publisher.extension']
+      }
+    );
+  });
+
+  test('wraps Windows .cmd CLIs through cmd.exe with quoted arguments', () => {
+    const invocation = resolveCliSpawnInvocation(
+      'C:\\VS Code\\bin\\code.cmd',
+      ['--extensions-dir', 'C:\\Temp\\support extensions', '--install-extension', 'publisher.extension'],
+      'win32'
+    );
+
+    expect(invocation.command).toBe(process.env.ComSpec || 'cmd.exe');
+    expect(invocation.args.slice(0, 3)).toEqual(['/d', '/s', '/c']);
+    expect(invocation.args[3]).toContain('"C:\\VS Code\\bin\\code.cmd"');
+    expect(invocation.args[3]).toContain('--extensions-dir');
+    expect(invocation.args[3]).toContain('"C:\\Temp\\support extensions"');
+    expect(invocation.args[3]).toContain('publisher.extension');
   });
 });
 

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -104,14 +104,6 @@ export function createMissingSupportExtensionsError(missingExtensionIds: string[
   );
 }
 
-function quoteWindowsShellArg(value: string): string {
-  if (!value.length) {
-    return '""';
-  }
-
-  return /[\s"&()[\]{}^=;!'+,`~|<>]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
-}
-
 export function resolveCliSpawnInvocation(
   cliPath: string,
   cliArgs: string[] = [],
@@ -122,7 +114,7 @@ export function resolveCliSpawnInvocation(
     // VS Code CLI through `cmd.exe` when the resolved launcher is a batch file.
     return {
       command: process.env.ComSpec || 'cmd.exe',
-      args: ['/d', '/s', '/c', [cliPath, ...cliArgs].map(quoteWindowsShellArg).join(' ')]
+      args: ['/d', '/s', '/c', cliPath, ...cliArgs]
     };
   }
 
@@ -292,8 +284,9 @@ function installExtensions(args: {
       args.extensionsDir
     ]);
     const res = spawnSync(invocation.command, invocation.args, {
-      stdio: ['ignore', 'inherit', 'inherit'],
+      stdio: ['pipe', 'inherit', 'inherit'],
       encoding: 'utf8',
+      input: 'y\n',
       env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
     });
     if (res.error || res.status !== 0) {

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -114,7 +114,7 @@ export function resolveCliSpawnInvocation(
     // VS Code CLI through `cmd.exe` when the resolved launcher is a batch file.
     return {
       command: process.env.ComSpec || 'cmd.exe',
-      args: ['/d', '/c', cliPath, ...cliArgs]
+      args: ['/d', '/s', '/c', 'call', cliPath, ...cliArgs]
     };
   }
 

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -104,6 +104,31 @@ export function createMissingSupportExtensionsError(missingExtensionIds: string[
   );
 }
 
+function quoteWindowsShellArg(value: string): string {
+  if (!value.length) {
+    return '""';
+  }
+
+  return /[\s"&()[\]{}^=;!'+,`~|<>]/.test(value) ? `"${value.replace(/"/g, '""')}"` : value;
+}
+
+export function resolveCliSpawnInvocation(
+  cliPath: string,
+  cliArgs: string[] = [],
+  targetPlatform: NodeJS.Platform = process.platform
+): { command: string; args: string[] } {
+  if (targetPlatform === 'win32' && /\.cmd$/i.test(cliPath)) {
+    // `spawnSync(code.cmd, ...)` can fail with EINVAL on Windows, so route the
+    // VS Code CLI through `cmd.exe` when the resolved launcher is a batch file.
+    return {
+      command: process.env.ComSpec || 'cmd.exe',
+      args: ['/d', '/s', '/c', [cliPath, ...cliArgs].map(quoteWindowsShellArg).join(' ')]
+    };
+  }
+
+  return { command: cliPath, args: cliArgs };
+}
+
 export function resolveWindowSizeArg(windowSize?: Partial<VscodeWindowSize>): string | undefined {
   const width = Number(windowSize?.width);
   const height = Number(windowSize?.height);
@@ -256,27 +281,31 @@ function installExtensions(args: {
 }): void {
   for (const id of args.extensionIds) {
     console.log(`[e2e] Installing VS Code support extension: ${id}`);
-    const res = spawnSync(
-      args.cliPath,
-      [
-        ...args.cliArgs,
-        '--install-extension',
-        id,
-        '--force',
-        '--user-data-dir',
-        args.userDataDir,
-        '--extensions-dir',
-        args.extensionsDir
-      ],
-      {
-        stdio: ['pipe', 'inherit', 'inherit'],
-        encoding: 'utf8',
-        input: 'y\n',
-        env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
-      }
-    );
-    if (res.status !== 0) {
-      console.warn(`[e2e] Failed to install VS Code support extension: ${id}`);
+    const invocation = resolveCliSpawnInvocation(args.cliPath, [
+      ...args.cliArgs,
+      '--install-extension',
+      id,
+      '--force',
+      '--user-data-dir',
+      args.userDataDir,
+      '--extensions-dir',
+      args.extensionsDir
+    ]);
+    const res = spawnSync(invocation.command, invocation.args, {
+      stdio: ['ignore', 'inherit', 'inherit'],
+      encoding: 'utf8',
+      env: { ...process.env, DONT_PROMPT_WSL_INSTALL: '1' }
+    });
+    if (res.error || res.status !== 0) {
+      const details = [
+        typeof res.status === 'number' ? `exit code ${res.status}` : undefined,
+        res.error?.message
+      ]
+        .filter(Boolean)
+        .join('; ');
+      console.warn(
+        `[e2e] Failed to install VS Code support extension: ${id}${details ? ` (${details})` : ''}`
+      );
     }
   }
 }

--- a/test/e2e/utils/vscode.ts
+++ b/test/e2e/utils/vscode.ts
@@ -114,7 +114,7 @@ export function resolveCliSpawnInvocation(
     // VS Code CLI through `cmd.exe` when the resolved launcher is a batch file.
     return {
       command: process.env.ComSpec || 'cmd.exe',
-      args: ['/d', '/s', '/c', cliPath, ...cliArgs]
+      args: ['/d', '/c', cliPath, ...cliArgs]
     };
   }
 


### PR DESCRIPTION
## Summary
- route VS Code support-extension installs through `cmd.exe` when the resolved CLI is `code.cmd` on Windows
- keep direct CLI execution on non-Windows platforms and add unit coverage for the invocation logic
- improve warning details when support-extension installation fails during E2E setup

## Why
The Playwright E2E runner installs required VS Code support extensions into an isolated profile before launching the workbench. On Windows, calling `spawnSync(code.cmd, ...)` was returning `EINVAL`, so the Apex Replay Debugger extension never landed in the isolated extensions cache and `replayDebugger.e2e.spec.ts` failed before the scenario could run.

## Impact
Windows E2E runs can now install Replay Debugger support extensions reliably in the isolated VS Code profile, which unblocks the replay debugger scenario and keeps the cached-extension flow reusable across runs.

## Validation
- `npm run test:e2e:utils -- vscode.test.ts`
- `npm run test:e2e -- --grep "launches replay debugger"`
- `npm run test:e2e`