### PR TITLE
chore(release): prepare 0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 ## Unreleased
 
+## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
+
 ### Bug Fixes
 
-- Tail/Logs: remove the webview troubleshooting command and harden Logs/Tail webviews for destroy-and-remount lifecycles by delaying mounts until visibility stabilizes, timing out failed boots silently, replaying provider-side snapshots, and persisting only UI state in the webview.
+- Build/Runtime: verify the bundled `linux-x64` runtime compatibility path for older-glibc environments and update `rustls-webpki` to a patched release so CI and published binaries stay aligned. ([#727](https://github.com/Electivus/Apex-Log-Viewer/pull/727)) ([#731](https://github.com/Electivus/Apex-Log-Viewer/pull/731))
+- E2E/Windows: fix support-extension installation so Windows end-to-end runs can bootstrap the helper extension reliably. ([#732](https://github.com/Electivus/Apex-Log-Viewer/pull/732))
+- Tail/Logs: remove the webview troubleshooting command and harden Logs/Tail webviews for destroy-and-remount lifecycles by delaying mounts until visibility stabilizes, timing out failed boots silently, replaying provider-side snapshots, and persisting only UI state in the webview. ([#733](https://github.com/Electivus/Apex-Log-Viewer/pull/733))
+
+### Docs
+
+- Maintainers/Docs: refresh AGENTS and repository workflow guidance so local build, test, release, and repo-navigation instructions match the current project layout. ([#730](https://github.com/Electivus/Apex-Log-Viewer/pull/730))
 
 ## [0.40.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.38.0...v0.40.0) (2026-04-13)
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.40.0",
+  "version": "0.42.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.40.0",
+  "version": "0.42.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -80,7 +80,7 @@
     },
     "apps/vscode-extension": {
       "name": "apex-log-viewer",
-      "version": "0.40.0",
+      "version": "0.42.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.15.1",


### PR DESCRIPTION
## Summary
- bump the extension/package-lock version to `0.42.0`
- roll `Unreleased` into the stable `0.42.0` changelog section
- cover all changes shipped since `v0.40.0`

## Verification
- `npm run test:scripts`
- `npm run build`