### PR TITLE
chore(release): prepare CLI 0.1.10 and extension 0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## Unreleased
 
+## [0.46.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.44.0...v0.46.0) (2026-04-29)
+
+### Bug Fixes
+
+- Logs/Runtime: make the org-first dated cache layout canonical, stop reading or writing legacy flat log files, keep unknown log dates under `unknown-date`, and preserve local cache reuse during bulk saves when org auth is unavailable. ([#765](https://github.com/Electivus/Apex-Log-Viewer/pull/765))
+
+### Chores
+
+- CLI/Runtime: bump the standalone runtime train to `0.1.10` so the extension release packages the org-first-only runtime assets.
+
 ## [0.44.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.42.0...v0.44.0) (2026-04-24)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.9"
+version = "0.1.10"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.44.0",
+  "version": "0.46.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.9",
-  "tag": "rust-v0.1.9",
+  "cliVersion": "0.1.10",
+  "tag": "rust-v0.1.10",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.9", path = "../alv-core" }
-alv-protocol = { version = "0.1.9", path = "../alv-protocol" }
+alv-core = { version = "0.1.10", path = "../alv-core" }
+alv-protocol = { version = "0.1.10", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.9", path = "../alv-app-server" }
-alv-core = { version = "0.1.9", path = "../alv-core" }
+alv-app-server = { version = "0.1.10", path = "../alv-app-server" }
+alv-core = { version = "0.1.10", path = "../alv-core" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.44.0",
+  "version": "0.46.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -81,7 +81,7 @@
     },
     "apps/vscode-extension": {
       "name": "apex-log-viewer",
-      "version": "0.44.0",
+      "version": "0.46.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.15.1",

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -188,8 +188,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.9',
-    tag: 'rust-v0.1.9',
+    cliVersion: '0.1.10',
+    tag: 'rust-v0.1.10',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary
- bump Rust CLI/runtime crates and npm runtime pin from 0.1.9 to 0.1.10
- bump the VS Code extension manifest and package lock to 0.46.0
- add 0.46.0 changelog notes for the org-first-only log cache release

## Verification
- npm run check-types
- npm run lint
- npm run test:scripts
- npm run test:rust
- git diff --check

## Post-merge release order
1. Push tag rust-v0.1.10 on the merged release commit and wait for Rust CLI Release to publish assets/npm packages.
2. After rust-v0.1.10 is green, push tag v0.46.0 on the same merged release commit so extension packaging fetches the newly published runtime.

Note: v0.45.1 already exists as a pre-release tag/release from the nightly flow, so the next stable extension version is 0.46.0.