### PR TITLE
Fix VS Code 1.90 test compatibility

### DIFF
--- a/apps/vscode-extension/src/test/mocha.setup.ts
+++ b/apps/vscode-extension/src/test/mocha.setup.ts
@@ -38,7 +38,8 @@ function installMinimalDomShims(): void {
 
 function shouldFallbackToMinimalDom(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  const code = typeof error === 'object' && error && 'code' in error ? String((error as { code?: unknown }).code || '') : '';
+  const rawCode = typeof error === 'object' && error && 'code' in error ? (error as { code?: unknown }).code : undefined;
+  const code = typeof rawCode === 'string' ? rawCode : '';
   return (
     (code === 'ERR_REQUIRE_ESM' || /ERR_REQUIRE_ESM/.test(message)) &&
     (/html-encoding-sniffer/.test(message) || /@exodus\/bytes/.test(message) || /jsdom/.test(message))

--- a/apps/vscode-extension/src/test/mocha.setup.ts
+++ b/apps/vscode-extension/src/test/mocha.setup.ts
@@ -1,12 +1,72 @@
-import { JSDOM } from 'jsdom';
+function installMinimalDomShims(): void {
+  class HTMLElementMock {}
 
-// Basic jsdom environment for React component tests
-const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
-(globalThis as any).window = dom.window;
-(globalThis as any).document = dom.window.document;
-Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
-(globalThis as any).HTMLElement = dom.window.HTMLElement;
-(globalThis as any).getComputedStyle = dom.window.getComputedStyle;
+  const document = {
+    body: {
+      appendChild() {},
+      removeChild() {}
+    },
+    documentElement: {},
+    createElement: () => ({
+      style: {},
+      appendChild() {},
+      removeChild() {},
+      remove() {},
+      setAttribute() {},
+      getAttribute() {
+        return null;
+      }
+    })
+  };
+
+  const navigator = { userAgent: 'node' };
+  const window = {
+    document,
+    navigator,
+    HTMLElement: HTMLElementMock,
+    getComputedStyle: () => ({
+      getPropertyValue: () => ''
+    })
+  };
+
+  (globalThis as any).window = window;
+  (globalThis as any).document = document;
+  Object.defineProperty(globalThis, 'navigator', { value: navigator, configurable: true });
+  (globalThis as any).HTMLElement = HTMLElementMock;
+  (globalThis as any).getComputedStyle = window.getComputedStyle;
+}
+
+function shouldFallbackToMinimalDom(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  const code = typeof error === 'object' && error && 'code' in error ? String((error as { code?: unknown }).code || '') : '';
+  return (
+    (code === 'ERR_REQUIRE_ESM' || /ERR_REQUIRE_ESM/.test(message)) &&
+    (/html-encoding-sniffer/.test(message) || /@exodus\/bytes/.test(message) || /jsdom/.test(message))
+  );
+}
+
+function installDomEnvironment(): void {
+  try {
+    // VS Code 1.90 ships an extension host Node runtime that cannot require the
+    // ESM-only transitive dependency pulled by newer jsdom releases.
+    const { JSDOM } = require('jsdom') as typeof import('jsdom');
+    const dom = new JSDOM('<!doctype html><html><body></body></html>', { url: 'http://localhost' });
+    (globalThis as any).window = dom.window;
+    (globalThis as any).document = dom.window.document;
+    Object.defineProperty(globalThis, 'navigator', { value: dom.window.navigator, configurable: true });
+    (globalThis as any).HTMLElement = dom.window.HTMLElement;
+    (globalThis as any).getComputedStyle = dom.window.getComputedStyle;
+    return;
+  } catch (error) {
+    if (!shouldFallbackToMinimalDom(error)) {
+      throw error;
+    }
+    console.warn('[mocha.setup] jsdom unavailable in this VS Code host; using minimal DOM shims instead.');
+    installMinimalDomShims();
+  }
+}
+
+installDomEnvironment();
 (globalThis as any).requestAnimationFrame = (cb: FrameRequestCallback) => setTimeout(() => cb(Date.now()), 0);
 (globalThis as any).cancelAnimationFrame = (id: number) => clearTimeout(id);
 class ResizeObserverMock {

--- a/test/e2e/specs/debugFlagsPanel.shared.ts
+++ b/test/e2e/specs/debugFlagsPanel.shared.ts
@@ -49,6 +49,14 @@ async function waitForDebugFlagsFrame(page: Page, timeoutMs: number): Promise<Fr
   );
 }
 
+async function tryWaitForDebugFlagsFrame(page: Page, timeoutMs: number): Promise<Frame | undefined> {
+  try {
+    return await waitForDebugFlagsFrame(page, timeoutMs);
+  } catch {
+    return undefined;
+  }
+}
+
 export async function openDebugFlagsFromLogs(vscodePage: Page): Promise<Frame> {
   await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
   await closeQuickInputIfOpen(vscodePage);
@@ -69,6 +77,20 @@ export async function openDebugFlagsFromLogs(vscodePage: Page): Promise<Frame> {
   await closeQuickInputIfOpen(vscodePage);
   await openDebugFlags.click({ force: true });
 
+  const initialFrame = await tryWaitForDebugFlagsFrame(vscodePage, 10_000);
+  if (initialFrame) {
+    return initialFrame;
+  }
+
+  await openDebugFlags.focus().catch(() => {});
+  await openDebugFlags.press('Enter').catch(() => {});
+
+  const keyboardFrame = await tryWaitForDebugFlagsFrame(vscodePage, 10_000);
+  if (keyboardFrame) {
+    return keyboardFrame;
+  }
+
+  await openDebugFlags.evaluate((button: HTMLButtonElement) => button.click()).catch(() => {});
   return await waitForDebugFlagsFrame(vscodePage, 180_000);
 }
 

--- a/test/e2e/utils/__tests__/commandPalette.test.ts
+++ b/test/e2e/utils/__tests__/commandPalette.test.ts
@@ -1,15 +1,36 @@
 import { runCommandWhenAvailable } from '../commandPalette';
 
-function createFakePage(noMatchVisibility: boolean[]) {
+function createFakePage(
+  noMatchVisibility: boolean[],
+  options?: {
+    requireComboboxSelector?: boolean;
+  }
+) {
   const keyboardPress = jest.fn(async () => {});
   const waitForTimeout = jest.fn(async () => {});
-  const inputWaitFor = jest.fn(async () => {});
-  const inputFill = jest.fn(async () => {});
+  const strictModeError = new Error('strict mode violation');
+  const legacyInputWaitFor = jest.fn(async () => {
+    if (options?.requireComboboxSelector) {
+      throw strictModeError;
+    }
+  });
+  const legacyInputFill = jest.fn(async () => {
+    if (options?.requireComboboxSelector) {
+      throw strictModeError;
+    }
+  });
+  const comboboxWaitFor = jest.fn(async () => {});
+  const comboboxFill = jest.fn(async () => {});
   const isVisible = jest.fn(async () => noMatchVisibility.shift() ?? false);
 
-  const inputLocator = {
-    waitFor: inputWaitFor,
-    fill: inputFill
+  const legacyInputLocator = {
+    waitFor: legacyInputWaitFor,
+    fill: legacyInputFill
+  };
+
+  const comboboxLocator = {
+    waitFor: comboboxWaitFor,
+    fill: comboboxFill
   };
 
   const widgetLocator = {
@@ -17,7 +38,13 @@ function createFakePage(noMatchVisibility: boolean[]) {
       if (selector !== 'input') {
         throw new Error(`Unexpected widget selector: ${selector}`);
       }
-      return inputLocator;
+      return legacyInputLocator;
+    }),
+    getByRole: jest.fn((role: string) => {
+      if (role !== 'combobox') {
+        throw new Error(`Unexpected widget role: ${role}`);
+      }
+      return comboboxLocator;
     }),
     getByText: jest.fn(() => ({
       isVisible
@@ -26,7 +53,7 @@ function createFakePage(noMatchVisibility: boolean[]) {
 
   const locator = jest.fn((selector: string) => {
     if (selector === 'div.quick-input-widget input') {
-      return inputLocator;
+      return legacyInputLocator;
     }
     if (selector === 'div.quick-input-widget') {
       return widgetLocator;
@@ -42,8 +69,10 @@ function createFakePage(noMatchVisibility: boolean[]) {
     } as any,
     keyboardPress,
     waitForTimeout,
-    inputWaitFor,
-    inputFill,
+    legacyInputWaitFor,
+    legacyInputFill,
+    comboboxWaitFor,
+    comboboxFill,
     isVisible
   };
 }
@@ -54,9 +83,9 @@ describe('runCommandWhenAvailable', () => {
 
     await runCommandWhenAvailable(fake.page, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 5_000 });
 
-    expect(fake.inputFill).toHaveBeenNthCalledWith(1, '> Electivus Apex Logs: Refresh Logs');
-    expect(fake.inputFill).toHaveBeenNthCalledWith(2, '> Electivus Apex Logs: Refresh Logs');
-    expect(fake.inputFill).toHaveBeenNthCalledWith(3, '> Electivus Apex Logs: Refresh Logs');
+    expect(fake.comboboxFill).toHaveBeenNthCalledWith(1, '> Electivus Apex Logs: Refresh Logs');
+    expect(fake.comboboxFill).toHaveBeenNthCalledWith(2, '> Electivus Apex Logs: Refresh Logs');
+    expect(fake.comboboxFill).toHaveBeenNthCalledWith(3, '> Electivus Apex Logs: Refresh Logs');
 
     const modifierShortcut = process.platform === 'darwin' ? 'Meta+P' : 'Control+P';
     expect(fake.keyboardPress.mock.calls.map(call => call[0])).toEqual([
@@ -75,6 +104,15 @@ describe('runCommandWhenAvailable', () => {
 
     await runCommandWhenAvailable(fake.page, '> View: Open View...', { timeoutMs: 1_000 });
 
-    expect(fake.inputFill).toHaveBeenCalledWith('> View: Open View...');
+    expect(fake.comboboxFill).toHaveBeenCalledWith('> View: Open View...');
+  });
+
+  test('targets the quick input combobox when a checkbox input is also present', async () => {
+    const fake = createFakePage([false], { requireComboboxSelector: true });
+
+    await runCommandWhenAvailable(fake.page, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 1_000 });
+
+    expect(fake.comboboxWaitFor).toHaveBeenCalledWith({ state: 'visible', timeout: 15_000 });
+    expect(fake.comboboxFill).toHaveBeenCalledWith('> Electivus Apex Logs: Refresh Logs');
   });
 });

--- a/test/e2e/utils/commandPalette.ts
+++ b/test/e2e/utils/commandPalette.ts
@@ -5,11 +5,17 @@ function getModifierKey(): 'Control' | 'Meta' {
   return process.platform === 'darwin' ? 'Meta' : 'Control';
 }
 
+function getQuickInput(page: Page) {
+  const widget = page.locator('div.quick-input-widget');
+  const input = widget.getByRole('combobox');
+  return { widget, input };
+}
+
 async function openQuickOpen(page: Page): Promise<void> {
   const modifier = getModifierKey();
   await page.keyboard.press(`${modifier}+P`);
 
-  const input = page.locator('div.quick-input-widget input');
+  const { input } = getQuickInput(page);
   await input.waitFor({ state: 'visible', timeout: 15_000 });
 }
 
@@ -23,8 +29,7 @@ function normalizeCommandQuery(command: string): string {
 
 async function openQuickOpenWithCommand(page: Page, command: string): Promise<boolean> {
   await openQuickOpen(page);
-  const widget = page.locator('div.quick-input-widget');
-  const input = widget.locator('input');
+  const { widget, input } = getQuickInput(page);
   await input.fill(normalizeCommandQuery(command));
   await page.waitForTimeout(50);
   return !(await noMatchingResults(widget).isVisible());
@@ -83,8 +88,7 @@ export async function runCommandWhenAvailable(
 export async function executeCommandId(page: Page, commandId: string): Promise<void> {
   await runCommand(page, 'Developer: Execute Command...');
 
-  const widget = page.locator('div.quick-input-widget');
-  const input = widget.locator('input');
+  const { widget, input } = getQuickInput(page);
   await input.waitFor({ state: 'visible', timeout: 15_000 });
   await input.fill(commandId);
   await page.waitForTimeout(50);
@@ -101,8 +105,7 @@ export async function executeCommandId(page: Page, commandId: string): Promise<v
 export async function openView(page: Page, viewName: string): Promise<void> {
   await runCommand(page, 'View: Open View...');
 
-  const widget = page.locator('div.quick-input-widget');
-  const input = widget.locator('input');
+  const { widget, input } = getQuickInput(page);
   await input.waitFor({ state: 'visible', timeout: 15_000 });
   await input.fill(viewName);
   await page.waitForTimeout(50);


### PR DESCRIPTION
## Summary
- target the command palette quick input via its `combobox` role and cover the strict-mode fallback in the E2E utility tests
- make the shared `Logs -> Debug Flags` E2E helper retry activation when VS Code 1.90 accepts the click gesture without dispatching the webview message
- keep the in-host extension test runner booting on VS Code 1.90 by falling back to minimal DOM shims when `jsdom` cannot load under that extension-host Node runtime

## Testing
- `npm run test:e2e:utils -- --runInBand --runTestsByPath test/e2e/utils/__tests__/commandPalette.test.ts`
- `npm run compile-tests`
- `node scripts/run-tests-cli.js --scope=unit --vscode=1.90.0`
- `VSCODE_TEST_VERSION=1.90.0 npm run test:e2e -- --workers=1`