### PR TITLE
[codex] Expose runtime trace failure details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Runtime/Logs: include sanitized runtime request/response payloads and Salesforce HTTP failure status, URL, and response body in trace logging so log refresh errors are diagnosable without exposing auth tokens.
+
 ## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1048,9 +1048,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
+++ b/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
@@ -3,7 +3,8 @@ import proxyquire from 'proxyquire';
 import type {
   DaemonProcess,
   JsonRpcErrorResponse,
-  JsonRpcSuccessResponse
+  JsonRpcSuccessResponse,
+  LogsListParams
 } from '../../../../../packages/app-server-client-ts/src/index';
 
 const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
@@ -47,7 +48,7 @@ suite('runtime client trace logging', () => {
     const traceEntries: unknown[][] = [];
     const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
       '../../../../src/utils/logger': {
-        isTraceEnabled: () => false,
+        isTraceEnabled: () => true,
         logTrace: (...parts: unknown[]) => traceEntries.push(parts),
         logWarn: () => undefined,
         '@noCallThru': true
@@ -128,7 +129,7 @@ suite('runtime client trace logging', () => {
     const traceEntries: unknown[][] = [];
     const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
       '../../../../src/utils/logger': {
-        isTraceEnabled: () => false,
+        isTraceEnabled: () => true,
         logTrace: (...parts: unknown[]) => traceEntries.push(parts),
         logWarn: () => undefined,
         '@noCallThru': true
@@ -211,6 +212,97 @@ suite('runtime client trace logging', () => {
     assert.match(serializedTrace, /received error response/);
     assert.match(serializedTrace, /"code":-32000/);
     assert.match(serializedTrace, /INVALID_SESSION_ID/);
+  });
+
+  test('skips trace payload redaction when trace logging is disabled', async () => {
+    const traceMessages: string[] = [];
+    const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
+      '../../../../src/utils/logger': {
+        isTraceEnabled: () => false,
+        logTrace: (...parts: unknown[]) => {
+          traceMessages.push(String(parts[0]));
+        },
+        logWarn: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/salesforce/path': {
+        getLoginShellEnv: async () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/utils/config': {
+        getConfig: () => '',
+        '@noCallThru': true
+      },
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      }
+    }) as typeof import('../../runtime/runtimeClient');
+
+    const requestParams = {};
+    Object.defineProperty(requestParams, 'accessToken', {
+      enumerable: true,
+      get() {
+        throw new Error('request trace payload should not be evaluated');
+      }
+    });
+    const responseRow = {};
+    Object.defineProperty(responseRow, 'accessToken', {
+      enumerable: true,
+      get() {
+        throw new Error('response trace payload should not be evaluated');
+      }
+    });
+
+    const daemon = createFakeDaemon({
+      onWrite(message, helpers) {
+        if (message.method === 'initialize') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              runtime_version: '0.1.0',
+              cli_version: '0.1.0',
+              protocol_version: '1',
+              channel: 'stable',
+              platform: 'win32',
+              arch: 'x64',
+              capabilities: {
+                orgs: true,
+                logs: true,
+                search: true,
+                tail: true,
+                debug_flags: true,
+                doctor: true
+              },
+              state_dir: '.alv/state',
+              cache_dir: '.alv/cache'
+            }
+          });
+          return;
+        }
+        if (message.method === 'logs/list') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: [responseRow]
+          });
+          return;
+        }
+        throw new Error(`unexpected method: ${message.method}`);
+      }
+    });
+
+    const client = new RuntimeClient({
+      createProcess: () => daemon,
+      prepareProcessEnv: async () => undefined
+    });
+
+    const rows = await client.logsList(requestParams as LogsListParams);
+
+    assert.equal(rows.length, 1);
+    assert.equal(traceMessages.includes('Runtime: send request'), false);
+    assert.equal(traceMessages.includes('Runtime: received success response'), false);
   });
 
   test('passes ALV_TRACE to the runtime process when extension trace logging is enabled', async () => {

--- a/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
+++ b/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
@@ -344,4 +344,58 @@ suite('runtime client trace logging', () => {
     assert.equal(seenEnv?.ALV_TRACE, '1');
     assert.equal(seenEnv?.PATH, 'C:\\sf\\bin');
   });
+
+  test('recreates the runtime process when trace logging is enabled after startup', async () => {
+    let traceEnabled = false;
+    let disposeCount = 0;
+    const seenEnvs: Array<NodeJS.ProcessEnv | undefined> = [];
+    const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
+      '../../../../src/utils/logger': {
+        isTraceEnabled: () => traceEnabled,
+        logTrace: () => undefined,
+        logWarn: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/salesforce/path': {
+        getLoginShellEnv: async () => ({ PATH: 'C:\\sf\\bin' }),
+        '@noCallThru': true
+      },
+      '../../../../src/utils/config': {
+        getConfig: () => '',
+        '@noCallThru': true
+      },
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      }
+    }) as typeof import('../../runtime/runtimeClient');
+
+    const client = new RuntimeClient({
+      createProcess: (_executable, env) => {
+        seenEnvs.push(env);
+        const daemon = createFakeDaemon({
+          onWrite() {
+            throw new Error('unexpected runtime write');
+          }
+        });
+        return {
+          ...daemon,
+          dispose() {
+            disposeCount += 1;
+          }
+        };
+      }
+    });
+
+    await client.startRuntime();
+    traceEnabled = true;
+    await client.startRuntime();
+
+    assert.equal(disposeCount, 1);
+    assert.equal(seenEnvs.length, 2);
+    assert.equal(seenEnvs[0]?.ALV_TRACE, undefined);
+    assert.equal(seenEnvs[0]?.PATH, 'C:\\sf\\bin');
+    assert.equal(seenEnvs[1]?.ALV_TRACE, '1');
+    assert.equal(seenEnvs[1]?.PATH, 'C:\\sf\\bin');
+  });
 });

--- a/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
+++ b/apps/vscode-extension/src/node-test/runtime/runtimeClient.trace.test.ts
@@ -1,0 +1,255 @@
+import assert from 'assert/strict';
+import proxyquire from 'proxyquire';
+import type {
+  DaemonProcess,
+  JsonRpcErrorResponse,
+  JsonRpcSuccessResponse
+} from '../../../../../packages/app-server-client-ts/src/index';
+
+const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
+
+function createFakeDaemon(handlers: {
+  onWrite: (
+    message: { id: string; method: string; params?: unknown },
+    helpers: {
+      emitMessage: (message: JsonRpcSuccessResponse<unknown> | JsonRpcErrorResponse) => void;
+    }
+  ) => void;
+}): DaemonProcess {
+  const messageListeners = new Set<(message: unknown) => void>();
+  return {
+    child: {} as DaemonProcess['child'],
+    onMessage(listener) {
+      messageListeners.add(listener);
+      return () => messageListeners.delete(listener);
+    },
+    onError() {
+      return () => undefined;
+    },
+    onExit() {
+      return () => undefined;
+    },
+    writeMessage(message) {
+      handlers.onWrite(message as { id: string; method: string; params?: unknown }, {
+        emitMessage: payload => {
+          for (const listener of messageListeners) {
+            listener(payload);
+          }
+        }
+      });
+    },
+    dispose() {}
+  };
+}
+
+suite('runtime client trace logging', () => {
+  test('logs full runtime responses while redacting auth secrets', async () => {
+    const traceEntries: unknown[][] = [];
+    const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
+      '../../../../src/utils/logger': {
+        isTraceEnabled: () => false,
+        logTrace: (...parts: unknown[]) => traceEntries.push(parts),
+        logWarn: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/salesforce/path': {
+        getLoginShellEnv: async () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/utils/config': {
+        getConfig: () => '',
+        '@noCallThru': true
+      },
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      }
+    }) as typeof import('../../runtime/runtimeClient');
+
+    const daemon = createFakeDaemon({
+      onWrite(message, helpers) {
+        if (message.method === 'initialize') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              runtime_version: '0.1.0',
+              cli_version: '0.1.0',
+              protocol_version: '1',
+              channel: 'stable',
+              platform: 'win32',
+              arch: 'x64',
+              capabilities: {
+                orgs: true,
+                logs: true,
+                search: true,
+                tail: true,
+                debug_flags: true,
+                doctor: true
+              },
+              state_dir: '.alv/state',
+              cache_dir: '.alv/cache'
+            }
+          });
+          return;
+        }
+        if (message.method === 'org/auth') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              username: 'demo@example.com',
+              instanceUrl: 'https://example.my.salesforce.com',
+              accessToken: 'secret-token'
+            }
+          });
+          return;
+        }
+        throw new Error(`unexpected method: ${message.method}`);
+      }
+    });
+
+    const client = new RuntimeClient({
+      createProcess: () => daemon,
+      prepareProcessEnv: async () => undefined
+    });
+
+    await client.getOrgAuth({ username: 'demo@example.com' });
+
+    const serializedTrace = JSON.stringify(traceEntries);
+    assert.match(serializedTrace, /received success response/);
+    assert.match(serializedTrace, /org\/auth/);
+    assert.match(serializedTrace, /"accessToken":"\[redacted\]"/);
+    assert.doesNotMatch(serializedTrace, /secret-token/);
+    assert.match(serializedTrace, /example\.my\.salesforce\.com/);
+  });
+
+  test('logs runtime error response codes and data, and preserves data on the thrown error', async () => {
+    const traceEntries: unknown[][] = [];
+    const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
+      '../../../../src/utils/logger': {
+        isTraceEnabled: () => false,
+        logTrace: (...parts: unknown[]) => traceEntries.push(parts),
+        logWarn: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/salesforce/path': {
+        getLoginShellEnv: async () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/utils/config': {
+        getConfig: () => '',
+        '@noCallThru': true
+      },
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      }
+    }) as typeof import('../../runtime/runtimeClient');
+
+    const daemon = createFakeDaemon({
+      onWrite(message, helpers) {
+        if (message.method === 'initialize') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              runtime_version: '0.1.0',
+              cli_version: '0.1.0',
+              protocol_version: '1',
+              channel: 'stable',
+              platform: 'win32',
+              arch: 'x64',
+              capabilities: {
+                orgs: true,
+                logs: true,
+                search: true,
+                tail: true,
+                debug_flags: true,
+                doctor: true
+              },
+              state_dir: '.alv/state',
+              cache_dir: '.alv/cache'
+            }
+          });
+          return;
+        }
+        if (message.method === 'logs/list') {
+          helpers.emitMessage({
+            jsonrpc: '2.0',
+            id: message.id,
+            error: {
+              code: -32000,
+              message: 'HTTP 403 Forbidden from https://example.my.salesforce.com/services/data/v64.0/tooling/query',
+              data: {
+                status: 403,
+                responseBody: '[{"message":"Session expired","errorCode":"INVALID_SESSION_ID"}]'
+              }
+            }
+          });
+          return;
+        }
+        throw new Error(`unexpected method: ${message.method}`);
+      }
+    });
+
+    const client = new RuntimeClient({
+      createProcess: () => daemon,
+      prepareProcessEnv: async () => undefined
+    });
+
+    await assert.rejects(client.logsList({ username: 'demo@example.com', limit: 1 }), error => {
+      assert.equal(error instanceof Error, true);
+      assert.match((error as Error).message, /HTTP 403 Forbidden/);
+      assert.match((error as Error).message, /INVALID_SESSION_ID/);
+      assert.equal((error as { code?: number }).code, -32000);
+      assert.equal((error as { data?: { status?: number } }).data?.status, 403);
+      return true;
+    });
+
+    const serializedTrace = JSON.stringify(traceEntries);
+    assert.match(serializedTrace, /received error response/);
+    assert.match(serializedTrace, /"code":-32000/);
+    assert.match(serializedTrace, /INVALID_SESSION_ID/);
+  });
+
+  test('passes ALV_TRACE to the runtime process when extension trace logging is enabled', async () => {
+    let seenEnv: NodeJS.ProcessEnv | undefined;
+    const { RuntimeClient } = proxyquireStrict('../../runtime/runtimeClient', {
+      '../../../../src/utils/logger': {
+        isTraceEnabled: () => true,
+        logTrace: () => undefined,
+        logWarn: () => undefined,
+        '@noCallThru': true
+      },
+      '../../../../src/salesforce/path': {
+        getLoginShellEnv: async () => ({ PATH: 'C:\\sf\\bin' }),
+        '@noCallThru': true
+      },
+      '../../../../src/utils/config': {
+        getConfig: () => '',
+        '@noCallThru': true
+      },
+      '../shared/telemetry': {
+        safeSendEvent: () => undefined,
+        '@noCallThru': true
+      }
+    }) as typeof import('../../runtime/runtimeClient');
+
+    const client = new RuntimeClient({
+      createProcess: (_executable, env) => {
+        seenEnv = env;
+        return createFakeDaemon({
+          onWrite() {
+            throw new Error('unexpected runtime write');
+          }
+        });
+      }
+    });
+
+    await client.startRuntime();
+
+    assert.equal(seenEnv?.ALV_TRACE, '1');
+    assert.equal(seenEnv?.PATH, 'C:\\sf\\bin');
+  });
+});

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -17,7 +17,7 @@ import type {
 } from '../../../../packages/app-server-client-ts/src/index';
 import { createDaemonProcess } from '../../../../packages/app-server-client-ts/src/index';
 import type { JsonRpcRequest, OrgListItem, OrgListParams } from '../../../../packages/app-server-client-ts/src/index';
-import { logTrace, logWarn } from '../../../../src/utils/logger';
+import { isTraceEnabled, logTrace, logWarn } from '../../../../src/utils/logger';
 import { getLoginShellEnv } from '../../../../src/salesforce/path';
 import { safeSendEvent } from '../shared/telemetry';
 import { resolveBundledBinary } from './bundledBinary';
@@ -34,6 +34,21 @@ import {
 type TimerHandle = ReturnType<typeof setTimeout>;
 const RUNTIME_EXIT_MESSAGE_PREFIX = 'runtime exited (';
 const RUNTIME_TELEMETRY_METHODS = new Set(['initialize', 'org/list', 'org/auth', 'logs/list', 'search/query', 'logs/triage']);
+const RUNTIME_TRACE_REDACTED = '[redacted]';
+const RUNTIME_TRACE_MAX_STRING_LENGTH = 8192;
+const RUNTIME_TRACE_SECRET_KEYS = new Set([
+  'accesstoken',
+  'access_token',
+  'authorization',
+  'clientsecret',
+  'client_secret',
+  'password',
+  'refreshtoken',
+  'refresh_token',
+  'sessionid',
+  'session_id',
+  'token'
+]);
 
 function getConfiguredRuntimePath(): string {
   const { getConfig } = require('../../../../src/utils/config') as typeof import('../../../../src/utils/config');
@@ -41,6 +56,7 @@ function getConfiguredRuntimePath(): string {
 }
 
 type PendingRequest = {
+  method: string;
   resolve: (value: unknown) => void;
   reject: (error: Error) => void;
   cleanup?: () => void;
@@ -67,6 +83,80 @@ export interface RuntimeClientOptions {
   request?: RuntimeRequestHandler;
   requestHandler?: RuntimeRequestHandler;
   schedule?: (callback: () => void, delayMs: number) => TimerHandle;
+}
+
+function redactRuntimeTraceValue(value: unknown, seen = new WeakSet<object>()): unknown {
+  if (typeof value === 'string') {
+    if (value.length <= RUNTIME_TRACE_MAX_STRING_LENGTH) {
+      return value;
+    }
+    return `${value.slice(0, RUNTIME_TRACE_MAX_STRING_LENGTH)}... [truncated ${
+      value.length - RUNTIME_TRACE_MAX_STRING_LENGTH
+    } chars]`;
+  }
+  if (value === null || value === undefined || typeof value !== 'object') {
+    return value;
+  }
+  if (seen.has(value)) {
+    return '[circular]';
+  }
+  seen.add(value);
+
+  if (Array.isArray(value)) {
+    return value.map(item => redactRuntimeTraceValue(item, seen));
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedKey = key.replace(/[-_]/g, '').toLowerCase();
+    redacted[key] = RUNTIME_TRACE_SECRET_KEYS.has(normalizedKey)
+      ? RUNTIME_TRACE_REDACTED
+      : redactRuntimeTraceValue(nestedValue, seen);
+  }
+  return redacted;
+}
+
+function formatRuntimeErrorData(data: unknown): string | undefined {
+  if (data === undefined) {
+    return undefined;
+  }
+  try {
+    const formatted = JSON.stringify(redactRuntimeTraceValue(data));
+    return formatted && formatted !== 'undefined' ? formatted : undefined;
+  } catch {
+    if (typeof data === 'string') {
+      return data;
+    }
+    if (
+      typeof data === 'number' ||
+      typeof data === 'boolean' ||
+      typeof data === 'bigint' ||
+      typeof data === 'symbol'
+    ) {
+      return String(data);
+    }
+    return Object.prototype.toString.call(data);
+  }
+}
+
+function createRuntimeResponseError(response: Partial<JsonRpcErrorResponse>): Error {
+  const message = response.error?.message || 'Runtime request failed';
+  const detail = formatRuntimeErrorData(response.error?.data);
+  const error = new Error(detail ? `${message}; data=${detail}` : message) as Error & {
+    code?: number;
+    data?: unknown;
+    responseId?: string;
+  };
+  if (typeof response.error?.code === 'number') {
+    error.code = response.error.code;
+  }
+  if (response.error?.data !== undefined) {
+    error.data = response.error.data;
+  }
+  if (typeof response.id === 'string') {
+    error.responseId = response.id;
+  }
+  return error;
 }
 
 export class RuntimeClient extends EventEmitter {
@@ -377,13 +467,14 @@ export class RuntimeClient extends EventEmitter {
       }
       cleanup = signal ? () => signal.removeEventListener('abort', onAbort) : undefined;
       this.pendingRequests.set(id, {
+        method,
         resolve: value => resolve(value as TResult),
         reject,
         cleanup
       });
     });
 
-    logTrace('Runtime: send request', { id, method });
+    logTrace('Runtime: send request', redactRuntimeTraceValue({ id, method, params }));
     try {
       daemon.writeMessage(request);
     } catch (error) {
@@ -459,12 +550,12 @@ export class RuntimeClient extends EventEmitter {
     pending.cleanup?.();
 
     if (response.error) {
-      logTrace('Runtime: received error response', { id: response.id, message: response.error.message });
-      pending.reject(new Error(response.error.message));
+      logTrace('Runtime: received error response', redactRuntimeTraceValue({ method: pending.method, response }));
+      pending.reject(createRuntimeResponseError(response));
       return;
     }
 
-    logTrace('Runtime: received success response', response.id);
+    logTrace('Runtime: received success response', redactRuntimeTraceValue({ method: pending.method, response }));
     pending.resolve(response.result);
   }
 
@@ -549,7 +640,7 @@ export class RuntimeClient extends EventEmitter {
 
   private async resolveProcessEnv(): Promise<NodeJS.ProcessEnv | undefined> {
     if (!this.prepareProcessEnv) {
-      return undefined;
+      return isTraceEnabled() ? { ...process.env, ALV_TRACE: '1' } : undefined;
     }
     if (!this.processEnvPromise) {
       this.processEnvPromise = this.prepareProcessEnv().catch(error => {
@@ -557,7 +648,15 @@ export class RuntimeClient extends EventEmitter {
         return undefined;
       });
     }
-    return this.processEnvPromise;
+    const env = await this.processEnvPromise;
+    if (!isTraceEnabled()) {
+      return env;
+    }
+    return {
+      ...process.env,
+      ...env,
+      ALV_TRACE: '1'
+    };
   }
 }
 

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -474,7 +474,9 @@ export class RuntimeClient extends EventEmitter {
       });
     });
 
-    logTrace('Runtime: send request', redactRuntimeTraceValue({ id, method, params }));
+    if (isTraceEnabled()) {
+      logTrace('Runtime: send request', redactRuntimeTraceValue({ id, method, params }));
+    }
     try {
       daemon.writeMessage(request);
     } catch (error) {
@@ -550,12 +552,16 @@ export class RuntimeClient extends EventEmitter {
     pending.cleanup?.();
 
     if (response.error) {
-      logTrace('Runtime: received error response', redactRuntimeTraceValue({ method: pending.method, response }));
+      if (isTraceEnabled()) {
+        logTrace('Runtime: received error response', redactRuntimeTraceValue({ method: pending.method, response }));
+      }
       pending.reject(createRuntimeResponseError(response));
       return;
     }
 
-    logTrace('Runtime: received success response', redactRuntimeTraceValue({ method: pending.method, response }));
+    if (isTraceEnabled()) {
+      logTrace('Runtime: received success response', redactRuntimeTraceValue({ method: pending.method, response }));
+    }
     pending.resolve(response.result);
   }
 

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -175,6 +175,7 @@ export class RuntimeClient extends EventEmitter {
   private readonly requestHandler: RuntimeRequestHandler | undefined;
   private readonly schedule: (callback: () => void, delayMs: number) => TimerHandle;
   private processEnvPromise: Promise<NodeJS.ProcessEnv | undefined> | undefined;
+  private daemonTraceEnabled: boolean | undefined;
 
   constructor(options: RuntimeClientOptions = {}) {
     super();
@@ -189,6 +190,15 @@ export class RuntimeClient extends EventEmitter {
   }
 
   async startRuntime(): Promise<DaemonProcess> {
+    const traceEnabled = isTraceEnabled();
+    if (this.daemon) {
+      if (this.daemonTraceEnabled !== traceEnabled && this.pendingRequests.size === 0) {
+        this.disposeDaemonAfterTraceModeChange(traceEnabled);
+      } else {
+        return this.daemon;
+      }
+    }
+
     if (this.daemon) {
       return this.daemon;
     }
@@ -198,7 +208,7 @@ export class RuntimeClient extends EventEmitter {
       configuredPath: getConfiguredRuntimePath(),
       bundledPath
     });
-    const env = await this.resolveProcessEnv();
+    const env = await this.resolveProcessEnv(traceEnabled);
     if (executableResolution.invalidConfiguredPath) {
       logWarn('Runtime: ignoring invalid configured runtime executable', executableResolution.invalidConfiguredPath);
     }
@@ -208,6 +218,7 @@ export class RuntimeClient extends EventEmitter {
     logTrace('Runtime: starting daemon', executableResolution.executable);
     const daemon = this.createProcess(executableResolution.executable, env);
     this.daemon = daemon;
+    this.daemonTraceEnabled = traceEnabled;
     this.attachDaemonStderrLogger(daemon);
     daemon.onMessage(message => {
       this.handleMessage(message);
@@ -446,7 +457,7 @@ export class RuntimeClient extends EventEmitter {
   }
 
   private async requestOnce<TResult>(method: string, params?: unknown, signal?: AbortSignal): Promise<TResult> {
-    const daemon = this.daemon ?? (await this.startRuntime());
+    const daemon = await this.startRuntime();
     const id = `${method}:${++this.nextRequestId}`;
     const request: JsonRpcRequest = {
       jsonrpc: '2.0',
@@ -517,6 +528,7 @@ export class RuntimeClient extends EventEmitter {
     logTrace('Runtime: restarting session', method);
     if (method === 'initialize') {
       this.daemon = undefined;
+      this.daemonTraceEnabled = undefined;
       this.initializePromise = undefined;
       return;
     }
@@ -586,8 +598,26 @@ export class RuntimeClient extends EventEmitter {
     logTrace('Runtime: daemon failure', { code, signal, message: error.message });
     this.failPendingRequests(error);
     this.daemon = undefined;
+    this.daemonTraceEnabled = undefined;
     this.initializePromise = undefined;
     this.emit(RUNTIME_EXIT_EVENT, { code, signal } satisfies RuntimeExitEvent);
+  }
+
+  private disposeDaemonAfterTraceModeChange(traceEnabled: boolean): void {
+    const daemon = this.daemon;
+    if (!daemon) {
+      return;
+    }
+    logTrace('Runtime: restarting daemon after trace mode change', { traceEnabled });
+    this.daemon = undefined;
+    this.daemonTraceEnabled = undefined;
+    this.initializePromise = undefined;
+    this.restartPromise = undefined;
+    try {
+      daemon.dispose();
+    } catch (error) {
+      logTrace('Runtime: daemon dispose after trace mode change failed', error instanceof Error ? error.message : String(error));
+    }
   }
 
   private normalizeDaemonError(error: Error): Error {
@@ -644,9 +674,9 @@ export class RuntimeClient extends EventEmitter {
     } catch {}
   }
 
-  private async resolveProcessEnv(): Promise<NodeJS.ProcessEnv | undefined> {
+  private async resolveProcessEnv(traceEnabled: boolean): Promise<NodeJS.ProcessEnv | undefined> {
     if (!this.prepareProcessEnv) {
-      return isTraceEnabled() ? { ...process.env, ALV_TRACE: '1' } : undefined;
+      return traceEnabled ? { ...process.env, ALV_TRACE: '1' } : undefined;
     }
     if (!this.processEnvPromise) {
       this.processEnvPromise = this.prepareProcessEnv().catch(error => {
@@ -655,7 +685,7 @@ export class RuntimeClient extends EventEmitter {
       });
     }
     const env = await this.processEnvPromise;
-    if (!isTraceEnabled()) {
+    if (!traceEnabled) {
       return env;
     }
     return {

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -4,6 +4,7 @@ use serde_json::Value;
 use std::{
     collections::BTreeMap,
     env,
+    error::Error as StdError,
     fs::{self, File},
     future::Future,
     io::Write,
@@ -32,6 +33,8 @@ const DEFAULT_API_VERSION: &str = "64.0";
 const HTTP_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
 const HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 const HTTP_CANCEL_POLL_INTERVAL: Duration = Duration::from_millis(10);
+const TRACE_ENV: &str = "ALV_TRACE";
+const TRACE_BODY_LIMIT: usize = 8192;
 
 static API_VERSION_OVERRIDES: OnceLock<Mutex<BTreeMap<String, String>>> = OnceLock::new();
 static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
@@ -520,6 +523,89 @@ fn http_runtime() -> &'static Runtime {
     })
 }
 
+fn trace_enabled() -> bool {
+    env::var(TRACE_ENV)
+        .ok()
+        .map(|value| {
+            let normalized = value.trim().to_ascii_lowercase();
+            !normalized.is_empty()
+                && normalized != "0"
+                && normalized != "false"
+                && normalized != "off"
+        })
+        .unwrap_or(false)
+}
+
+fn trace_http(message: &str) {
+    if trace_enabled() {
+        eprintln!("[alv-core trace] {message}");
+    }
+}
+
+fn truncate_for_trace(value: &str) -> String {
+    let mut end = 0;
+    for (index, _) in value.char_indices() {
+        if index > TRACE_BODY_LIMIT {
+            break;
+        }
+        end = index;
+    }
+
+    if value.len() <= TRACE_BODY_LIMIT {
+        return value.to_string();
+    }
+
+    if end == 0 {
+        end = TRACE_BODY_LIMIT.min(value.len());
+    }
+    format!(
+        "{}... [truncated {} bytes]",
+        &value[..end],
+        value.len().saturating_sub(end)
+    )
+}
+
+fn response_body_text(body: &[u8]) -> String {
+    String::from_utf8_lossy(body).trim().to_string()
+}
+
+fn format_status_error(status: StatusCode, url: &str, body: &[u8]) -> String {
+    let body_text = response_body_text(body);
+    if body_text.is_empty() {
+        format!("HTTP {status} from {url}")
+    } else {
+        format!(
+            "HTTP {status} from {url}: {}",
+            truncate_for_trace(&body_text)
+        )
+    }
+}
+
+fn format_request_error(error: &reqwest::Error, url: &str) -> String {
+    let mut message = match error.status() {
+        Some(status) => format!("HTTP request failed with {status} for {url}: {error}"),
+        None => format!("HTTP request failed for {url}: {error}"),
+    };
+
+    let mut sources = Vec::new();
+    let mut source = StdError::source(error);
+    while let Some(error_source) = source {
+        let text = error_source.to_string();
+        if !text.trim().is_empty() {
+            sources.push(text);
+        }
+        source = error_source.source();
+        if sources.len() >= 8 {
+            break;
+        }
+    }
+    if !sources.is_empty() {
+        message.push_str("; caused by: ");
+        message.push_str(&sources.join(" -> "));
+    }
+    message
+}
+
 #[derive(Debug)]
 enum HttpRequestError {
     Cancelled,
@@ -593,8 +679,10 @@ fn run_http_request_with_cancel(
     cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, HttpRequestError> {
     let auth = auth.clone();
+    let request_url = url.to_string();
     run_async_operation_with_cancel(
         async move {
+            trace_http(&format!("HTTP GET {request_url}"));
             let response = http_client()
                 .get(url)
                 .header("Authorization", format!("Bearer {}", auth.access_token))
@@ -606,21 +694,39 @@ fn run_http_request_with_cancel(
                 Ok(response) => {
                     let status = response.status();
                     match response.bytes().await {
-                        Ok(body) if status.is_success() => Ok(body.to_vec()),
-                        Ok(body) => Err(HttpRequestError::Failed {
-                            status: Some(status),
-                            message: String::from_utf8_lossy(&body).trim().to_string(),
-                        }),
-                        Err(error) => Err(HttpRequestError::Failed {
-                            status: Some(status),
-                            message: error.to_string(),
-                        }),
+                        Ok(body) if status.is_success() => {
+                            trace_http(&format!(
+                                "HTTP response {status} {request_url} body_bytes={}",
+                                body.len()
+                            ));
+                            Ok(body.to_vec())
+                        }
+                        Ok(body) => {
+                            let message = format_status_error(status, &request_url, &body);
+                            trace_http(&format!("HTTP response error {message}"));
+                            Err(HttpRequestError::Failed {
+                                status: Some(status),
+                                message,
+                            })
+                        }
+                        Err(error) => {
+                            let message = format!(
+                                "failed to read HTTP response body from {request_url} after {status}: {error}"
+                            );
+                            trace_http(&message);
+                            Err(HttpRequestError::Failed {
+                                status: Some(status),
+                                message,
+                            })
+                        }
                     }
                 }
-                Err(error) => Err(HttpRequestError::Failed {
-                    status: error.status(),
-                    message: error.to_string(),
-                }),
+                Err(error) => {
+                    let status = error.status();
+                    let message = format_request_error(&error, &request_url);
+                    trace_http(&message);
+                    Err(HttpRequestError::Failed { status, message })
+                }
             }
         },
         cancellation,

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -243,6 +243,47 @@ fn logs_runtime_smoke_lists_logs_over_rest_with_auth_fixture() {
 }
 
 #[test]
+fn logs_runtime_smoke_includes_http_status_url_and_body_in_list_failures() {
+    let _guard = lock_test_guard();
+
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 403,
+        content_type: "application/json",
+        body: br#"[{"message":"Session expired or invalid","errorCode":"INVALID_SESSION_ID"}]"#
+            .to_vec(),
+    }]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let error = list_logs_with_cancel(
+        &LogsListParams {
+            username: Some("demo@example.com".to_string()),
+            limit: Some(1),
+            cursor: None,
+            offset: Some(0),
+        },
+        &CancellationToken::new(),
+    )
+    .expect_err("logs/list should surface the REST failure details");
+
+    assert!(
+        error.contains("HTTP 403 Forbidden"),
+        "expected status in error, got: {error}"
+    );
+    assert!(
+        error.contains("/services/data/v64.0/tooling/query"),
+        "expected request URL in error, got: {error}"
+    );
+    assert!(
+        error.contains("INVALID_SESSION_ID") && error.contains("Session expired or invalid"),
+        "expected response body in error, got: {error}"
+    );
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
+}
+
+#[test]
 fn logs_runtime_smoke_falls_back_to_org_max_api_version_for_logs_list() {
     let _guard = lock_test_guard();
 
@@ -1417,10 +1458,7 @@ if /I "%*"=="org display --json --verbose -o demo@example.com" (
 echo Unexpected sf args: %* 1>&2
 exit /b 1
 "#
-    .replace(
-        "__ORG_DISPLAY_JSON__",
-        &org_display_fixture(&base_url).replace('\"', "\"\""),
-    );
+    .replace("__ORG_DISPLAY_JSON__", &org_display_fixture(&base_url));
     let sf_cmd = write_fake_sf_cmd(&fake_bin_root, &script_body);
 
     std::env::set_var("ALV_SF_BIN_PATH", &sf_cmd);

--- a/packages/app-server-client-ts/src/index.ts
+++ b/packages/app-server-client-ts/src/index.ts
@@ -117,6 +117,7 @@ export type JsonRpcSuccessResponse<TResult> = {
 export type JsonRpcErrorObject = {
   code: number;
   message: string;
+  data?: unknown;
 };
 
 export type JsonRpcErrorResponse = {

--- a/scripts/run-playwright-e2e.js
+++ b/scripts/run-playwright-e2e.js
@@ -21,6 +21,7 @@ const requiredBuildArtifacts = [
   'apps/vscode-extension/media/logViewer.js',
   'apps/vscode-extension/media/debugFlags.js'
 ];
+const DEFAULT_PLAYWRIGHT_RETRIES = '2';
 
 function execFileAsync(file, args, options = {}) {
   return new Promise((resolve, reject) => {
@@ -99,11 +100,12 @@ async function ensureBuildArtifacts(repoRoot, options = {}) {
 }
 
 function resolvePlaywrightInvocation(extraArgs) {
-  const configuredRetries = String(process.env.PLAYWRIGHT_RETRIES || '').trim();
-  if (configuredRetries !== '' && !/^\d+$/.test(configuredRetries)) {
+  const rawRetries = String(process.env.PLAYWRIGHT_RETRIES ?? '').trim();
+  const configuredRetries = rawRetries === '' ? DEFAULT_PLAYWRIGHT_RETRIES : rawRetries;
+  if (!/^\d+$/.test(configuredRetries)) {
     throw new Error(`PLAYWRIGHT_RETRIES must be a non-negative integer, got '${configuredRetries}'.`);
   }
-  const retryArgs = configuredRetries === '' ? [] : [`--retries=${configuredRetries}`];
+  const retryArgs = [`--retries=${configuredRetries}`];
 
   try {
     // Prefer the local Playwright CLI directly. On Windows under Git Bash,

--- a/scripts/run-playwright-e2e.test.js
+++ b/scripts/run-playwright-e2e.test.js
@@ -128,6 +128,29 @@ test('resolveBuildInvocation uses cmd.exe on Windows to avoid npm.cmd spawn issu
   assert.deepEqual(invocation.args, ['/d', '/s', '/c', 'npm.cmd', 'run', 'build']);
 });
 
+test('resolvePlaywrightInvocation defaults to two retries for three total E2E attempts', () => {
+  const originalRetries = process.env.PLAYWRIGHT_RETRIES;
+  delete process.env.PLAYWRIGHT_RETRIES;
+
+  try {
+    const invocation = resolvePlaywrightInvocation(['--grep', 'smoke']);
+
+    assert.deepEqual(invocation.args.slice(0, 5), [
+      require.resolve('@playwright/test/cli'),
+      'test',
+      '--retries=2',
+      '--grep',
+      'smoke'
+    ]);
+  } finally {
+    if (originalRetries === undefined) {
+      delete process.env.PLAYWRIGHT_RETRIES;
+    } else {
+      process.env.PLAYWRIGHT_RETRIES = originalRetries;
+    }
+  }
+});
+
 test('resolvePlaywrightInvocation includes a retries override when PLAYWRIGHT_RETRIES is set', () => {
   const originalRetries = process.env.PLAYWRIGHT_RETRIES;
   process.env.PLAYWRIGHT_RETRIES = '0';


### PR DESCRIPTION
## Summary

- Log full sanitized JSON-RPC runtime request and response payloads when trace logging is enabled, including error code/data instead of only the message.
- Pass `ALV_TRACE=1` into the Rust runtime whenever the extension trace setting is enabled, so runtime HTTP diagnostics reach the VS Code output channel through stderr.
- Include Salesforce HTTP status, request URL, and response body in runtime log-list failures while keeping successful response logging compact.
- Default the Playwright E2E runner to two retries, giving flaky VS Code/org setup tests up to three total attempts while preserving `PLAYWRIGHT_RETRIES` overrides.

## Why

When log refresh failed, the extension only showed a generic `error sending request` message and the runtime trace did not include the response body or structured error details. That made Salesforce/API/auth failures hard to diagnose even with trace enabled.

## Validation

- `npm ci`
- `npm run check-types`
- `npm run lint`
- `npm run test:extension:node`
- `node --test scripts/run-playwright-e2e.test.js`
- `cargo test -p alv-core`
- `rustfmt --edition 2021 --check crates/alv-core/src/logs.rs crates/alv-core/tests/logs_runtime_smoke.rs`
- `npm run test:e2e` (7 passed)
- `git diff --check`