### PR TITLE
fix(logs): preserve dated org cache layout

### DIFF
--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -662,6 +662,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           {
             username: selectedOrg,
             logIds: toScan.map(log => log.Id),
+            logStartTimes: Object.fromEntries(
+              toScan
+                .filter(log => typeof log.StartTime === 'string' && log.StartTime.trim().length > 0)
+                .map(log => [log.Id, log.StartTime])
+            ),
             workspaceRoot: getWorkspaceRoot()
           },
           controller.signal

--- a/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
+++ b/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
@@ -9,6 +9,56 @@ function delay(ms: number): Promise<void> {
 }
 
 suite('ensureApexLogsDir', () => {
+  test('buildLogFilePathWithUsername computes paths without creating directories', () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async (): Promise<never> => {
+            throw new Error('pure path builder should not create directories');
+          }
+        }
+      }
+    });
+
+    const result = workspaceModule.buildLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      '2026-03-30T18:39:58.000Z'
+    );
+
+    assert.deepEqual(result, {
+      dir: path.join(workspaceRoot, 'apexlogs', 'orgs', 'User_Name@example.com', 'logs', '2026-03-30'),
+      filePath: path.join(
+        workspaceRoot,
+        'apexlogs',
+        'orgs',
+        'User_Name@example.com',
+        'logs',
+        '2026-03-30',
+        '07L000000000001AA.log'
+      )
+    });
+  });
+
   test('getLogFilePathWithUsername builds org-first dated paths', async () => {
     const workspaceRoot = path.join('/tmp', 'alv-workspace');
     const apexlogsDir = path.join(workspaceRoot, 'apexlogs');

--- a/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
+++ b/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
@@ -9,6 +9,116 @@ function delay(ms: number): Promise<void> {
 }
 
 suite('ensureApexLogsDir', () => {
+  test('getLogFilePathWithUsername builds org-first dated paths', async () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const datedDir = path.join(
+      apexlogsDir,
+      'orgs',
+      'User_Name@example.com',
+      'logs',
+      '2026-03-30'
+    );
+    const mkdirCalls: Array<{ dir: string; options: { recursive: boolean } }> = [];
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async (dir: string, options: { recursive: boolean }): Promise<void> => {
+            mkdirCalls.push({ dir, options });
+          },
+          stat: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          }
+        }
+      }
+    });
+
+    const result = await workspaceModule.getLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      '2026-03-30T18:39:58.000Z'
+    );
+
+    assert.deepEqual(result, {
+      dir: datedDir,
+      filePath: path.join(datedDir, '07L000000000001AA.log')
+    });
+    assert.deepEqual(
+      mkdirCalls.map(call => call.dir),
+      [apexlogsDir, datedDir]
+    );
+    assert.equal(mkdirCalls.every(call => call.options.recursive === true), true);
+  });
+
+  test('getLogFilePathWithUsername uses unknown-date for invalid start times', async () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const unknownDateDir = path.join(
+      apexlogsDir,
+      'orgs',
+      'User_Name@example.com',
+      'logs',
+      'unknown-date'
+    );
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async () => undefined,
+          stat: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          }
+        }
+      }
+    });
+
+    const result = await workspaceModule.getLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      'undefined-date'
+    );
+
+    assert.deepEqual(result, {
+      dir: unknownDateDir,
+      filePath: path.join(unknownDateDir, '07L000000000001AA.log')
+    });
+  });
+
   test('does not append duplicate apexlogs/ entries when called concurrently', async () => {
     const workspaceRoot = path.join('/tmp', 'alv-workspace');
     const apexlogsDir = path.join(workspaceRoot, 'apexlogs');

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -423,6 +423,9 @@ suite('LogService', () => {
       },
       fs: {
         promises: {
+          access: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          },
           writeFile: async () => {}
         }
       }
@@ -449,6 +452,118 @@ suite('LogService', () => {
     assert.ok(itemStatuses.includes('existing'));
     assert.ok(itemStatuses.includes('downloaded'));
     assert.ok(itemStatuses.includes('failed'));
+  });
+
+  test('ensureLogsSaved passes StartTime to the log file path builder', async () => {
+    const pathCalls: Array<{ username?: string; logId: string; startTime?: string }> = [];
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => 'body'
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'u', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'u', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async (
+          username: string | undefined,
+          logId: string,
+          startTime?: string
+        ) => {
+          pathCalls.push({ username, logId, startTime });
+          return { dir: '/tmp', filePath: `/tmp/${logId}.log` };
+        },
+        findExistingLogFile: async () => undefined
+      },
+      fs: {
+        promises: {
+          writeFile: async () => {}
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    await svc.ensureLogsSaved(
+      [{ Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.deepEqual(pathCalls, [
+      {
+        username: 'u',
+        logId: '07L000000000001AA',
+        startTime: '2026-03-30T18:39:58.000Z'
+      }
+    ]);
+  });
+
+  test('ensureLogsSaved materializes known StartTime caches into the dated path', async () => {
+    const logId = '07L0000000000DT1';
+    const existingPath = '/tmp/apexlogs/orgs/user@example.com/logs/unknown-date/07L0000000000DT1.log';
+    const datedPath = '/tmp/apexlogs/orgs/user@example.com/logs/2026-03-30/07L0000000000DT1.log';
+    const copies: Array<{ from: string; to: string }> = [];
+    let fetchCalls = 0;
+    let writeCalls = 0;
+
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => {
+          fetchCalls++;
+          return 'body';
+        }
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async (
+          username: string | undefined,
+          id: string,
+          startTime?: string
+        ) => {
+          assert.equal(username, 'user@example.com');
+          assert.equal(id, logId);
+          assert.equal(startTime, '2026-03-30T18:39:58.000Z');
+          return { dir: path.dirname(datedPath), filePath: datedPath };
+        },
+        findExistingLogFile: async (id: string, username?: string) =>
+          id === logId && username === 'user@example.com' ? existingPath : undefined
+      },
+      fs: {
+        promises: {
+          access: async (target: string): Promise<void> => {
+            if (target === datedPath) {
+              throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            }
+          },
+          mkdir: async () => {},
+          copyFile: async (from: string, to: string) => {
+            copies.push({ from, to });
+          },
+          writeFile: async () => {
+            writeCalls++;
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved(
+      [{ Id: logId, StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.deepEqual(copies, [{ from: existingPath, to: datedPath }]);
+    assert.equal(fetchCalls, 0, 'should not download when an older cached body exists');
+    assert.equal(writeCalls, 0, 'should not rewrite the body after copying the cache hit');
+    assert.equal(summary.success, 1);
+    assert.equal(summary.existing, 1);
+    assert.equal(summary.downloaded, 0);
   });
 
   test('ensureLogsSaved reports missing logs when downloadMissing is disabled', async () => {

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert/strict';
 import proxyquire from 'proxyquire';
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { OrgAuth } from '../../../../src/salesforce/types';
@@ -382,6 +383,7 @@ suite('LogService', () => {
         },
         fs: {
           promises: {
+            mkdir: async () => {},
             writeFile: async (target: string) => {
               await new Promise(resolve => setTimeout(resolve, 1));
               storedPath = target;
@@ -422,10 +424,12 @@ suite('LogService', () => {
         findExistingLogFile: async (logId: string) => (logId === '1' ? '/tmp/1.log' : undefined)
       },
       fs: {
+        constants: fsConstants,
         promises: {
           access: async (): Promise<never> => {
             throw Object.assign(new Error('missing'), { code: 'ENOENT' });
           },
+          mkdir: async () => {},
           writeFile: async () => {}
         }
       }
@@ -467,7 +471,7 @@ suite('LogService', () => {
       },
       ...createRuntimeClientStub({ username: 'u', accessToken: 't', instanceUrl: 'url' }),
       '../utils/workspace': {
-        getLogFilePathWithUsername: async (
+        buildLogFilePathWithUsername: (
           username: string | undefined,
           logId: string,
           startTime?: string
@@ -475,10 +479,17 @@ suite('LogService', () => {
           pathCalls.push({ username, logId, startTime });
           return { dir: '/tmp', filePath: `/tmp/${logId}.log` };
         },
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
         findExistingLogFile: async () => undefined
       },
       fs: {
         promises: {
+          access: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          },
+          mkdir: async () => {},
           writeFile: async () => {}
         }
       }
@@ -521,7 +532,7 @@ suite('LogService', () => {
       },
       ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
       '../utils/workspace': {
-        getLogFilePathWithUsername: async (
+        buildLogFilePathWithUsername: (
           username: string | undefined,
           id: string,
           startTime?: string
@@ -531,10 +542,14 @@ suite('LogService', () => {
           assert.equal(startTime, '2026-03-30T18:39:58.000Z');
           return { dir: path.dirname(datedPath), filePath: datedPath };
         },
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
         findExistingLogFile: async (id: string, username?: string) =>
           id === logId && username === 'user@example.com' ? existingPath : undefined
       },
       fs: {
+        constants: fsConstants,
         promises: {
           access: async (target: string): Promise<void> => {
             if (target === datedPath) {
@@ -542,7 +557,8 @@ suite('LogService', () => {
             }
           },
           mkdir: async () => {},
-          copyFile: async (from: string, to: string) => {
+          copyFile: async (from: string, to: string, mode?: number) => {
+            assert.equal(mode, fsConstants.COPYFILE_EXCL);
             copies.push({ from, to });
           },
           writeFile: async () => {
@@ -561,6 +577,68 @@ suite('LogService', () => {
     assert.deepEqual(copies, [{ from: existingPath, to: datedPath }]);
     assert.equal(fetchCalls, 0, 'should not download when an older cached body exists');
     assert.equal(writeCalls, 0, 'should not rewrite the body after copying the cache hit');
+    assert.equal(summary.success, 1);
+    assert.equal(summary.existing, 1);
+    assert.equal(summary.downloaded, 0);
+  });
+
+  test('ensureLogsSaved does not overwrite a dated cache created during materialization', async () => {
+    const logId = '07L0000000000DT2';
+    const existingPath = '/tmp/apexlogs/orgs/user@example.com/logs/unknown-date/07L0000000000DT2.log';
+    const datedPath = '/tmp/apexlogs/orgs/user@example.com/logs/2026-03-30/07L0000000000DT2.log';
+    let accessCalls = 0;
+    let copyCalls = 0;
+
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => {
+          throw new Error('should not download when a cache hit exists');
+        }
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        buildLogFilePathWithUsername: () => ({ dir: path.dirname(datedPath), filePath: datedPath }),
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
+        findExistingLogFile: async () => existingPath
+      },
+      fs: {
+        constants: fsConstants,
+        promises: {
+          access: async (target: string): Promise<void> => {
+            assert.equal(target, datedPath);
+            accessCalls++;
+            if (accessCalls === 1) {
+              throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            }
+          },
+          mkdir: async () => {},
+          copyFile: async (_from: string, _to: string, mode?: number) => {
+            copyCalls++;
+            assert.equal(mode, fsConstants.COPYFILE_EXCL);
+            throw Object.assign(new Error('exists'), { code: 'EEXIST' });
+          },
+          writeFile: async () => {
+            throw new Error('should not rewrite the dated cache');
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved(
+      [{ Id: logId, StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.equal(copyCalls, 1);
+    assert.equal(accessCalls, 2, 'should re-check the dated path after EEXIST');
     assert.equal(summary.success, 1);
     assert.equal(summary.existing, 1);
     assert.equal(summary.downloaded, 0);
@@ -635,6 +713,7 @@ suite('LogService', () => {
       },
       fs: {
         promises: {
+          mkdir: async () => {},
           writeFile: async (target: string) => {
             writeTargets.push(target);
           }

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -401,11 +401,11 @@ suite('SfLogsViewProvider behavior', () => {
     const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
     cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
     cli.logsList = async () => [
-      { Id: '07L000000000001AA', LogLength: 10 },
-      { Id: '07L000000000002AA', LogLength: 20 }
+      { Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z', LogLength: 10 },
+      { Id: '07L000000000002AA', StartTime: '2026-03-30T18:40:58.000Z', LogLength: 20 }
     ];
-    const triageCalls: Array<{ logIds: string[]; workspaceRoot?: string }> = [];
-    cli.logsTriage = async (params: { logIds: string[]; workspaceRoot?: string }) => {
+    const triageCalls: Array<{ logIds: string[]; logStartTimes?: Record<string, string>; workspaceRoot?: string }> = [];
+    cli.logsTriage = async (params: { logIds: string[]; logStartTimes?: Record<string, string>; workspaceRoot?: string }) => {
       triageCalls.push(params);
       return [
         {
@@ -462,6 +462,10 @@ suite('SfLogsViewProvider behavior', () => {
     assert.equal(errorHead?.primaryReason, 'Fatal exception');
     assert.equal(errorHead?.reasons?.[0]?.code, 'fatal_exception');
     assert.equal(triageCalls[0]?.workspaceRoot, '/tmp/alv-workspace');
+    assert.deepEqual(triageCalls[0]?.logStartTimes, {
+      '07L000000000001AA': '2026-03-30T18:39:58.000Z',
+      '07L000000000002AA': '2026-03-30T18:40:58.000Z'
+    });
   });
 
   test('refresh cancellation aborts background error scan', async () => {

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -6,7 +6,7 @@ use alv_core::{
 use alv_protocol::messages::{InitializeParams, InitializeResult, RuntimeCapabilities};
 use serde_json::Value;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt::Write as _,
     io::{self, BufRead, Write},
     sync::mpsc::{self, RecvTimeoutError},
@@ -442,6 +442,9 @@ fn parse_request_line(request: &str) -> Result<ParsedRequest, String> {
             log_ids: string_vec_field(&params, "logIds")
                 .or_else(|| string_vec_field(&params, "log_ids"))
                 .unwrap_or_default(),
+            log_start_times: string_map_field(&params, "logStartTimes")
+                .or_else(|| string_map_field(&params, "log_start_times"))
+                .unwrap_or_default(),
             username: params
                 .get("username")
                 .and_then(Value::as_str)
@@ -530,6 +533,23 @@ fn string_vec_field(source: &Value, field: &str) -> Option<Vec<String>> {
     })
 }
 
+fn string_map_field(source: &Value, field: &str) -> Option<BTreeMap<String, String>> {
+    source.get(field).and_then(Value::as_object).map(|items| {
+        items
+            .iter()
+            .filter_map(|(key, value)| {
+                let key = key.trim();
+                let value = value.as_str()?.trim();
+                if key.is_empty() || value.is_empty() {
+                    None
+                } else {
+                    Some((key.to_string(), value.to_string()))
+                }
+            })
+            .collect()
+    })
+}
+
 fn escape_json(value: &str) -> String {
     let mut escaped = String::new();
     for character in value.chars() {
@@ -591,5 +611,42 @@ mod tests {
         assert_eq!(params.username.as_deref(), Some("selected@example.com"));
         assert_eq!(params.workspace_root.as_deref(), Some("/tmp/demo"));
         assert_eq!(params.log_ids, vec!["07L000000000001AA".to_string()]);
+    }
+
+    #[test]
+    fn parse_request_line_reads_logs_triage_start_times() {
+        let parsed = parse_request_line(
+            r#"{
+              "jsonrpc":"2.0",
+              "id":"triage:1",
+              "method":"logs/triage",
+              "params":{
+                "logIds":["07L000000000001AA"],
+                "logStartTimes":{"07L000000000001AA":"2026-03-30T18:39:58.000Z"},
+                "username":"selected@example.com",
+                "workspaceRoot":"/tmp/demo"
+              }
+            }"#,
+        )
+        .expect("logs/triage request should parse");
+
+        let ParsedRequest::Call(call) = parsed else {
+            panic!("expected a normal call");
+        };
+
+        let ServerOperation::LogsTriage(params) = call.operation else {
+            panic!("expected logs/triage operation");
+        };
+
+        assert_eq!(params.username.as_deref(), Some("selected@example.com"));
+        assert_eq!(params.workspace_root.as_deref(), Some("/tmp/demo"));
+        assert_eq!(params.log_ids, vec!["07L000000000001AA".to_string()]);
+        assert_eq!(
+            params
+                .log_start_times
+                .get("07L000000000001AA")
+                .map(String::as_str),
+            Some("2026-03-30T18:39:58.000Z")
+        );
     }
 }

--- a/crates/alv-core/src/log_store.rs
+++ b/crates/alv-core/src/log_store.rs
@@ -94,15 +94,24 @@ pub fn log_file_path_for_start_time(
     start_time: &str,
     log_id: &str,
 ) -> PathBuf {
-    let day = start_time
-        .get(0..10)
-        .filter(|value| value.len() == 10)
-        .unwrap_or("unknown-date");
+    let day = log_day_dir_name_for_start_time(start_time);
 
     org_dir(workspace_root, raw_org)
         .join("logs")
         .join(day)
         .join(format!("{log_id}.log"))
+}
+
+fn log_day_dir_name_for_start_time(start_time: &str) -> &str {
+    let Some(day) = start_time.get(0..10) else {
+        return "unknown-date";
+    };
+
+    if is_yyyy_mm_dd(day) {
+        day
+    } else {
+        "unknown-date"
+    }
 }
 
 pub fn unknown_date_log_path(workspace_root: Option<&str>, raw_org: &str, log_id: &str) -> PathBuf {
@@ -238,7 +247,9 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
 
     for entry in fs::read_dir(logs_root).ok()?.flatten() {
         let day_dir = entry.path();
-        if !day_dir.is_dir() || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref()) {
+        if !day_dir.is_dir()
+            || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref())
+        {
             continue;
         }
 
@@ -251,20 +262,23 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
     None
 }
 
-fn is_supported_log_day_dir_name(name: &str) -> bool {
-    name == "unknown-date"
-        || matches!(
-            name.as_bytes(),
-            [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
-                if y1.is_ascii_digit()
-                    && y2.is_ascii_digit()
-                    && y3.is_ascii_digit()
-                    && y4.is_ascii_digit()
-                    && m1.is_ascii_digit()
-                    && m2.is_ascii_digit()
-                    && d1.is_ascii_digit()
-                    && d2.is_ascii_digit()
-        )
+pub(crate) fn is_supported_log_day_dir_name(name: &str) -> bool {
+    name == "unknown-date" || is_yyyy_mm_dd(name)
+}
+
+fn is_yyyy_mm_dd(value: &str) -> bool {
+    matches!(
+        value.as_bytes(),
+        [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
+            if y1.is_ascii_digit()
+                && y2.is_ascii_digit()
+                && y3.is_ascii_digit()
+                && y4.is_ascii_digit()
+                && m1.is_ascii_digit()
+                && m2.is_ascii_digit()
+                && d1.is_ascii_digit()
+                && d2.is_ascii_digit()
+    )
 }
 
 fn find_log_in_orgs_root(orgs_root: &Path, log_id: &str) -> Option<PathBuf> {

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     fs::{self, File},
-    io::{BufRead, BufReader},
+    io::{copy, BufRead, BufReader},
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -192,15 +192,42 @@ fn materialize_existing_at_preferred_path(
         fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
     }
-    match fs::copy(existing_path, preferred_path) {
-        Ok(_) => Ok(Some(preferred_path.to_path_buf())),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(format!(
+    let mut source = match File::open(existing_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "failed to read cached log {}: {error}",
+                existing_path.display()
+            ))
+        }
+    };
+    let mut destination = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(preferred_path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Ok(Some(preferred_path.to_path_buf()));
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to create cached log {}: {error}",
+                preferred_path.display()
+            ));
+        }
+    };
+    if let Err(error) = copy(&mut source, &mut destination) {
+        let _ = fs::remove_file(preferred_path);
+        return Err(format!(
             "failed to materialize cached log {} from {}: {error}",
             preferred_path.display(),
             existing_path.display()
-        )),
+        ));
     }
+
+    Ok(Some(preferred_path.to_path_buf()))
 }
 
 fn summarize_file(

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -4,8 +4,10 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::File,
+    collections::BTreeMap,
+    fs::{self, File},
     io::{BufRead, BufReader},
+    path::{Path, PathBuf},
     thread,
     time::Duration,
 };
@@ -17,6 +19,8 @@ const TEST_TRIAGE_LINE_DELAY_MS_ENV: &str = "ALV_TEST_TRIAGE_LINE_DELAY_MS";
 pub struct LogsTriageParams {
     #[serde(alias = "log_ids")]
     pub log_ids: Vec<String>,
+    #[serde(default, rename = "logStartTimes", alias = "log_start_times")]
+    pub log_start_times: BTreeMap<String, String>,
     pub username: Option<String>,
     #[serde(alias = "workspace_root")]
     pub workspace_root: Option<String>,
@@ -94,6 +98,25 @@ fn triage_log_item(
     canonical_username: Option<&str>,
     cancellation: &CancellationToken,
 ) -> Result<LogTriageItem, String> {
+    let resolved_username = canonical_username.unwrap_or("default");
+    let preferred_path = params.log_start_times.get(log_id).map(|start_time| {
+        log_store::log_file_path_for_start_time(
+            params.workspace_root.as_deref(),
+            resolved_username,
+            start_time,
+            log_id,
+        )
+    });
+
+    if let Some(path) = preferred_path.as_ref().filter(|path| path.is_file()) {
+        let (code_unit_started, summary) = summarize_file(path, cancellation)?;
+        return Ok(LogTriageItem {
+            log_id: log_id.to_string(),
+            code_unit_started,
+            summary,
+        });
+    }
+
     let existing_path = match canonical_username {
         Some(username) => find_scoped_cached_log_path(
             params.workspace_root.as_deref(),
@@ -120,14 +143,20 @@ fn triage_log_item(
     };
 
     let path = match existing_path {
-        Some(existing) => existing,
+        Some(existing) => materialize_existing_at_preferred_path(
+            &existing,
+            preferred_path.as_deref(),
+            cancellation,
+        )?
+        .unwrap_or(existing),
         None => {
-            let resolved_username = canonical_username.unwrap_or("default");
-            let target_path = log_store::unknown_date_log_path(
-                params.workspace_root.as_deref(),
-                resolved_username,
-                log_id,
-            );
+            let target_path = preferred_path.unwrap_or_else(|| {
+                log_store::unknown_date_log_path(
+                    params.workspace_root.as_deref(),
+                    resolved_username,
+                    log_id,
+                )
+            });
             download_log_to_path_with_cancel(
                 log_id,
                 params.username.as_deref(),
@@ -146,8 +175,36 @@ fn triage_log_item(
     })
 }
 
+fn materialize_existing_at_preferred_path(
+    existing_path: &Path,
+    preferred_path: Option<&Path>,
+    cancellation: &CancellationToken,
+) -> Result<Option<PathBuf>, String> {
+    let Some(preferred_path) = preferred_path else {
+        return Ok(None);
+    };
+    if existing_path == preferred_path {
+        return Ok(Some(preferred_path.to_path_buf()));
+    }
+
+    cancellation.check_cancelled()?;
+    if let Some(parent) = preferred_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    match fs::copy(existing_path, preferred_path) {
+        Ok(_) => Ok(Some(preferred_path.to_path_buf())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!(
+            "failed to materialize cached log {} from {}: {error}",
+            preferred_path.display(),
+            existing_path.display()
+        )),
+    }
+}
+
 fn summarize_file(
-    path: &std::path::Path,
+    path: &Path,
     cancellation: &CancellationToken,
 ) -> Result<(Option<String>, LogTriageSummary), String> {
     let file = File::open(path)
@@ -279,25 +336,24 @@ fn legacy_scoped_paths(
     candidates
 }
 
-fn find_log_in_tree(root: &std::path::Path, log_id: &str) -> Option<std::path::PathBuf> {
-    if !root.exists() {
+fn find_log_in_tree(root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !root.is_dir() {
         return None;
     }
 
     for entry in std::fs::read_dir(root).ok()?.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            if let Some(found) = find_log_in_tree(&path, log_id) {
-                return Some(found);
-            }
+        let day_dir = entry.path();
+        if !day_dir.is_dir()
+            || !log_store::is_supported_log_day_dir_name(
+                entry.file_name().to_string_lossy().as_ref(),
+            )
+        {
             continue;
         }
 
-        if path
-            .file_name()
-            .is_some_and(|file_name| file_name.to_string_lossy() == format!("{log_id}.log"))
-        {
-            return Some(path);
+        let candidate = day_dir.join(format!("{log_id}.log"));
+        if candidate.is_file() {
+            return Some(candidate);
         }
     }
 

--- a/crates/alv-core/tests/log_store_layout.rs
+++ b/crates/alv-core/tests/log_store_layout.rs
@@ -50,6 +50,34 @@ fn log_store_places_logs_under_org_and_day_directory() {
 }
 
 #[test]
+fn log_store_uses_unknown_date_for_invalid_start_time_values() {
+    let workspace_root = make_temp_workspace("invalid-day");
+    let file_path = log_file_path_for_start_time(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "default@example.com",
+        "undefined-date",
+        "07L000000000003AA",
+    );
+
+    assert_eq!(
+        file_path,
+        workspace_root
+            .join("apexlogs")
+            .join("orgs")
+            .join("default@example.com")
+            .join("logs")
+            .join("unknown-date")
+            .join("07L000000000003AA.log")
+    );
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn log_store_finds_new_layout_before_legacy_flat_files() {
     let workspace_root = make_temp_workspace("find-cache");
     let safe_org = safe_target_org("default@example.com");

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -916,6 +916,7 @@ fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory()
     );
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("default@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -931,6 +932,109 @@ fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory()
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_triage_downloads_missing_log_into_start_time_day_directory() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("ensure-dated-layout");
+    let fixture_dir = make_temp_workspace("ensure-dated-fixture");
+    let log_id = "07L00000000000DT1";
+    fs::write(
+        fixture_dir.join(format!("{log_id}.log")),
+        "09:00:00.0|USER_INFO|fixture body\n",
+    )
+    .expect("fixture log should be writable");
+
+    std::env::set_var(
+        TEST_APEX_LOG_FIXTURE_DIR_ENV,
+        fixture_dir.display().to_string(),
+    );
+    let items = triage_logs(&LogsTriageParams {
+        log_ids: vec![log_id.to_string()],
+        log_start_times: std::collections::BTreeMap::from([(
+            log_id.to_string(),
+            "2026-03-30T18:39:58.000Z".to_string(),
+        )]),
+        username: Some("default@example.com".to_string()),
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("logs/triage should download and summarize the fixture log");
+
+    assert_eq!(items.len(), 1);
+    let cached = find_cached_log_path(Some(&workspace_root.display().to_string()), log_id)
+        .expect("triage should cache the downloaded fixture log");
+
+    assert!(
+        cached.ends_with("apexlogs/orgs/default@example.com/logs/2026-03-30/07L00000000000DT1.log")
+    );
+
+    std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    fs::remove_dir_all(fixture_dir).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_triage_materializes_unknown_date_cache_for_known_start_time() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("triage-materialize-dated-layout");
+    let log_id = "07L00000000000DM1";
+    let unknown_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("unknown-date")
+        .join(format!("{log_id}.log"));
+    fs::create_dir_all(
+        unknown_path
+            .parent()
+            .expect("unknown-date parent should exist"),
+    )
+    .expect("unknown-date parent should be creatable");
+    fs::write(
+        &unknown_path,
+        "09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|Materialized.handle\n",
+    )
+    .expect("unknown-date cached log should be writable");
+
+    let items = triage_logs(&LogsTriageParams {
+        log_ids: vec![log_id.to_string()],
+        log_start_times: std::collections::BTreeMap::from([(
+            log_id.to_string(),
+            "2026-03-30T18:39:58.000Z".to_string(),
+        )]),
+        username: Some("default@example.com".to_string()),
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect(
+        "logs/triage should materialize the dated cache path from an existing unknown-date copy",
+    );
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].code_unit_started.as_deref(),
+        Some("Materialized.handle")
+    );
+    let dated_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("2026-03-30")
+        .join(format!("{log_id}.log"));
+    assert!(
+        dated_path.is_file(),
+        "triage should create the dated cache copy"
+    );
+    assert!(
+        unknown_path.is_file(),
+        "triage should preserve the older cache hit"
+    );
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
@@ -951,6 +1055,7 @@ fn logs_runtime_smoke_triage_uses_legacy_bare_log_fallback_for_scoped_requests()
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("selected@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1024,6 +1129,7 @@ fn logs_runtime_smoke_triage_ignores_wrong_org_cached_copy_when_alias_resolves_c
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1086,6 +1192,7 @@ fn logs_runtime_smoke_triage_uses_canonical_username_tree_for_alias_input() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1136,6 +1243,7 @@ fn logs_runtime_smoke_triage_falls_back_to_raw_alias_scoped_cache_without_auth()
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1181,6 +1289,7 @@ fn logs_runtime_smoke_triage_respects_cancellation_mid_file() {
     let result = triage_logs_with_cancel(
         &LogsTriageParams {
             log_ids: vec!["07L000000000001AA".to_string()],
+            log_start_times: Default::default(),
             username: None,
             workspace_root: Some(workspace_root.display().to_string()),
         },
@@ -1215,6 +1324,7 @@ fn logs_runtime_smoke_triage_uses_default_legacy_cache_without_username() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1296,6 +1406,7 @@ fn logs_runtime_smoke_triages_logs_and_caches_fixture_downloads() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("demo@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1348,6 +1459,7 @@ fn logs_runtime_smoke_triage_returns_partial_results_when_one_log_is_unreadable(
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![missing_log_id.to_string(), readable_log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("demo@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })

--- a/packages/app-server-client-ts/src/index.ts
+++ b/packages/app-server-client-ts/src/index.ts
@@ -83,6 +83,7 @@ export type RuntimeLogTriageSummary = {
 export type LogsTriageParams = {
   username?: string;
   logIds: string[];
+  logStartTimes?: Record<string, string>;
   workspaceRoot?: string;
 };
 

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { promises as fs } from 'fs';
+import * as path from 'path';
 import { createLimiter, type Limiter } from '../utils/limiter';
 import { fetchApexLogBody, extractCodeUnitStartedFromLines } from '../salesforce/http';
 import type { ApexLogCursor } from '../salesforce/http';
@@ -42,6 +43,11 @@ export type EnsureLogsSavedOptions = {
   onItemComplete?: (result: EnsureLogsSavedItemResult) => void;
 };
 
+type EnsureLogFileResult = {
+  filePath: string;
+  source: 'existing' | 'downloaded';
+};
+
 export type ClassifyLogsForErrorsProgress = {
   logId: string;
   summary: LogTriageSummary;
@@ -63,7 +69,7 @@ export class LogService {
   private saveConcurrency: number;
   private classifyLimiter: Limiter;
   private classifyConcurrency: number;
-  private inFlightSaves = new Map<string, Promise<string>>();
+  private inFlightSaves = new Map<string, Promise<EnsureLogFileResult>>();
 
   constructor(headConcurrency = 5) {
     this.headConcurrency = headConcurrency;
@@ -133,27 +139,59 @@ export class LogService {
     logId: string,
     selectedOrg?: string,
     signal?: AbortSignal,
-    authHint?: OrgAuth
+    authHint?: OrgAuth,
+    startTime?: string
   ): Promise<string> {
+    return (await this.ensureLogFileResult(logId, selectedOrg, signal, authHint, startTime)).filePath;
+  }
+
+  private async ensureLogFileResult(
+    logId: string,
+    selectedOrg?: string,
+    signal?: AbortSignal,
+    authHint?: OrgAuth,
+    startTime?: string
+  ): Promise<EnsureLogFileResult> {
     const auth = authHint ?? (await this.getOrgAuth(selectedOrg, signal));
+    const preferredPath = await this.resolvePreferredLogPath(auth.username, logId, startTime);
+    if (preferredPath && (await this.fileExists(preferredPath))) {
+      return { filePath: preferredPath, source: 'existing' };
+    }
+
     const existing = await findExistingLogFile(logId, auth.username);
     if (existing) {
-      return existing;
+      const materialized = await this.materializeExistingAtPreferredPath(existing, preferredPath, signal);
+      if (materialized) {
+        return materialized;
+      }
+      return { filePath: existing, source: 'existing' };
     }
-    const key = `${auth.username ?? ''}:${logId}`;
+
+    const key = `${auth.username ?? ''}:${logId}:${preferredPath ?? ''}`;
     const pending = this.inFlightSaves.get(key);
     if (pending) {
       return pending;
     }
-    const task = (async () => {
+    const task: Promise<EnsureLogFileResult> = (async (): Promise<EnsureLogFileResult> => {
+      if (preferredPath && (await this.fileExists(preferredPath))) {
+        return { filePath: preferredPath, source: 'existing' };
+      }
+
       const maybeExisting = await findExistingLogFile(logId, auth.username);
       if (maybeExisting) {
-        return maybeExisting;
+        const materialized = await this.materializeExistingAtPreferredPath(maybeExisting, preferredPath, signal);
+        if (materialized) {
+          return materialized;
+        }
+        return { filePath: maybeExisting, source: 'existing' };
       }
-      const { filePath } = await getLogFilePathWithUsername(auth.username, logId);
+      const { filePath } = preferredPath
+        ? { filePath: preferredPath }
+        : await getLogFilePathWithUsername(auth.username, logId, startTime);
       const body = await fetchApexLogBody(auth, logId, undefined, signal);
+      this.throwIfAborted(signal);
       await fs.writeFile(filePath, body, 'utf8');
-      return filePath;
+      return { filePath, source: 'downloaded' };
     })();
     this.inFlightSaves.set(key, task);
     try {
@@ -162,6 +200,64 @@ export class LogService {
     } finally {
       this.inFlightSaves.delete(key);
     }
+  }
+
+  private async resolvePreferredLogPath(
+    username: string | undefined,
+    logId: string,
+    startTime?: string
+  ): Promise<string | undefined> {
+    if (typeof startTime !== 'string' || startTime.trim().length === 0) {
+      return undefined;
+    }
+
+    return (await getLogFilePathWithUsername(username, logId, startTime)).filePath;
+  }
+
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch (e: any) {
+      if (e && e.code === 'ENOENT') {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private async materializeExistingAtPreferredPath(
+    existingPath: string,
+    preferredPath: string | undefined,
+    signal?: AbortSignal
+  ): Promise<EnsureLogFileResult | undefined> {
+    if (!preferredPath) {
+      return undefined;
+    }
+    if (path.resolve(existingPath) === path.resolve(preferredPath)) {
+      return { filePath: preferredPath, source: 'existing' };
+    }
+
+    this.throwIfAborted(signal);
+    try {
+      await fs.mkdir(path.dirname(preferredPath), { recursive: true });
+      await fs.copyFile(existingPath, preferredPath);
+      return { filePath: preferredPath, source: 'existing' };
+    } catch (e: any) {
+      if (e && e.code === 'ENOENT') {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) {
+      return;
+    }
+    const error = new Error('Request aborted');
+    error.name = 'AbortError';
+    throw error;
   }
 
   private async loadCodeUnitFromSavedLog(
@@ -262,7 +358,8 @@ export class LogService {
               return;
             }
             const existingPath = await findExistingLogFile(log.Id, selectedUsername);
-            const filePath = existingPath ?? (await this.ensureLogFile(log.Id, selectedOrg, signal));
+            const filePath =
+              existingPath ?? (await this.ensureLogFile(log.Id, selectedOrg, signal, undefined, log.StartTime));
             if (signal?.aborted) {
               return;
             }
@@ -367,22 +464,15 @@ export class LogService {
           }
           try {
             if (downloadMissing) {
-              const existing = await findExistingLogFile(log.Id, selectedUsername);
-              if (existing) {
-                summary.success++;
-                summary.existing++;
-                options?.onItemComplete?.({ logId: log.Id, status: 'existing' });
-                return;
-              }
-              await this.ensureLogFile(log.Id, selectedOrg, signal, authHint);
+              const result = await this.ensureLogFileResult(log.Id, selectedOrg, signal, authHint, log.StartTime);
               if (signal?.aborted) {
                 summary.cancelled++;
                 options?.onItemComplete?.({ logId: log.Id, status: 'cancelled' });
                 return;
               }
               summary.success++;
-              summary.downloaded++;
-              options?.onItemComplete?.({ logId: log.Id, status: 'downloaded' });
+              summary[result.source]++;
+              options?.onItemComplete?.({ logId: log.Id, status: result.source });
             } else {
               const existing = await findExistingLogFile(log.Id, selectedUsername);
               if (!existing) {

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import { promises as fs } from 'fs';
+import { constants as fsConstants, promises as fs } from 'fs';
 import * as path from 'path';
 import { createLimiter, type Limiter } from '../utils/limiter';
 import { fetchApexLogBody, extractCodeUnitStartedFromLines } from '../salesforce/http';
 import type { ApexLogCursor } from '../salesforce/http';
 import type { OrgAuth } from '../salesforce/types';
 import type { ApexLogRow } from '../../apps/vscode-extension/src/shared/types';
-import { getLogFilePathWithUsername, findExistingLogFile } from '../utils/workspace';
+import { buildLogFilePathWithUsername, getLogFilePathWithUsername, findExistingLogFile } from '../utils/workspace';
 import { ensureReplayDebuggerAvailable } from '../utils/replayDebugger';
 import { getErrorMessage } from '../utils/error';
 import { logWarn, logInfo } from '../utils/logger';
@@ -190,6 +190,7 @@ export class LogService {
         : await getLogFilePathWithUsername(auth.username, logId, startTime);
       const body = await fetchApexLogBody(auth, logId, undefined, signal);
       this.throwIfAborted(signal);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
       await fs.writeFile(filePath, body, 'utf8');
       return { filePath, source: 'downloaded' };
     })();
@@ -211,7 +212,7 @@ export class LogService {
       return undefined;
     }
 
-    return (await getLogFilePathWithUsername(username, logId, startTime)).filePath;
+    return buildLogFilePathWithUsername(username, logId, startTime).filePath;
   }
 
   private async fileExists(filePath: string): Promise<boolean> {
@@ -241,9 +242,12 @@ export class LogService {
     this.throwIfAborted(signal);
     try {
       await fs.mkdir(path.dirname(preferredPath), { recursive: true });
-      await fs.copyFile(existingPath, preferredPath);
+      await fs.copyFile(existingPath, preferredPath, fsConstants.COPYFILE_EXCL);
       return { filePath: preferredPath, source: 'existing' };
     } catch (e: any) {
+      if (e && e.code === 'EEXIST' && (await this.fileExists(preferredPath))) {
+        return { filePath: preferredPath, source: 'existing' };
+      }
       if (e && e.code === 'ENOENT') {
         return undefined;
       }

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -343,7 +343,11 @@ export class TailService {
     const header = `=== ApexLog ${id ?? ''} | ${r?.StartTime ?? ''} | ${r?.Operation ?? ''} | ${r?.Status ?? ''} | ${r?.LogLength ?? ''}`;
     lines.push(header);
     try {
-      const { filePath } = await this.getLogFilePathWithUsername(auth.username, id ?? String(Date.now()));
+      const { filePath } = await this.getLogFilePathWithUsername(
+        auth.username,
+        id ?? String(Date.now()),
+        typeof r?.StartTime === 'string' ? r.StartTime : undefined
+      );
       await fs.writeFile(filePath, body, 'utf8');
       if (id) {
         this.addLogPath(id, filePath);
@@ -514,8 +518,9 @@ export class TailService {
 
   private async getLogFilePathWithUsername(
     username: string | undefined,
-    logId: string
+    logId: string,
+    startTime?: string
   ): Promise<{ dir: string; filePath: string }> {
-    return utilGetLogFilePathWithUsername(username, logId);
+    return utilGetLogFilePathWithUsername(username, logId, startTime);
   }
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -117,20 +117,29 @@ export async function ensureApexLogsDir(): Promise<string> {
 }
 
 /**
- * Build a username-prefixed log file path under `apexlogs`.
+ * Build an org-first log file path under `apexlogs`.
  */
 export async function getLogFilePathWithUsername(
   username: string | undefined,
-  logId: string
+  logId: string,
+  startTime?: string
 ): Promise<{ dir: string; filePath: string }> {
-  const dir = await ensureApexLogsDir();
+  const rootDir = await ensureApexLogsDir();
   const safeUser = toSafeLogUserName(username);
-  const filePath = path.join(dir, `${safeUser}_${logId}.log`);
+  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${logId}.log`);
   return { dir, filePath };
 }
 
 function toSafeLogUserName(username: string | undefined): string {
   return (username || 'default').replace(/[^a-zA-Z0-9_.@-]+/g, '_');
+}
+
+function toLogDayDirName(startTime: string | undefined): string {
+  const value = typeof startTime === 'string' ? startTime.trim() : '';
+  const day = value.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day : 'unknown-date';
 }
 
 function isSupportedLogDayDirName(name: string): boolean {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -117,18 +117,31 @@ export async function ensureApexLogsDir(): Promise<string> {
 }
 
 /**
- * Build an org-first log file path under `apexlogs`.
+ * Build an org-first log file path under `apexlogs` without touching the filesystem.
+ */
+export function buildLogFilePathWithUsername(
+  username: string | undefined,
+  logId: string,
+  startTime?: string
+): { dir: string; filePath: string } {
+  const rootDir = getApexLogsDir();
+  const safeUser = toSafeLogUserName(username);
+  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  const filePath = path.join(dir, `${logId}.log`);
+  return { dir, filePath };
+}
+
+/**
+ * Build an org-first log file path under `apexlogs` and ensure its directories exist.
  */
 export async function getLogFilePathWithUsername(
   username: string | undefined,
   logId: string,
   startTime?: string
 ): Promise<{ dir: string; filePath: string }> {
-  const rootDir = await ensureApexLogsDir();
-  const safeUser = toSafeLogUserName(username);
-  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  await ensureApexLogsDir();
+  const { dir, filePath } = buildLogFilePathWithUsername(username, logId, startTime);
   await fs.mkdir(dir, { recursive: true });
-  const filePath = path.join(dir, `${logId}.log`);
   return { dir, filePath };
 }
 


### PR DESCRIPTION
## Summary
- Writes TypeScript-saved Apex logs to the canonical org-first dated cache layout using ApexLog `StartTime`, while keeping legacy flat files as read fallbacks.
- Threads `logStartTimes` through extension triage requests, the app-server client/server contract, and Rust triage downloads so missing logs land under the correct day directory instead of `unknown-date` when the date is known.
- Materializes existing `unknown-date` or legacy cache hits into the dated path when `StartTime` is later available, and keeps unsupported nested cache folders out of Rust triage lookup.

## Test Plan
- [x] `npx tsc -p tsconfig.test.json --noEmit`
- [x] `npm run compile-tests`
- [x] `npm run check-types`
- [x] `npm run lint`
- [x] `node scripts/run-tests-cli.js --scope=unit --timeout=480000` (340 passing)
- [x] `cargo test -p alv-core`
- [x] `cargo test -p alv-app-server`

## Notes
- Existing legacy flat cache files remain readable for backward compatibility.
- Local uncommitted `.vscode/settings.json` was intentionally left out of this branch.