### PR TITLE
chore(ci): use Claude Opus 4.7 in workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -42,6 +42,8 @@ jobs:
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
+          claude_args: |
+            --model claude-opus-4-7
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -39,6 +39,7 @@ jobs:
         uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1
         with:
           claude_code_oauth_token: ${{ env.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,8 @@ jobs:
         uses: anthropics/claude-code-action@5d5c10a4f389689f992ea10bb14dcb6fcc83146d # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          claude_args: |
+            --model claude-opus-4-7
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |

--- a/scripts/repo-security.test.js
+++ b/scripts/repo-security.test.js
@@ -930,6 +930,7 @@ test('Claude review workflow skips the action when the OAuth token is unavailabl
   assert.equal(job.env.CLAUDE_CODE_OAUTH_TOKEN, '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}');
   assert.equal(actionStep.if, "${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}");
   assert.equal(actionStep.with.claude_code_oauth_token, '${{ env.CLAUDE_CODE_OAUTH_TOKEN }}');
+  assert.equal(actionStep.with.github_token, '${{ github.token }}');
   assert.match(actionStep.with.claude_args, /--model\s+claude-opus-4-7/);
   assert.equal(skipStep.if, "${{ env.CLAUDE_CODE_OAUTH_TOKEN == '' }}");
   assert.match(skipStep.run, /Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is unavailable/);

--- a/scripts/repo-security.test.js
+++ b/scripts/repo-security.test.js
@@ -896,6 +896,7 @@ test('all workflow uses refs are pinned to full commit SHAs', () => {
 test('Claude workflow only responds to trusted collaborators and has write permissions for repo actions', () => {
   const workflow = yaml.parse(read('.github/workflows/claude.yml'));
   const job = workflow.jobs.claude;
+  const actionStep = job.steps.find(step => step.id === 'claude');
 
   assert.deepEqual(Object.keys(workflow.on).sort(), [
     'issue_comment',
@@ -912,6 +913,7 @@ test('Claude workflow only responds to trusted collaborators and has write permi
   assert.match(job.if, /github\.event\.review\.author_association == 'OWNER'/);
   assert.match(job.if, /github\.event\.review\.author_association == 'MEMBER'/);
   assert.match(job.if, /github\.event\.review\.author_association == 'COLLABORATOR'/);
+  assert.match(actionStep.with.claude_args, /--model\s+claude-opus-4-7/);
 });
 
 test('Claude review workflow skips the action when the OAuth token is unavailable', () => {
@@ -928,6 +930,7 @@ test('Claude review workflow skips the action when the OAuth token is unavailabl
   assert.equal(job.env.CLAUDE_CODE_OAUTH_TOKEN, '${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}');
   assert.equal(actionStep.if, "${{ env.CLAUDE_CODE_OAUTH_TOKEN != '' }}");
   assert.equal(actionStep.with.claude_code_oauth_token, '${{ env.CLAUDE_CODE_OAUTH_TOKEN }}');
+  assert.match(actionStep.with.claude_args, /--model\s+claude-opus-4-7/);
   assert.equal(skipStep.if, "${{ env.CLAUDE_CODE_OAUTH_TOKEN == '' }}");
   assert.match(skipStep.run, /Skipping Claude Code Review because CLAUDE_CODE_OAUTH_TOKEN is unavailable/);
 });


### PR DESCRIPTION
## Summary
- configure both Claude GitHub workflows to pass `--model claude-opus-4-7`
- add repo-security assertions so future workflow edits keep the explicit model pin
- note that the repository Actions allowlist was updated to permit `anthropics/claude-code-action` and its `oven-sh/setup-bun` dependency, which was the startup failure behind run 24739190470

## Verification
- `node --test scripts/repo-security.test.js`

## Context
- failing run: https://github.com/Electivus/Apex-Log-Viewer/actions/runs/24739190470
- official Claude Code Actions docs say Opus 4.7 is enabled by setting `--model claude-opus-4-7`