### PR TITLE
fix(logs): use org-first cache layout only

### DIFF
--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -662,6 +662,11 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           {
             username: selectedOrg,
             logIds: toScan.map(log => log.Id),
+            logStartTimes: Object.fromEntries(
+              toScan
+                .filter(log => typeof log.StartTime === 'string' && log.StartTime.trim().length > 0)
+                .map(log => [log.Id, log.StartTime])
+            ),
             workspaceRoot: getWorkspaceRoot()
           },
           controller.signal

--- a/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
+++ b/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
@@ -9,6 +9,56 @@ function delay(ms: number): Promise<void> {
 }
 
 suite('ensureApexLogsDir', () => {
+  test('buildLogFilePathWithUsername computes paths without creating directories', () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async (): Promise<never> => {
+            throw new Error('pure path builder should not create directories');
+          }
+        }
+      }
+    });
+
+    const result = workspaceModule.buildLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      '2026-03-30T18:39:58.000Z'
+    );
+
+    assert.deepEqual(result, {
+      dir: path.join(workspaceRoot, 'apexlogs', 'orgs', 'User_Name@example.com', 'logs', '2026-03-30'),
+      filePath: path.join(
+        workspaceRoot,
+        'apexlogs',
+        'orgs',
+        'User_Name@example.com',
+        'logs',
+        '2026-03-30',
+        '07L000000000001AA.log'
+      )
+    });
+  });
+
   test('getLogFilePathWithUsername builds org-first dated paths', async () => {
     const workspaceRoot = path.join('/tmp', 'alv-workspace');
     const apexlogsDir = path.join(workspaceRoot, 'apexlogs');

--- a/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
+++ b/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
@@ -9,6 +9,116 @@ function delay(ms: number): Promise<void> {
 }
 
 suite('ensureApexLogsDir', () => {
+  test('getLogFilePathWithUsername builds org-first dated paths', async () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const datedDir = path.join(
+      apexlogsDir,
+      'orgs',
+      'User_Name@example.com',
+      'logs',
+      '2026-03-30'
+    );
+    const mkdirCalls: Array<{ dir: string; options: { recursive: boolean } }> = [];
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async (dir: string, options: { recursive: boolean }): Promise<void> => {
+            mkdirCalls.push({ dir, options });
+          },
+          stat: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          }
+        }
+      }
+    });
+
+    const result = await workspaceModule.getLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      '2026-03-30T18:39:58.000Z'
+    );
+
+    assert.deepEqual(result, {
+      dir: datedDir,
+      filePath: path.join(datedDir, '07L000000000001AA.log')
+    });
+    assert.deepEqual(
+      mkdirCalls.map(call => call.dir),
+      [apexlogsDir, datedDir]
+    );
+    assert.equal(mkdirCalls.every(call => call.options.recursive === true), true);
+  });
+
+  test('getLogFilePathWithUsername uses unknown-date for invalid start times', async () => {
+    const workspaceRoot = path.join('/tmp', 'alv-workspace');
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const unknownDateDir = path.join(
+      apexlogsDir,
+      'orgs',
+      'User_Name@example.com',
+      'logs',
+      'unknown-date'
+    );
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async () => undefined,
+          stat: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          }
+        }
+      }
+    });
+
+    const result = await workspaceModule.getLogFilePathWithUsername(
+      'User Name@example.com',
+      '07L000000000001AA',
+      'undefined-date'
+    );
+
+    assert.deepEqual(result, {
+      dir: unknownDateDir,
+      filePath: path.join(unknownDateDir, '07L000000000001AA.log')
+    });
+  });
+
   test('does not append duplicate apexlogs/ entries when called concurrently', async () => {
     const workspaceRoot = path.join('/tmp', 'alv-workspace');
     const apexlogsDir = path.join(workspaceRoot, 'apexlogs');

--- a/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
+++ b/apps/vscode-extension/src/test/ensureApexLogsDir.test.ts
@@ -1,4 +1,6 @@
 import assert from 'assert/strict';
+import { promises as fs } from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 import proxyquire from 'proxyquire';
 
@@ -167,6 +169,103 @@ suite('ensureApexLogsDir', () => {
       dir: unknownDateDir,
       filePath: path.join(unknownDateDir, '07L000000000001AA.log')
     });
+  });
+
+  test('purgeSavedLogs removes expired org-first log files only', async () => {
+    const workspaceRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'alv-purge-'));
+    const apexlogsDir = path.join(workspaceRoot, 'apexlogs');
+    const expiredNestedId = '07L000000000102AA';
+    const keptNestedId = '07L000000000103AA';
+    const freshNestedId = '07L000000000104AA';
+    const unsupportedNestedId = '07L000000000105AA';
+    const ignoredFlat = path.join(apexlogsDir, 'default_07L000000000101AA.log');
+    const expiredNested = path.join(
+      apexlogsDir,
+      'orgs',
+      'target@example.com',
+      'logs',
+      '2026-03-30',
+      `${expiredNestedId}.log`
+    );
+    const keptNested = path.join(
+      apexlogsDir,
+      'orgs',
+      'target@example.com',
+      'logs',
+      '2026-03-30',
+      `${keptNestedId}.log`
+    );
+    const freshNested = path.join(
+      apexlogsDir,
+      'orgs',
+      'target@example.com',
+      'logs',
+      '2026-03-30',
+      `${freshNestedId}.log`
+    );
+    const unsupportedNested = path.join(
+      apexlogsDir,
+      'orgs',
+      'target@example.com',
+      'logs',
+      'not-a-day',
+      `${unsupportedNestedId}.log`
+    );
+
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict('../../../../src/utils/workspace', {
+      './logger': {
+        logInfo: () => undefined,
+        logWarn: () => undefined
+      },
+      vscode: {
+        workspace: {
+          workspaceFolders: [{ uri: { fsPath: workspaceRoot } }]
+        },
+        Range: class {
+          constructor(
+            public readonly startLine: number,
+            public readonly startCharacter: number,
+            public readonly endLine: number,
+            public readonly endCharacter: number
+          ) {}
+        }
+      }
+    });
+
+    const writeOldLog = async (filePath: string): Promise<void> => {
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
+      await fs.writeFile(filePath, 'body', 'utf8');
+      const old = new Date(Date.now() - 1000 * 60 * 60 * 2);
+      await fs.utimes(filePath, old, old);
+    };
+    const fileExists = async (filePath: string): Promise<boolean> =>
+      fs
+        .stat(filePath)
+        .then(stat => stat.isFile())
+        .catch(() => false);
+
+    try {
+      await writeOldLog(ignoredFlat);
+      await writeOldLog(expiredNested);
+      await writeOldLog(keptNested);
+      await writeOldLog(unsupportedNested);
+      await fs.mkdir(path.dirname(freshNested), { recursive: true });
+      await fs.writeFile(freshNested, 'body', 'utf8');
+
+      const removed = await workspaceModule.purgeSavedLogs({
+        keepIds: new Set([keptNestedId]),
+        maxAgeMs: 1000 * 60 * 60
+      });
+
+      assert.equal(removed, 1);
+      assert.equal(await fileExists(ignoredFlat), true);
+      assert.equal(await fileExists(expiredNested), false);
+      assert.equal(await fileExists(keptNested), true);
+      assert.equal(await fileExists(freshNested), true);
+      assert.equal(await fileExists(unsupportedNested), true);
+    } finally {
+      await fs.rm(workspaceRoot, { recursive: true, force: true });
+    }
   });
 
   test('does not append duplicate apexlogs/ entries when called concurrently', async () => {

--- a/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
+++ b/apps/vscode-extension/src/test/findExistingLogFile.runtime.test.ts
@@ -55,8 +55,66 @@ suite('findExistingLogFile runtime lookup', () => {
     ]);
   });
 
-  test('falls back to local lookup when the runtime request fails', async () => {
-    const localPath = path.join('/tmp/alv-workspace', 'apexlogs', 'demo_07L000000000002AA.log');
+  test('falls back to org-first local lookup when the runtime request fails', async () => {
+    const localPath = path.join(
+      '/tmp/alv-workspace',
+      'apexlogs',
+      'orgs',
+      'demo',
+      'logs',
+      '2026-03-30',
+      '07L000000000002AA.log'
+    );
+    const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict(
+      '../../../../src/utils/workspace',
+      {
+        vscode: {
+          workspace: {
+            workspaceFolders: [{ uri: { fsPath: '/tmp/alv-workspace' } }]
+          }
+        },
+        '../../apps/vscode-extension/src/runtime/runtimeClient': {
+          runtimeClient: {
+            resolveCachedLogPath: async () => {
+              throw new Error('daemon unavailable');
+            }
+          }
+        },
+        fs: {
+          promises: {
+            readdir: async (target: string, options?: { withFileTypes?: boolean }) => {
+              if (target.endsWith(path.join('orgs', 'demo', 'logs'))) {
+                return [directoryEntry('2026-03-30')];
+              }
+              if (target.endsWith(path.join('orgs', 'demo', 'logs', '2026-03-30'))) {
+                return [];
+              }
+              if (options?.withFileTypes) {
+                return [];
+              }
+              return [];
+            },
+            stat: async (target: string) => {
+              if (target === localPath) {
+                return { isFile: () => true };
+              }
+              throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+            }
+          }
+        },
+        './logger': {
+          logInfo: () => undefined,
+          logWarn: () => undefined
+        }
+      }
+    );
+
+    const result = await workspaceModule.findExistingLogFile('07L000000000002AA', 'demo');
+
+    assert.equal(result, localPath);
+  });
+
+  test('ignores flat files when the runtime request fails', async () => {
     const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyquireStrict(
       '../../../../src/utils/workspace',
       {
@@ -94,7 +152,7 @@ suite('findExistingLogFile runtime lookup', () => {
 
     const result = await workspaceModule.findExistingLogFile('07L000000000002AA', 'demo');
 
-    assert.equal(result, localPath);
+    assert.equal(result, undefined);
   });
 
   test('ignores unsupported local log subdirectories when the runtime request fails', async () => {

--- a/apps/vscode-extension/src/test/findExistingLogFile.test.ts
+++ b/apps/vscode-extension/src/test/findExistingLogFile.test.ts
@@ -74,4 +74,34 @@ suite('integration: findExistingLogFile', () => {
       await fs.rm(dir, { recursive: true, force: true });
     }
   });
+
+  test('findExistingLogFile ignores flat files when username is provided', async () => {
+    const dir = getApexLogsDir();
+    const logId = '07L000000000004AA';
+    const flatFile = path.join(dir, `target@example.com_${logId}.log`);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(flatFile, 'body', 'utf8');
+
+    try {
+      const result = await findExistingLogFile(logId, 'target@example.com');
+      assert.equal(result, undefined);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('findExistingLogFile ignores flat files when no username is provided', async () => {
+    const dir = getApexLogsDir();
+    const logId = '07L000000000005AA';
+    const flatFile = path.join(dir, `${logId}.log`);
+    await fs.mkdir(dir, { recursive: true });
+    await fs.writeFile(flatFile, 'body', 'utf8');
+
+    try {
+      const result = await findExistingLogFile(logId);
+      assert.equal(result, undefined);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/apps/vscode-extension/src/test/getLogIdFromLogFilePath.test.ts
+++ b/apps/vscode-extension/src/test/getLogIdFromLogFilePath.test.ts
@@ -18,14 +18,16 @@ const workspaceModule: typeof import('../../../../src/utils/workspace') = proxyq
 const { getLogIdFromLogFilePath } = workspaceModule;
 
 suite('getLogIdFromLogFilePath', () => {
-  test('extracts log id from username-prefixed filenames', () => {
-    const result = getLogIdFromLogFilePath('/tmp/default_07L000000000001AA.log');
+  test('extracts log id from org-first log filenames', () => {
+    const result = getLogIdFromLogFilePath(
+      '/tmp/apexlogs/orgs/default@example.com/logs/2026-03-30/07L000000000001AA.log'
+    );
     assert.equal(result, '07L000000000001AA');
   });
 
-  test('extracts log id from legacy filenames', () => {
-    const result = getLogIdFromLogFilePath('/tmp/07L000000000001AA.log');
-    assert.equal(result, '07L000000000001AA');
+  test('returns undefined for username-prefixed flat filenames', () => {
+    const result = getLogIdFromLogFilePath('/tmp/default_07L000000000001AA.log');
+    assert.equal(result, undefined);
   });
 
   test('returns undefined for non-matching filenames', () => {

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -423,6 +423,9 @@ suite('LogService', () => {
       },
       fs: {
         promises: {
+          access: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          },
           writeFile: async () => {}
         }
       }
@@ -449,6 +452,118 @@ suite('LogService', () => {
     assert.ok(itemStatuses.includes('existing'));
     assert.ok(itemStatuses.includes('downloaded'));
     assert.ok(itemStatuses.includes('failed'));
+  });
+
+  test('ensureLogsSaved passes StartTime to the log file path builder', async () => {
+    const pathCalls: Array<{ username?: string; logId: string; startTime?: string }> = [];
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => 'body'
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'u', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'u', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async (
+          username: string | undefined,
+          logId: string,
+          startTime?: string
+        ) => {
+          pathCalls.push({ username, logId, startTime });
+          return { dir: '/tmp', filePath: `/tmp/${logId}.log` };
+        },
+        findExistingLogFile: async () => undefined
+      },
+      fs: {
+        promises: {
+          writeFile: async () => {}
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    await svc.ensureLogsSaved(
+      [{ Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.deepEqual(pathCalls, [
+      {
+        username: 'u',
+        logId: '07L000000000001AA',
+        startTime: '2026-03-30T18:39:58.000Z'
+      }
+    ]);
+  });
+
+  test('ensureLogsSaved materializes known StartTime caches into the dated path', async () => {
+    const logId = '07L0000000000DT1';
+    const existingPath = '/tmp/apexlogs/orgs/user@example.com/logs/unknown-date/07L0000000000DT1.log';
+    const datedPath = '/tmp/apexlogs/orgs/user@example.com/logs/2026-03-30/07L0000000000DT1.log';
+    const copies: Array<{ from: string; to: string }> = [];
+    let fetchCalls = 0;
+    let writeCalls = 0;
+
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => {
+          fetchCalls++;
+          return 'body';
+        }
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async (
+          username: string | undefined,
+          id: string,
+          startTime?: string
+        ) => {
+          assert.equal(username, 'user@example.com');
+          assert.equal(id, logId);
+          assert.equal(startTime, '2026-03-30T18:39:58.000Z');
+          return { dir: path.dirname(datedPath), filePath: datedPath };
+        },
+        findExistingLogFile: async (id: string, username?: string) =>
+          id === logId && username === 'user@example.com' ? existingPath : undefined
+      },
+      fs: {
+        promises: {
+          access: async (target: string): Promise<void> => {
+            if (target === datedPath) {
+              throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            }
+          },
+          mkdir: async () => {},
+          copyFile: async (from: string, to: string) => {
+            copies.push({ from, to });
+          },
+          writeFile: async () => {
+            writeCalls++;
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved(
+      [{ Id: logId, StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.deepEqual(copies, [{ from: existingPath, to: datedPath }]);
+    assert.equal(fetchCalls, 0, 'should not download when an older cached body exists');
+    assert.equal(writeCalls, 0, 'should not rewrite the body after copying the cache hit');
+    assert.equal(summary.success, 1);
+    assert.equal(summary.existing, 1);
+    assert.equal(summary.downloaded, 0);
   });
 
   test('ensureLogsSaved reports missing logs when downloadMissing is disabled', async () => {

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -685,6 +685,66 @@ suite('LogService', () => {
     assert.ok(statuses.includes('existing'));
   });
 
+  test('ensureLogsSaved reuses existing local cache when auth is unavailable', async () => {
+    const logId = '07L0000000000CA1';
+    const cachedPath = '/tmp/apexlogs/orgs/user@example.com/logs/2026-03-30/07L0000000000CA1.log';
+    const lookupCalls: Array<{ logId: string; username?: string }> = [];
+    let authCalls = 0;
+    let fetchCalls = 0;
+    let writeCalls = 0;
+
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => {
+          fetchCalls++;
+          return 'body';
+        }
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => {
+          throw new Error('should use runtime auth');
+        }
+      },
+      '../../apps/vscode-extension/src/runtime/runtimeClient': {
+        runtimeClient: {
+          getOrgAuth: async () => {
+            authCalls++;
+            throw new Error('auth unavailable');
+          }
+        }
+      },
+      '../utils/workspace': {
+        getLogFilePathWithUsername: async () => ({ dir: '/tmp', filePath: '/tmp/should-not-write.log' }),
+        findExistingLogFile: async (id: string, username?: string) => {
+          lookupCalls.push({ logId: id, username });
+          return id === logId && username === 'user@example.com' ? cachedPath : undefined;
+        }
+      },
+      fs: {
+        promises: {
+          mkdir: async () => {},
+          writeFile: async () => {
+            writeCalls++;
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved([{ Id: logId } as ApexLogRow], 'user@example.com');
+
+    assert.deepEqual(lookupCalls, [{ logId, username: 'user@example.com' }]);
+    assert.equal(authCalls, 0, 'should check the selected org cache before resolving auth');
+    assert.equal(fetchCalls, 0, 'should not download when a local cache exists');
+    assert.equal(writeCalls, 0, 'should not write when a local cache exists');
+    assert.equal(summary.success, 1);
+    assert.equal(summary.existing, 1);
+    assert.equal(summary.downloaded, 0);
+    assert.equal(summary.failed, 0);
+  });
+
   test('ensureLogsSaved reuses authHint without calling CLI auth again', async () => {
     let authCalls = 0;
     const writeTargets: string[] = [];

--- a/apps/vscode-extension/src/test/logService.test.ts
+++ b/apps/vscode-extension/src/test/logService.test.ts
@@ -2,6 +2,7 @@ import assert from 'assert/strict';
 import proxyquire from 'proxyquire';
 import * as vscode from 'vscode';
 import * as fs from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import * as os from 'os';
 import * as path from 'path';
 import type { OrgAuth } from '../../../../src/salesforce/types';
@@ -382,6 +383,7 @@ suite('LogService', () => {
         },
         fs: {
           promises: {
+            mkdir: async () => {},
             writeFile: async (target: string) => {
               await new Promise(resolve => setTimeout(resolve, 1));
               storedPath = target;
@@ -422,10 +424,12 @@ suite('LogService', () => {
         findExistingLogFile: async (logId: string) => (logId === '1' ? '/tmp/1.log' : undefined)
       },
       fs: {
+        constants: fsConstants,
         promises: {
           access: async (): Promise<never> => {
             throw Object.assign(new Error('missing'), { code: 'ENOENT' });
           },
+          mkdir: async () => {},
           writeFile: async () => {}
         }
       }
@@ -467,7 +471,7 @@ suite('LogService', () => {
       },
       ...createRuntimeClientStub({ username: 'u', accessToken: 't', instanceUrl: 'url' }),
       '../utils/workspace': {
-        getLogFilePathWithUsername: async (
+        buildLogFilePathWithUsername: (
           username: string | undefined,
           logId: string,
           startTime?: string
@@ -475,10 +479,17 @@ suite('LogService', () => {
           pathCalls.push({ username, logId, startTime });
           return { dir: '/tmp', filePath: `/tmp/${logId}.log` };
         },
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
         findExistingLogFile: async () => undefined
       },
       fs: {
         promises: {
+          access: async (): Promise<never> => {
+            throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+          },
+          mkdir: async () => {},
           writeFile: async () => {}
         }
       }
@@ -521,7 +532,7 @@ suite('LogService', () => {
       },
       ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
       '../utils/workspace': {
-        getLogFilePathWithUsername: async (
+        buildLogFilePathWithUsername: (
           username: string | undefined,
           id: string,
           startTime?: string
@@ -531,10 +542,14 @@ suite('LogService', () => {
           assert.equal(startTime, '2026-03-30T18:39:58.000Z');
           return { dir: path.dirname(datedPath), filePath: datedPath };
         },
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
         findExistingLogFile: async (id: string, username?: string) =>
           id === logId && username === 'user@example.com' ? existingPath : undefined
       },
       fs: {
+        constants: fsConstants,
         promises: {
           access: async (target: string): Promise<void> => {
             if (target === datedPath) {
@@ -542,7 +557,8 @@ suite('LogService', () => {
             }
           },
           mkdir: async () => {},
-          copyFile: async (from: string, to: string) => {
+          copyFile: async (from: string, to: string, mode?: number) => {
+            assert.equal(mode, fsConstants.COPYFILE_EXCL);
             copies.push({ from, to });
           },
           writeFile: async () => {
@@ -561,6 +577,68 @@ suite('LogService', () => {
     assert.deepEqual(copies, [{ from: existingPath, to: datedPath }]);
     assert.equal(fetchCalls, 0, 'should not download when an older cached body exists');
     assert.equal(writeCalls, 0, 'should not rewrite the body after copying the cache hit');
+    assert.equal(summary.success, 1);
+    assert.equal(summary.existing, 1);
+    assert.equal(summary.downloaded, 0);
+  });
+
+  test('ensureLogsSaved does not overwrite a dated cache created during materialization', async () => {
+    const logId = '07L0000000000DT2';
+    const existingPath = '/tmp/apexlogs/orgs/user@example.com/logs/unknown-date/07L0000000000DT2.log';
+    const datedPath = '/tmp/apexlogs/orgs/user@example.com/logs/2026-03-30/07L0000000000DT2.log';
+    let accessCalls = 0;
+    let copyCalls = 0;
+
+    const { LogService } = proxyquireStrict('../../../../src/services/logService', {
+      '../salesforce/http': {
+        fetchApexLogs: async () => [],
+        extractCodeUnitStartedFromLines: () => undefined,
+        fetchApexLogBody: async () => {
+          throw new Error('should not download when a cache hit exists');
+        }
+      },
+      '../salesforce/cli': {
+        getOrgAuth: async () => ({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' })
+      },
+      ...createRuntimeClientStub({ username: 'user@example.com', accessToken: 't', instanceUrl: 'url' }),
+      '../utils/workspace': {
+        buildLogFilePathWithUsername: () => ({ dir: path.dirname(datedPath), filePath: datedPath }),
+        getLogFilePathWithUsername: async () => {
+          throw new Error('dated path computation should not create directories early');
+        },
+        findExistingLogFile: async () => existingPath
+      },
+      fs: {
+        constants: fsConstants,
+        promises: {
+          access: async (target: string): Promise<void> => {
+            assert.equal(target, datedPath);
+            accessCalls++;
+            if (accessCalls === 1) {
+              throw Object.assign(new Error('missing'), { code: 'ENOENT' });
+            }
+          },
+          mkdir: async () => {},
+          copyFile: async (_from: string, _to: string, mode?: number) => {
+            copyCalls++;
+            assert.equal(mode, fsConstants.COPYFILE_EXCL);
+            throw Object.assign(new Error('exists'), { code: 'EEXIST' });
+          },
+          writeFile: async () => {
+            throw new Error('should not rewrite the dated cache');
+          }
+        }
+      }
+    });
+
+    const svc = new LogService(1);
+    const summary = await svc.ensureLogsSaved(
+      [{ Id: logId, StartTime: '2026-03-30T18:39:58.000Z' } as ApexLogRow],
+      'default'
+    );
+
+    assert.equal(copyCalls, 1);
+    assert.equal(accessCalls, 2, 'should re-check the dated path after EEXIST');
     assert.equal(summary.success, 1);
     assert.equal(summary.existing, 1);
     assert.equal(summary.downloaded, 0);
@@ -635,6 +713,7 @@ suite('LogService', () => {
       },
       fs: {
         promises: {
+          mkdir: async () => {},
           writeFile: async (target: string) => {
             writeTargets.push(target);
           }

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -401,11 +401,11 @@ suite('SfLogsViewProvider behavior', () => {
     const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
     cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
     cli.logsList = async () => [
-      { Id: '07L000000000001AA', LogLength: 10 },
-      { Id: '07L000000000002AA', LogLength: 20 }
+      { Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z', LogLength: 10 },
+      { Id: '07L000000000002AA', StartTime: '2026-03-30T18:40:58.000Z', LogLength: 20 }
     ];
-    const triageCalls: Array<{ logIds: string[]; workspaceRoot?: string }> = [];
-    cli.logsTriage = async (params: { logIds: string[]; workspaceRoot?: string }) => {
+    const triageCalls: Array<{ logIds: string[]; logStartTimes?: Record<string, string>; workspaceRoot?: string }> = [];
+    cli.logsTriage = async (params: { logIds: string[]; logStartTimes?: Record<string, string>; workspaceRoot?: string }) => {
       triageCalls.push(params);
       return [
         {
@@ -462,6 +462,10 @@ suite('SfLogsViewProvider behavior', () => {
     assert.equal(errorHead?.primaryReason, 'Fatal exception');
     assert.equal(errorHead?.reasons?.[0]?.code, 'fatal_exception');
     assert.equal(triageCalls[0]?.workspaceRoot, '/tmp/alv-workspace');
+    assert.deepEqual(triageCalls[0]?.logStartTimes, {
+      '07L000000000001AA': '2026-03-30T18:39:58.000Z',
+      '07L000000000002AA': '2026-03-30T18:40:58.000Z'
+    });
   });
 
   test('refresh cancellation aborts background error scan', async () => {

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -6,7 +6,7 @@ use alv_core::{
 use alv_protocol::messages::{InitializeParams, InitializeResult, RuntimeCapabilities};
 use serde_json::Value;
 use std::{
-    collections::HashMap,
+    collections::{BTreeMap, HashMap},
     fmt::Write as _,
     io::{self, BufRead, Write},
     sync::mpsc::{self, RecvTimeoutError},
@@ -442,6 +442,9 @@ fn parse_request_line(request: &str) -> Result<ParsedRequest, String> {
             log_ids: string_vec_field(&params, "logIds")
                 .or_else(|| string_vec_field(&params, "log_ids"))
                 .unwrap_or_default(),
+            log_start_times: string_map_field(&params, "logStartTimes")
+                .or_else(|| string_map_field(&params, "log_start_times"))
+                .unwrap_or_default(),
             username: params
                 .get("username")
                 .and_then(Value::as_str)
@@ -530,6 +533,23 @@ fn string_vec_field(source: &Value, field: &str) -> Option<Vec<String>> {
     })
 }
 
+fn string_map_field(source: &Value, field: &str) -> Option<BTreeMap<String, String>> {
+    source.get(field).and_then(Value::as_object).map(|items| {
+        items
+            .iter()
+            .filter_map(|(key, value)| {
+                let key = key.trim();
+                let value = value.as_str()?.trim();
+                if key.is_empty() || value.is_empty() {
+                    None
+                } else {
+                    Some((key.to_string(), value.to_string()))
+                }
+            })
+            .collect()
+    })
+}
+
 fn escape_json(value: &str) -> String {
     let mut escaped = String::new();
     for character in value.chars() {
@@ -591,5 +611,42 @@ mod tests {
         assert_eq!(params.username.as_deref(), Some("selected@example.com"));
         assert_eq!(params.workspace_root.as_deref(), Some("/tmp/demo"));
         assert_eq!(params.log_ids, vec!["07L000000000001AA".to_string()]);
+    }
+
+    #[test]
+    fn parse_request_line_reads_logs_triage_start_times() {
+        let parsed = parse_request_line(
+            r#"{
+              "jsonrpc":"2.0",
+              "id":"triage:1",
+              "method":"logs/triage",
+              "params":{
+                "logIds":["07L000000000001AA"],
+                "logStartTimes":{"07L000000000001AA":"2026-03-30T18:39:58.000Z"},
+                "username":"selected@example.com",
+                "workspaceRoot":"/tmp/demo"
+              }
+            }"#,
+        )
+        .expect("logs/triage request should parse");
+
+        let ParsedRequest::Call(call) = parsed else {
+            panic!("expected a normal call");
+        };
+
+        let ServerOperation::LogsTriage(params) = call.operation else {
+            panic!("expected logs/triage operation");
+        };
+
+        assert_eq!(params.username.as_deref(), Some("selected@example.com"));
+        assert_eq!(params.workspace_root.as_deref(), Some("/tmp/demo"));
+        assert_eq!(params.log_ids, vec!["07L000000000001AA".to_string()]);
+        assert_eq!(
+            params
+                .log_start_times
+                .get("07L000000000001AA")
+                .map(String::as_str),
+            Some("2026-03-30T18:39:58.000Z")
+        );
     }
 }

--- a/crates/alv-app-server/tests/app_server_smoke.rs
+++ b/crates/alv-app-server/tests/app_server_smoke.rs
@@ -176,10 +176,15 @@ fn app_server_smoke_routes_logs_search_and_triage_requests() {
     );
 
     let workspace_root = make_temp_dir("workspace");
-    let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should be created");
+    let cache_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&cache_dir).expect("apexlogs dir should be created");
     fs::write(
-        apexlogs_dir.join("default_07L000000000001AA.log"),
+        cache_dir.join("07L000000000001AA.log"),
         "09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|AccountService.handle\n09:00:01.0|EXCEPTION_THROWN|System.NullPointerException: boom\n",
     )
     .expect("cached log should be writable");

--- a/crates/alv-cli/src/commands/logs.rs
+++ b/crates/alv-cli/src/commands/logs.rs
@@ -99,15 +99,7 @@ fn run_status(args: LogStatusArgs) -> Result<i32, String> {
     let safe_target_org = log_store::safe_target_org(&resolved_username);
     let apexlogs_root = log_store::resolve_apexlogs_root(Some(&workspace_root));
     let entry = sync_state.orgs.get(&resolved_username);
-    let legacy_scopes =
-        legacy_scope_candidates(args.target_org.as_deref(), Some(&resolved_username));
-    let legacy_scope_refs = legacy_scopes.iter().map(String::as_str).collect::<Vec<_>>();
-    let log_count = discover_local_log_ids(
-        Some(&workspace_root),
-        Some(&resolved_username),
-        &legacy_scope_refs,
-    )?
-    .len();
+    let log_count = discover_local_log_ids(Some(&workspace_root), Some(&resolved_username))?.len();
 
     let result = StatusResult {
         target_org: resolved_username,
@@ -150,14 +142,7 @@ fn run_search(args: LogSearchArgs) -> Result<i32, String> {
         Some(&workspace_root),
         &sync_state,
     )?;
-    let legacy_scopes =
-        legacy_scope_candidates(args.target_org.as_deref(), resolved_username.as_deref());
-    let legacy_scope_refs = legacy_scopes.iter().map(String::as_str).collect::<Vec<_>>();
-    let log_ids = discover_local_log_ids(
-        Some(&workspace_root),
-        resolved_username.as_deref(),
-        &legacy_scope_refs,
-    )?;
+    let log_ids = discover_local_log_ids(Some(&workspace_root), resolved_username.as_deref())?;
     let result = search_query(&SearchQueryParams {
         query: query.clone(),
         log_ids: log_ids.clone(),
@@ -394,58 +379,24 @@ fn find_org_metadata_by_alias_in_root(
 fn discover_local_log_ids(
     workspace_root: Option<&str>,
     resolved_username: Option<&str>,
-    legacy_scopes: &[&str],
 ) -> Result<Vec<String>, String> {
     let mut ids = BTreeSet::new();
     let apexlogs_root = log_store::resolve_apexlogs_root(workspace_root);
 
     if let Some(target_org) = resolved_username {
-        collect_log_ids_in_tree(
+        collect_log_ids_in_logs_dir(
             &log_store::org_dir(workspace_root, target_org).join("logs"),
             &mut ids,
         )?;
-        let scopes = if legacy_scopes.is_empty() {
-            vec![target_org]
-        } else {
-            legacy_scopes.to_vec()
-        };
-        for scope in scopes {
-            collect_legacy_scoped_log_ids(&apexlogs_root, scope, &mut ids)?;
-        }
     } else {
-        collect_log_ids_in_tree(&apexlogs_root.join("orgs"), &mut ids)?;
-        collect_legacy_flat_log_ids(&apexlogs_root, &mut ids)?;
+        collect_log_ids_in_orgs_root(&apexlogs_root.join("orgs"), &mut ids)?;
     }
 
     Ok(ids.into_iter().collect())
 }
 
-fn legacy_scope_candidates(
-    requested_target_org: Option<&str>,
-    resolved_username: Option<&str>,
-) -> Vec<String> {
-    let mut scopes = Vec::new();
-
-    if let Some(resolved_username) = resolved_username
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        scopes.push(resolved_username.to_string());
-    }
-
-    if let Some(requested_target_org) = requested_target_org
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-        .filter(|value| !scopes.iter().any(|existing| existing == value))
-    {
-        scopes.push(requested_target_org.to_string());
-    }
-
-    scopes
-}
-
-fn collect_log_ids_in_tree(root: &Path, ids: &mut BTreeSet<String>) -> Result<(), String> {
-    if !root.exists() {
+fn collect_log_ids_in_orgs_root(root: &Path, ids: &mut BTreeSet<String>) -> Result<(), String> {
+    if !root.is_dir() {
         return Ok(());
     }
 
@@ -454,91 +405,81 @@ fn collect_log_ids_in_tree(root: &Path, ids: &mut BTreeSet<String>) -> Result<()
     {
         let entry = entry.map_err(|error| format!("failed to read {}: {error}", root.display()))?;
         let path = entry.path();
-        if path.is_dir() {
-            collect_log_ids_in_tree(&path, ids)?;
+        if !path.is_dir() {
             continue;
         }
 
-        if path.extension().and_then(|value| value.to_str()) != Some("log") {
+        collect_log_ids_in_logs_dir(&path.join("logs"), ids)?;
+    }
+
+    Ok(())
+}
+
+fn collect_log_ids_in_logs_dir(logs_root: &Path, ids: &mut BTreeSet<String>) -> Result<(), String> {
+    if !logs_root.is_dir() {
+        return Ok(());
+    }
+
+    for entry in fs::read_dir(logs_root)
+        .map_err(|error| format!("failed to read {}: {error}", logs_root.display()))?
+    {
+        let entry =
+            entry.map_err(|error| format!("failed to read {}: {error}", logs_root.display()))?;
+        let day_dir = entry.path();
+        if !day_dir.is_dir()
+            || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref())
+        {
             continue;
         }
 
-        if let Some(log_id) = extract_log_id(&path) {
-            ids.insert(log_id);
+        for file_entry in fs::read_dir(&day_dir)
+            .map_err(|error| format!("failed to read {}: {error}", day_dir.display()))?
+        {
+            let file_entry = file_entry
+                .map_err(|error| format!("failed to read {}: {error}", day_dir.display()))?;
+            let path = file_entry.path();
+            if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("log") {
+                continue;
+            }
+
+            if let Some(log_id) = extract_log_id(&path) {
+                ids.insert(log_id);
+            }
         }
     }
 
     Ok(())
 }
 
-fn collect_legacy_flat_log_ids(root: &Path, ids: &mut BTreeSet<String>) -> Result<(), String> {
-    if !root.exists() {
-        return Ok(());
-    }
-
-    for entry in
-        fs::read_dir(root).map_err(|error| format!("failed to read {}: {error}", root.display()))?
-    {
-        let entry = entry.map_err(|error| format!("failed to read {}: {error}", root.display()))?;
-        let path = entry.path();
-        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("log") {
-            continue;
-        }
-
-        if let Some(log_id) = extract_log_id(&path) {
-            ids.insert(log_id);
-        }
-    }
-
-    Ok(())
+fn is_supported_log_day_dir_name(name: &str) -> bool {
+    name == "unknown-date" || is_yyyy_mm_dd(name)
 }
 
-fn collect_legacy_scoped_log_ids(
-    root: &Path,
-    target_org: &str,
-    ids: &mut BTreeSet<String>,
-) -> Result<(), String> {
-    if !root.exists() {
-        return Ok(());
-    }
-
-    let prefix = format!("{}_", log_store::safe_target_org(target_org));
-    for entry in
-        fs::read_dir(root).map_err(|error| format!("failed to read {}: {error}", root.display()))?
-    {
-        let entry = entry.map_err(|error| format!("failed to read {}: {error}", root.display()))?;
-        let path = entry.path();
-        if !path.is_file() || path.extension().and_then(|value| value.to_str()) != Some("log") {
-            continue;
-        }
-
-        let Some(file_name) = path.file_name().and_then(|value| value.to_str()) else {
-            continue;
-        };
-        let is_bare = !file_name.contains('_');
-        if !file_name.starts_with(&prefix) && !is_bare {
-            continue;
-        }
-
-        if let Some(log_id) = extract_log_id(&path) {
-            ids.insert(log_id);
-        }
-    }
-
-    Ok(())
+fn is_yyyy_mm_dd(value: &str) -> bool {
+    matches!(
+        value.as_bytes(),
+        [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
+            if y1.is_ascii_digit()
+                && y2.is_ascii_digit()
+                && y3.is_ascii_digit()
+                && y4.is_ascii_digit()
+                && m1.is_ascii_digit()
+                && m2.is_ascii_digit()
+                && d1.is_ascii_digit()
+                && d2.is_ascii_digit()
+    )
 }
 
 fn extract_log_id(path: &Path) -> Option<String> {
     let stem = path.file_stem()?.to_str()?.trim();
-    if stem.is_empty() {
-        return None;
-    }
-
-    let log_id = stem.rsplit('_').next().unwrap_or(stem).trim();
-    if log_id.is_empty() {
-        None
+    if (15..=18).contains(&stem.len())
+        && stem
+            .chars()
+            .all(|character| character.is_ascii_alphanumeric())
+    {
+        Some(stem.to_string())
     } else {
-        Some(log_id.to_string())
+        None
     }
 }
 

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -539,48 +539,6 @@ fn cli_smoke_logs_search_json_stays_local_first() {
 }
 
 #[test]
-fn cli_smoke_logs_search_json_keeps_alias_scoped_legacy_logs() {
-    let _guard = lock_test_guard();
-
-    let unique = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("clock should be after unix epoch")
-        .as_nanos();
-    let workspace_root = std::env::temp_dir().join(format!("alv-cli-search-legacy-alias-{unique}"));
-    let apexlogs_root = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_root).expect("apexlogs dir should exist");
-    fs::write(
-        apexlogs_root.join("ALV_ALIAS_07L000000000005AA.log"),
-        "09:00:00.0|FATAL_ERROR|System.NullPointerException\n",
-    )
-    .expect("legacy alias-scoped log should be writable");
-
-    let output = apex_log_viewer_command()
-        .current_dir(&workspace_root)
-        .env(
-            "ALV_TEST_SF_ORG_DISPLAY_JSON",
-            r#"{"result":{"username":"default@example.com","accessToken":"token","instanceUrl":"https://default.example.com"}}"#,
-        )
-        .args([
-            "logs",
-            "search",
-            "NullPointerException",
-            "--json",
-            "--target-org",
-            "ALV_ALIAS",
-        ])
-        .output()
-        .expect("search should execute");
-
-    assert!(output.status.success(), "search should exit successfully");
-    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
-    assert_eq!(json["target_org"], "default@example.com");
-    assert_eq!(json["matches"][0]["log_id"], "07L000000000005AA");
-
-    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
-}
-
-#[test]
 fn cli_smoke_logs_search_json_resolves_alias_without_local_metadata() {
     let _guard = lock_test_guard();
 
@@ -675,7 +633,7 @@ fn cli_smoke_logs_search_json_uses_local_alias_resolution_without_auth() {
 }
 
 #[test]
-fn cli_smoke_logs_search_json_falls_back_to_alias_cache_without_auth_or_metadata() {
+fn cli_smoke_logs_search_json_uses_alias_org_first_cache_without_auth_or_metadata() {
     let _guard = lock_test_guard();
 
     let unique = SystemTime::now()
@@ -684,13 +642,18 @@ fn cli_smoke_logs_search_json_falls_back_to_alias_cache_without_auth_or_metadata
         .as_nanos();
     let workspace_root =
         std::env::temp_dir().join(format!("alv-cli-search-alias-offline-{unique}"));
-    let apexlogs_root = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_root).expect("apexlogs dir should exist");
+    let log_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("ALV_ALIAS")
+        .join("logs")
+        .join("2026-03-30");
+    fs::create_dir_all(&log_dir).expect("log dir should exist");
     fs::write(
-        apexlogs_root.join("ALV_ALIAS_07L000000000007AA.log"),
+        log_dir.join("07L000000000007AA.log"),
         "09:00:00.0|FATAL_ERROR|AliasOfflineNeedle\n",
     )
-    .expect("legacy alias-scoped log should be writable");
+    .expect("alias-scoped log should be writable");
 
     let output = apex_log_viewer_command()
         .current_dir(&workspace_root)

--- a/crates/alv-core/src/log_store.rs
+++ b/crates/alv-core/src/log_store.rs
@@ -202,39 +202,19 @@ pub fn find_cached_log_path(
         return None;
     }
 
-    let root = resolve_apexlogs_root(workspace_root);
-
     if let Some(username) = resolved_username.filter(|value| !value.trim().is_empty()) {
         let scoped_root = org_dir(workspace_root, username).join("logs");
         if let Some(found) = find_log_in_logs_dir(&scoped_root, log_id) {
             return Some(found);
         }
 
-        let safe_username = safe_target_org(username);
-        for candidate in [
-            root.join(format!("{safe_username}_{log_id}.log")),
-            root.join(format!("{log_id}.log")),
-        ] {
-            if candidate.is_file() {
-                return Some(candidate);
-            }
-        }
-
         return None;
     }
 
+    let root = resolve_apexlogs_root(workspace_root);
     let orgs_root = root.join("orgs");
     if let Some(found) = find_log_in_orgs_root(&orgs_root, log_id) {
         return Some(found);
-    }
-
-    let entries = fs::read_dir(&root).ok()?;
-    for entry in entries.flatten() {
-        let path = entry.path();
-        let file_name = path.file_name()?.to_string_lossy();
-        if file_name == format!("{log_id}.log") || file_name.ends_with(&format!("_{log_id}.log")) {
-            return Some(path);
-        }
     }
 
     None

--- a/crates/alv-core/src/log_store.rs
+++ b/crates/alv-core/src/log_store.rs
@@ -94,15 +94,24 @@ pub fn log_file_path_for_start_time(
     start_time: &str,
     log_id: &str,
 ) -> PathBuf {
-    let day = start_time
-        .get(0..10)
-        .filter(|value| value.len() == 10)
-        .unwrap_or("unknown-date");
+    let day = log_day_dir_name_for_start_time(start_time);
 
     org_dir(workspace_root, raw_org)
         .join("logs")
         .join(day)
         .join(format!("{log_id}.log"))
+}
+
+fn log_day_dir_name_for_start_time(start_time: &str) -> &str {
+    let Some(day) = start_time.get(0..10) else {
+        return "unknown-date";
+    };
+
+    if is_yyyy_mm_dd(day) {
+        day
+    } else {
+        "unknown-date"
+    }
 }
 
 pub fn unknown_date_log_path(workspace_root: Option<&str>, raw_org: &str, log_id: &str) -> PathBuf {
@@ -238,7 +247,9 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
 
     for entry in fs::read_dir(logs_root).ok()?.flatten() {
         let day_dir = entry.path();
-        if !day_dir.is_dir() || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref()) {
+        if !day_dir.is_dir()
+            || !is_supported_log_day_dir_name(entry.file_name().to_string_lossy().as_ref())
+        {
             continue;
         }
 
@@ -251,20 +262,23 @@ fn find_log_in_logs_dir(logs_root: &Path, log_id: &str) -> Option<PathBuf> {
     None
 }
 
-fn is_supported_log_day_dir_name(name: &str) -> bool {
-    name == "unknown-date"
-        || matches!(
-            name.as_bytes(),
-            [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
-                if y1.is_ascii_digit()
-                    && y2.is_ascii_digit()
-                    && y3.is_ascii_digit()
-                    && y4.is_ascii_digit()
-                    && m1.is_ascii_digit()
-                    && m2.is_ascii_digit()
-                    && d1.is_ascii_digit()
-                    && d2.is_ascii_digit()
-        )
+pub(crate) fn is_supported_log_day_dir_name(name: &str) -> bool {
+    name == "unknown-date" || is_yyyy_mm_dd(name)
+}
+
+fn is_yyyy_mm_dd(value: &str) -> bool {
+    matches!(
+        value.as_bytes(),
+        [y1, y2, y3, y4, b'-', m1, m2, b'-', d1, d2]
+            if y1.is_ascii_digit()
+                && y2.is_ascii_digit()
+                && y3.is_ascii_digit()
+                && y4.is_ascii_digit()
+                && m1.is_ascii_digit()
+                && m2.is_ascii_digit()
+                && d1.is_ascii_digit()
+                && d2.is_ascii_digit()
+    )
 }
 
 fn find_log_in_orgs_root(orgs_root: &Path, log_id: &str) -> Option<PathBuf> {

--- a/crates/alv-core/src/logs.rs
+++ b/crates/alv-core/src/logs.rs
@@ -275,16 +275,6 @@ pub fn run_sf_log_list_json_detailed_with_cancel(
     run_tooling_logs_query_with_cancel_detailed(&auth, params, cancellation)
 }
 
-pub fn resolve_apex_logs_dir(workspace_root: Option<&str>) -> PathBuf {
-    match workspace_root
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        Some(root) => Path::new(root).join("apexlogs"),
-        None => env::temp_dir().join("apexlogs"),
-    }
-}
-
 pub fn find_cached_log_path(workspace_root: Option<&str>, log_id: &str) -> Option<PathBuf> {
     crate::log_store::find_cached_log_path(workspace_root, log_id, None)
 }
@@ -309,9 +299,11 @@ pub fn ensure_log_file_cached_with_cancel(
         return Ok(existing);
     }
 
-    let target_dir = resolve_apex_logs_dir(workspace_root);
-    let safe_user = sanitize_username(username);
-    let target_path = target_dir.join(format!("{safe_user}_{log_id}.log"));
+    let target_path = crate::log_store::unknown_date_log_path(
+        workspace_root,
+        username.unwrap_or("default"),
+        log_id,
+    );
 
     download_log_to_path_with_cancel(log_id, username, &target_path, cancellation)
 }
@@ -478,22 +470,6 @@ fn maybe_fixture_log_list_json(cancellation: &CancellationToken) -> Result<Optio
     maybe_test_delay(TEST_LOGS_CANCEL_DELAY_MS_ENV, cancellation)?;
     cancellation.check_cancelled()?;
     Ok(Some(fixture))
-}
-
-fn sanitize_username(username: Option<&str>) -> String {
-    let trimmed = username.unwrap_or("default").trim();
-    let sanitized = trimmed
-        .chars()
-        .map(|character| match character {
-            'a'..='z' | 'A'..='Z' | '0'..='9' | '_' | '.' | '@' | '-' => character,
-            _ => '_',
-        })
-        .collect::<String>();
-    if sanitized.is_empty() {
-        "default".to_string()
-    } else {
-        sanitized
-    }
 }
 
 fn escape_soql_literal(value: &str) -> String {

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -12,7 +12,6 @@ use std::{
 };
 
 const TEST_SEARCH_LINE_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_LINE_DELAY_MS";
-const TEST_SEARCH_ROOT_INDEX_DELAY_MS_ENV: &str = "ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS";
 const CANCELLED_MESSAGE: &str = "request cancelled";
 type CachedLogPathIndex = BTreeMap<String, Vec<PathBuf>>;
 
@@ -79,7 +78,6 @@ pub fn search_query_with_cancel(
         params.workspace_root.as_deref(),
         raw_username_hint,
         canonical_username.as_deref(),
-        &log_ids,
         cancellation,
     )?;
 
@@ -130,10 +128,6 @@ pub fn search_query_with_cancel(
 
 fn maybe_test_delay(cancellation: &CancellationToken) -> io::Result<()> {
     maybe_test_delay_for_env(TEST_SEARCH_LINE_DELAY_MS_ENV, cancellation)
-}
-
-fn maybe_test_root_index_delay(cancellation: &CancellationToken) -> io::Result<()> {
-    maybe_test_delay_for_env(TEST_SEARCH_ROOT_INDEX_DELAY_MS_ENV, cancellation)
 }
 
 fn maybe_test_delay_for_env(env_name: &str, cancellation: &CancellationToken) -> io::Result<()> {
@@ -263,28 +257,18 @@ fn build_cached_log_path_index(
     workspace_root: Option<&str>,
     raw_username_hint: Option<&str>,
     canonical_username: Option<&str>,
-    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
     match canonical_username {
-        Some(username) => build_scoped_cached_log_path_index(
-            workspace_root,
-            raw_username_hint,
-            username,
-            requested_log_ids,
-            cancellation,
-        ),
+        Some(username) => {
+            build_scoped_cached_log_path_index(workspace_root, username, cancellation)
+        }
         None => {
             if let Some(raw_username) = raw_username_hint
                 .map(str::trim)
                 .filter(|value| !value.is_empty())
             {
-                build_raw_scoped_cached_log_path_index(
-                    workspace_root,
-                    raw_username,
-                    requested_log_ids,
-                    cancellation,
-                )
+                build_raw_scoped_cached_log_path_index(workspace_root, raw_username, cancellation)
             } else {
                 build_unscoped_cached_log_path_index(workspace_root, cancellation)
             }
@@ -296,11 +280,13 @@ fn build_unscoped_cached_log_path_index(
     workspace_root: Option<&str>,
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
     let mut index = CachedLogPathIndex::new();
 
-    collect_log_path_index_in_tree(&root.join("orgs"), cancellation, &mut index)?;
-    collect_root_log_path_index(&root, &[], true, cancellation, &mut index)?;
+    collect_log_path_index_in_orgs_root(
+        &log_store::resolve_apexlogs_root(workspace_root).join("orgs"),
+        cancellation,
+        &mut index,
+    )?;
     sort_and_dedup_path_index(&mut index);
 
     Ok(index)
@@ -308,37 +294,13 @@ fn build_unscoped_cached_log_path_index(
 
 fn build_scoped_cached_log_path_index(
     workspace_root: Option<&str>,
-    raw_username: Option<&str>,
     canonical_username: &str,
-    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
     let mut index = CachedLogPathIndex::new();
 
-    collect_log_path_index_in_tree(
+    collect_log_path_index_in_logs_dir(
         &log_store::org_dir(workspace_root, canonical_username).join("logs"),
-        cancellation,
-        &mut index,
-    )?;
-
-    let canonical_safe = log_store::safe_target_org(canonical_username);
-    let mut allowed_prefixes = vec![canonical_safe];
-    if let Some(raw_username) = raw_username
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let raw_safe = log_store::safe_target_org(raw_username);
-        if raw_safe != allowed_prefixes[0] {
-            allowed_prefixes.push(raw_safe);
-        }
-    }
-
-    collect_requested_root_log_paths(
-        &root,
-        requested_log_ids,
-        &allowed_prefixes,
-        true,
         cancellation,
         &mut index,
     )?;
@@ -350,25 +312,12 @@ fn build_scoped_cached_log_path_index(
 fn build_raw_scoped_cached_log_path_index(
     workspace_root: Option<&str>,
     raw_username: &str,
-    requested_log_ids: &[String],
     cancellation: &CancellationToken,
 ) -> Result<CachedLogPathIndex, String> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
     let mut index = CachedLogPathIndex::new();
 
-    collect_log_path_index_in_tree(
+    collect_log_path_index_in_logs_dir(
         &log_store::org_dir(workspace_root, raw_username).join("logs"),
-        cancellation,
-        &mut index,
-    )?;
-
-    let raw_safe = log_store::safe_target_org(raw_username);
-    let allowed_prefixes = vec![raw_safe];
-    collect_requested_root_log_paths(
-        &root,
-        requested_log_ids,
-        &allowed_prefixes,
-        true,
         cancellation,
         &mut index,
     )?;
@@ -377,138 +326,81 @@ fn build_raw_scoped_cached_log_path_index(
     Ok(index)
 }
 
-fn collect_log_path_index_in_tree(
-    root: &Path,
+fn collect_log_path_index_in_orgs_root(
+    orgs_root: &Path,
     cancellation: &CancellationToken,
     index: &mut CachedLogPathIndex,
 ) -> Result<(), String> {
-    if !root.exists() {
+    if !orgs_root.is_dir() {
         return Ok(());
     }
 
-    let Ok(entries) = fs::read_dir(root) else {
-        return Ok(());
-    };
-
-    for entry in entries.flatten() {
-        cancellation.check_cancelled()?;
-
-        let path = entry.path();
-        if path.is_dir() {
-            collect_log_path_index_in_tree(&path, cancellation, index)?;
-            continue;
-        }
-
-        let Some(file_name) = path.file_name() else {
-            continue;
-        };
-        let file_name = file_name.to_string_lossy().into_owned();
-        let Some(log_id) = file_name.strip_suffix(".log") else {
-            continue;
-        };
-        if log_id.trim().is_empty() {
-            continue;
-        }
-
-        push_index_path(index, &log_id, path);
-    }
-
-    Ok(())
-}
-
-fn collect_requested_root_log_paths(
-    root: &Path,
-    requested_log_ids: &[String],
-    allowed_prefixes: &[String],
-    include_bare_log: bool,
-    cancellation: &CancellationToken,
-    index: &mut CachedLogPathIndex,
-) -> Result<(), String> {
-    for log_id in requested_log_ids {
-        cancellation.check_cancelled()?;
-
-        for candidate in root_log_candidates(root, log_id, allowed_prefixes, include_bare_log) {
-            if candidate.is_file() {
-                push_index_path(index, log_id, candidate);
-            }
-        }
-    }
-
-    Ok(())
-}
-
-fn collect_root_log_path_index(
-    root: &Path,
-    allowed_prefixes: &[String],
-    include_all_prefixed_paths: bool,
-    cancellation: &CancellationToken,
-    index: &mut CachedLogPathIndex,
-) -> Result<(), String> {
-    let Ok(entries) = fs::read_dir(root) else {
+    let Ok(entries) = fs::read_dir(orgs_root) else {
         return Ok(());
     };
 
     for entry in entries.flatten() {
         cancellation.check_cancelled()?;
-        maybe_test_root_index_delay(cancellation).map_err(|error| error.to_string())?;
-
-        let path = entry.path();
-        if !path.is_file() {
+        let org_dir = entry.path();
+        if !org_dir.is_dir() {
             continue;
         }
 
-        let Some(file_name) = path.file_name() else {
+        collect_log_path_index_in_logs_dir(&org_dir.join("logs"), cancellation, index)?;
+    }
+
+    Ok(())
+}
+
+fn collect_log_path_index_in_logs_dir(
+    logs_root: &Path,
+    cancellation: &CancellationToken,
+    index: &mut CachedLogPathIndex,
+) -> Result<(), String> {
+    if !logs_root.is_dir() {
+        return Ok(());
+    }
+
+    let Ok(day_entries) = fs::read_dir(logs_root) else {
+        return Ok(());
+    };
+
+    for day_entry in day_entries.flatten() {
+        cancellation.check_cancelled()?;
+        let day_dir = day_entry.path();
+        if !day_dir.is_dir()
+            || !log_store::is_supported_log_day_dir_name(
+                day_entry.file_name().to_string_lossy().as_ref(),
+            )
+        {
             continue;
-        };
-        let file_name = file_name.to_string_lossy().into_owned();
-        let Some((prefix, log_id)) = parse_root_log_file_name(&file_name) else {
+        }
+
+        let Ok(file_entries) = fs::read_dir(&day_dir) else {
             continue;
         };
 
-        if let Some(prefix) = prefix {
-            let include_prefixed = include_all_prefixed_paths
-                || allowed_prefixes
-                    .iter()
-                    .any(|allowed_prefix| allowed_prefix == prefix);
-            if !include_prefixed {
+        for file_entry in file_entries.flatten() {
+            cancellation.check_cancelled()?;
+            let path = file_entry.path();
+            if !path.is_file() {
                 continue;
             }
+            let Some(file_name) = path.file_name() else {
+                continue;
+            };
+            let file_name = file_name.to_string_lossy().into_owned();
+            let Some(log_id) = file_name.strip_suffix(".log") else {
+                continue;
+            };
+            if log_id.trim().is_empty() {
+                continue;
+            }
+            push_index_path(index, log_id, path);
         }
-
-        if log_id.trim().is_empty() {
-            continue;
-        }
-        push_index_path(index, &log_id, path);
     }
 
     Ok(())
-}
-
-fn root_log_candidates(
-    root: &Path,
-    log_id: &str,
-    allowed_prefixes: &[String],
-    include_bare_log: bool,
-) -> Vec<PathBuf> {
-    let mut candidates = Vec::new();
-    for prefix in allowed_prefixes {
-        candidates.push(root.join(format!("{prefix}_{log_id}.log")));
-    }
-    if include_bare_log {
-        candidates.push(root.join(format!("{log_id}.log")));
-    }
-    candidates
-}
-
-fn parse_root_log_file_name(file_name: &str) -> Option<(Option<&str>, &str)> {
-    let stem = file_name.strip_suffix(".log")?;
-    match stem.rsplit_once('_') {
-        Some((prefix, log_id)) if !prefix.is_empty() && !log_id.is_empty() => {
-            Some((Some(prefix), log_id))
-        }
-        _ if !stem.is_empty() => Some((None, stem)),
-        _ => None,
-    }
 }
 
 fn push_index_path(index: &mut CachedLogPathIndex, log_id: &str, path: PathBuf) {

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use std::{
     collections::BTreeMap,
     fs::{self, File},
-    io::{BufRead, BufReader},
+    io::{copy, BufRead, BufReader},
     path::{Path, PathBuf},
     thread,
     time::Duration,
@@ -192,15 +192,42 @@ fn materialize_existing_at_preferred_path(
         fs::create_dir_all(parent)
             .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
     }
-    match fs::copy(existing_path, preferred_path) {
-        Ok(_) => Ok(Some(preferred_path.to_path_buf())),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
-        Err(error) => Err(format!(
+    let mut source = match File::open(existing_path) {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => {
+            return Err(format!(
+                "failed to read cached log {}: {error}",
+                existing_path.display()
+            ))
+        }
+    };
+    let mut destination = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(preferred_path)
+    {
+        Ok(file) => file,
+        Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+            return Ok(Some(preferred_path.to_path_buf()));
+        }
+        Err(error) => {
+            return Err(format!(
+                "failed to create cached log {}: {error}",
+                preferred_path.display()
+            ));
+        }
+    };
+    if let Err(error) = copy(&mut source, &mut destination) {
+        let _ = fs::remove_file(preferred_path);
+        return Err(format!(
             "failed to materialize cached log {} from {}: {error}",
             preferred_path.display(),
             existing_path.display()
-        )),
+        ));
     }
+
+    Ok(Some(preferred_path.to_path_buf()))
 }
 
 fn summarize_file(

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -294,18 +294,12 @@ fn resolve_canonical_username(username: Option<&str>) -> Result<Option<String>, 
 fn find_scoped_cached_log_path(
     workspace_root: Option<&str>,
     log_id: &str,
-    raw_username: Option<&str>,
+    _raw_username: Option<&str>,
     canonical_username: &str,
 ) -> Option<std::path::PathBuf> {
     let scoped_root = log_store::org_dir(workspace_root, canonical_username).join("logs");
     if let Some(found) = find_log_in_tree(&scoped_root, log_id) {
         return Some(found);
-    }
-
-    for candidate in legacy_scoped_paths(workspace_root, log_id, raw_username, canonical_username) {
-        if candidate.is_file() {
-            return Some(candidate);
-        }
     }
 
     None
@@ -324,43 +318,7 @@ fn find_raw_scoped_cached_log_path(
         return Some(found);
     }
 
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let raw_safe = log_store::safe_target_org(raw_username);
-    for candidate in [
-        root.join(format!("{raw_safe}_{log_id}.log")),
-        root.join(format!("{log_id}.log")),
-    ] {
-        if candidate.is_file() {
-            return Some(candidate);
-        }
-    }
-
     None
-}
-
-fn legacy_scoped_paths(
-    workspace_root: Option<&str>,
-    log_id: &str,
-    raw_username: Option<&str>,
-    canonical_username: &str,
-) -> Vec<std::path::PathBuf> {
-    let root = log_store::resolve_apexlogs_root(workspace_root);
-    let mut candidates = Vec::new();
-    let canonical_safe = log_store::safe_target_org(canonical_username);
-    candidates.push(root.join(format!("{canonical_safe}_{log_id}.log")));
-
-    if let Some(raw_username) = raw_username
-        .map(str::trim)
-        .filter(|value| !value.is_empty())
-    {
-        let raw_safe = log_store::safe_target_org(raw_username);
-        if raw_safe != canonical_safe {
-            candidates.push(root.join(format!("{raw_safe}_{log_id}.log")));
-        }
-    }
-
-    candidates.push(root.join(format!("{log_id}.log")));
-    candidates
 }
 
 fn find_log_in_tree(root: &Path, log_id: &str) -> Option<PathBuf> {

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -98,7 +98,13 @@ fn triage_log_item(
     canonical_username: Option<&str>,
     cancellation: &CancellationToken,
 ) -> Result<LogTriageItem, String> {
-    let resolved_username = canonical_username.unwrap_or("default");
+    let fallback_username = params
+        .username
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or("default");
+    let resolved_username = canonical_username.unwrap_or(fallback_username);
     let preferred_path = params.log_start_times.get(log_id).map(|start_time| {
         log_store::log_file_path_for_start_time(
             params.workspace_root.as_deref(),

--- a/crates/alv-core/src/triage.rs
+++ b/crates/alv-core/src/triage.rs
@@ -4,8 +4,10 @@ use crate::{
 };
 use serde::{Deserialize, Serialize};
 use std::{
-    fs::File,
+    collections::BTreeMap,
+    fs::{self, File},
     io::{BufRead, BufReader},
+    path::{Path, PathBuf},
     thread,
     time::Duration,
 };
@@ -17,6 +19,8 @@ const TEST_TRIAGE_LINE_DELAY_MS_ENV: &str = "ALV_TEST_TRIAGE_LINE_DELAY_MS";
 pub struct LogsTriageParams {
     #[serde(alias = "log_ids")]
     pub log_ids: Vec<String>,
+    #[serde(default, rename = "logStartTimes", alias = "log_start_times")]
+    pub log_start_times: BTreeMap<String, String>,
     pub username: Option<String>,
     #[serde(alias = "workspace_root")]
     pub workspace_root: Option<String>,
@@ -94,6 +98,25 @@ fn triage_log_item(
     canonical_username: Option<&str>,
     cancellation: &CancellationToken,
 ) -> Result<LogTriageItem, String> {
+    let resolved_username = canonical_username.unwrap_or("default");
+    let preferred_path = params.log_start_times.get(log_id).map(|start_time| {
+        log_store::log_file_path_for_start_time(
+            params.workspace_root.as_deref(),
+            resolved_username,
+            start_time,
+            log_id,
+        )
+    });
+
+    if let Some(path) = preferred_path.as_ref().filter(|path| path.is_file()) {
+        let (code_unit_started, summary) = summarize_file(path, cancellation)?;
+        return Ok(LogTriageItem {
+            log_id: log_id.to_string(),
+            code_unit_started,
+            summary,
+        });
+    }
+
     let existing_path = match canonical_username {
         Some(username) => find_scoped_cached_log_path(
             params.workspace_root.as_deref(),
@@ -120,14 +143,20 @@ fn triage_log_item(
     };
 
     let path = match existing_path {
-        Some(existing) => existing,
+        Some(existing) => materialize_existing_at_preferred_path(
+            &existing,
+            preferred_path.as_deref(),
+            cancellation,
+        )?
+        .unwrap_or(existing),
         None => {
-            let resolved_username = canonical_username.unwrap_or("default");
-            let target_path = log_store::unknown_date_log_path(
-                params.workspace_root.as_deref(),
-                resolved_username,
-                log_id,
-            );
+            let target_path = preferred_path.unwrap_or_else(|| {
+                log_store::unknown_date_log_path(
+                    params.workspace_root.as_deref(),
+                    resolved_username,
+                    log_id,
+                )
+            });
             download_log_to_path_with_cancel(
                 log_id,
                 params.username.as_deref(),
@@ -146,8 +175,36 @@ fn triage_log_item(
     })
 }
 
+fn materialize_existing_at_preferred_path(
+    existing_path: &Path,
+    preferred_path: Option<&Path>,
+    cancellation: &CancellationToken,
+) -> Result<Option<PathBuf>, String> {
+    let Some(preferred_path) = preferred_path else {
+        return Ok(None);
+    };
+    if existing_path == preferred_path {
+        return Ok(Some(preferred_path.to_path_buf()));
+    }
+
+    cancellation.check_cancelled()?;
+    if let Some(parent) = preferred_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+    match fs::copy(existing_path, preferred_path) {
+        Ok(_) => Ok(Some(preferred_path.to_path_buf())),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(format!(
+            "failed to materialize cached log {} from {}: {error}",
+            preferred_path.display(),
+            existing_path.display()
+        )),
+    }
+}
+
 fn summarize_file(
-    path: &std::path::Path,
+    path: &Path,
     cancellation: &CancellationToken,
 ) -> Result<(Option<String>, LogTriageSummary), String> {
     let file = File::open(path)
@@ -279,25 +336,24 @@ fn legacy_scoped_paths(
     candidates
 }
 
-fn find_log_in_tree(root: &std::path::Path, log_id: &str) -> Option<std::path::PathBuf> {
-    if !root.exists() {
+fn find_log_in_tree(root: &Path, log_id: &str) -> Option<PathBuf> {
+    if !root.is_dir() {
         return None;
     }
 
     for entry in std::fs::read_dir(root).ok()?.flatten() {
-        let path = entry.path();
-        if path.is_dir() {
-            if let Some(found) = find_log_in_tree(&path, log_id) {
-                return Some(found);
-            }
+        let day_dir = entry.path();
+        if !day_dir.is_dir()
+            || !log_store::is_supported_log_day_dir_name(
+                entry.file_name().to_string_lossy().as_ref(),
+            )
+        {
             continue;
         }
 
-        if path
-            .file_name()
-            .is_some_and(|file_name| file_name.to_string_lossy() == format!("{log_id}.log"))
-        {
-            return Some(path);
+        let candidate = day_dir.join(format!("{log_id}.log"));
+        if candidate.is_file() {
+            return Some(candidate);
         }
     }
 

--- a/crates/alv-core/tests/log_store_layout.rs
+++ b/crates/alv-core/tests/log_store_layout.rs
@@ -78,7 +78,7 @@ fn log_store_uses_unknown_date_for_invalid_start_time_values() {
 }
 
 #[test]
-fn log_store_finds_new_layout_before_legacy_flat_files() {
+fn log_store_uses_org_first_layout_when_flat_files_also_exist() {
     let workspace_root = make_temp_workspace("find-cache");
     let safe_org = safe_target_org("default@example.com");
     let new_path = workspace_root
@@ -92,10 +92,10 @@ fn log_store_finds_new_layout_before_legacy_flat_files() {
         .expect("new layout dir should be creatable");
     fs::write(&new_path, "new-layout").expect("new layout log should be writable");
 
-    let legacy_path = workspace_root
+    let flat_path = workspace_root
         .join("apexlogs")
         .join("default_07L000000000001AA.log");
-    fs::write(&legacy_path, "legacy-layout").expect("legacy log should be writable");
+    fs::write(&flat_path, "flat-layout").expect("flat log should be writable");
 
     let found = find_cached_log_path(
         Some(
@@ -113,14 +113,13 @@ fn log_store_finds_new_layout_before_legacy_flat_files() {
 }
 
 #[test]
-fn log_store_falls_back_to_legacy_flat_files_when_new_layout_is_absent() {
-    let workspace_root = make_temp_workspace("legacy-only");
-    fs::create_dir_all(workspace_root.join("apexlogs"))
-        .expect("legacy cache dir should be creatable");
-    let legacy_path = workspace_root
+fn log_store_ignores_flat_files_when_org_first_layout_is_absent() {
+    let workspace_root = make_temp_workspace("flat-only");
+    fs::create_dir_all(workspace_root.join("apexlogs")).expect("cache dir should be creatable");
+    let flat_path = workspace_root
         .join("apexlogs")
         .join("default_07L000000000002AA.log");
-    fs::write(&legacy_path, "legacy-layout").expect("legacy log should be writable");
+    fs::write(&flat_path, "flat-layout").expect("flat log should be writable");
 
     let found = find_cached_log_path(
         Some(
@@ -130,16 +129,18 @@ fn log_store_falls_back_to_legacy_flat_files_when_new_layout_is_absent() {
         ),
         "07L000000000002AA",
         None,
-    )
-    .expect("cache lookup should return a legacy path");
+    );
 
-    assert_eq!(found, legacy_path);
+    assert!(
+        found.is_none(),
+        "cache lookup should ignore flat files at apexlogs root"
+    );
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
-fn log_store_scoped_lookup_uses_matching_legacy_flat_file_without_cross_org_leakage() {
-    let workspace_root = make_temp_workspace("scoped-legacy-only");
+fn log_store_scoped_lookup_ignores_matching_flat_file_without_cross_org_leakage() {
+    let workspace_root = make_temp_workspace("scoped-flat-only");
     let apexlogs_root = workspace_root.join("apexlogs");
     fs::create_dir_all(
         apexlogs_root
@@ -160,8 +161,8 @@ fn log_store_scoped_lookup_uses_matching_legacy_flat_file_without_cross_org_leak
         "other-org",
     )
     .expect("other org cached log should be writable");
-    let scoped_legacy = apexlogs_root.join(format!("selected@example.com_{log_id}.log"));
-    fs::write(&scoped_legacy, "scoped-legacy").expect("scoped legacy log should be writable");
+    let scoped_flat = apexlogs_root.join(format!("selected@example.com_{log_id}.log"));
+    fs::write(&scoped_flat, "scoped-flat").expect("scoped flat log should be writable");
 
     let found = find_cached_log_path(
         Some(
@@ -171,10 +172,12 @@ fn log_store_scoped_lookup_uses_matching_legacy_flat_file_without_cross_org_leak
         ),
         log_id,
         Some("selected@example.com"),
-    )
-    .expect("scoped lookup should return the matching legacy flat path");
+    );
 
-    assert_eq!(found, scoped_legacy);
+    assert!(
+        found.is_none(),
+        "scoped lookup should ignore matching flat files at apexlogs root"
+    );
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 

--- a/crates/alv-core/tests/log_store_layout.rs
+++ b/crates/alv-core/tests/log_store_layout.rs
@@ -50,6 +50,34 @@ fn log_store_places_logs_under_org_and_day_directory() {
 }
 
 #[test]
+fn log_store_uses_unknown_date_for_invalid_start_time_values() {
+    let workspace_root = make_temp_workspace("invalid-day");
+    let file_path = log_file_path_for_start_time(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        "default@example.com",
+        "undefined-date",
+        "07L000000000003AA",
+    );
+
+    assert_eq!(
+        file_path,
+        workspace_root
+            .join("apexlogs")
+            .join("orgs")
+            .join("default@example.com")
+            .join("logs")
+            .join("unknown-date")
+            .join("07L000000000003AA.log")
+    );
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn log_store_finds_new_layout_before_legacy_flat_files() {
     let workspace_root = make_temp_workspace("find-cache");
     let safe_org = safe_target_org("default@example.com");

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -1259,6 +1259,69 @@ fn logs_runtime_smoke_triage_uses_raw_alias_org_first_cache_without_auth() {
 }
 
 #[test]
+fn logs_runtime_smoke_triage_materializes_raw_alias_cache_to_raw_alias_date() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("triage-alias-offline-dated");
+    let apexlogs_dir = workspace_root.join("apexlogs");
+    let alias_org_dir = apexlogs_dir
+        .join("orgs")
+        .join("Alias_Org")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&alias_org_dir).expect("alias org log dir should exist");
+    let log_id = "07L0000000000ALD";
+    fs::write(
+        alias_org_dir.join(format!("{log_id}.log")),
+        "\
+09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|AliasDated.handle\n\
+09:00:01.0|EXCEPTION_THROWN|System.NullPointerException: boom\n",
+    )
+    .expect("alias-scoped log should be writable");
+
+    let items = triage_logs(&LogsTriageParams {
+        log_ids: vec![log_id.to_string()],
+        log_start_times: std::collections::BTreeMap::from([(
+            log_id.to_string(),
+            "2026-03-30T18:39:58.000Z".to_string(),
+        )]),
+        username: Some("Alias Org".to_string()),
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("logs/triage should reuse the raw alias org-first cache when auth is unavailable");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].code_unit_started.as_deref(),
+        Some("AliasDated.handle")
+    );
+    assert!(
+        workspace_root
+            .join("apexlogs")
+            .join("orgs")
+            .join("Alias_Org")
+            .join("logs")
+            .join("2026-03-30")
+            .join(format!("{log_id}.log"))
+            .is_file(),
+        "triage should materialize the dated cache under the raw alias org"
+    );
+    assert!(
+        !workspace_root
+            .join("apexlogs")
+            .join("orgs")
+            .join("default")
+            .join("logs")
+            .join("2026-03-30")
+            .join(format!("{log_id}.log"))
+            .exists(),
+        "triage should not materialize alias caches under default"
+    );
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
 fn logs_runtime_smoke_triage_respects_cancellation_mid_file() {
     let _guard = lock_test_guard();
 

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -90,13 +90,6 @@ fn org_dirs_in_iteration_order(orgs_root: &PathBuf) -> Vec<PathBuf> {
     dirs
 }
 
-fn write_legacy_root_noise_logs(apexlogs_dir: &PathBuf, prefix: &str, count: usize) {
-    for index in 0..count {
-        fs::write(apexlogs_dir.join(format!("{prefix}_{index:05}.log")), "")
-            .expect("noise log should be writable");
-    }
-}
-
 #[cfg(windows)]
 fn write_fake_sf_cmd(root: &PathBuf, body: &str) -> PathBuf {
     let script_path = root.join("sf.cmd");
@@ -447,10 +440,15 @@ fn logs_runtime_smoke_search_respects_cancellation_mid_scan() {
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("search-cancel");
-    let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let cache_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&cache_dir).expect("cache dir should exist");
     fs::write(
-        apexlogs_dir.join("default_07L000000000001AA.log"),
+        cache_dir.join("07L000000000001AA.log"),
         (0..200)
             .map(|index| format!("09:00:{index:02}.0|USER_INFO|line {index}\n"))
             .collect::<String>(),
@@ -520,10 +518,6 @@ fn logs_runtime_smoke_search_with_blank_log_ids_short_circuits_before_cache_inde
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("search-empty-log-ids");
-    let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
-    write_legacy_root_noise_logs(&apexlogs_dir, "noise", 64);
-    std::env::set_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS", "2");
 
     let token = CancellationToken::new();
     let cancel_handle = token.clone();
@@ -548,7 +542,6 @@ fn logs_runtime_smoke_search_with_blank_log_ids_short_circuits_before_cache_inde
     assert!(result.pending_log_ids.is_empty());
     assert!(result.snippets.is_empty());
 
-    std::env::remove_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
@@ -578,7 +571,6 @@ fn logs_runtime_smoke_search_checks_duplicate_log_ids_across_org_trees() {
     let first_scanned_log_dir = ordered_org_dirs[0].join("logs").join("2026-03-30");
     let later_log_dir = ordered_org_dirs[1].join("logs").join("2026-03-30");
 
-    // The legacy implementation stops at the first cached path for the log id.
     // Keep the first-scanned copy wrong and the later copy correct so this test
     // only passes when search continues beyond the first org-tree match.
     fs::write(
@@ -658,10 +650,10 @@ fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_org_duplicate_
 }
 
 #[test]
-fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_legacy_root_match() {
+fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_flat_root_matches() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("search-scoped-ignore-other-legacy-root");
+    let workspace_root = make_temp_workspace("search-scoped-ignore-flat-root");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     let log_id = "07L00000000000SR1";
@@ -669,62 +661,65 @@ fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_other_legacy_root_ma
         apexlogs_dir.join(format!("selected@example.com_{log_id}.log")),
         "09:00:00.0|USER_INFO|selected root cache does not contain the needle\n",
     )
-    .expect("selected-org legacy root log should be writable");
+    .expect("selected-org flat root log should be writable");
     fs::write(
         apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
-        "09:00:00.0|FATAL_ERROR|ScopedLegacyRootNeedle\n",
+        "09:00:00.0|FATAL_ERROR|ScopedFlatRootNeedle\n",
     )
-    .expect("other-org legacy root log should be writable");
+    .expect("other-org flat root log should be writable");
 
     let result = search_query(&SearchQueryParams {
-        query: "ScopedLegacyRootNeedle".to_string(),
+        query: "ScopedFlatRootNeedle".to_string(),
         log_ids: vec![log_id.to_string()],
         username: Some("selected@example.com".to_string()),
         raw_username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("search/query should ignore other-org legacy flat cache files");
+    .expect("search/query should ignore flat cache files");
 
     assert!(result.log_ids.is_empty());
-    assert!(result.pending_log_ids.is_empty());
+    assert_eq!(result.pending_log_ids, vec![log_id.to_string()]);
     assert!(!result.snippets.contains_key(log_id));
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
-fn logs_runtime_smoke_search_scoped_to_selected_org_uses_legacy_bare_log_fallback() {
+fn logs_runtime_smoke_search_scoped_to_selected_org_ignores_bare_flat_log() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("search-scoped-legacy-bare");
+    let workspace_root = make_temp_workspace("search-scoped-flat-bare");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     fs::write(
         apexlogs_dir.join("07L00000000000LB1.log"),
-        "09:00:00.0|FATAL_ERROR|LegacyBareNeedle\n",
+        "09:00:00.0|FATAL_ERROR|FlatBareNeedle\n",
     )
-    .expect("legacy bare log should be writable");
+    .expect("bare flat log should be writable");
 
     let result = search_query(&SearchQueryParams {
-        query: "LegacyBareNeedle".to_string(),
+        query: "FlatBareNeedle".to_string(),
         log_ids: vec!["07L00000000000LB1".to_string()],
         username: Some("selected@example.com".to_string()),
         raw_username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("search/query should honor the legacy bare-log fallback");
+    .expect("search/query should ignore bare flat logs");
 
-    assert_eq!(result.log_ids, vec!["07L00000000000LB1".to_string()]);
-    assert!(result.pending_log_ids.is_empty());
+    assert!(result.log_ids.is_empty());
+    assert_eq!(
+        result.pending_log_ids,
+        vec!["07L00000000000LB1".to_string()]
+    );
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
-fn logs_runtime_smoke_search_scoped_hit_skips_unrelated_legacy_root_scan() {
+fn logs_runtime_smoke_search_scoped_hit_ignores_unrelated_flat_root_files() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("search-scoped-skip-legacy-root-scan");
+    let workspace_root = make_temp_workspace("search-scoped-ignore-flat-root");
     let apexlogs_dir = workspace_root.join("apexlogs");
     let selected_org_dir = apexlogs_dir
         .join("orgs")
@@ -738,8 +733,10 @@ fn logs_runtime_smoke_search_scoped_hit_skips_unrelated_legacy_root_scan() {
         "09:00:00.0|FATAL_ERROR|ScopedIndexedNeedle\n",
     )
     .expect("selected org cached log should be writable");
-    write_legacy_root_noise_logs(&apexlogs_dir, "otherorg", 64);
-    std::env::set_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS", "2");
+    for index in 0..64 {
+        fs::write(apexlogs_dir.join(format!("otherorg_{index:05}.log")), "")
+            .expect("flat noise log should be writable");
+    }
 
     let token = CancellationToken::new();
     let cancel_handle = token.clone();
@@ -758,7 +755,7 @@ fn logs_runtime_smoke_search_scoped_hit_skips_unrelated_legacy_root_scan() {
         },
         &token,
     )
-    .expect("scoped search should not scan unrelated legacy root entries");
+    .expect("scoped search should ignore unrelated flat root entries");
 
     assert_eq!(result.log_ids, vec![log_id.to_string()]);
     let snippet = result
@@ -767,23 +764,27 @@ fn logs_runtime_smoke_search_scoped_hit_skips_unrelated_legacy_root_scan() {
         .expect("matched log should include snippet");
     assert!(snippet.text.contains("ScopedIndexedNeedle"));
 
-    std::env::remove_var("ALV_TEST_SEARCH_ROOT_INDEX_DELAY_MS");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
-fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth() {
+fn logs_runtime_smoke_search_uses_raw_alias_org_first_cache_without_auth() {
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("search-alias-offline");
     let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let alias_org_dir = apexlogs_dir
+        .join("orgs")
+        .join("Alias_Org")
+        .join("logs")
+        .join("2026-03-30");
+    fs::create_dir_all(&alias_org_dir).expect("alias org log dir should exist");
     let log_id = "07L0000000000AS1";
     fs::write(
-        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        alias_org_dir.join(format!("{log_id}.log")),
         "09:00:00.0|FATAL_ERROR|AliasScopedNeedle\n",
     )
-    .expect("legacy alias-scoped log should be writable");
+    .expect("alias-scoped log should be writable");
     let wrong_org_dir = apexlogs_dir
         .join("orgs")
         .join("other@example.com")
@@ -803,7 +804,9 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
         raw_username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("search/query should use the raw alias-scoped cache when auth is unavailable");
+    .expect(
+        "search/query should use the raw alias-scoped org-first cache when auth is unavailable",
+    );
 
     assert_eq!(result.log_ids, vec![log_id.to_string()]);
     let snippet = result
@@ -816,10 +819,10 @@ fn logs_runtime_smoke_search_falls_back_to_raw_alias_scoped_cache_without_auth()
 }
 
 #[test]
-fn logs_runtime_smoke_search_raw_alias_scope_ignores_other_legacy_root_match() {
+fn logs_runtime_smoke_search_raw_alias_scope_ignores_flat_root_matches() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("search-alias-offline-legacy-root");
+    let workspace_root = make_temp_workspace("search-alias-offline-flat-root");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     let log_id = "07L0000000000AR1";
@@ -827,12 +830,12 @@ fn logs_runtime_smoke_search_raw_alias_scope_ignores_other_legacy_root_match() {
         apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
         "09:00:00.0|USER_INFO|alias root cache does not contain the needle\n",
     )
-    .expect("alias-scoped legacy root log should be writable");
+    .expect("alias-scoped flat root log should be writable");
     fs::write(
         apexlogs_dir.join(format!("other@example.com_{log_id}.log")),
         "09:00:00.0|FATAL_ERROR|AliasRootScopeNeedle\n",
     )
-    .expect("other-org legacy root log should be writable");
+    .expect("other-org flat root log should be writable");
 
     let result = search_query(&SearchQueryParams {
         query: "AliasRootScopeNeedle".to_string(),
@@ -841,28 +844,28 @@ fn logs_runtime_smoke_search_raw_alias_scope_ignores_other_legacy_root_match() {
         raw_username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("search/query should ignore unrelated legacy root files during raw alias fallback");
+    .expect("search/query should ignore flat root files during raw alias lookup");
 
     assert!(result.log_ids.is_empty());
-    assert!(result.pending_log_ids.is_empty());
+    assert_eq!(result.pending_log_ids, vec![log_id.to_string()]);
     assert!(!result.snippets.contains_key(log_id));
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
-fn logs_runtime_smoke_search_uses_legacy_alias_scoped_cache_when_alias_resolves() {
+fn logs_runtime_smoke_search_alias_resolution_ignores_flat_alias_cache() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("search-alias-canonical-legacy");
+    let workspace_root = make_temp_workspace("search-alias-canonical-flat");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     let log_id = "07L0000000000AC1";
     fs::write(
         apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
-        "09:00:00.0|FATAL_ERROR|AliasCanonicalLegacyNeedle\n",
+        "09:00:00.0|FATAL_ERROR|AliasCanonicalFlatNeedle\n",
     )
-    .expect("legacy alias-scoped log should be writable");
+    .expect("flat alias-scoped log should be writable");
 
     std::env::set_var(
         TEST_ORG_DISPLAY_JSON_ENV,
@@ -877,21 +880,17 @@ fn logs_runtime_smoke_search_uses_legacy_alias_scoped_cache_when_alias_resolves(
     );
 
     let result = search_query(&SearchQueryParams {
-        query: "AliasCanonicalLegacyNeedle".to_string(),
+        query: "AliasCanonicalFlatNeedle".to_string(),
         log_ids: vec![log_id.to_string()],
         username: Some("Alias Org".to_string()),
         raw_username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("search/query should keep the alias-scoped legacy fallback after alias resolution");
+    .expect("search/query should ignore flat alias-scoped cache after alias resolution");
 
-    assert_eq!(result.log_ids, vec![log_id.to_string()]);
-    assert!(result.pending_log_ids.is_empty());
-    let snippet = result
-        .snippets
-        .get(log_id)
-        .expect("matched log should include snippet");
-    assert!(snippet.text.contains("AliasCanonicalLegacyNeedle"));
+    assert!(result.log_ids.is_empty());
+    assert_eq!(result.pending_log_ids, vec![log_id.to_string()]);
+    assert!(!result.snippets.contains_key(log_id));
 
     std::env::remove_var(TEST_ORG_DISPLAY_JSON_ENV);
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
@@ -1038,20 +1037,21 @@ fn logs_runtime_smoke_triage_materializes_unknown_date_cache_for_known_start_tim
 }
 
 #[test]
-fn logs_runtime_smoke_triage_uses_legacy_bare_log_fallback_for_scoped_requests() {
+fn logs_runtime_smoke_triage_ignores_bare_flat_log_for_scoped_requests() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("triage-scoped-legacy-bare");
+    let workspace_root = make_temp_workspace("triage-scoped-flat-bare");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     let log_id = "07L00000000000LB2";
     fs::write(
         apexlogs_dir.join(format!("{log_id}.log")),
         "\
-09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|LegacyBare.handle\n\
+09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|FlatBare.handle\n\
 09:00:01.0|EXCEPTION_THROWN|System.NullPointerException: boom\n",
     )
-    .expect("legacy bare log should be writable");
+    .expect("bare flat log should be writable");
+    std::env::set_var("ALV_SF_BIN_PATH", workspace_root.join("missing-sf"));
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
@@ -1059,29 +1059,19 @@ fn logs_runtime_smoke_triage_uses_legacy_bare_log_fallback_for_scoped_requests()
         username: Some("selected@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("logs/triage should honor the legacy bare-log fallback");
+    .expect("logs/triage should ignore the bare flat log and report the missing download path");
 
     assert_eq!(items.len(), 1);
-    assert_eq!(
-        items[0].code_unit_started.as_deref(),
-        Some("LegacyBare.handle")
-    );
-    assert_eq!(
-        items[0].summary.primary_reason.as_deref(),
-        Some("Fatal exception")
-    );
-    assert!(
-        !workspace_root
-            .join("apexlogs")
-            .join("orgs")
-            .join("selected@example.com")
-            .join("logs")
-            .join("unknown-date")
-            .join(format!("{log_id}.log"))
-            .exists(),
-        "triage should reuse the legacy bare log instead of downloading a duplicate copy"
-    );
+    assert_eq!(items[0].code_unit_started, None);
+    assert!(items[0].summary.has_errors);
+    assert!(items[0]
+        .summary
+        .primary_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("Log triage unavailable"));
 
+    std::env::remove_var("ALV_SF_BIN_PATH");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
@@ -1215,7 +1205,7 @@ fn logs_runtime_smoke_triage_uses_canonical_username_tree_for_alias_input() {
 }
 
 #[test]
-fn logs_runtime_smoke_triage_falls_back_to_raw_alias_scoped_cache_without_auth() {
+fn logs_runtime_smoke_triage_uses_raw_alias_org_first_cache_without_auth() {
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("triage-alias-offline");
@@ -1233,13 +1223,19 @@ fn logs_runtime_smoke_triage_falls_back_to_raw_alias_scoped_cache_without_auth()
         "09:00:00.0|USER_INFO|wrong org cached copy\n",
     )
     .expect("wrong org cached log should be writable");
+    let alias_org_dir = apexlogs_dir
+        .join("orgs")
+        .join("Alias_Org")
+        .join("logs")
+        .join("2026-03-30");
+    fs::create_dir_all(&alias_org_dir).expect("alias org log dir should exist");
     fs::write(
-        apexlogs_dir.join(format!("Alias_Org_{log_id}.log")),
+        alias_org_dir.join(format!("{log_id}.log")),
         "\
 09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|AliasOffline.handle\n\
 09:00:01.0|EXCEPTION_THROWN|System.NullPointerException: boom\n",
     )
-    .expect("legacy alias-scoped log should be writable");
+    .expect("alias-scoped log should be writable");
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
@@ -1247,7 +1243,7 @@ fn logs_runtime_smoke_triage_falls_back_to_raw_alias_scoped_cache_without_auth()
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("logs/triage should reuse the raw alias-scoped cache when auth is unavailable");
+    .expect("logs/triage should reuse the raw alias org-first cache when auth is unavailable");
 
     assert_eq!(items.len(), 1);
     assert_eq!(
@@ -1267,10 +1263,15 @@ fn logs_runtime_smoke_triage_respects_cancellation_mid_file() {
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("triage-cancel");
-    let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let cache_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&cache_dir).expect("cache dir should exist");
     fs::write(
-        apexlogs_dir.join("default_07L000000000001AA.log"),
+        cache_dir.join("07L000000000001AA.log"),
         (0..200)
             .map(|index| format!("09:00:{index:02}.0|USER_INFO|line {index}\n"))
             .collect::<String>(),
@@ -1306,10 +1307,10 @@ fn logs_runtime_smoke_triage_respects_cancellation_mid_file() {
 }
 
 #[test]
-fn logs_runtime_smoke_triage_uses_default_legacy_cache_without_username() {
+fn logs_runtime_smoke_triage_ignores_default_flat_cache_without_username() {
     let _guard = lock_test_guard();
 
-    let workspace_root = make_temp_workspace("triage-default-legacy");
+    let workspace_root = make_temp_workspace("triage-default-flat");
     let apexlogs_dir = workspace_root.join("apexlogs");
     fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
     let log_id = "07L0000000000DEF";
@@ -1319,7 +1320,7 @@ fn logs_runtime_smoke_triage_uses_default_legacy_cache_without_username() {
 09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|DefaultCache.handle\n\
 09:00:01.0|EXCEPTION_THROWN|System.NullPointerException: boom\n",
     )
-    .expect("default-scoped cached log should be writable");
+    .expect("default-scoped flat log should be writable");
     std::env::set_var("ALV_SF_BIN_PATH", workspace_root.join("missing-sf"));
 
     let items = triage_logs(&LogsTriageParams {
@@ -1328,17 +1329,17 @@ fn logs_runtime_smoke_triage_uses_default_legacy_cache_without_username() {
         username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
-    .expect("logs/triage should reuse default-scoped legacy cache without calling sf");
+    .expect("logs/triage should ignore default-scoped flat cache without calling sf");
 
     assert_eq!(items.len(), 1);
-    assert_eq!(
-        items[0].code_unit_started.as_deref(),
-        Some("DefaultCache.handle")
-    );
-    assert_eq!(
-        items[0].summary.primary_reason.as_deref(),
-        Some("Fatal exception")
-    );
+    assert_eq!(items[0].code_unit_started, None);
+    assert!(items[0].summary.has_errors);
+    assert!(items[0]
+        .summary
+        .primary_reason
+        .as_deref()
+        .unwrap_or_default()
+        .contains("Log triage unavailable"));
 
     std::env::remove_var("ALV_SF_BIN_PATH");
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
@@ -1349,10 +1350,15 @@ fn logs_runtime_smoke_searches_cached_logs_with_pending_ids() {
     let _guard = lock_test_guard();
 
     let workspace_root = make_temp_workspace("search");
-    let apexlogs_dir = workspace_root.join("apexlogs");
-    fs::create_dir_all(&apexlogs_dir).expect("apexlogs dir should exist");
+    let cache_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&cache_dir).expect("cache dir should exist");
     fs::write(
-        apexlogs_dir.join("default_07L000000000001AA.log"),
+        cache_dir.join("07L000000000001AA.log"),
         "09:00:00.0|USER_INFO|NullPointerException happened here\n",
     )
     .expect("cached log should be writable");
@@ -1542,6 +1548,13 @@ fn logs_runtime_smoke_ensure_log_cache_uses_fixture_copy() {
     )
     .expect("ensure_log_file_cached should copy fixture into workspace cache");
     assert!(cached.exists());
+    assert!(
+        cached.ends_with("apexlogs/orgs/cache@example.com/logs/unknown-date/07L00000000000ENS.log")
+    );
+    assert!(!workspace_root
+        .join("apexlogs")
+        .join(format!("cache@example.com_{log_id}.log"))
+        .exists());
 
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
@@ -1568,6 +1581,13 @@ fn logs_runtime_smoke_downloads_log_body_over_rest_into_cache() {
     )
     .expect("ensure_log_file_cached should fetch the ApexLog body via REST");
     assert!(cached.exists());
+    assert!(
+        cached.ends_with("apexlogs/orgs/demo@example.com/logs/unknown-date/07L000000000REST.log")
+    );
+    assert!(!workspace_root
+        .join("apexlogs")
+        .join(format!("demo@example.com_{log_id}.log"))
+        .exists());
     assert_eq!(
         fs::read_to_string(&cached).expect("cached log should be readable"),
         "09:00:00.0|USER_INFO|rest body\n"

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -916,6 +916,7 @@ fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory()
     );
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("default@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -931,6 +932,109 @@ fn logs_runtime_smoke_triage_downloads_missing_log_into_unknown_date_directory()
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_triage_downloads_missing_log_into_start_time_day_directory() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("ensure-dated-layout");
+    let fixture_dir = make_temp_workspace("ensure-dated-fixture");
+    let log_id = "07L00000000000DT1";
+    fs::write(
+        fixture_dir.join(format!("{log_id}.log")),
+        "09:00:00.0|USER_INFO|fixture body\n",
+    )
+    .expect("fixture log should be writable");
+
+    std::env::set_var(
+        TEST_APEX_LOG_FIXTURE_DIR_ENV,
+        fixture_dir.display().to_string(),
+    );
+    let items = triage_logs(&LogsTriageParams {
+        log_ids: vec![log_id.to_string()],
+        log_start_times: std::collections::BTreeMap::from([(
+            log_id.to_string(),
+            "2026-03-30T18:39:58.000Z".to_string(),
+        )]),
+        username: Some("default@example.com".to_string()),
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("logs/triage should download and summarize the fixture log");
+
+    assert_eq!(items.len(), 1);
+    let cached = find_cached_log_path(Some(&workspace_root.display().to_string()), log_id)
+        .expect("triage should cache the downloaded fixture log");
+
+    assert!(
+        cached.ends_with("apexlogs/orgs/default@example.com/logs/2026-03-30/07L00000000000DT1.log")
+    );
+
+    std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    fs::remove_dir_all(fixture_dir).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_triage_materializes_unknown_date_cache_for_known_start_time() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("triage-materialize-dated-layout");
+    let log_id = "07L00000000000DM1";
+    let unknown_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("unknown-date")
+        .join(format!("{log_id}.log"));
+    fs::create_dir_all(
+        unknown_path
+            .parent()
+            .expect("unknown-date parent should exist"),
+    )
+    .expect("unknown-date parent should be creatable");
+    fs::write(
+        &unknown_path,
+        "09:00:00.0|CODE_UNIT_STARTED|[EXTERNAL]|Materialized.handle\n",
+    )
+    .expect("unknown-date cached log should be writable");
+
+    let items = triage_logs(&LogsTriageParams {
+        log_ids: vec![log_id.to_string()],
+        log_start_times: std::collections::BTreeMap::from([(
+            log_id.to_string(),
+            "2026-03-30T18:39:58.000Z".to_string(),
+        )]),
+        username: Some("default@example.com".to_string()),
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect(
+        "logs/triage should materialize the dated cache path from an existing unknown-date copy",
+    );
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(
+        items[0].code_unit_started.as_deref(),
+        Some("Materialized.handle")
+    );
+    let dated_path = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default@example.com")
+        .join("logs")
+        .join("2026-03-30")
+        .join(format!("{log_id}.log"));
+    assert!(
+        dated_path.is_file(),
+        "triage should create the dated cache copy"
+    );
+    assert!(
+        unknown_path.is_file(),
+        "triage should preserve the older cache hit"
+    );
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }
 
 #[test]
@@ -951,6 +1055,7 @@ fn logs_runtime_smoke_triage_uses_legacy_bare_log_fallback_for_scoped_requests()
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("selected@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1024,6 +1129,7 @@ fn logs_runtime_smoke_triage_ignores_wrong_org_cached_copy_when_alias_resolves_c
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1086,6 +1192,7 @@ fn logs_runtime_smoke_triage_uses_canonical_username_tree_for_alias_input() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1136,6 +1243,7 @@ fn logs_runtime_smoke_triage_falls_back_to_raw_alias_scoped_cache_without_auth()
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("Alias Org".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1181,6 +1289,7 @@ fn logs_runtime_smoke_triage_respects_cancellation_mid_file() {
     let result = triage_logs_with_cancel(
         &LogsTriageParams {
             log_ids: vec!["07L000000000001AA".to_string()],
+            log_start_times: Default::default(),
             username: None,
             workspace_root: Some(workspace_root.display().to_string()),
         },
@@ -1215,6 +1324,7 @@ fn logs_runtime_smoke_triage_uses_default_legacy_cache_without_username() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: None,
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1296,6 +1406,7 @@ fn logs_runtime_smoke_triages_logs_and_caches_fixture_downloads() {
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("demo@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })
@@ -1348,6 +1459,7 @@ fn logs_runtime_smoke_triage_returns_partial_results_when_one_log_is_unreadable(
 
     let items = triage_logs(&LogsTriageParams {
         log_ids: vec![missing_log_id.to_string(), readable_log_id.to_string()],
+        log_start_times: Default::default(),
         username: Some("demo@example.com".to_string()),
         workspace_root: Some(workspace_root.display().to_string()),
     })

--- a/packages/app-server-client-ts/src/index.ts
+++ b/packages/app-server-client-ts/src/index.ts
@@ -83,6 +83,7 @@ export type RuntimeLogTriageSummary = {
 export type LogsTriageParams = {
   username?: string;
   logIds: string[];
+  logStartTimes?: Record<string, string>;
   workspaceRoot?: string;
 };
 

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
 import { promises as fs } from 'fs';
+import * as path from 'path';
 import { createLimiter, type Limiter } from '../utils/limiter';
 import { fetchApexLogBody, extractCodeUnitStartedFromLines } from '../salesforce/http';
 import type { ApexLogCursor } from '../salesforce/http';
@@ -42,6 +43,11 @@ export type EnsureLogsSavedOptions = {
   onItemComplete?: (result: EnsureLogsSavedItemResult) => void;
 };
 
+type EnsureLogFileResult = {
+  filePath: string;
+  source: 'existing' | 'downloaded';
+};
+
 export type ClassifyLogsForErrorsProgress = {
   logId: string;
   summary: LogTriageSummary;
@@ -63,7 +69,7 @@ export class LogService {
   private saveConcurrency: number;
   private classifyLimiter: Limiter;
   private classifyConcurrency: number;
-  private inFlightSaves = new Map<string, Promise<string>>();
+  private inFlightSaves = new Map<string, Promise<EnsureLogFileResult>>();
 
   constructor(headConcurrency = 5) {
     this.headConcurrency = headConcurrency;
@@ -133,27 +139,59 @@ export class LogService {
     logId: string,
     selectedOrg?: string,
     signal?: AbortSignal,
-    authHint?: OrgAuth
+    authHint?: OrgAuth,
+    startTime?: string
   ): Promise<string> {
+    return (await this.ensureLogFileResult(logId, selectedOrg, signal, authHint, startTime)).filePath;
+  }
+
+  private async ensureLogFileResult(
+    logId: string,
+    selectedOrg?: string,
+    signal?: AbortSignal,
+    authHint?: OrgAuth,
+    startTime?: string
+  ): Promise<EnsureLogFileResult> {
     const auth = authHint ?? (await this.getOrgAuth(selectedOrg, signal));
+    const preferredPath = await this.resolvePreferredLogPath(auth.username, logId, startTime);
+    if (preferredPath && (await this.fileExists(preferredPath))) {
+      return { filePath: preferredPath, source: 'existing' };
+    }
+
     const existing = await findExistingLogFile(logId, auth.username);
     if (existing) {
-      return existing;
+      const materialized = await this.materializeExistingAtPreferredPath(existing, preferredPath, signal);
+      if (materialized) {
+        return materialized;
+      }
+      return { filePath: existing, source: 'existing' };
     }
-    const key = `${auth.username ?? ''}:${logId}`;
+
+    const key = `${auth.username ?? ''}:${logId}:${preferredPath ?? ''}`;
     const pending = this.inFlightSaves.get(key);
     if (pending) {
       return pending;
     }
-    const task = (async () => {
+    const task: Promise<EnsureLogFileResult> = (async (): Promise<EnsureLogFileResult> => {
+      if (preferredPath && (await this.fileExists(preferredPath))) {
+        return { filePath: preferredPath, source: 'existing' };
+      }
+
       const maybeExisting = await findExistingLogFile(logId, auth.username);
       if (maybeExisting) {
-        return maybeExisting;
+        const materialized = await this.materializeExistingAtPreferredPath(maybeExisting, preferredPath, signal);
+        if (materialized) {
+          return materialized;
+        }
+        return { filePath: maybeExisting, source: 'existing' };
       }
-      const { filePath } = await getLogFilePathWithUsername(auth.username, logId);
+      const { filePath } = preferredPath
+        ? { filePath: preferredPath }
+        : await getLogFilePathWithUsername(auth.username, logId, startTime);
       const body = await fetchApexLogBody(auth, logId, undefined, signal);
+      this.throwIfAborted(signal);
       await fs.writeFile(filePath, body, 'utf8');
-      return filePath;
+      return { filePath, source: 'downloaded' };
     })();
     this.inFlightSaves.set(key, task);
     try {
@@ -162,6 +200,64 @@ export class LogService {
     } finally {
       this.inFlightSaves.delete(key);
     }
+  }
+
+  private async resolvePreferredLogPath(
+    username: string | undefined,
+    logId: string,
+    startTime?: string
+  ): Promise<string | undefined> {
+    if (typeof startTime !== 'string' || startTime.trim().length === 0) {
+      return undefined;
+    }
+
+    return (await getLogFilePathWithUsername(username, logId, startTime)).filePath;
+  }
+
+  private async fileExists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath);
+      return true;
+    } catch (e: any) {
+      if (e && e.code === 'ENOENT') {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  private async materializeExistingAtPreferredPath(
+    existingPath: string,
+    preferredPath: string | undefined,
+    signal?: AbortSignal
+  ): Promise<EnsureLogFileResult | undefined> {
+    if (!preferredPath) {
+      return undefined;
+    }
+    if (path.resolve(existingPath) === path.resolve(preferredPath)) {
+      return { filePath: preferredPath, source: 'existing' };
+    }
+
+    this.throwIfAborted(signal);
+    try {
+      await fs.mkdir(path.dirname(preferredPath), { recursive: true });
+      await fs.copyFile(existingPath, preferredPath);
+      return { filePath: preferredPath, source: 'existing' };
+    } catch (e: any) {
+      if (e && e.code === 'ENOENT') {
+        return undefined;
+      }
+      throw e;
+    }
+  }
+
+  private throwIfAborted(signal?: AbortSignal): void {
+    if (!signal?.aborted) {
+      return;
+    }
+    const error = new Error('Request aborted');
+    error.name = 'AbortError';
+    throw error;
   }
 
   private async loadCodeUnitFromSavedLog(
@@ -262,7 +358,8 @@ export class LogService {
               return;
             }
             const existingPath = await findExistingLogFile(log.Id, selectedUsername);
-            const filePath = existingPath ?? (await this.ensureLogFile(log.Id, selectedOrg, signal));
+            const filePath =
+              existingPath ?? (await this.ensureLogFile(log.Id, selectedOrg, signal, undefined, log.StartTime));
             if (signal?.aborted) {
               return;
             }
@@ -367,22 +464,15 @@ export class LogService {
           }
           try {
             if (downloadMissing) {
-              const existing = await findExistingLogFile(log.Id, selectedUsername);
-              if (existing) {
-                summary.success++;
-                summary.existing++;
-                options?.onItemComplete?.({ logId: log.Id, status: 'existing' });
-                return;
-              }
-              await this.ensureLogFile(log.Id, selectedOrg, signal, authHint);
+              const result = await this.ensureLogFileResult(log.Id, selectedOrg, signal, authHint, log.StartTime);
               if (signal?.aborted) {
                 summary.cancelled++;
                 options?.onItemComplete?.({ logId: log.Id, status: 'cancelled' });
                 return;
               }
               summary.success++;
-              summary.downloaded++;
-              options?.onItemComplete?.({ logId: log.Id, status: 'downloaded' });
+              summary[result.source]++;
+              options?.onItemComplete?.({ logId: log.Id, status: result.source });
             } else {
               const existing = await findExistingLogFile(log.Id, selectedUsername);
               if (!existing) {

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
-import { promises as fs } from 'fs';
+import { constants as fsConstants, promises as fs } from 'fs';
 import * as path from 'path';
 import { createLimiter, type Limiter } from '../utils/limiter';
 import { fetchApexLogBody, extractCodeUnitStartedFromLines } from '../salesforce/http';
 import type { ApexLogCursor } from '../salesforce/http';
 import type { OrgAuth } from '../salesforce/types';
 import type { ApexLogRow } from '../../apps/vscode-extension/src/shared/types';
-import { getLogFilePathWithUsername, findExistingLogFile } from '../utils/workspace';
+import { buildLogFilePathWithUsername, getLogFilePathWithUsername, findExistingLogFile } from '../utils/workspace';
 import { ensureReplayDebuggerAvailable } from '../utils/replayDebugger';
 import { getErrorMessage } from '../utils/error';
 import { logWarn, logInfo } from '../utils/logger';
@@ -190,6 +190,7 @@ export class LogService {
         : await getLogFilePathWithUsername(auth.username, logId, startTime);
       const body = await fetchApexLogBody(auth, logId, undefined, signal);
       this.throwIfAborted(signal);
+      await fs.mkdir(path.dirname(filePath), { recursive: true });
       await fs.writeFile(filePath, body, 'utf8');
       return { filePath, source: 'downloaded' };
     })();
@@ -211,7 +212,7 @@ export class LogService {
       return undefined;
     }
 
-    return (await getLogFilePathWithUsername(username, logId, startTime)).filePath;
+    return buildLogFilePathWithUsername(username, logId, startTime).filePath;
   }
 
   private async fileExists(filePath: string): Promise<boolean> {
@@ -241,9 +242,12 @@ export class LogService {
     this.throwIfAborted(signal);
     try {
       await fs.mkdir(path.dirname(preferredPath), { recursive: true });
-      await fs.copyFile(existingPath, preferredPath);
+      await fs.copyFile(existingPath, preferredPath, fsConstants.COPYFILE_EXCL);
       return { filePath: preferredPath, source: 'existing' };
     } catch (e: any) {
+      if (e && e.code === 'EEXIST' && (await this.fileExists(preferredPath))) {
+        return { filePath: preferredPath, source: 'existing' };
+      }
       if (e && e.code === 'ENOENT') {
         return undefined;
       }

--- a/src/services/logService.ts
+++ b/src/services/logService.ts
@@ -150,21 +150,32 @@ export class LogService {
     selectedOrg?: string,
     signal?: AbortSignal,
     authHint?: OrgAuth,
-    startTime?: string
+    startTime?: string,
+    options?: { checkCacheBeforeAuth?: boolean }
   ): Promise<EnsureLogFileResult> {
-    const auth = authHint ?? (await this.getOrgAuth(selectedOrg, signal));
-    const preferredPath = await this.resolvePreferredLogPath(auth.username, logId, startTime);
-    if (preferredPath && (await this.fileExists(preferredPath))) {
-      return { filePath: preferredPath, source: 'existing' };
+    const preAuthUsername =
+      authHint?.username ?? (selectedOrg && selectedOrg !== 'default' ? selectedOrg : undefined);
+    if (options?.checkCacheBeforeAuth && preAuthUsername) {
+      const preAuthExisting = await findExistingLogFile(logId, preAuthUsername);
+      if (preAuthExisting) {
+        return { filePath: preAuthExisting, source: 'existing' };
+      }
     }
 
-    const existing = await findExistingLogFile(logId, auth.username);
-    if (existing) {
-      const materialized = await this.materializeExistingAtPreferredPath(existing, preferredPath, signal);
-      if (materialized) {
-        return materialized;
+    let auth: OrgAuth;
+    try {
+      auth = authHint ?? (await this.getOrgAuth(selectedOrg, signal));
+    } catch (error) {
+      const cachedWithoutAuth = await this.resolveCachedLogResult(logId, undefined, undefined, signal);
+      if (cachedWithoutAuth) {
+        return cachedWithoutAuth;
       }
-      return { filePath: existing, source: 'existing' };
+      throw error;
+    }
+    const preferredPath = await this.resolvePreferredLogPath(auth.username, logId, startTime);
+    const cached = await this.resolveCachedLogResult(logId, auth.username, preferredPath, signal);
+    if (cached) {
+      return cached;
     }
 
     const key = `${auth.username ?? ''}:${logId}:${preferredPath ?? ''}`;
@@ -177,13 +188,9 @@ export class LogService {
         return { filePath: preferredPath, source: 'existing' };
       }
 
-      const maybeExisting = await findExistingLogFile(logId, auth.username);
-      if (maybeExisting) {
-        const materialized = await this.materializeExistingAtPreferredPath(maybeExisting, preferredPath, signal);
-        if (materialized) {
-          return materialized;
-        }
-        return { filePath: maybeExisting, source: 'existing' };
+      const maybeCached = await this.resolveCachedLogResult(logId, auth.username, preferredPath, signal);
+      if (maybeCached) {
+        return maybeCached;
       }
       const { filePath } = preferredPath
         ? { filePath: preferredPath }
@@ -201,6 +208,28 @@ export class LogService {
     } finally {
       this.inFlightSaves.delete(key);
     }
+  }
+
+  private async resolveCachedLogResult(
+    logId: string,
+    username: string | undefined,
+    preferredPath: string | undefined,
+    signal?: AbortSignal
+  ): Promise<EnsureLogFileResult | undefined> {
+    if (preferredPath && (await this.fileExists(preferredPath))) {
+      return { filePath: preferredPath, source: 'existing' };
+    }
+
+    const existing = await findExistingLogFile(logId, username);
+    if (!existing) {
+      return undefined;
+    }
+
+    const materialized = await this.materializeExistingAtPreferredPath(existing, preferredPath, signal);
+    if (materialized) {
+      return materialized;
+    }
+    return { filePath: existing, source: 'existing' };
   }
 
   private async resolvePreferredLogPath(
@@ -446,7 +475,9 @@ export class LogService {
     const downloadMissing = options?.downloadMissing !== false;
     const authHint = options?.authHint;
     const validLogs = logs.filter((log): log is ApexLogRow & { Id: string } => typeof log?.Id === 'string' && log.Id.length > 0);
-    const selectedUsername = await this.resolveSelectedUsername(selectedOrg, signal, authHint);
+    const selectedUsername = downloadMissing
+      ? authHint?.username
+      : await this.resolveSelectedUsername(selectedOrg, signal, authHint);
     const summary: EnsureLogsSavedSummary = {
       total: validLogs.length,
       success: 0,
@@ -468,7 +499,9 @@ export class LogService {
           }
           try {
             if (downloadMissing) {
-              const result = await this.ensureLogFileResult(log.Id, selectedOrg, signal, authHint, log.StartTime);
+              const result = await this.ensureLogFileResult(log.Id, selectedOrg, signal, authHint, log.StartTime, {
+                checkCacheBeforeAuth: true
+              });
               if (signal?.aborted) {
                 summary.cancelled++;
                 options?.onItemComplete?.({ logId: log.Id, status: 'cancelled' });

--- a/src/utils/tailService.ts
+++ b/src/utils/tailService.ts
@@ -343,7 +343,11 @@ export class TailService {
     const header = `=== ApexLog ${id ?? ''} | ${r?.StartTime ?? ''} | ${r?.Operation ?? ''} | ${r?.Status ?? ''} | ${r?.LogLength ?? ''}`;
     lines.push(header);
     try {
-      const { filePath } = await this.getLogFilePathWithUsername(auth.username, id ?? String(Date.now()));
+      const { filePath } = await this.getLogFilePathWithUsername(
+        auth.username,
+        id ?? String(Date.now()),
+        typeof r?.StartTime === 'string' ? r.StartTime : undefined
+      );
       await fs.writeFile(filePath, body, 'utf8');
       if (id) {
         this.addLogPath(id, filePath);
@@ -514,8 +518,9 @@ export class TailService {
 
   private async getLogFilePathWithUsername(
     username: string | undefined,
-    logId: string
+    logId: string,
+    startTime?: string
   ): Promise<{ dir: string; filePath: string }> {
-    return utilGetLogFilePathWithUsername(username, logId);
+    return utilGetLogFilePathWithUsername(username, logId, startTime);
   }
 }

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -117,20 +117,29 @@ export async function ensureApexLogsDir(): Promise<string> {
 }
 
 /**
- * Build a username-prefixed log file path under `apexlogs`.
+ * Build an org-first log file path under `apexlogs`.
  */
 export async function getLogFilePathWithUsername(
   username: string | undefined,
-  logId: string
+  logId: string,
+  startTime?: string
 ): Promise<{ dir: string; filePath: string }> {
-  const dir = await ensureApexLogsDir();
+  const rootDir = await ensureApexLogsDir();
   const safeUser = toSafeLogUserName(username);
-  const filePath = path.join(dir, `${safeUser}_${logId}.log`);
+  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  await fs.mkdir(dir, { recursive: true });
+  const filePath = path.join(dir, `${logId}.log`);
   return { dir, filePath };
 }
 
 function toSafeLogUserName(username: string | undefined): string {
   return (username || 'default').replace(/[^a-zA-Z0-9_.@-]+/g, '_');
+}
+
+function toLogDayDirName(startTime: string | undefined): string {
+  const value = typeof startTime === 'string' ? startTime.trim() : '';
+  const day = value.slice(0, 10);
+  return /^\d{4}-\d{2}-\d{2}$/.test(day) ? day : 'unknown-date';
 }
 
 function isSupportedLogDayDirName(name: string): boolean {

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -209,7 +209,7 @@ async function findExistingLogFileInOrgsDir(orgsDir: string, logId: string): Pro
 }
 
 /**
- * Find a previously saved log file (username-prefixed or legacy `<id>.log`).
+ * Find a previously saved log file in the org-first log cache.
  */
 export async function findExistingLogFile(logId: string, username?: string): Promise<string | undefined> {
   const dir = getApexLogsDir();
@@ -240,31 +240,13 @@ export async function findExistingLogFile(logId: string, username?: string): Pro
         return orgFirst;
       }
     }
-
-    const entries = await fs.readdir(dir);
-    if (username) {
-      const exact = `${toSafeLogUserName(username)}_${logId}.log`;
-      if (entries.includes(exact)) {
-        return path.join(dir, exact);
-      }
-    }
-    const legacy = entries.find(name => name === `${logId}.log`);
-    if (legacy) {
-      return path.join(dir, legacy);
-    }
-    if (!username) {
-      const preferred = entries.find(name => name.endsWith(`_${logId}.log`));
-      if (preferred) {
-        return path.join(dir, preferred);
-      }
-    }
   } catch {
     // ignore
   }
   return undefined;
 }
 
-const LOG_FILE_REGEX = /^(?:[a-zA-Z0-9_.@-]+_)?([a-zA-Z0-9]{15,18})\.log$/;
+const LOG_FILE_REGEX = /^([a-zA-Z0-9]{15,18})\.log$/;
 
 function extractLogIdFromFileName(fileName: string): string | undefined {
   if (!fileName.toLowerCase().endsWith('.log')) {
@@ -272,6 +254,49 @@ function extractLogIdFromFileName(fileName: string): string | undefined {
   }
   const match = LOG_FILE_REGEX.exec(fileName);
   return match ? match[1] : undefined;
+}
+
+function isPurgeCandidateFile(entry: import('fs').Dirent): boolean {
+  return entry.isFile() && !entry.isSymbolicLink();
+}
+
+async function readPurgeDir(dir: string): Promise<import('fs').Dirent[]> {
+  try {
+    return await fs.readdir(dir, { withFileTypes: true });
+  } catch (error: any) {
+    if (error && (error.code === 'ENOENT' || error.code === 'ENOTDIR')) {
+      return [];
+    }
+    logWarn('Workspace: failed to inspect cached log directory', dir, '->', error);
+    return [];
+  }
+}
+
+async function collectOrgFirstPurgeCandidatePaths(rootDir: string): Promise<string[]> {
+  const orgsDir = path.join(rootDir, 'orgs');
+  const candidates: string[] = [];
+
+  for (const orgEntry of await readPurgeDir(orgsDir)) {
+    if (!orgEntry.isDirectory()) {
+      continue;
+    }
+
+    const logsDir = path.join(orgsDir, orgEntry.name, 'logs');
+    for (const dayEntry of await readPurgeDir(logsDir)) {
+      if (!dayEntry.isDirectory() || !isSupportedLogDayDirName(dayEntry.name)) {
+        continue;
+      }
+
+      const dayDir = path.join(logsDir, dayEntry.name);
+      for (const fileEntry of await readPurgeDir(dayDir)) {
+        if (isPurgeCandidateFile(fileEntry)) {
+          candidates.push(path.join(dayDir, fileEntry.name));
+        }
+      }
+    }
+  }
+
+  return candidates;
 }
 
 export function getLogIdFromLogFilePath(filePath: string): string | undefined {
@@ -288,33 +313,21 @@ export async function purgeSavedLogs(options: {
   if (signal?.aborted) {
     throw new Error('aborted');
   }
-  const dir = getApexLogsDir();
-  let entries: import('fs').Dirent[];
-  try {
-    entries = await fs.readdir(dir, { withFileTypes: true });
-  } catch (e: any) {
-    if (e && e.code === 'ENOENT') {
-      return 0;
-    }
-    throw e;
-  }
   let removed = 0;
   const now = Date.now();
-  for (const entry of entries) {
+  const candidatePaths = await collectOrgFirstPurgeCandidatePaths(getApexLogsDir());
+
+  for (const filePath of candidatePaths) {
     if (signal?.aborted) {
       throw new Error('aborted');
     }
-    if (!entry.isFile() || entry.isSymbolicLink()) {
-      continue;
-    }
-    const logId = extractLogIdFromFileName(entry.name);
+    const logId = getLogIdFromLogFilePath(filePath);
     if (!logId) {
       continue;
     }
     if (keepIds?.has(logId)) {
       continue;
     }
-    const filePath = path.join(dir, entry.name);
     try {
       if (typeof maxAgeMs === 'number' && Number.isFinite(maxAgeMs)) {
         const stat = await fs.stat(filePath);

--- a/src/utils/workspace.ts
+++ b/src/utils/workspace.ts
@@ -117,18 +117,31 @@ export async function ensureApexLogsDir(): Promise<string> {
 }
 
 /**
- * Build an org-first log file path under `apexlogs`.
+ * Build an org-first log file path under `apexlogs` without touching the filesystem.
+ */
+export function buildLogFilePathWithUsername(
+  username: string | undefined,
+  logId: string,
+  startTime?: string
+): { dir: string; filePath: string } {
+  const rootDir = getApexLogsDir();
+  const safeUser = toSafeLogUserName(username);
+  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  const filePath = path.join(dir, `${logId}.log`);
+  return { dir, filePath };
+}
+
+/**
+ * Build an org-first log file path under `apexlogs` and ensure its directories exist.
  */
 export async function getLogFilePathWithUsername(
   username: string | undefined,
   logId: string,
   startTime?: string
 ): Promise<{ dir: string; filePath: string }> {
-  const rootDir = await ensureApexLogsDir();
-  const safeUser = toSafeLogUserName(username);
-  const dir = path.join(rootDir, 'orgs', safeUser, 'logs', toLogDayDirName(startTime));
+  await ensureApexLogsDir();
+  const { dir, filePath } = buildLogFilePathWithUsername(username, logId, startTime);
   await fs.mkdir(dir, { recursive: true });
-  const filePath = path.join(dir, `${logId}.log`);
   return { dir, filePath };
 }
 


### PR DESCRIPTION
## Summary
- write saved Apex logs only under `apexlogs/orgs/<org>/logs/<day>/<logId>.log`
- remove flat cache fallback reads for `<logId>.log` and `<org>_<logId>.log` across extension, runtime, CLI search/status, and app-server cache resolution
- keep `unknown-date` as the org-first bucket for missing or invalid StartTime, and copy existing `unknown-date` org-first entries to a dated path when StartTime is later known
- make cache purge traverse only the org-first log tree and ignore flat files at `apexlogs/`

Supersedes #764 after the scope changed from transition compatibility to org-first-only cache behavior.

## Verification
- `npm run compile-tests`
- `npm run check-types`
- `npm run lint`
- `node scripts/run-tests-cli.js --scope=unit --timeout=480000` (344 passing)
- `cargo test -p alv-core`
- `cargo test -p alv-app-server`
- `cargo test -p apex-log-viewer-cli --test cli_smoke -- --nocapture`
