### PR TITLE
fix(runtime): propagate log refresh error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- Runtime/Logs: include sanitized runtime request/response payloads and Salesforce HTTP failure status, URL, and response body in trace logging so log refresh errors are diagnosable without exposing auth tokens.
+- Runtime/Logs: include sanitized runtime request/response payloads and propagate Salesforce HTTP failure status, URL, response body, and transport causes in trace logging so log refresh errors are diagnosable without exposing auth tokens.
 
 ## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
 

--- a/crates/alv-app-server/src/handlers/logs.rs
+++ b/crates/alv-app-server/src/handlers/logs.rs
@@ -1,5 +1,5 @@
 use alv_core::{
-    logs::{list_logs_with_cancel, CancellationToken, LogsListParams},
+    logs::{list_logs_detailed_with_cancel, CancellationToken, LogsListParams, LogsRuntimeError},
     search::{search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs_with_cancel, LogsTriageParams},
 };
@@ -22,10 +22,11 @@ pub struct ResolveCachedLogPathResult {
 pub fn handle_logs_list_with_cancel(
     params: LogsListParams,
     cancellation: &CancellationToken,
-) -> Result<String, String> {
-    let rows = list_logs_with_cancel(&params, cancellation)?;
-    serde_json::to_string(&rows)
-        .map_err(|error| format!("failed to serialize logs/list response: {error}"))
+) -> Result<String, LogsRuntimeError> {
+    let rows = list_logs_detailed_with_cancel(&params, cancellation)?;
+    serde_json::to_string(&rows).map_err(|error| {
+        LogsRuntimeError::from_message(format!("failed to serialize logs/list response: {error}"))
+    })
 }
 
 pub fn handle_search_query_with_cancel(

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -1,5 +1,5 @@
 use alv_core::{
-    logs::{CancellationToken, LogsCursor, LogsListParams},
+    logs::{CancellationToken, LogsCursor, LogsListParams, LogsRuntimeError},
     search::SearchQueryParams,
     triage::LogsTriageParams,
 };
@@ -25,6 +25,47 @@ mod orgs_handler;
 const WORKER_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const JSONRPC_SERVER_ERROR: i32 = -32000;
 pub const CLI_VERSION_ENV: &str = "ALV_CLI_VERSION";
+
+#[derive(Debug, Clone)]
+struct ServerError {
+    message: String,
+    data_json: Option<String>,
+}
+
+impl ServerError {
+    fn message(&self) -> &str {
+        &self.message
+    }
+
+    fn data_json(&self) -> Option<&str> {
+        self.data_json.as_deref()
+    }
+
+    fn into_message(self) -> String {
+        self.message
+    }
+}
+
+impl From<String> for ServerError {
+    fn from(message: String) -> Self {
+        Self {
+            message,
+            data_json: None,
+        }
+    }
+}
+
+impl From<LogsRuntimeError> for ServerError {
+    fn from(error: LogsRuntimeError) -> Self {
+        let data_json = error
+            .data()
+            .and_then(|data| serde_json::to_string(data).ok());
+        Self {
+            message: error.message().to_string(),
+            data_json,
+        }
+    }
+}
 
 enum ParsedRequest {
     Cancel { request_id: String },
@@ -163,7 +204,9 @@ pub fn handle_request_line(request: &str) -> Result<Option<String>, String> {
         ParsedRequest::Cancel { .. } => Ok(None),
         ParsedRequest::Call(call) => {
             let cancellation = CancellationToken::new();
-            execute_call(call, &cancellation).map(Some)
+            execute_call(call, &cancellation)
+                .map(Some)
+                .map_err(ServerError::into_message)
         }
     }
 }
@@ -200,8 +243,15 @@ fn spawn_request_worker(
         let response = match execute_call(call, &cancellation) {
             Ok(response) if !cancellation.is_cancelled() => Some(response),
             Ok(_) => None,
-            Err(error) if cancellation.is_cancelled() || is_cancelled_error(&error) => None,
-            Err(error) => Some(jsonrpc_error(&request_id, JSONRPC_SERVER_ERROR, &error)),
+            Err(error) if cancellation.is_cancelled() || is_cancelled_error(error.message()) => {
+                None
+            }
+            Err(error) => Some(jsonrpc_error(
+                &request_id,
+                JSONRPC_SERVER_ERROR,
+                error.message(),
+                error.data_json(),
+            )),
         };
 
         let _ = worker_sender.send(WorkerCompletion {
@@ -229,7 +279,7 @@ fn finish_request<W: Write>(
     Ok(())
 }
 
-fn execute_call(call: ServerCall, cancellation: &CancellationToken) -> Result<String, String> {
+fn execute_call(call: ServerCall, cancellation: &CancellationToken) -> Result<String, ServerError> {
     match call.operation {
         ServerOperation::Initialize(params) => {
             let result = handle_initialize(params);
@@ -266,6 +316,7 @@ fn execute_call(call: ServerCall, cancellation: &CancellationToken) -> Result<St
             &call.id,
             -32601,
             &format!("method not found: {method}"),
+            None,
         )),
     }
 }
@@ -436,9 +487,12 @@ fn jsonrpc_result(id: &str, result_json: &str) -> String {
     )
 }
 
-fn jsonrpc_error(id: &str, code: i32, message: &str) -> String {
+fn jsonrpc_error(id: &str, code: i32, message: &str, data_json: Option<&str>) -> String {
+    let data = data_json
+        .map(|json| format!(",\"data\":{json}"))
+        .unwrap_or_default();
     format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"{}\",\"error\":{{\"code\":{code},\"message\":\"{}\"}}}}",
+        "{{\"jsonrpc\":\"2.0\",\"id\":\"{}\",\"error\":{{\"code\":{code},\"message\":\"{}\"{data}}}}}",
         escape_json(id),
         escape_json(message)
     )

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -283,7 +283,7 @@ fn app_server_smoke_includes_structured_logs_error_data_in_jsonrpc_response() {
     assert!(
         parsed["error"]["data"]["url"]
             .as_str()
-            .is_some_and(|url| url.contains("/services/data/v64.0/tooling/query")),
+            .is_some_and(|url| url.contains("/services/data/v") && url.contains("/tooling/query")),
         "expected request URL in error data, got: {parsed}"
     );
     assert!(

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
-    io::{self, Write},
+    io::{self, Read, Write},
+    net::TcpListener,
     sync::Arc,
     sync::{Mutex, OnceLock},
     thread,
@@ -10,7 +11,10 @@ use std::{
 
 use alv_app_server::server::{handle_initialize, handle_request_line, run_event_loop};
 use alv_app_server::transport_stdio::{bounded_transport_channel, TRANSPORT_QUEUE_CAPACITY};
-use alv_core::logs::{TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV};
+use alv_core::{
+    auth::TEST_ORG_DISPLAY_JSON_ENV,
+    logs::{TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV},
+};
 use alv_protocol::messages::InitializeParams;
 
 fn test_guard() -> &'static Mutex<()> {
@@ -26,6 +30,43 @@ fn make_temp_dir(name: &str) -> std::path::PathBuf {
     let dir = std::env::temp_dir().join(format!("alv-app-server-{name}-{nonce}"));
     fs::create_dir_all(&dir).expect("temp dir should be created");
     dir
+}
+
+fn org_display_fixture(instance_url: &str) -> String {
+    format!(
+        r#"{{"result":{{"username":"demo@example.com","accessToken":"token","instanceUrl":"{instance_url}"}}}}"#
+    )
+}
+
+fn spawn_single_http_response(
+    status: &str,
+    content_type: &str,
+    body: &'static [u8],
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+    let address = listener
+        .local_addr()
+        .expect("test server address should be available");
+    let status = status.to_string();
+    let content_type = content_type.to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("test server should accept request");
+        let mut buffer = [0_u8; 4096];
+        let _ = stream.read(&mut buffer);
+        let headers = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .write_all(headers.as_bytes())
+            .expect("test server should write headers");
+        stream
+            .write_all(body)
+            .expect("test server should write body");
+    });
+    (format!("http://{address}"), handle)
 }
 
 #[derive(Clone, Default)]
@@ -162,21 +203,37 @@ fn app_server_smoke_routes_logs_search_and_triage_requests() {
     assert!(list_response.contains("\"Id\":\"07L000000000001AA\""));
     assert!(list_response.contains("\"Operation\":\"ExecuteAnonymous\""));
 
-    let search_response = handle_request_line(&format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"search:1\",\"method\":\"search/query\",\"params\":{{\"query\":\"nullpointerexception\",\"logIds\":[\"07L000000000001AA\",\"07L000000000002AA\"],\"workspaceRoot\":\"{}\"}}}}",
-        workspace_root.display()
-    ))
-    .expect("search/query request should succeed")
-    .expect("search/query should emit a response");
+    let search_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "search:1",
+        "method": "search/query",
+        "params": {
+            "query": "nullpointerexception",
+            "logIds": ["07L000000000001AA", "07L000000000002AA"],
+            "workspaceRoot": workspace_root.display().to_string()
+        }
+    })
+    .to_string();
+    let search_response = handle_request_line(&search_request)
+        .expect("search/query request should succeed")
+        .expect("search/query should emit a response");
     assert!(search_response.contains("\"logIds\":[\"07L000000000001AA\"]"));
     assert!(search_response.contains("\"pendingLogIds\":[\"07L000000000002AA\"]"));
 
-    let triage_response = handle_request_line(&format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"triage:1\",\"method\":\"logs/triage\",\"params\":{{\"username\":\"demo@example.com\",\"logIds\":[\"07L00000000000TRI\"],\"workspaceRoot\":\"{}\"}}}}",
-        workspace_root.display()
-    ))
-    .expect("logs/triage request should succeed")
-    .expect("logs/triage should emit a response");
+    let triage_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "triage:1",
+        "method": "logs/triage",
+        "params": {
+            "username": "demo@example.com",
+            "logIds": ["07L00000000000TRI"],
+            "workspaceRoot": workspace_root.display().to_string()
+        }
+    })
+    .to_string();
+    let triage_response = handle_request_line(&triage_request)
+        .expect("logs/triage request should succeed")
+        .expect("logs/triage should emit a response");
     assert!(triage_response.contains("\"logId\":\"07L00000000000TRI\""));
     assert!(triage_response.contains("\"codeUnitStarted\":\"AccountService.handle\""));
     assert!(triage_response.contains("\"primaryReason\":\"Fatal exception\""));
@@ -185,6 +242,59 @@ fn app_server_smoke_routes_logs_search_and_triage_requests() {
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     fs::remove_dir_all(workspace_root).expect("workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
+fn app_server_smoke_includes_structured_logs_error_data_in_jsonrpc_response() {
+    let _guard = test_guard().lock().expect("test guard should lock");
+
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let (base_url, server_handle) = spawn_single_http_response(
+        "403 Forbidden",
+        "application/json",
+        br#"[{"message":"Session expired or invalid","errorCode":"INVALID_SESSION_ID"}]"#,
+    );
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let (sender, receiver) = bounded_transport_channel::<String>();
+    let writer = SharedBuffer::default();
+    sender
+        .blocking_send(
+            r#"{"jsonrpc":"2.0","id":"logs:error-data","method":"logs/list","params":{"limit":1}}"#
+                .to_string(),
+        )
+        .expect("logs/list request should be sent");
+    drop(sender);
+
+    run_event_loop(receiver, writer.clone()).expect("event loop should process failed request");
+    let output = writer.into_string();
+    let parsed: serde_json::Value =
+        serde_json::from_str(output.trim()).expect("error response should be valid JSON");
+
+    assert_eq!(parsed["id"].as_str(), Some("logs:error-data"));
+    assert_eq!(parsed["error"]["code"].as_i64(), Some(-32000));
+    assert!(
+        parsed["error"]["message"]
+            .as_str()
+            .is_some_and(|message| message.contains("HTTP 403 Forbidden")),
+        "expected status in error message, got: {parsed}"
+    );
+    assert_eq!(parsed["error"]["data"]["status"].as_u64(), Some(403));
+    assert!(
+        parsed["error"]["data"]["url"]
+            .as_str()
+            .is_some_and(|url| url.contains("/services/data/v64.0/tooling/query")),
+        "expected request URL in error data, got: {parsed}"
+    );
+    assert!(
+        parsed["error"]["data"]["responseBody"]
+            .as_str()
+            .is_some_and(|body| body.contains("INVALID_SESSION_ID")),
+        "expected Salesforce response body in error data, got: {parsed}"
+    );
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("test server should complete");
 }
 
 #[test]
@@ -205,12 +315,20 @@ fn app_server_smoke_resolves_cached_log_paths() {
     .expect("cached log dir should be creatable");
     fs::write(&cached_path, "body").expect("cached log should be writable");
 
-    let response = handle_request_line(&format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:1\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000001AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
-        workspace_root.display()
-    ))
-    .expect("resolve request should succeed")
-    .expect("resolve request should emit a response");
+    let request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resolve:1",
+        "method": "logs/resolveCachedPath",
+        "params": {
+            "logId": "07L000000000001AA",
+            "username": "demo@example.com",
+            "workspaceRoot": workspace_root.display().to_string()
+        }
+    })
+    .to_string();
+    let response = handle_request_line(&request)
+        .expect("resolve request should succeed")
+        .expect("resolve request should emit a response");
 
     assert!(response.contains("\"id\":\"resolve:1\""));
     assert!(response.contains("\"path\":\""));
@@ -237,22 +355,38 @@ fn app_server_smoke_drops_stale_cached_log_path_hits() {
     .expect("cached log dir should be creatable");
     fs::write(&cached_path, "body").expect("cached log should be writable");
 
-    let first_response = handle_request_line(&format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:stale-1\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000009AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
-        workspace_root.display()
-    ))
-    .expect("first resolve request should succeed")
-    .expect("first resolve request should emit a response");
+    let first_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resolve:stale-1",
+        "method": "logs/resolveCachedPath",
+        "params": {
+            "logId": "07L000000000009AA",
+            "username": "demo@example.com",
+            "workspaceRoot": workspace_root.display().to_string()
+        }
+    })
+    .to_string();
+    let first_response = handle_request_line(&first_request)
+        .expect("first resolve request should succeed")
+        .expect("first resolve request should emit a response");
     assert!(first_response.contains("07L000000000009AA.log"));
 
     fs::remove_file(&cached_path).expect("cached log should be removable");
 
-    let second_response = handle_request_line(&format!(
-        "{{\"jsonrpc\":\"2.0\",\"id\":\"resolve:stale-2\",\"method\":\"logs/resolveCachedPath\",\"params\":{{\"logId\":\"07L000000000009AA\",\"username\":\"demo@example.com\",\"workspaceRoot\":\"{}\"}}}}",
-        workspace_root.display()
-    ))
-    .expect("second resolve request should succeed")
-    .expect("second resolve request should emit a response");
+    let second_request = serde_json::json!({
+        "jsonrpc": "2.0",
+        "id": "resolve:stale-2",
+        "method": "logs/resolveCachedPath",
+        "params": {
+            "logId": "07L000000000009AA",
+            "username": "demo@example.com",
+            "workspaceRoot": workspace_root.display().to_string()
+        }
+    })
+    .to_string();
+    let second_response = handle_request_line(&second_request)
+        .expect("second resolve request should succeed")
+        .expect("second resolve request should emit a response");
 
     assert!(
         !second_response.contains("\"path\":\""),

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -5,6 +5,7 @@ use std::{
     collections::BTreeMap,
     env,
     error::Error as StdError,
+    fmt,
     fs::{self, File},
     future::Future,
     io::Write,
@@ -134,6 +135,57 @@ pub struct LogRow {
     pub log_user: Option<LogUser>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct RuntimeErrorData {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_body: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub causes: Vec<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogsRuntimeError {
+    message: String,
+    data: Option<RuntimeErrorData>,
+}
+
+impl LogsRuntimeError {
+    pub fn from_message(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn with_data(message: impl Into<String>, data: Option<RuntimeErrorData>) -> Self {
+        Self {
+            message: message.into(),
+            data,
+        }
+    }
+
+    pub fn message(&self) -> &str {
+        &self.message
+    }
+
+    pub fn data(&self) -> Option<&RuntimeErrorData> {
+        self.data.as_ref()
+    }
+}
+
+impl fmt::Display for LogsRuntimeError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(&self.message)
+    }
+}
+
+impl StdError for LogsRuntimeError {}
+
 pub fn list_logs(params: &LogsListParams) -> Result<Vec<LogRow>, String> {
     list_logs_with_cancel(params, &CancellationToken::new())
 }
@@ -142,8 +194,15 @@ pub fn list_logs_with_cancel(
     params: &LogsListParams,
     cancellation: &CancellationToken,
 ) -> Result<Vec<LogRow>, String> {
-    let json = run_sf_log_list_json_with_cancel(params, cancellation)?;
-    list_logs_from_json(&json)
+    list_logs_detailed_with_cancel(params, cancellation).map_err(|error| error.to_string())
+}
+
+pub fn list_logs_detailed_with_cancel(
+    params: &LogsListParams,
+    cancellation: &CancellationToken,
+) -> Result<Vec<LogRow>, LogsRuntimeError> {
+    let json = run_sf_log_list_json_detailed_with_cancel(params, cancellation)?;
+    list_logs_from_json(&json).map_err(LogsRuntimeError::from_message)
 }
 
 pub fn list_logs_from_json(json: &str) -> Result<Vec<LogRow>, String> {
@@ -194,13 +253,26 @@ pub fn run_sf_log_list_json_with_cancel(
     params: &LogsListParams,
     cancellation: &CancellationToken,
 ) -> Result<String, String> {
-    if let Some(fixture) = maybe_fixture_log_list_json(cancellation)? {
+    run_sf_log_list_json_detailed_with_cancel(params, cancellation)
+        .map_err(|error| error.to_string())
+}
+
+pub fn run_sf_log_list_json_detailed_with_cancel(
+    params: &LogsListParams,
+    cancellation: &CancellationToken,
+) -> Result<String, LogsRuntimeError> {
+    if let Some(fixture) =
+        maybe_fixture_log_list_json(cancellation).map_err(LogsRuntimeError::from_message)?
+    {
         return Ok(fixture);
     }
 
-    cancellation.check_cancelled()?;
-    let auth = auth::resolve_org_auth(params.username.as_deref())?;
-    run_tooling_logs_query_with_cancel(&auth, params, cancellation)
+    cancellation
+        .check_cancelled()
+        .map_err(LogsRuntimeError::from_message)?;
+    let auth = auth::resolve_org_auth(params.username.as_deref())
+        .map_err(LogsRuntimeError::from_message)?;
+    run_tooling_logs_query_with_cancel_detailed(&auth, params, cancellation)
 }
 
 pub fn resolve_apex_logs_dir(workspace_root: Option<&str>) -> PathBuf {
@@ -370,11 +442,22 @@ fn run_tooling_logs_query_with_cancel(
     params: &LogsListParams,
     cancellation: &CancellationToken,
 ) -> Result<String, String> {
-    cancellation.check_cancelled()?;
+    run_tooling_logs_query_with_cancel_detailed(auth, params, cancellation)
+        .map_err(|error| error.to_string())
+}
+
+fn run_tooling_logs_query_with_cancel_detailed(
+    auth: &OrgAuth,
+    params: &LogsListParams,
+    cancellation: &CancellationToken,
+) -> Result<String, LogsRuntimeError> {
+    cancellation
+        .check_cancelled()
+        .map_err(LogsRuntimeError::from_message)?;
     let safe_page_size = params.limit.unwrap_or(100).clamp(1, 200);
     let safe_offset = params.offset.unwrap_or(0);
     let soql = build_logs_query(safe_page_size, safe_offset, params);
-    request_tooling_query_json(auth, &soql, cancellation)
+    request_tooling_query_json_detailed(auth, &soql, cancellation)
 }
 
 fn maybe_test_delay(env_key: &str, cancellation: &CancellationToken) -> Result<(), String> {
@@ -569,6 +652,15 @@ fn response_body_text(body: &[u8]) -> String {
     String::from_utf8_lossy(body).trim().to_string()
 }
 
+fn optional_truncated_text(value: String) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(truncate_for_trace(trimmed))
+    }
+}
+
 fn format_status_error(status: StatusCode, url: &str, body: &[u8]) -> String {
     let body_text = response_body_text(body);
     if body_text.is_empty() {
@@ -581,27 +673,34 @@ fn format_status_error(status: StatusCode, url: &str, body: &[u8]) -> String {
     }
 }
 
-fn format_request_error(error: &reqwest::Error, url: &str) -> String {
+fn request_error_causes(error: &reqwest::Error) -> Vec<String> {
+    let mut causes = Vec::new();
+    let mut source = StdError::source(error);
+    while let Some(error_source) = source {
+        let text = error_source.to_string();
+        if !text.trim().is_empty() {
+            causes.push(truncate_for_trace(text.trim()));
+        }
+        source = error_source.source();
+        if causes.len() >= 8 {
+            break;
+        }
+    }
+    if causes.is_empty() {
+        causes.push(truncate_for_trace(&error.to_string()));
+    }
+    causes
+}
+
+fn format_request_error(error: &reqwest::Error, url: &str, causes: &[String]) -> String {
     let mut message = match error.status() {
         Some(status) => format!("HTTP request failed with {status} for {url}: {error}"),
         None => format!("HTTP request failed for {url}: {error}"),
     };
 
-    let mut sources = Vec::new();
-    let mut source = StdError::source(error);
-    while let Some(error_source) = source {
-        let text = error_source.to_string();
-        if !text.trim().is_empty() {
-            sources.push(text);
-        }
-        source = error_source.source();
-        if sources.len() >= 8 {
-            break;
-        }
-    }
-    if !sources.is_empty() {
+    if !causes.is_empty() {
         message.push_str("; caused by: ");
-        message.push_str(&sources.join(" -> "));
+        message.push_str(&causes.join(" -> "));
     }
     message
 }
@@ -612,6 +711,7 @@ enum HttpRequestError {
     Failed {
         status: Option<StatusCode>,
         message: String,
+        data: Option<RuntimeErrorData>,
     },
 }
 
@@ -620,6 +720,13 @@ impl HttpRequestError {
         match self {
             Self::Cancelled => CANCELLED_MESSAGE.to_string(),
             Self::Failed { message, .. } => message.clone(),
+        }
+    }
+
+    fn into_logs_runtime_error(self) -> LogsRuntimeError {
+        match self {
+            Self::Cancelled => LogsRuntimeError::from_message(CANCELLED_MESSAGE),
+            Self::Failed { message, data, .. } => LogsRuntimeError::with_data(message, data),
         }
     }
 }
@@ -650,6 +757,7 @@ where
                 return Err(HttpRequestError::Failed {
                     status: None,
                     message: "HTTP request task terminated unexpectedly".to_string(),
+                    data: None,
                 });
             }
         }
@@ -666,6 +774,7 @@ where
                 return Err(HttpRequestError::Failed {
                     status: None,
                     message: "HTTP request task terminated unexpectedly".to_string(),
+                    data: None,
                 });
             }
         }
@@ -702,11 +811,18 @@ fn run_http_request_with_cancel(
                             Ok(body.to_vec())
                         }
                         Ok(body) => {
+                            let body_text = response_body_text(&body);
                             let message = format_status_error(status, &request_url, &body);
                             trace_http(&format!("HTTP response error {message}"));
                             Err(HttpRequestError::Failed {
                                 status: Some(status),
                                 message,
+                                data: Some(RuntimeErrorData {
+                                    status: Some(status.as_u16()),
+                                    url: Some(request_url.clone()),
+                                    response_body: optional_truncated_text(body_text),
+                                    causes: Vec::new(),
+                                }),
                             })
                         }
                         Err(error) => {
@@ -717,15 +833,31 @@ fn run_http_request_with_cancel(
                             Err(HttpRequestError::Failed {
                                 status: Some(status),
                                 message,
+                                data: Some(RuntimeErrorData {
+                                    status: Some(status.as_u16()),
+                                    url: Some(request_url.clone()),
+                                    response_body: None,
+                                    causes: vec![truncate_for_trace(&error.to_string())],
+                                }),
                             })
                         }
                     }
                 }
                 Err(error) => {
                     let status = error.status();
-                    let message = format_request_error(&error, &request_url);
+                    let causes = request_error_causes(&error);
+                    let message = format_request_error(&error, &request_url, &causes);
                     trace_http(&message);
-                    Err(HttpRequestError::Failed { status, message })
+                    Err(HttpRequestError::Failed {
+                        status,
+                        message,
+                        data: Some(RuntimeErrorData {
+                            status: status.map(|value| value.as_u16()),
+                            url: Some(request_url.clone()),
+                            response_body: None,
+                            causes,
+                        }),
+                    })
                 }
             }
         },
@@ -740,27 +872,45 @@ fn request_bytes_with_version_fallback(
     accept: &'static str,
     cancellation: &CancellationToken,
 ) -> Result<Vec<u8>, String> {
+    request_bytes_with_version_fallback_detailed(auth, path, query_pairs, accept, cancellation)
+        .map_err(|error| error.to_string())
+}
+
+fn request_bytes_with_version_fallback_detailed(
+    auth: &OrgAuth,
+    path: &str,
+    query_pairs: &[(&str, &str)],
+    accept: &'static str,
+    cancellation: &CancellationToken,
+) -> Result<Vec<u8>, LogsRuntimeError> {
     let mut attempted_fallback = false;
 
     loop {
-        cancellation.check_cancelled()?;
+        cancellation
+            .check_cancelled()
+            .map_err(LogsRuntimeError::from_message)?;
         let active_version = get_effective_api_version(auth);
-        let mut url = build_versioned_url(auth, &active_version, path)?;
+        let mut url = build_versioned_url(auth, &active_version, path)
+            .map_err(LogsRuntimeError::from_message)?;
         for (key, value) in query_pairs {
             url.query_pairs_mut().append_pair(key, value);
         }
 
         match run_http_request_with_cancel(auth, url, accept, cancellation) {
             Ok(bytes) => return Ok(bytes),
-            Err(HttpRequestError::Cancelled) => return Err(CANCELLED_MESSAGE.to_string()),
+            Err(HttpRequestError::Cancelled) => {
+                return Err(LogsRuntimeError::from_message(CANCELLED_MESSAGE));
+            }
             Err(HttpRequestError::Failed {
                 status: Some(StatusCode::NOT_FOUND),
                 message,
+                data,
             }) if !attempted_fallback => {
                 let requested = parse_api_version(&active_version);
-                let Some(org_max_version) = discover_org_max_api_version(auth, cancellation)?
+                let Some(org_max_version) = discover_org_max_api_version(auth, cancellation)
+                    .map_err(LogsRuntimeError::from_message)?
                 else {
-                    return Err(message);
+                    return Err(LogsRuntimeError::with_data(message, data));
                 };
                 let org_max = parse_api_version(&org_max_version);
                 if requested.is_some() && org_max.is_some() && requested > org_max {
@@ -768,27 +918,28 @@ fn request_bytes_with_version_fallback(
                     attempted_fallback = true;
                     continue;
                 }
-                return Err(message);
+                return Err(LogsRuntimeError::with_data(message, data));
             }
-            Err(error) => return Err(error.to_string_message()),
+            Err(error) => return Err(error.into_logs_runtime_error()),
         }
     }
 }
 
-fn request_tooling_query_json(
+fn request_tooling_query_json_detailed(
     auth: &OrgAuth,
     soql: &str,
     cancellation: &CancellationToken,
-) -> Result<String, String> {
-    let bytes = request_bytes_with_version_fallback(
+) -> Result<String, LogsRuntimeError> {
+    let bytes = request_bytes_with_version_fallback_detailed(
         auth,
         "/tooling/query",
         &[("q", soql)],
         "application/json",
         cancellation,
     )?;
-    String::from_utf8(bytes)
-        .map_err(|error| format!("invalid UTF-8 in Tooling query response: {error}"))
+    String::from_utf8(bytes).map_err(|error| {
+        LogsRuntimeError::from_message(format!("invalid UTF-8 in Tooling query response: {error}"))
+    })
 }
 
 fn fetch_apex_log_body_with_cancel(

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -15,8 +15,8 @@ use alv_core::{
     auth::TEST_ORG_DISPLAY_JSON_ENV,
     logs::{
         ensure_log_file_cached, extract_code_unit_started, find_cached_log_path,
-        list_logs_with_cancel, CancellationToken, LogsListParams, TEST_APEX_LOG_FIXTURE_DIR_ENV,
-        TEST_SF_LOG_LIST_JSON_ENV,
+        list_logs_detailed_with_cancel, list_logs_with_cancel, CancellationToken, LogsListParams,
+        TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV,
     },
     search::{search_query, search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs, triage_logs_with_cancel, LogsTriageParams},
@@ -277,6 +277,51 @@ fn logs_runtime_smoke_includes_http_status_url_and_body_in_list_failures() {
     assert!(
         error.contains("INVALID_SESSION_ID") && error.contains("Session expired or invalid"),
         "expected response body in error, got: {error}"
+    );
+
+    std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
+    server_handle.join().expect("server thread should complete");
+}
+
+#[test]
+fn logs_runtime_smoke_exposes_structured_http_error_data() {
+    let _guard = lock_test_guard();
+
+    std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);
+    let (base_url, server_handle) = spawn_scripted_http_server(vec![ScriptedHttpResponse {
+        status: 403,
+        content_type: "application/json",
+        body: br#"[{"message":"Session expired or invalid","errorCode":"INVALID_SESSION_ID"}]"#
+            .to_vec(),
+    }]);
+    std::env::set_var(TEST_ORG_DISPLAY_JSON_ENV, org_display_fixture(&base_url));
+
+    let error = list_logs_detailed_with_cancel(
+        &LogsListParams {
+            username: Some("demo@example.com".to_string()),
+            limit: Some(1),
+            cursor: None,
+            offset: Some(0),
+        },
+        &CancellationToken::new(),
+    )
+    .expect_err("logs/list should expose structured REST failure details");
+
+    let data = error
+        .data()
+        .expect("HTTP list failures should include structured data");
+    assert_eq!(data.status, Some(403));
+    assert!(
+        data.url
+            .as_deref()
+            .is_some_and(|url| url.contains("/services/data/v64.0/tooling/query")),
+        "expected request URL in data, got: {data:?}"
+    );
+    assert!(
+        data.response_body
+            .as_deref()
+            .is_some_and(|body| body.contains("INVALID_SESSION_ID")),
+        "expected response body in data, got: {data:?}"
     );
 
     std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -314,7 +314,7 @@ fn logs_runtime_smoke_exposes_structured_http_error_data() {
     assert!(
         data.url
             .as_deref()
-            .is_some_and(|url| url.contains("/services/data/v64.0/tooling/query")),
+            .is_some_and(|url| url.contains("/services/data/v") && url.contains("/tooling/query")),
         "expected request URL in data, got: {data:?}"
     );
     assert!(


### PR DESCRIPTION
## Summary
- propagate structured `logs/list` HTTP failure details through the app-server JSON-RPC `error.data`
- include Salesforce HTTP status, request URL, response body, and transport cause chain for runtime log refresh failures
- add Rust smoke coverage proving the core exposes structured error data and the app-server serializes it to JSON-RPC

## Tests
- `cargo test -p alv-app-server app_server_smoke`
- `cargo test -p alv-core logs_runtime_smoke`
- `git diff --check`