### PR TITLE
fix(cli): surface log sync error details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Runtime/Logs: include sanitized runtime request/response payloads and propagate Salesforce HTTP failure status, URL, response body, and transport causes in trace logging so log refresh errors are diagnosable without exposing auth tokens.
+- CLI/Logs: bump the bundled runtime train to `0.1.8` and make `logs sync` print the propagated Salesforce HTTP status, URL, response body, and causes in both text and `--json` error output.
 
 ## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.7"
+version = "0.1.8"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.7"
+version = "0.1.8"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.7",
-  "tag": "rust-v0.1.7",
+  "cliVersion": "0.1.8",
+  "tag": "rust-v0.1.8",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.7", path = "../alv-core" }
-alv-protocol = { version = "0.1.7", path = "../alv-protocol" }
+alv-core = { version = "0.1.8", path = "../alv-core" }
+alv-protocol = { version = "0.1.8", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.7", path = "../alv-app-server" }
-alv-core = { version = "0.1.7", path = "../alv-core" }
+alv-app-server = { version = "0.1.8", path = "../alv-app-server" }
+alv-core = { version = "0.1.8", path = "../alv-core" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-cli/src/commands/logs.rs
+++ b/crates/alv-cli/src/commands/logs.rs
@@ -2,8 +2,8 @@ use crate::cli::{LogSearchArgs, LogStatusArgs, LogSyncArgs, LogsArgs, LogsComman
 use alv_core::{
     auth,
     log_store::{self, OrgMetadata, SyncState},
-    logs::CancellationToken,
-    logs_sync::{sync_logs_with_cancel, LogsSyncParams, LogsSyncResult},
+    logs::{CancellationToken, LogsRuntimeError, RuntimeErrorData},
+    logs_sync::{sync_logs_detailed_with_cancel, LogsSyncParams, LogsSyncResult},
     search::{search_query, SearchQueryParams, SearchQueryResult, SearchSnippet},
 };
 use serde::Serialize;
@@ -44,6 +44,14 @@ struct SearchResult {
     pending_log_ids: Vec<String>,
 }
 
+#[derive(Debug, Serialize)]
+struct CommandErrorResult<'a> {
+    status: &'static str,
+    message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<&'a RuntimeErrorData>,
+}
+
 pub fn run(args: LogsArgs) -> Result<i32, String> {
     match args.command {
         LogsCommand::Sync(sync) => run_sync(sync),
@@ -53,15 +61,17 @@ pub fn run(args: LogsArgs) -> Result<i32, String> {
 }
 
 fn run_sync(args: LogSyncArgs) -> Result<i32, String> {
+    let json = args.json;
     let params = LogsSyncParams {
         target_org: args.target_org,
         workspace_root: Some(workspace_root_string()?),
         force_full: args.force_full,
         concurrency: args.concurrency,
     };
-    let result = sync_logs_with_cancel(&params, &CancellationToken::new())?;
+    let result = sync_logs_detailed_with_cancel(&params, &CancellationToken::new())
+        .map_err(|error| format_logs_error(&error, json))?;
 
-    if args.json {
+    if json {
         print_json(&result)?;
     } else {
         print_sync_summary(&result);
@@ -213,6 +223,43 @@ fn print_json<T: Serialize>(value: &T) -> Result<(), String> {
     let output = serde_json::to_string_pretty(value).map_err(|error| error.to_string())?;
     println!("{output}");
     Ok(())
+}
+
+fn format_logs_error(error: &LogsRuntimeError, json: bool) -> String {
+    if json {
+        let output = CommandErrorResult {
+            status: "error",
+            message: error.message(),
+            data: error.data(),
+        };
+        return serde_json::to_string_pretty(&output)
+            .unwrap_or_else(|_| error.message().to_string());
+    }
+
+    let mut lines = vec![error.message().to_string()];
+    if let Some(data) = error.data() {
+        if let Some(status) = data.status {
+            lines.push(format!("HTTP status: {status}"));
+        }
+        if let Some(url) = data.url.as_deref().filter(|value| !value.trim().is_empty()) {
+            lines.push(format!("URL: {url}"));
+        }
+        if let Some(body) = data
+            .response_body
+            .as_deref()
+            .filter(|value| !value.trim().is_empty())
+        {
+            lines.push("Response body:".to_string());
+            lines.push(body.to_string());
+        }
+        if !data.causes.is_empty() {
+            lines.push("Caused by:".to_string());
+            for cause in &data.causes {
+                lines.push(format!("- {cause}"));
+            }
+        }
+    }
+    lines.join("\n")
 }
 
 fn print_sync_summary(result: &LogsSyncResult) {

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -1,6 +1,6 @@
 use std::{
     fs,
-    io::{BufRead, BufReader, Read, Write},
+    io::{BufRead, BufReader, ErrorKind, Read, Write},
     net::TcpListener,
     process::{Child, ChildStdin, Command, Stdio},
     sync::{
@@ -12,6 +12,15 @@ use std::{
 };
 
 use serde_json::Value;
+
+const PROXY_ENV_VARS: &[&str] = &[
+    "ALL_PROXY",
+    "all_proxy",
+    "HTTP_PROXY",
+    "http_proxy",
+    "HTTPS_PROXY",
+    "https_proxy",
+];
 
 fn test_guard() -> &'static Mutex<()> {
     static GUARD: OnceLock<Mutex<()>> = OnceLock::new();
@@ -30,6 +39,16 @@ fn org_display_fixture(instance_url: &str) -> String {
     )
 }
 
+fn apex_log_viewer_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"));
+    for key in PROXY_ENV_VARS {
+        command.env_remove(key);
+    }
+    command.env("NO_PROXY", "127.0.0.1,localhost");
+    command.env("no_proxy", "127.0.0.1,localhost");
+    command
+}
+
 fn spawn_single_http_response(
     status: &str,
     content_type: &str,
@@ -42,9 +61,23 @@ fn spawn_single_http_response(
     let status = status.to_string();
     let content_type = content_type.to_string();
     let handle = thread::spawn(move || {
-        let (mut stream, _) = listener
-            .accept()
-            .expect("test server should accept request");
+        listener
+            .set_nonblocking(true)
+            .expect("test server should become nonblocking");
+        let deadline = Instant::now() + Duration::from_secs(30);
+        let (mut stream, _) = loop {
+            match listener.accept() {
+                Ok(connection) => break connection,
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    assert!(
+                        Instant::now() < deadline,
+                        "test server timed out waiting for request"
+                    );
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(error) => panic!("test server accept failed: {error}"),
+            }
+        };
         let mut buffer = [0_u8; 4096];
         let _ = stream.read(&mut buffer);
         let headers = format!(
@@ -69,7 +102,7 @@ struct AppServerHarness {
 
 impl AppServerHarness {
     fn spawn() -> Self {
-        let mut child = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+        let mut child = apex_log_viewer_command()
             .args(["app-server", "--stdio"])
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
@@ -134,7 +167,7 @@ impl Drop for AppServerHarness {
 
 #[test]
 fn cli_smoke_prints_help_for_standalone_invocation() {
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .output()
         .expect("help should execute");
 
@@ -147,7 +180,7 @@ fn cli_smoke_prints_help_for_standalone_invocation() {
 
 #[test]
 fn cli_smoke_shows_logs_subcommands_in_help() {
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .args(["logs", "--help"])
         .output()
         .expect("help should execute");
@@ -161,7 +194,7 @@ fn cli_smoke_shows_logs_subcommands_in_help() {
 
 #[test]
 fn cli_smoke_shows_target_org_in_sync_help() {
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .args(["logs", "sync", "--help"])
         .output()
         .expect("help should execute");
@@ -191,7 +224,7 @@ fn cli_smoke_logs_sync_json_emits_structured_result_and_writes_state() {
     )
     .expect("fixture log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .env(
             "ALV_TEST_SF_LOG_LIST_JSON",
@@ -237,7 +270,7 @@ fn cli_smoke_logs_sync_failure_prints_http_details() {
         b"simulated list failure",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .env(
             "ALV_TEST_SF_ORG_DISPLAY_JSON",
@@ -290,7 +323,7 @@ fn cli_smoke_logs_sync_json_failure_prints_error_data() {
         br#"{"message":"temporary Salesforce failure"}"#,
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .env(
             "ALV_TEST_SF_ORG_DISPLAY_JSON",
@@ -337,7 +370,7 @@ fn cli_smoke_logs_status_json_reads_existing_sync_state() {
     )
     .expect("sync state should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args([
             "logs",
@@ -374,7 +407,7 @@ fn cli_smoke_logs_status_json_prefers_explicit_target_org_over_cached_default() 
     )
     .expect("sync state should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args(["logs", "status", "--json", "--target-org", "ALV_ALIAS"])
         .output()
@@ -444,7 +477,7 @@ fn cli_smoke_logs_status_json_prefers_synced_metadata_when_alias_matches_multipl
     )
     .expect("synced org log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args(["logs", "status", "--json", "--target-org", "ALV_ALIAS"])
         .output()
@@ -481,7 +514,7 @@ fn cli_smoke_logs_search_json_stays_local_first() {
     )
     .expect("cached log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args([
             "logs",
@@ -519,7 +552,7 @@ fn cli_smoke_logs_search_json_keeps_alias_scoped_legacy_logs() {
     )
     .expect("legacy alias-scoped log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .env(
             "ALV_TEST_SF_ORG_DISPLAY_JSON",
@@ -566,7 +599,7 @@ fn cli_smoke_logs_search_json_resolves_alias_without_local_metadata() {
     )
     .expect("cached log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .env(
             "ALV_TEST_SF_ORG_DISPLAY_JSON",
@@ -617,7 +650,7 @@ fn cli_smoke_logs_search_json_uses_local_alias_resolution_without_auth() {
     )
     .expect("org metadata should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args([
             "logs",
@@ -656,7 +689,7 @@ fn cli_smoke_logs_search_json_falls_back_to_alias_cache_without_auth_or_metadata
     )
     .expect("legacy alias-scoped log should be writable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args([
             "logs",
@@ -688,7 +721,7 @@ fn cli_smoke_logs_search_rejects_empty_query() {
     let workspace_root = std::env::temp_dir().join(format!("alv-cli-search-empty-{unique}"));
     fs::create_dir_all(&workspace_root).expect("workspace should exist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+    let output = apex_log_viewer_command()
         .current_dir(&workspace_root)
         .args(["logs", "search", "   "])
         .output()

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -78,6 +78,9 @@ fn spawn_single_http_response(
                 Err(error) => panic!("test server accept failed: {error}"),
             }
         };
+        stream
+            .set_read_timeout(Some(Duration::from_secs(1)))
+            .expect("test server should set read timeout");
         let mut buffer = [0_u8; 4096];
         let _ = stream.read(&mut buffer);
         let headers = format!(

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -1,6 +1,7 @@
 use std::{
     fs,
-    io::{BufRead, BufReader, Write},
+    io::{BufRead, BufReader, Read, Write},
+    net::TcpListener,
     process::{Child, ChildStdin, Command, Stdio},
     sync::{
         mpsc::{self, Receiver},
@@ -21,6 +22,43 @@ fn lock_test_guard() -> std::sync::MutexGuard<'static, ()> {
     test_guard()
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+fn org_display_fixture(instance_url: &str) -> String {
+    format!(
+        r#"{{"result":{{"username":"default@example.com","accessToken":"token","instanceUrl":"{instance_url}"}}}}"#
+    )
+}
+
+fn spawn_single_http_response(
+    status: &str,
+    content_type: &str,
+    body: &'static [u8],
+) -> (String, thread::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("test server should bind");
+    let address = listener
+        .local_addr()
+        .expect("test server address should be available");
+    let status = status.to_string();
+    let content_type = content_type.to_string();
+    let handle = thread::spawn(move || {
+        let (mut stream, _) = listener
+            .accept()
+            .expect("test server should accept request");
+        let mut buffer = [0_u8; 4096];
+        let _ = stream.read(&mut buffer);
+        let headers = format!(
+            "HTTP/1.1 {status}\r\nContent-Type: {content_type}\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+            body.len()
+        );
+        stream
+            .write_all(headers.as_bytes())
+            .expect("test server should write headers");
+        stream
+            .write_all(body)
+            .expect("test server should write body");
+    });
+    (format!("http://{address}"), handle)
 }
 
 struct AppServerHarness {
@@ -181,6 +219,105 @@ fn cli_smoke_logs_sync_json_emits_structured_result_and_writes_state() {
 
     fs::remove_dir_all(workspace_root).expect("workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
+fn cli_smoke_logs_sync_failure_prints_http_details() {
+    let _guard = lock_test_guard();
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+    let workspace_root = std::env::temp_dir().join(format!("alv-cli-sync-failure-{unique}"));
+    fs::create_dir_all(&workspace_root).expect("workspace should exist");
+    let (base_url, server_handle) = spawn_single_http_response(
+        "500 Internal Server Error",
+        "text/plain",
+        b"simulated list failure",
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+        .current_dir(&workspace_root)
+        .env(
+            "ALV_TEST_SF_ORG_DISPLAY_JSON",
+            org_display_fixture(&base_url),
+        )
+        .args(["logs", "sync"])
+        .output()
+        .expect("sync should execute");
+
+    assert!(!output.status.success(), "sync should fail");
+    let stderr = String::from_utf8(output.stderr).expect("stderr should be utf8");
+    assert!(
+        stderr.contains("HTTP 500 Internal Server Error"),
+        "expected HTTP message, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("HTTP status: 500"),
+        "expected status detail, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("URL:"),
+        "expected URL detail, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("/services/data/") && stderr.contains("/tooling/query"),
+        "expected tooling query URL, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("Response body:") && stderr.contains("simulated list failure"),
+        "expected response body detail, got: {stderr}"
+    );
+
+    server_handle.join().expect("server thread should complete");
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
+}
+
+#[test]
+fn cli_smoke_logs_sync_json_failure_prints_error_data() {
+    let _guard = lock_test_guard();
+
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+    let workspace_root = std::env::temp_dir().join(format!("alv-cli-sync-json-failure-{unique}"));
+    fs::create_dir_all(&workspace_root).expect("workspace should exist");
+    let (base_url, server_handle) = spawn_single_http_response(
+        "503 Service Unavailable",
+        "application/json",
+        br#"{"message":"temporary Salesforce failure"}"#,
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_apex-log-viewer"))
+        .current_dir(&workspace_root)
+        .env(
+            "ALV_TEST_SF_ORG_DISPLAY_JSON",
+            org_display_fixture(&base_url),
+        )
+        .args(["logs", "sync", "--json"])
+        .output()
+        .expect("sync should execute");
+
+    assert!(!output.status.success(), "sync should fail");
+    let stderr_json: Value =
+        serde_json::from_slice(&output.stderr).expect("stderr should be valid json");
+    assert_eq!(stderr_json["status"], "error");
+    assert_eq!(stderr_json["data"]["status"], 503);
+    assert!(
+        stderr_json["data"]["url"]
+            .as_str()
+            .is_some_and(|value| value.contains("/tooling/query")),
+        "expected tooling query URL, got: {stderr_json}"
+    );
+    assert_eq!(
+        stderr_json["data"]["responseBody"],
+        r#"{"message":"temporary Salesforce failure"}"#
+    );
+
+    server_handle.join().expect("server thread should complete");
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
 }
 
 #[test]

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -316,16 +316,18 @@ pub fn ensure_log_file_cached_with_cancel(
     download_log_to_path_with_cancel(log_id, username, &target_path, cancellation)
 }
 
-pub(crate) fn list_logs_for_auth_with_cancel(
+pub(crate) fn list_logs_for_auth_detailed_with_cancel(
     auth: &OrgAuth,
     params: &LogsListParams,
     cancellation: &CancellationToken,
-) -> Result<Vec<LogRow>, String> {
-    if let Some(fixture) = maybe_fixture_log_list_json(cancellation)? {
-        return list_logs_from_json(&fixture);
+) -> Result<Vec<LogRow>, LogsRuntimeError> {
+    if let Some(fixture) =
+        maybe_fixture_log_list_json(cancellation).map_err(LogsRuntimeError::from_message)?
+    {
+        return list_logs_from_json(&fixture).map_err(LogsRuntimeError::from_message);
     }
-    let json = run_tooling_logs_query_with_cancel(auth, params, cancellation)?;
-    list_logs_from_json(&json)
+    let json = run_tooling_logs_query_with_cancel_detailed(auth, params, cancellation)?;
+    list_logs_from_json(&json).map_err(LogsRuntimeError::from_message)
 }
 
 pub(crate) fn download_log_to_path_for_auth_with_cancel(
@@ -435,15 +437,6 @@ fn build_logs_query(page_size: usize, offset: usize, params: &LogsListParams) ->
             "{base_select} ORDER BY StartTime DESC, Id DESC LIMIT {page_size} OFFSET {offset}"
         ),
     }
-}
-
-fn run_tooling_logs_query_with_cancel(
-    auth: &OrgAuth,
-    params: &LogsListParams,
-    cancellation: &CancellationToken,
-) -> Result<String, String> {
-    run_tooling_logs_query_with_cancel_detailed(auth, params, cancellation)
-        .map_err(|error| error.to_string())
 }
 
 fn run_tooling_logs_query_with_cancel_detailed(

--- a/crates/alv-core/src/logs_sync.rs
+++ b/crates/alv-core/src/logs_sync.rs
@@ -7,8 +7,8 @@ use crate::{
         LOG_STORE_LAYOUT_VERSION,
     },
     logs::{
-        download_log_to_path_for_auth_with_cancel, list_logs_for_auth_with_cancel,
-        CancellationToken, LogRow, LogsCursor, LogsListParams,
+        download_log_to_path_for_auth_with_cancel, list_logs_for_auth_detailed_with_cancel,
+        CancellationToken, LogRow, LogsCursor, LogsListParams, LogsRuntimeError,
     },
     orgs::list_orgs,
 };
@@ -49,11 +49,22 @@ pub fn sync_logs_with_cancel(
     params: &LogsSyncParams,
     cancellation: &CancellationToken,
 ) -> Result<LogsSyncResult, String> {
-    cancellation.check_cancelled()?;
-    write_version_file(params.workspace_root.as_deref(), LOG_STORE_LAYOUT_VERSION)?;
+    sync_logs_detailed_with_cancel(params, cancellation).map_err(|error| error.to_string())
+}
+
+pub fn sync_logs_detailed_with_cancel(
+    params: &LogsSyncParams,
+    cancellation: &CancellationToken,
+) -> Result<LogsSyncResult, LogsRuntimeError> {
+    cancellation
+        .check_cancelled()
+        .map_err(LogsRuntimeError::from_message)?;
+    write_version_file(params.workspace_root.as_deref(), LOG_STORE_LAYOUT_VERSION)
+        .map_err(LogsRuntimeError::from_message)?;
     let started_at = timestamp_now();
 
-    let auth = auth::resolve_org_auth(params.target_org.as_deref())?;
+    let auth = auth::resolve_org_auth(params.target_org.as_deref())
+        .map_err(LogsRuntimeError::from_message)?;
     let resolved_username = auth
         .username
         .clone()
@@ -73,12 +84,14 @@ pub fn sync_logs_with_cancel(
         })
         .and_then(|org| org.alias)
         .or(requested_alias);
-    let previous = read_sync_state(params.workspace_root.as_deref())?
+    let previous = read_sync_state(params.workspace_root.as_deref())
+        .map_err(LogsRuntimeError::from_message)?
         .orgs
         .get(&resolved_username)
         .cloned();
 
-    let mut state = read_sync_state(params.workspace_root.as_deref())?;
+    let mut state = read_sync_state(params.workspace_root.as_deref())
+        .map_err(LogsRuntimeError::from_message)?;
     let mut downloaded = 0usize;
     let mut cached = 0usize;
     let mut failed = 0usize;
@@ -87,7 +100,7 @@ pub fn sync_logs_with_cancel(
     let sync_concurrency = normalize_sync_concurrency(params.concurrency);
 
     loop {
-        let mut rows = match list_logs_for_auth_with_cancel(
+        let mut rows = match list_logs_for_auth_detailed_with_cancel(
             &auth,
             &LogsListParams {
                 username: params.target_org.clone(),
@@ -98,7 +111,9 @@ pub fn sync_logs_with_cancel(
             cancellation,
         ) {
             Ok(rows) => rows,
-            Err(error) if error == CANCELLED_MESSAGE || cancellation.is_cancelled() => break,
+            Err(error) if error.message() == CANCELLED_MESSAGE || cancellation.is_cancelled() => {
+                break
+            }
             Err(error) => return Err(error),
         };
         rows.sort_by(|left, right| {
@@ -190,7 +205,8 @@ pub fn sync_logs_with_cancel(
                 last_error: None,
             },
         );
-        write_sync_state(params.workspace_root.as_deref(), &state)?;
+        write_sync_state(params.workspace_root.as_deref(), &state)
+            .map_err(LogsRuntimeError::from_message)?;
     }
 
     write_org_metadata(
@@ -206,7 +222,8 @@ pub fn sync_logs_with_cancel(
             instance_url: Some(auth.instance_url),
             updated_at: finished_at.clone(),
         },
-    )?;
+    )
+    .map_err(LogsRuntimeError::from_message)?;
 
     Ok(LogsSyncResult {
         status: status.clone(),

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -188,8 +188,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.7',
-    tag: 'rust-v0.1.7',
+    cliVersion: '0.1.8',
+    tag: 'rust-v0.1.8',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary
- surface structured Salesforce HTTP diagnostics in the standalone `apex-log-viewer logs sync` command
- emit detailed text errors and structured `--json` error payloads with status, URL, response body, and causes
- bump the Rust runtime train to `0.1.8` and pin the extension runtime bundle to `rust-v0.1.8`

## Verification
- `cargo test -p apex-log-viewer-cli cli_smoke_logs_sync`
- `cargo test -p alv-core logs_sync_smoke_propagates_list_failures`
- `cargo test -p alv-app-server app_server_smoke_includes_structured_logs_error_data_in_jsonrpc_response`
- `npm run build:runtime`
- `apps\vscode-extension\bin\win32-x64\apex-log-viewer.exe --version` -> `apex-log-viewer 0.1.8`

## Release note
After this PR merges, create/push the Rust runtime tag `rust-v0.1.8` so the CLI release workflow publishes the runtime assets consumed by the extension release.