### PR TITLE
[codex] Prepare 0.44.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,23 @@
 
 ## Unreleased
 
+## [0.44.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.42.0...v0.44.0) (2026-04-24)
+
 ### Bug Fixes
 
-- Runtime/Logs: include sanitized runtime request/response payloads and propagate Salesforce HTTP failure status, URL, response body, and transport causes in trace logging so log refresh errors are diagnosable without exposing auth tokens.
-- CLI/Logs: bump the bundled runtime train to `0.1.8` and make `logs sync` print the propagated Salesforce HTTP status, URL, response body, and causes in both text and `--json` error output.
-- Runtime/CLI: trust native OS TLS roots and system proxy settings so CLI and bundled runtime requests succeed in corporate MITM environments on Windows, macOS, and Linux.
+- Runtime/Logs: include sanitized runtime request/response payloads and propagate Salesforce HTTP failure status, URL, response body, and transport causes in trace logging so log refresh errors are diagnosable without exposing auth tokens. ([#751](https://github.com/Electivus/Apex-Log-Viewer/pull/751)) ([#753](https://github.com/Electivus/Apex-Log-Viewer/pull/753))
+- CLI/Logs: bump the bundled runtime train to `0.1.9` and make `logs sync` print the propagated Salesforce HTTP status, URL, response body, and causes in both text and `--json` error output. ([#755](https://github.com/Electivus/Apex-Log-Viewer/pull/755)) ([#757](https://github.com/Electivus/Apex-Log-Viewer/pull/757))
+- Runtime/CLI: trust native OS TLS roots and system proxy settings so CLI and bundled runtime requests succeed in corporate MITM environments on Windows, macOS, and Linux. ([#756](https://github.com/Electivus/Apex-Log-Viewer/pull/756))
+- Tests/Extension: restore VS Code 1.90 extension-host compatibility. ([#743](https://github.com/Electivus/Apex-Log-Viewer/pull/743))
+- CI/Prerelease: compute unique nightly pre-release versions and keep Claude review on the default model. ([#745](https://github.com/Electivus/Apex-Log-Viewer/pull/745)) ([#752](https://github.com/Electivus/Apex-Log-Viewer/pull/752))
+
+### Tests
+
+- E2E/Proxy: add an authenticated proxy lab for runtime and extension networking coverage. ([#754](https://github.com/Electivus/Apex-Log-Viewer/pull/754))
+
+### Chores
+
+- GitHub/Automation: add the Claude Code GitHub workflow. ([#742](https://github.com/Electivus/Apex-Log-Viewer/pull/742))
 
 ## [0.42.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.40.0...v0.42.0) (2026-04-20)
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.42.0",
+  "version": "0.44.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.42.0",
+  "version": "0.44.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -81,7 +81,7 @@
     },
     "apps/vscode-extension": {
       "name": "apex-log-viewer",
-      "version": "0.42.0",
+      "version": "0.44.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.15.1",


### PR DESCRIPTION
## Summary

- bump the VS Code extension package metadata from `0.42.0` to `0.44.0`
- promote the `Unreleased` changelog items into the stable `0.44.0` section
- include the changes shipped through the `0.43.x` pre-release train, including runtime trace details, CLI `0.1.9`, corporate proxy/TLS support, CI fixes, and E2E proxy coverage

## Release notes

This prepares the next stable release after `v0.42.0`. The stable tag should be `v0.44.0` after merge so `.github/workflows/release.yml` publishes on the stable channel.

## Validation

- `git diff --check`
- `node --test scripts/docs-release.test.js scripts/compute-prerelease-version.test.js scripts/packaging-ci.test.js`
- metadata check: `apps/vscode-extension/package.json`, `package-lock.json`, and `package-lock.json#packages[apps/vscode-extension]` are all `0.44.0`