### PR TITLE
[codex] Prepare CLI 0.1.9 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Runtime/Logs: include sanitized runtime request/response payloads and propagate Salesforce HTTP failure status, URL, response body, and transport causes in trace logging so log refresh errors are diagnosable without exposing auth tokens.
 - CLI/Logs: bump the bundled runtime train to `0.1.8` and make `logs sync` print the propagated Salesforce HTTP status, URL, response body, and causes in both text and `--json` error output.
+- Runtime/CLI: trust native OS TLS roots and system proxy settings so CLI and bundled runtime requests succeed in corporate MITM environments on Windows, macOS, and Linux.
 
 ## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.8"
+version = "0.1.9"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.8"
+version = "0.1.9"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.8",
-  "tag": "rust-v0.1.8",
+  "cliVersion": "0.1.9",
+  "tag": "rust-v0.1.9",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.8", path = "../alv-core" }
-alv-protocol = { version = "0.1.8", path = "../alv-protocol" }
+alv-core = { version = "0.1.9", path = "../alv-core" }
+alv-protocol = { version = "0.1.9", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.8", path = "../alv-app-server" }
-alv-core = { version = "0.1.8", path = "../alv-core" }
+alv-app-server = { version = "0.1.9", path = "../alv-app-server" }
+alv-core = { version = "0.1.9", path = "../alv-core" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.8"
+version = "0.1.9"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -188,8 +188,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.8',
-    tag: 'rust-v0.1.8',
+    cliVersion: '0.1.9',
+    tag: 'rust-v0.1.9',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary

- bump the Rust CLI/runtime crate train from `0.1.8` to `0.1.9`
- pin `config/runtime-bundle.json` to `rust-v0.1.9` so extension packaging follows the tested CLI artifact
- note the native TLS roots + system proxy fix in the changelog and keep release packaging assertions aligned

## Why

- `rust-v0.1.8` is already released, and `main` now contains the corporate TLS/proxy runtime fix from #756
- this release PR prepares the next standalone CLI/runtime tag so corporate MITM environments can use the shipped runtime successfully across Windows, macOS, and Linux

## Impact

- next CLI tag can publish the native/meta npm packages and GitHub release assets for `0.1.9`
- extension packaging will fetch the `0.1.9` tested runtime once that tag is published

## Validation

- `cargo test -p apex-log-viewer-cli --test cli_smoke`
- `cargo test -p alv-core`
- `node --test scripts/packaging-ci.test.js scripts/fetch-runtime-release.test.js scripts/docs-release.test.js`
