### PR TITLE
fix(webview): improve slow startup resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Logs/Tail: increase webview startup timing windows so slow corporate machines can finish VS Code webview/service-worker bootstrap before the extension retries the mount.
+- Logs/Tail: retain webview context while hidden, avoid placeholder remounts during hide/show, and add a diagnostics package command with lifecycle evidence for service-worker/bootstrap failures.
+
 ## [0.46.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.44.0...v0.46.0) (2026-04-29)
 
 ### Bug Fixes

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -408,6 +408,11 @@
         "category": "Electivus Apex Logs"
       },
       {
+        "command": "sfLogs.copyDiagnostics",
+        "title": "%command.copyDiagnostics.title%",
+        "category": "Electivus Apex Logs"
+      },
+      {
         "command": "sfLogs.resetCliCache",
         "title": "Reset CLI Cache",
         "category": "Electivus Apex Logs"
@@ -443,9 +448,14 @@
           "group": "moreActions@98"
         },
         {
-          "command": "sfLogs.showOutput",
+          "command": "sfLogs.copyDiagnostics",
           "when": "view == sfLogViewer || view == sfLogTail",
           "group": "moreActions@99"
+        },
+        {
+          "command": "sfLogs.showOutput",
+          "when": "view == sfLogViewer || view == sfLogTail",
+          "group": "moreActions@100"
         }
       ],
       "editor/title": [

--- a/apps/vscode-extension/package.nls.json
+++ b/apps/vscode-extension/package.nls.json
@@ -11,6 +11,7 @@
   "command.openLogsEditor.title": "Open Logs in Editor Area",
   "command.openTailEditor.title": "Open Tail in Editor Area",
   "command.openLogInViewer.title": "Open in Apex Log Viewer",
+  "command.copyDiagnostics.title": "Copy Diagnostics Package",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Number of logs to fetch per page (effective maximum: 200). Higher values fetch more per request but may slow the UI or increase API load.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Maximum concurrent requests to fetch log headers. Very high values may overload Salesforce APIs or hit rate limits.",
@@ -61,5 +62,7 @@
   "logsCleanup.done": "Deleted {0} Apex log(s).",
   "logsCleanup.failed": "Failed to clear logs: {0}",
   "logsCleanup.hintStorageFull": "Org log storage appears to be full. Use “Clear logs” → “All org logs” to free up space.",
-  "logsCleanup.actionClearAll": "Clear org logs…"
+  "logsCleanup.actionClearAll": "Clear org logs…",
+  "diagnostics.copied": "Electivus Apex Logs: diagnostics package copied to clipboard.",
+  "diagnostics.copyFailed": "Electivus Apex Logs: failed to copy diagnostics: {0}"
 }

--- a/apps/vscode-extension/package.nls.pt-br.json
+++ b/apps/vscode-extension/package.nls.pt-br.json
@@ -11,6 +11,7 @@
   "command.openLogsEditor.title": "Abrir Logs na Área do Editor",
   "command.openTailEditor.title": "Abrir Tail na Área do Editor",
   "command.openLogInViewer.title": "Abrir no Apex Log Viewer",
+  "command.copyDiagnostics.title": "Copiar Pacote de Diagnóstico",
   "configuration.title": "Electivus Apex Logs",
   "configuration.electivus.apexLogs.pageSize.description": "Quantidade de logs por página (máximo efetivo: 200). Valores maiores trazem mais por requisição, mas podem deixar a UI mais lenta ou aumentar a carga nas APIs.",
   "configuration.electivus.apexLogs.headConcurrency.description": "Número máximo de requisições concorrentes para buscar cabeçalhos. Valores muito altos podem sobrecarregar as APIs do Salesforce ou atingir limites de rate.",
@@ -61,5 +62,7 @@
   "logsCleanup.done": "Excluídos {0} log(s) Apex.",
   "logsCleanup.failed": "Falha ao limpar logs: {0}",
   "logsCleanup.hintStorageFull": "Os logs da org parecem estar cheios. Use “Limpar logs” → “Todos da org” para liberar espaço.",
-  "logsCleanup.actionClearAll": "Limpar logs da org…"
+  "logsCleanup.actionClearAll": "Limpar logs da org…",
+  "diagnostics.copied": "Electivus Apex Logs: pacote de diagnóstico copiado para a área de transferência.",
+  "diagnostics.copyFailed": "Electivus Apex Logs: falha ao copiar diagnóstico: {0}"
 }

--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,10 +1,22 @@
 import * as vscode from 'vscode';
-import { SfLogsViewProvider } from './provider/SfLogsViewProvider';
+import {
+  SfLogsViewProvider,
+  WEBVIEW_READY_TIMEOUT_MS,
+  WEBVIEW_STABLE_VISIBILITY_DELAY_MS
+} from './provider/SfLogsViewProvider';
 import { SfLogTailViewProvider } from './provider/SfLogTailViewProvider';
 import type { OrgItem } from './shared/types';
 import * as path from 'path';
 import { setApiVersion, getApiVersion, clearListCache } from '../../../src/salesforce/http';
-import { logInfo, logWarn, logError, showOutput, setTraceEnabled, disposeLogger } from '../../../src/utils/logger';
+import {
+  logInfo,
+  logWarn,
+  logError,
+  showOutput,
+  setTraceEnabled,
+  disposeLogger,
+  getRecentLogEntries
+} from '../../../src/utils/logger';
 import { localize } from '../../../src/utils/localize';
 import { activateTelemetry, safeSendEvent, safeSendException, disposeTelemetry } from './shared/telemetry';
 import { CacheManager } from '../../../src/utils/cacheManager';
@@ -17,9 +29,78 @@ import { getBooleanConfig, affectsConfiguration } from '../../../src/utils/confi
 import { getErrorMessage } from '../../../src/utils/error';
 import { findSalesforceProjectInfo, isApexLogDocument, getLogIdFromLogFilePath } from '../../../src/utils/workspace';
 import { ApexLogCodeLensProvider } from './provider/ApexLogCodeLensProvider';
+import { getWebviewDiagnosticEvents } from './shared/webviewDiagnostics';
+import { formatDiagnosticsPackageMarkdown, type DiagnosticsPackage } from './shared/diagnosticsPackage';
 
 interface OrgQuickPick extends vscode.QuickPickItem {
   username: string;
+}
+
+function getExtensionVersion(context: vscode.ExtensionContext): string {
+  const packageJSON = (context as any).extension?.packageJSON ?? (context as any).extensionPackageJSON;
+  return typeof packageJSON?.version === 'string' ? packageJSON.version : 'unknown';
+}
+
+function buildDiagnosticsPackage(
+  context: vscode.ExtensionContext,
+  provider: SfLogsViewProvider,
+  tailProvider: SfLogTailViewProvider,
+  salesforceProject: Awaited<ReturnType<typeof findSalesforceProjectInfo>>,
+  generatedAt = new Date().toISOString()
+): DiagnosticsPackage {
+  const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
+  const providerStates = [provider.getWebviewDiagnosticState(), tailProvider.getWebviewDiagnosticState()];
+  const logsEditorState = LogsEditorPanel.getDiagnosticState();
+  const tailEditorState = TailEditorPanel.getDiagnosticState();
+  if (logsEditorState) {
+    providerStates.push(logsEditorState);
+  }
+  if (tailEditorState) {
+    providerStates.push(tailEditorState);
+  }
+  return {
+    generatedAt,
+    extension: {
+      name: 'Electivus Apex Log Viewer',
+      version: getExtensionVersion(context)
+    },
+    vscode: {
+      version: vscode.version,
+      appName: vscode.env.appName,
+      appHost: (vscode.env as any).appHost,
+      appRoot: (vscode.env as any).appRoot,
+      language: vscode.env.language,
+      remoteName: vscode.env.remoteName,
+      uiKind: vscode.env.uiKind
+    },
+    process: {
+      platform: process.platform,
+      arch: process.arch,
+      versions: {
+        node: process.versions.node,
+        electron: process.versions.electron,
+        chrome: process.versions.chrome,
+        v8: process.versions.v8
+      }
+    },
+    workspace: {
+      hasWorkspace: workspaceFolders.length > 0,
+      workspaceFolderCount: workspaceFolders.length,
+      workspaceFolders: workspaceFolders.map(folder => folder.uri.fsPath),
+      hasSalesforceProject: !!salesforceProject,
+      salesforceProjectRoot: salesforceProject?.workspaceRoot,
+      salesforceProjectFile: salesforceProject?.projectFilePath,
+      sourceApiVersion: salesforceProject?.sourceApiVersion
+    },
+    webview: {
+      retainContextWhenHidden: true,
+      stableVisibilityDelayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS,
+      readyTimeoutMs: WEBVIEW_READY_TIMEOUT_MS,
+      providers: providerStates,
+      events: getWebviewDiagnosticEvents()
+    },
+    recentLogs: getRecentLogEntries()
+  };
 }
 
 async function initializePersistentCache(context: vscode.ExtensionContext): Promise<void> {
@@ -82,14 +163,18 @@ export async function activate(context: vscode.ExtensionContext) {
   const provider = new SfLogsViewProvider(context);
   context.subscriptions.push(
     provider,
-    vscode.window.registerWebviewViewProvider(SfLogsViewProvider.viewType, provider)
+    vscode.window.registerWebviewViewProvider(SfLogsViewProvider.viewType, provider, {
+      webviewOptions: { retainContextWhenHidden: true }
+    })
   );
 
   // Register Tail view provider
   const tailProvider = new SfLogTailViewProvider(context);
   context.subscriptions.push(
     tailProvider,
-    vscode.window.registerWebviewViewProvider(SfLogTailViewProvider.viewType, tailProvider)
+    vscode.window.registerWebviewViewProvider(SfLogTailViewProvider.viewType, tailProvider, {
+      webviewOptions: { retainContextWhenHidden: true }
+    })
   );
 
   context.subscriptions.push(
@@ -249,6 +334,34 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.commands.registerCommand('sfLogs.showOutput', () => {
       safeSendEvent('command.showOutput', { outcome: 'invoked' });
       showOutput(true);
+    })
+  );
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('sfLogs.copyDiagnostics', async () => {
+      try {
+        const diagnostics = buildDiagnosticsPackage(context, provider, tailProvider, salesforceProject);
+        const markdown = formatDiagnosticsPackageMarkdown(diagnostics);
+        await vscode.env.clipboard.writeText(markdown);
+        logInfo(
+          'Diagnostics package copied to clipboard with',
+          diagnostics.webview.events.length,
+          'webview event(s) and',
+          diagnostics.recentLogs.length,
+          'log line(s).'
+        );
+        vscode.window.showInformationMessage(
+          localize('diagnostics.copied', 'Electivus Apex Logs: diagnostics package copied to clipboard.')
+        );
+        safeSendEvent('command.copyDiagnostics', { outcome: 'ok' });
+      } catch (e) {
+        const msg = getErrorMessage(e);
+        logWarn('Command sfLogs.copyDiagnostics failed ->', msg);
+        vscode.window.showErrorMessage(
+          localize('diagnostics.copyFailed', 'Electivus Apex Logs: failed to copy diagnostics: {0}', msg)
+        );
+        safeSendEvent('command.copyDiagnostics', { outcome: 'error' });
+      }
     })
   );
 

--- a/apps/vscode-extension/src/panel/LogsEditorPanel.ts
+++ b/apps/vscode-extension/src/panel/LogsEditorPanel.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
 import { localize } from '../../../../src/utils/localize';
 import { disposeAll } from './disposeAll';
+import type { WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
 
 interface ShowOptions {
   selectedOrg?: string;
@@ -14,6 +15,10 @@ export class LogsEditorPanel {
 
   static initialize(context: vscode.ExtensionContext): void {
     this.context = context;
+  }
+
+  static getDiagnosticState(): WebviewProviderDiagnosticState | undefined {
+    return this.instance?.controller.getWebviewDiagnosticState();
   }
 
   static async show(options?: ShowOptions): Promise<void> {
@@ -62,6 +67,7 @@ export class LogsEditorPanel {
       { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
       {
         enableScripts: true,
+        retainContextWhenHidden: true,
         localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
       }
     );

--- a/apps/vscode-extension/src/panel/TailEditorPanel.ts
+++ b/apps/vscode-extension/src/panel/TailEditorPanel.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import { SfLogTailViewProvider } from '../provider/SfLogTailViewProvider';
 import { localize } from '../../../../src/utils/localize';
 import { disposeAll } from './disposeAll';
+import type { WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
 
 interface ShowOptions {
   selectedOrg?: string;
@@ -14,6 +15,10 @@ export class TailEditorPanel {
 
   static initialize(context: vscode.ExtensionContext): void {
     this.context = context;
+  }
+
+  static getDiagnosticState(): WebviewProviderDiagnosticState | undefined {
+    return this.instance?.controller.getWebviewDiagnosticState();
   }
 
   static async show(options?: ShowOptions): Promise<void> {
@@ -62,6 +67,7 @@ export class TailEditorPanel {
       { viewColumn: vscode.ViewColumn.Active, preserveFocus: false },
       {
         enableScripts: true,
+        retainContextWhenHidden: true,
         localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
       }
     );

--- a/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
@@ -25,9 +25,38 @@ import { LogViewerPanel } from '../panel/LogViewerPanel';
 import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
 import { runtimeClient } from '../runtime/runtimeClient';
 import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
+import { recordWebviewEvent, type WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
 
-export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 200;
-export const WEBVIEW_READY_TIMEOUT_MS = 5000;
+// Corporate-managed notebooks can take several seconds to initialize VS Code
+// webviews and their internal service worker. Keep these windows generous so a
+// slow-but-healthy startup is not torn down into a remount loop.
+export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 1000;
+export const WEBVIEW_READY_TIMEOUT_MS = 30000;
+const WEBVIEW_REPLAY_RETRY_DELAY_MS = 250;
+const WEBVIEW_REPLAY_MAX_RETRIES = 3;
+const TAIL_REPLAYABLE_VISIBLE_UPDATE_TYPES = new Set<ExtensionToWebviewMessage['type']>([
+  'loading',
+  'error',
+  'orgs',
+  'debugLevels',
+  'tailStatus',
+  'tailData',
+  'tailReset',
+  'tailConfig'
+]);
+
+interface ReplayDeliveryBatch {
+  pending: number;
+  dropped: boolean;
+  resetRetryBudgetOnSuccess: boolean;
+}
+
+interface WebviewPostOptions {
+  replay?: boolean;
+  requeueReplayOnDrop?: boolean;
+  onDelivered?: () => void;
+  replayBatch?: ReplayDeliveryBatch;
+}
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = 'sfLogTail';
@@ -38,8 +67,12 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   private readonly readyTimeoutListeners = new Set<() => void>();
   private disposed = false;
   private ready = false;
+  private contentMounted = false;
+  private needsReplayOnVisible = false;
   private mountTimer: ReturnType<typeof setTimeout> | undefined;
   private readyTimer: ReturnType<typeof setTimeout> | undefined;
+  private visibleReplayRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  private visibleReplayRetryAttempts = 0;
   private mountSequence = 0;
   private selectedOrg: string | undefined;
   private tailService = new TailService(m => this.post(m));
@@ -53,7 +86,9 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   private debugLevelsBootstrapNeedsRefresh = false;
   private tailRunningSnapshot = false;
   private tailBufferSizeSnapshot = DEFAULT_TAIL_BUFFER_LINES;
+  private tailResetNeedsReplay = false;
   private errorMessage: string | undefined;
+  private errorClearNeedsReplay = false;
 
   constructor(private readonly context: vscode.ExtensionContext) {
     this.tailService.setOrg(this.selectedOrg);
@@ -183,6 +218,36 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     return this.ready && !this.disposed;
   }
 
+  public getWebviewDiagnosticState(): WebviewProviderDiagnosticState {
+    return {
+      surface: 'tail',
+      hasHost: !!this.host,
+      hostKind: this.host?.kind,
+      visible: this.host?.visible,
+      ready: this.ready,
+      disposed: this.disposed,
+      contentMounted: this.contentMounted,
+      mountSequence: this.mountSequence,
+      mountTimerActive: this.mountTimer !== undefined,
+      readyTimerActive: this.readyTimer !== undefined,
+      needsReplayOnVisible: this.needsReplayOnVisible,
+      snapshots: {
+        loading: this.loadingState,
+        hasOrgsSnapshot: this.hasOrgsSnapshot,
+        orgCount: this.orgsSnapshot.length,
+        hasDebugLevelsSnapshot: this.hasDebugLevelsSnapshot,
+        debugLevelCount: this.debugLevelsSnapshot.length,
+        tailRunning: this.tailRunningSnapshot,
+        tailBufferSize: this.tailBufferSizeSnapshot,
+        bufferedLineCount: this.tailService.getBufferedLines().length,
+        tailResetNeedsReplay: this.tailResetNeedsReplay,
+        hasError: this.errorMessage !== undefined,
+        visibleReplayRetryTimerActive: this.visibleReplayRetryTimer !== undefined,
+        visibleReplayRetryAttempts: this.visibleReplayRetryAttempts
+      }
+    };
+  }
+
   public onDidReadyTimeout(listener: () => void): vscode.Disposable {
     this.readyTimeoutListeners.add(listener);
     return {
@@ -195,6 +260,10 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   public dispose(): void {
     this.disposed = true;
     this.ready = false;
+    this.contentMounted = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
+    this.tailResetNeedsReplay = false;
     this.view = undefined;
     this.host = undefined;
     this.clearBootstrapTimers();
@@ -251,13 +320,31 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     }
   }
 
+  private clearVisibleReplayRetryTimer(): void {
+    if (this.visibleReplayRetryTimer) {
+      clearTimeout(this.visibleReplayRetryTimer);
+      this.visibleReplayRetryTimer = undefined;
+    }
+  }
+
   private clearBootstrapTimers(): void {
     this.clearMountTimer();
     this.clearReadyTimer();
+    this.clearVisibleReplayRetryTimer();
   }
 
   private showPlaceholder(host: BoundWebviewHost): void {
+    this.contentMounted = false;
     host.webview.html = this.getPlaceholderHtml();
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'placeholder',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
   }
 
   private scheduleMount(host = this.host): void {
@@ -265,6 +352,16 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       return;
     }
     this.clearMountTimer();
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'mountScheduled',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { delayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS }
+    });
     this.mountTimer = setTimeout(() => {
       this.mountTimer = undefined;
       if (this.host !== host || this.disposed || !host.visible) {
@@ -276,8 +373,25 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
 
   private mountWebview(host: BoundWebviewHost): void {
     this.ready = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
     const mountId = ++this.mountSequence;
+    this.contentMounted = true;
     host.webview.html = this.getHtmlForWebview(host.webview, mountId);
+    this.startReadyTimer(host, mountId);
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'mounted',
+      hostKind: host.kind,
+      mountSequence: mountId,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
+    logInfo(`Tail webview mounted (${host.kind}).`);
+  }
+
+  private startReadyTimer(host: BoundWebviewHost, mountId: number): void {
     this.clearReadyTimer();
     this.readyTimer = setTimeout(() => {
       this.readyTimer = undefined;
@@ -285,6 +399,16 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         return;
       }
       logWarn(`Tail webview did not report ready within ${WEBVIEW_READY_TIMEOUT_MS}ms (${host.kind}).`);
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'readyTimeout',
+        hostKind: host.kind,
+        mountSequence: mountId,
+        visible: host.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted,
+        details: { timeoutMs: WEBVIEW_READY_TIMEOUT_MS }
+      });
       this.ready = false;
       this.showPlaceholder(host);
       if (host.kind === 'editor') {
@@ -294,7 +418,6 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         this.scheduleMount(host);
       }
     }, WEBVIEW_READY_TIMEOUT_MS);
-    logInfo(`Tail webview mounted (${host.kind}).`);
   }
 
   private fireReadyTimeout(): void {
@@ -310,9 +433,45 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       return;
     }
     if (!visible) {
-      this.ready = false;
       this.clearBootstrapTimers();
-      this.showPlaceholder(host);
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'hidden',
+        hostKind: host.kind,
+        mountSequence: this.mountSequence,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+      return;
+    }
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'visible',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { needsReplayOnVisible: this.needsReplayOnVisible }
+    });
+    if (this.ready) {
+      if (this.needsReplayOnVisible) {
+        this.replayRetainedState(host, visible, 'replayedOnVisible', true);
+      }
+      return;
+    }
+    if (this.contentMounted && this.mountSequence > 0) {
+      this.startReadyTimer(host, this.mountSequence);
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'resumedPendingReady',
+        hostKind: host.kind,
+        mountSequence: this.mountSequence,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
       return;
     }
     this.scheduleMount(host);
@@ -325,14 +484,42 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     if (mountSequence === undefined) {
       if (this.mountSequence > 1) {
         logInfo(`Tail webview ignored unsequenced stale ready (${this.host.kind}).`);
+        recordWebviewEvent({
+          surface: 'tail',
+          event: 'ignoredUnsequencedReady',
+          hostKind: this.host.kind,
+          mountSequence: this.mountSequence,
+          visible: this.host.visible,
+          ready: this.ready,
+          contentMounted: this.contentMounted
+        });
         return;
       }
     } else if (mountSequence !== this.mountSequence) {
       logInfo(`Tail webview ignored stale ready (${this.host.kind}).`);
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'ignoredStaleReady',
+        hostKind: this.host.kind,
+        mountSequence: this.mountSequence,
+        visible: this.host.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted,
+        details: { receivedMountSequence: mountSequence }
+      });
       return;
     }
     this.ready = true;
     this.clearReadyTimer();
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'ready',
+      hostKind: this.host.kind,
+      mountSequence: this.mountSequence,
+      visible: this.host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
     this.post({ type: 'init', locale: vscode.env.language });
     this.replaySnapshot();
     const needsBootstrap =
@@ -349,26 +536,74 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     }
   }
 
-  private replaySnapshot(): void {
-    this.post({ type: 'loading', value: this.loadingState }, { replay: true });
+  private replayRetainedState(
+    host: BoundWebviewHost,
+    visible: boolean,
+    event: string,
+    resetRetryBudget: boolean
+  ): void {
+    if (resetRetryBudget) {
+      this.visibleReplayRetryAttempts = 0;
+    }
+    const replayBatch: ReplayDeliveryBatch = {
+      pending: 0,
+      dropped: false,
+      resetRetryBudgetOnSuccess: !resetRetryBudget
+    };
+    this.needsReplayOnVisible = false;
+    this.post({ type: 'init', locale: vscode.env.language }, { requeueReplayOnDrop: true, replayBatch });
+    this.replaySnapshot({ requeueReplayOnDrop: true, replayBatch });
+    recordWebviewEvent({
+      surface: 'tail',
+      event,
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { retryAttempts: this.visibleReplayRetryAttempts }
+    });
+  }
+
+  private replaySnapshot(options?: WebviewPostOptions): void {
+    const replayOptions: WebviewPostOptions = {
+      replay: true,
+      requeueReplayOnDrop: options?.requeueReplayOnDrop,
+      replayBatch: options?.replayBatch
+    };
+    this.post({ type: 'loading', value: this.loadingState }, replayOptions);
     if (this.hasOrgsSnapshot) {
-      this.post({ type: 'orgs', data: this.orgsSnapshot, selected: this.selectedOrg }, { replay: true });
+      this.post({ type: 'orgs', data: this.orgsSnapshot, selected: this.selectedOrg }, replayOptions);
     }
     if (this.hasDebugLevelsSnapshot) {
       this.post(
         { type: 'debugLevels', data: this.debugLevelsSnapshot, active: this.activeDebugLevelSnapshot },
-        { replay: true }
+        replayOptions
       );
     }
-    this.post({ type: 'tailConfig', tailBufferSize: this.tailBufferSizeSnapshot }, { replay: true });
-    this.post({ type: 'tailStatus', running: this.tailRunningSnapshot }, { replay: true });
+    this.post({ type: 'tailConfig', tailBufferSize: this.tailBufferSizeSnapshot }, replayOptions);
+    this.post({ type: 'tailStatus', running: this.tailRunningSnapshot }, replayOptions);
     const bufferedLines = this.tailService.getBufferedLines();
     if (bufferedLines.length > 0) {
-      this.post({ type: 'tailReset' }, { replay: true });
-      this.post({ type: 'tailData', lines: bufferedLines }, { replay: true });
+      this.post({ type: 'tailReset' }, replayOptions);
+      this.post({ type: 'tailData', lines: bufferedLines }, replayOptions);
+    } else if (this.tailResetNeedsReplay) {
+      this.post({ type: 'tailReset' }, replayOptions);
     }
     if (this.errorMessage !== undefined) {
-      this.post({ type: 'error', message: this.errorMessage }, { replay: true });
+      this.post({ type: 'error', message: this.errorMessage }, replayOptions);
+    } else if (this.errorClearNeedsReplay) {
+      this.post(
+        { type: 'error', message: undefined },
+        {
+          ...replayOptions,
+          onDelivered: () => {
+            if (this.errorMessage === undefined) {
+              this.errorClearNeedsReplay = false;
+            }
+          }
+        }
+      );
     }
   }
 
@@ -377,7 +612,29 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     this.post({ type: 'tailReset' });
   }
 
-  private post(msg: ExtensionToWebviewMessage, options?: { replay?: boolean }): void {
+  private settleReplayDeliveryBatch(batch: ReplayDeliveryBatch | undefined): void {
+    if (!batch) {
+      return;
+    }
+    batch.pending = Math.max(0, batch.pending - 1);
+    if (batch.pending > 0) {
+      return;
+    }
+    if (!batch.dropped && batch.resetRetryBudgetOnSuccess && !this.needsReplayOnVisible) {
+      this.visibleReplayRetryAttempts = 0;
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'replayRetryBudgetResetAfterDelivery',
+        hostKind: this.host?.kind,
+        mountSequence: this.mountSequence,
+        visible: this.host?.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+    }
+  }
+
+  private post(msg: ExtensionToWebviewMessage, options?: WebviewPostOptions): void {
     let shouldClearWebviewError = false;
     switch (msg.type) {
       case 'loading':
@@ -385,6 +642,9 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         break;
       case 'error':
         this.errorMessage = msg.message;
+        if (msg.message !== undefined) {
+          this.errorClearNeedsReplay = false;
+        }
         break;
       case 'orgs':
         this.hasOrgsSnapshot = true;
@@ -409,13 +669,173 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
           shouldClearWebviewError = true;
         }
         break;
+      case 'tailReset':
+        if (!options?.replay) {
+          this.tailResetNeedsReplay = true;
+        }
+        break;
       case 'tailConfig':
         this.tailBufferSizeSnapshot = msg.tailBufferSize;
         break;
     }
-    this.view?.webview.postMessage(msg);
+    const visible = this.host?.visible ?? false;
+    if (this.host && !visible && !options?.replay) {
+      this.needsReplayOnVisible = true;
+      this.visibleReplayRetryAttempts = 0;
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'messagePostedWhileHidden',
+        hostKind: this.host.kind,
+        mountSequence: this.mountSequence,
+        messageType: msg.type,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+    }
+    const postContext = {
+      hostKind: this.host?.kind,
+      mountSequence: this.mountSequence,
+      visible: this.host?.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    };
+    const scheduleVisibleReplayRetry = () => {
+      if (
+        !postContext.visible ||
+        !this.host ||
+        !this.host.visible ||
+        !this.ready ||
+        this.visibleReplayRetryTimer ||
+        this.visibleReplayRetryAttempts >= WEBVIEW_REPLAY_MAX_RETRIES
+      ) {
+        return;
+      }
+
+      const host = this.host;
+      const mountSequence = this.mountSequence;
+      const attempt = ++this.visibleReplayRetryAttempts;
+      this.visibleReplayRetryTimer = setTimeout(() => {
+        this.visibleReplayRetryTimer = undefined;
+        if (
+          this.disposed ||
+          this.host !== host ||
+          !host.visible ||
+          !this.ready ||
+          mountSequence !== this.mountSequence ||
+          !this.needsReplayOnVisible
+        ) {
+          return;
+        }
+        this.replayRetainedState(host, true, 'retriedReplayAfterDroppedPost', false);
+      }, WEBVIEW_REPLAY_RETRY_DELAY_MS);
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'scheduledReplayRetryAfterDroppedPost',
+        hostKind: postContext.hostKind,
+        mountSequence: postContext.mountSequence,
+        messageType: msg.type,
+        visible: postContext.visible,
+        ready: postContext.ready,
+        contentMounted: postContext.contentMounted,
+        details: { attempt, delayMs: WEBVIEW_REPLAY_RETRY_DELAY_MS }
+      });
+    };
+    const requeueReplay = () => {
+      const requeueReason = options?.requeueReplayOnDrop
+        ? 'explicit'
+        : !options?.replay &&
+            postContext.visible === true &&
+            postContext.ready === true &&
+            TAIL_REPLAYABLE_VISIBLE_UPDATE_TYPES.has(msg.type)
+          ? 'visibleUpdate'
+          : undefined;
+      if (!requeueReason || this.disposed || postContext.mountSequence !== this.mountSequence) {
+        return;
+      }
+      this.needsReplayOnVisible = true;
+      scheduleVisibleReplayRetry();
+      recordWebviewEvent({
+        surface: 'tail',
+        event: 'replayRequeuedAfterDroppedPost',
+        hostKind: postContext.hostKind,
+        mountSequence: postContext.mountSequence,
+        messageType: msg.type,
+        visible: postContext.visible,
+        ready: postContext.ready,
+        contentMounted: postContext.contentMounted,
+        details: { reason: requeueReason }
+      });
+    };
+    const replayBatch = options?.replayBatch;
+    if (replayBatch) {
+      replayBatch.pending += 1;
+    }
+    const postResult = this.view?.webview.postMessage(msg);
+    if (postResult) {
+      postResult.then(
+        delivered => {
+          if (!delivered) {
+            if (replayBatch) {
+              replayBatch.dropped = true;
+            }
+            recordWebviewEvent({
+              surface: 'tail',
+              event: 'messageDropped',
+              hostKind: postContext.hostKind,
+              mountSequence: postContext.mountSequence,
+              messageType: msg.type,
+              visible: postContext.visible,
+              ready: postContext.ready,
+              contentMounted: postContext.contentMounted
+            });
+            logInfo('Tail webview postMessage dropped', msg.type);
+            requeueReplay();
+          } else {
+            if (msg.type === 'tailReset') {
+              this.tailResetNeedsReplay = false;
+            }
+            options?.onDelivered?.();
+          }
+          this.settleReplayDeliveryBatch(replayBatch);
+        },
+        error => {
+          if (replayBatch) {
+            replayBatch.dropped = true;
+          }
+          recordWebviewEvent({
+            surface: 'tail',
+            event: 'messagePostRejected',
+            hostKind: postContext.hostKind,
+            mountSequence: postContext.mountSequence,
+            messageType: msg.type,
+            visible: postContext.visible,
+            ready: postContext.ready,
+            contentMounted: postContext.contentMounted,
+            details: { error: getErrorMessage(error) }
+          });
+          logWarn('Tail webview postMessage failed ->', getErrorMessage(error));
+          requeueReplay();
+          this.settleReplayDeliveryBatch(replayBatch);
+        }
+      );
+    } else if (replayBatch) {
+      replayBatch.dropped = true;
+      this.settleReplayDeliveryBatch(replayBatch);
+    }
     if (shouldClearWebviewError) {
-      this.view?.webview.postMessage({ type: 'error', message: undefined });
+      this.errorClearNeedsReplay = true;
+      this.post(
+        { type: 'error', message: undefined },
+        {
+          requeueReplayOnDrop: true,
+          onDelivered: () => {
+            if (this.errorMessage === undefined) {
+              this.errorClearNeedsReplay = false;
+            }
+          }
+        }
+      );
     }
   }
 
@@ -648,6 +1068,10 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     this.view = host;
     this.disposed = false;
     this.ready = false;
+    this.contentMounted = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
+    this.tailResetNeedsReplay = false;
     this.clearBootstrapTimers();
     host.webview.options = {
       enableScripts: true,
@@ -655,6 +1079,15 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     };
     this.showPlaceholder(host);
     logInfo(`Tail webview resolved (${host.kind}).`);
+    recordWebviewEvent({
+      surface: 'tail',
+      event: 'resolved',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
 
     this.hostDisposables.push(
       host.onDidDispose(() => {
@@ -663,12 +1096,24 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         }
         this.disposed = true;
         this.ready = false;
+        this.contentMounted = false;
+        this.needsReplayOnVisible = false;
+        this.visibleReplayRetryAttempts = 0;
         this.view = undefined;
         this.host = undefined;
         this.clearBootstrapTimers();
         // Stop timers and clear caches, but keep controller disposal separate.
         this.tailService.stop();
         logInfo(`Tail webview disposed; stopped tail (${host.kind}).`);
+        recordWebviewEvent({
+          surface: 'tail',
+          event: 'disposed',
+          hostKind: host.kind,
+          mountSequence: this.mountSequence,
+          visible: host.visible,
+          ready: this.ready,
+          contentMounted: this.contentMounted
+        });
       }),
       host.onDidChangeVisibility(visible => {
         this.handleVisibilityChange(host, visible);

--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -30,16 +30,48 @@ import {
 import { normalizeLogTriageSummary, type LogDiagnostic, type LogTriageSummary } from '../shared/logTriage';
 import { bucketQueryLength } from '../shared/telemetryBuckets';
 import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
+import { recordWebviewEvent, type WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
 
 const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
-export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 200;
-export const WEBVIEW_READY_TIMEOUT_MS = 5000;
+// Corporate-managed notebooks can take several seconds to initialize VS Code
+// webviews and their internal service worker. Keep these windows generous so a
+// slow-but-healthy startup is not torn down into a remount loop.
+export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 1000;
+export const WEBVIEW_READY_TIMEOUT_MS = 30000;
+const WEBVIEW_REPLAY_RETRY_DELAY_MS = 250;
+const WEBVIEW_REPLAY_MAX_RETRIES = 3;
+const LOGS_REPLAYABLE_VISIBLE_UPDATE_TYPES = new Set<ExtensionToWebviewMessage['type']>([
+  'loading',
+  'error',
+  'warning',
+  'orgs',
+  'logsColumns',
+  'logs',
+  'appendLogs',
+  'logHead',
+  'errorScanStatus',
+  'searchMatches',
+  'searchStatus'
+]);
 
 interface LogHeadSnapshot {
   codeUnitStarted?: string;
   hasErrors?: boolean;
   primaryReason?: string;
   reasons?: LogDiagnostic[];
+}
+
+interface ReplayDeliveryBatch {
+  pending: number;
+  dropped: boolean;
+  resetRetryBudgetOnSuccess: boolean;
+}
+
+interface WebviewPostOptions {
+  replay?: boolean;
+  requeueReplayOnDrop?: boolean;
+  onDelivered?: () => void;
+  replayBatch?: ReplayDeliveryBatch;
 }
 
 export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
@@ -53,8 +85,12 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   private currentOffset = 0;
   private disposed = false;
   private ready = false;
+  private contentMounted = false;
+  private needsReplayOnVisible = false;
   private mountTimer: ReturnType<typeof setTimeout> | undefined;
   private readyTimer: ReturnType<typeof setTimeout> | undefined;
+  private visibleReplayRetryTimer: ReturnType<typeof setTimeout> | undefined;
+  private visibleReplayRetryAttempts = 0;
   private mountSequence = 0;
   private refreshToken = 0;
   private activeRefreshToken: number | undefined;
@@ -73,6 +109,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   private logHeadByLogId = new Map<string, LogHeadSnapshot>();
   private errorByLogId = new Map<string, LogTriageSummary>();
   private errorMessage: string | undefined;
+  private errorClearNeedsReplay = false;
   private warningMessage: string | undefined;
   private loadingState = false;
   private errorScanStatusSnapshot: {
@@ -161,6 +198,36 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     return this.ready && !this.disposed;
   }
 
+  public getWebviewDiagnosticState(): WebviewProviderDiagnosticState {
+    return {
+      surface: 'logs',
+      hasHost: !!this.host,
+      hostKind: this.host?.kind,
+      visible: this.host?.visible,
+      ready: this.ready,
+      disposed: this.disposed,
+      contentMounted: this.contentMounted,
+      mountSequence: this.mountSequence,
+      mountTimerActive: this.mountTimer !== undefined,
+      readyTimerActive: this.readyTimer !== undefined,
+      needsReplayOnVisible: this.needsReplayOnVisible,
+      snapshots: {
+        hasOrgsSnapshot: this.hasOrgsSnapshot,
+        orgCount: this.orgsSnapshot.length,
+        hasLogsSnapshot: this.hasLogsSnapshot,
+        logCount: this.currentLogs.length,
+        currentHasMore: this.currentHasMore,
+        loading: this.loadingState,
+        hasError: this.errorMessage !== undefined,
+        errorClearNeedsReplay: this.errorClearNeedsReplay,
+        searchStatus: this.searchStatusSnapshot,
+        errorScanStatus: this.errorScanStatusSnapshot.state,
+        visibleReplayRetryTimerActive: this.visibleReplayRetryTimer !== undefined,
+        visibleReplayRetryAttempts: this.visibleReplayRetryAttempts
+      }
+    };
+  }
+
   public onDidReadyTimeout(listener: () => void): vscode.Disposable {
     this.readyTimeoutListeners.add(listener);
     return {
@@ -173,6 +240,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   public dispose(): void {
     this.disposed = true;
     this.ready = false;
+    this.contentMounted = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
     this.view = undefined;
     this.host = undefined;
     this.clearBootstrapTimers();
@@ -1461,13 +1531,31 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
   }
 
+  private clearVisibleReplayRetryTimer(): void {
+    if (this.visibleReplayRetryTimer) {
+      clearTimeout(this.visibleReplayRetryTimer);
+      this.visibleReplayRetryTimer = undefined;
+    }
+  }
+
   private clearBootstrapTimers(): void {
     this.clearMountTimer();
     this.clearReadyTimer();
+    this.clearVisibleReplayRetryTimer();
   }
 
   private showPlaceholder(host: BoundWebviewHost): void {
+    this.contentMounted = false;
     host.webview.html = this.getPlaceholderHtml();
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'placeholder',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
   }
 
   private scheduleMount(host = this.host): void {
@@ -1475,6 +1563,16 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       return;
     }
     this.clearMountTimer();
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'mountScheduled',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { delayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS }
+    });
     this.mountTimer = setTimeout(() => {
       this.mountTimer = undefined;
       if (this.host !== host || this.disposed || !host.visible) {
@@ -1486,8 +1584,25 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
   private mountWebview(host: BoundWebviewHost): void {
     this.ready = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
     const mountId = ++this.mountSequence;
+    this.contentMounted = true;
     host.webview.html = this.getHtmlForWebview(host.webview, mountId);
+    this.startReadyTimer(host, mountId);
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'mounted',
+      hostKind: host.kind,
+      mountSequence: mountId,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
+    logInfo(`Logs webview mounted (${host.kind}).`);
+  }
+
+  private startReadyTimer(host: BoundWebviewHost, mountId: number): void {
     this.clearReadyTimer();
     this.readyTimer = setTimeout(() => {
       this.readyTimer = undefined;
@@ -1495,6 +1610,16 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         return;
       }
       logWarn(`Logs webview did not report ready within ${WEBVIEW_READY_TIMEOUT_MS}ms (${host.kind}).`);
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'readyTimeout',
+        hostKind: host.kind,
+        mountSequence: mountId,
+        visible: host.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted,
+        details: { timeoutMs: WEBVIEW_READY_TIMEOUT_MS }
+      });
       this.ready = false;
       this.showPlaceholder(host);
       if (host.kind === 'editor') {
@@ -1504,7 +1629,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.scheduleMount(host);
       }
     }, WEBVIEW_READY_TIMEOUT_MS);
-    logInfo(`Logs webview mounted (${host.kind}).`);
   }
 
   private fireReadyTimeout(): void {
@@ -1520,9 +1644,45 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       return;
     }
     if (!visible) {
-      this.ready = false;
       this.clearBootstrapTimers();
-      this.showPlaceholder(host);
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'hidden',
+        hostKind: host.kind,
+        mountSequence: this.mountSequence,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+      return;
+    }
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'visible',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { needsReplayOnVisible: this.needsReplayOnVisible }
+    });
+    if (this.ready) {
+      if (this.needsReplayOnVisible) {
+        this.replayRetainedState(host, visible, 'replayedOnVisible', true);
+      }
+      return;
+    }
+    if (this.contentMounted && this.mountSequence > 0) {
+      this.startReadyTimer(host, this.mountSequence);
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'resumedPendingReady',
+        hostKind: host.kind,
+        mountSequence: this.mountSequence,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
       return;
     }
     this.scheduleMount(host);
@@ -1535,15 +1695,43 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     if (mountSequence === undefined) {
       if (this.mountSequence > 1) {
         logInfo(`Logs webview ignored unsequenced stale ready (${this.host.kind}).`);
+        recordWebviewEvent({
+          surface: 'logs',
+          event: 'ignoredUnsequencedReady',
+          hostKind: this.host.kind,
+          mountSequence: this.mountSequence,
+          visible: this.host.visible,
+          ready: this.ready,
+          contentMounted: this.contentMounted
+        });
         return;
       }
     } else if (mountSequence !== this.mountSequence) {
       logInfo(`Logs webview ignored stale ready (${this.host.kind}).`);
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'ignoredStaleReady',
+        hostKind: this.host.kind,
+        mountSequence: this.mountSequence,
+        visible: this.host.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted,
+        details: { receivedMountSequence: mountSequence }
+      });
       return;
     }
     this.ready = true;
     this.clearReadyTimer();
     logInfo(`Logs webview ready (${this.host.kind}).`);
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'ready',
+      hostKind: this.host.kind,
+      mountSequence: this.mountSequence,
+      visible: this.host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
     await this.bootstrapWebview();
   }
 
@@ -1575,7 +1763,49 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
   }
 
-  private replaySnapshot(): void {
+  private replayRetainedState(
+    host: BoundWebviewHost,
+    visible: boolean,
+    event: string,
+    resetRetryBudget: boolean
+  ): void {
+    if (resetRetryBudget) {
+      this.visibleReplayRetryAttempts = 0;
+    }
+    const replayBatch: ReplayDeliveryBatch = {
+      pending: 0,
+      dropped: false,
+      resetRetryBudgetOnSuccess: !resetRetryBudget
+    };
+    this.needsReplayOnVisible = false;
+    this.post(
+      {
+        type: 'init',
+        locale: vscode.env.language,
+        fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
+        logsColumns: this.logsColumns
+      },
+      { requeueReplayOnDrop: true, replayBatch }
+    );
+    this.replaySnapshot({ requeueReplayOnDrop: true, replayBatch });
+    recordWebviewEvent({
+      surface: 'logs',
+      event,
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted,
+      details: { retryAttempts: this.visibleReplayRetryAttempts }
+    });
+  }
+
+  private replaySnapshot(options?: WebviewPostOptions): void {
+    const replayOptions: WebviewPostOptions = {
+      replay: true,
+      requeueReplayOnDrop: options?.requeueReplayOnDrop,
+      replayBatch: options?.replayBatch
+    };
     if (this.hasOrgsSnapshot) {
       this.post(
         {
@@ -1583,14 +1813,14 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           data: this.orgsSnapshot,
           selected: this.selectedOrgSnapshot
         },
-        { replay: true }
+        replayOptions
       );
     }
-    this.post({ type: 'warning', message: this.warningMessage }, { replay: true });
-    this.post({ type: 'loading', value: this.loadingState }, { replay: true });
-    this.post({ type: 'errorScanStatus', ...this.errorScanStatusSnapshot }, { replay: true });
+    this.post({ type: 'warning', message: this.warningMessage }, replayOptions);
+    this.post({ type: 'loading', value: this.loadingState }, replayOptions);
+    this.post({ type: 'errorScanStatus', ...this.errorScanStatusSnapshot }, replayOptions);
     if (this.hasLogsSnapshot && !this.logsBootstrapNeedsRefresh) {
-      this.post({ type: 'logs', data: this.currentLogs, hasMore: this.currentHasMore }, { replay: true });
+      this.post({ type: 'logs', data: this.currentLogs, hasMore: this.currentHasMore }, replayOptions);
       for (const [logId, snapshot] of this.logHeadByLogId.entries()) {
         this.post(
           {
@@ -1601,7 +1831,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             ...(snapshot.primaryReason !== undefined ? { primaryReason: snapshot.primaryReason } : {}),
             ...(snapshot.reasons !== undefined ? { reasons: snapshot.reasons } : {})
           },
-          { replay: true }
+          replayOptions
         );
       }
       this.post(
@@ -1614,12 +1844,24 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             ? { pendingLogIds: this.searchMatchesSnapshot.pendingLogIds }
             : {})
         },
-        { replay: true }
+        replayOptions
       );
-      this.post({ type: 'searchStatus', state: this.searchStatusSnapshot }, { replay: true });
+      this.post({ type: 'searchStatus', state: this.searchStatusSnapshot }, replayOptions);
     }
     if (this.errorMessage !== undefined) {
-      this.post({ type: 'error', message: this.errorMessage }, { replay: true });
+      this.post({ type: 'error', message: this.errorMessage }, replayOptions);
+    } else if (this.errorClearNeedsReplay) {
+      this.post(
+        { type: 'error', message: undefined },
+        {
+          ...replayOptions,
+          onDelivered: () => {
+            if (this.errorMessage === undefined) {
+              this.errorClearNeedsReplay = false;
+            }
+          }
+        }
+      );
     }
   }
 
@@ -1630,6 +1872,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     this.view = host;
     this.disposed = false;
     this.ready = false;
+    this.contentMounted = false;
+    this.needsReplayOnVisible = false;
+    this.visibleReplayRetryAttempts = 0;
     this.clearBootstrapTimers();
     host.webview.options = {
       enableScripts: true,
@@ -1637,6 +1882,15 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     };
     this.showPlaceholder(host);
     logInfo(`Logs webview resolved (${host.kind}).`);
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'resolved',
+      hostKind: host.kind,
+      mountSequence: this.mountSequence,
+      visible: host.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    });
 
     this.hostDisposables.push(
       host.onDidDispose(() => {
@@ -1645,6 +1899,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         }
         this.disposed = true;
         this.ready = false;
+        this.contentMounted = false;
+        this.needsReplayOnVisible = false;
+        this.visibleReplayRetryAttempts = 0;
         this.view = undefined;
         this.host = undefined;
         this.clearBootstrapTimers();
@@ -1656,6 +1913,15 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.searchAbortController = undefined;
         }
         logInfo(`Logs webview disposed (${host.kind}).`);
+        recordWebviewEvent({
+          surface: 'logs',
+          event: 'disposed',
+          hostKind: host.kind,
+          mountSequence: this.mountSequence,
+          visible: host.visible,
+          ready: this.ready,
+          contentMounted: this.contentMounted
+        });
       }),
       host.onDidChangeVisibility(visible => {
         this.handleVisibilityChange(host, visible);
@@ -1677,7 +1943,29 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     this.handleVisibilityChange(host, host.visible);
   }
 
-  private post(msg: ExtensionToWebviewMessage, options?: { replay?: boolean }): void {
+  private settleReplayDeliveryBatch(batch: ReplayDeliveryBatch | undefined): void {
+    if (!batch) {
+      return;
+    }
+    batch.pending = Math.max(0, batch.pending - 1);
+    if (batch.pending > 0) {
+      return;
+    }
+    if (!batch.dropped && batch.resetRetryBudgetOnSuccess && !this.needsReplayOnVisible) {
+      this.visibleReplayRetryAttempts = 0;
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'replayRetryBudgetResetAfterDelivery',
+        hostKind: this.host?.kind,
+        mountSequence: this.mountSequence,
+        visible: this.host?.visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+    }
+  }
+
+  private post(msg: ExtensionToWebviewMessage, options?: WebviewPostOptions): void {
     let shouldClearWebviewError = false;
     switch (msg.type) {
       case 'loading':
@@ -1688,6 +1976,9 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         break;
       case 'error':
         this.errorMessage = msg.message;
+        if (msg.message !== undefined) {
+          this.errorClearNeedsReplay = false;
+        }
         break;
       case 'orgs':
         this.hasOrgsSnapshot = true;
@@ -1699,7 +1990,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.currentHasMore = !!msg.hasMore;
         if (!options?.replay) {
           this.logsBootstrapNeedsRefresh = false;
-          this.errorMessage = undefined;
+          if (this.errorMessage !== undefined) {
+            this.errorMessage = undefined;
+            shouldClearWebviewError = true;
+          }
         }
         break;
       case 'appendLogs':
@@ -1744,9 +2038,161 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.searchStatusSnapshot = msg.state === 'loading' ? 'loading' : 'idle';
         break;
     }
-    this.view?.webview.postMessage(msg);
+    const visible = this.host?.visible ?? false;
+    if (this.host && !visible && !options?.replay) {
+      this.needsReplayOnVisible = true;
+      this.visibleReplayRetryAttempts = 0;
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'messagePostedWhileHidden',
+        hostKind: this.host.kind,
+        mountSequence: this.mountSequence,
+        messageType: msg.type,
+        visible,
+        ready: this.ready,
+        contentMounted: this.contentMounted
+      });
+    }
+    const postContext = {
+      hostKind: this.host?.kind,
+      mountSequence: this.mountSequence,
+      visible: this.host?.visible,
+      ready: this.ready,
+      contentMounted: this.contentMounted
+    };
+    const scheduleVisibleReplayRetry = () => {
+      if (
+        !postContext.visible ||
+        !this.host ||
+        !this.host.visible ||
+        !this.ready ||
+        this.visibleReplayRetryTimer ||
+        this.visibleReplayRetryAttempts >= WEBVIEW_REPLAY_MAX_RETRIES
+      ) {
+        return;
+      }
+
+      const host = this.host;
+      const mountSequence = this.mountSequence;
+      const attempt = ++this.visibleReplayRetryAttempts;
+      this.visibleReplayRetryTimer = setTimeout(() => {
+        this.visibleReplayRetryTimer = undefined;
+        if (
+          this.disposed ||
+          this.host !== host ||
+          !host.visible ||
+          !this.ready ||
+          mountSequence !== this.mountSequence ||
+          !this.needsReplayOnVisible
+        ) {
+          return;
+        }
+        this.replayRetainedState(host, true, 'retriedReplayAfterDroppedPost', false);
+      }, WEBVIEW_REPLAY_RETRY_DELAY_MS);
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'scheduledReplayRetryAfterDroppedPost',
+        hostKind: postContext.hostKind,
+        mountSequence: postContext.mountSequence,
+        messageType: msg.type,
+        visible: postContext.visible,
+        ready: postContext.ready,
+        contentMounted: postContext.contentMounted,
+        details: { attempt, delayMs: WEBVIEW_REPLAY_RETRY_DELAY_MS }
+      });
+    };
+    const requeueReplay = () => {
+      const requeueReason = options?.requeueReplayOnDrop
+        ? 'explicit'
+        : !options?.replay &&
+            postContext.visible === true &&
+            postContext.ready === true &&
+            LOGS_REPLAYABLE_VISIBLE_UPDATE_TYPES.has(msg.type)
+          ? 'visibleUpdate'
+          : undefined;
+      if (!requeueReason || this.disposed || postContext.mountSequence !== this.mountSequence) {
+        return;
+      }
+      this.needsReplayOnVisible = true;
+      scheduleVisibleReplayRetry();
+      recordWebviewEvent({
+        surface: 'logs',
+        event: 'replayRequeuedAfterDroppedPost',
+        hostKind: postContext.hostKind,
+        mountSequence: postContext.mountSequence,
+        messageType: msg.type,
+        visible: postContext.visible,
+        ready: postContext.ready,
+        contentMounted: postContext.contentMounted,
+        details: { reason: requeueReason }
+      });
+    };
+    const replayBatch = options?.replayBatch;
+    if (replayBatch) {
+      replayBatch.pending += 1;
+    }
+    const postResult = this.view?.webview.postMessage(msg);
+    if (postResult) {
+      postResult.then(
+        delivered => {
+          if (!delivered) {
+            if (replayBatch) {
+              replayBatch.dropped = true;
+            }
+            recordWebviewEvent({
+              surface: 'logs',
+              event: 'messageDropped',
+              hostKind: postContext.hostKind,
+              mountSequence: postContext.mountSequence,
+              messageType: msg.type,
+              visible: postContext.visible,
+              ready: postContext.ready,
+              contentMounted: postContext.contentMounted
+            });
+            logTrace('Logs webview postMessage dropped', msg.type);
+            requeueReplay();
+          } else {
+            options?.onDelivered?.();
+          }
+          this.settleReplayDeliveryBatch(replayBatch);
+        },
+        error => {
+          if (replayBatch) {
+            replayBatch.dropped = true;
+          }
+          recordWebviewEvent({
+            surface: 'logs',
+            event: 'messagePostRejected',
+            hostKind: postContext.hostKind,
+            mountSequence: postContext.mountSequence,
+            messageType: msg.type,
+            visible: postContext.visible,
+            ready: postContext.ready,
+            contentMounted: postContext.contentMounted,
+            details: { error: getErrorMessage(error) }
+          });
+          logWarn('Logs webview postMessage failed ->', getErrorMessage(error));
+          requeueReplay();
+          this.settleReplayDeliveryBatch(replayBatch);
+        }
+      );
+    } else if (replayBatch) {
+      replayBatch.dropped = true;
+      this.settleReplayDeliveryBatch(replayBatch);
+    }
     if (shouldClearWebviewError) {
-      this.view?.webview.postMessage({ type: 'error', message: undefined });
+      this.errorClearNeedsReplay = true;
+      this.post(
+        { type: 'error', message: undefined },
+        {
+          requeueReplayOnDrop: true,
+          onDelivered: () => {
+            if (this.errorMessage === undefined) {
+              this.errorClearNeedsReplay = false;
+            }
+          }
+        }
+      );
     }
   }
 }

--- a/apps/vscode-extension/src/shared/diagnosticsPackage.ts
+++ b/apps/vscode-extension/src/shared/diagnosticsPackage.ts
@@ -1,0 +1,85 @@
+import type { LogEntry } from '../../../../src/utils/logger';
+import type { WebviewLifecycleEvent, WebviewProviderDiagnosticState } from './webviewDiagnostics';
+
+export interface DiagnosticsPackage {
+  generatedAt: string;
+  extension: {
+    name: string;
+    version: string;
+  };
+  vscode: {
+    version: string;
+    appName?: string;
+    appHost?: string;
+    appRoot?: string;
+    language?: string;
+    remoteName?: string;
+    uiKind?: string | number;
+  };
+  process: {
+    platform: string;
+    arch: string;
+    versions: {
+      node?: string;
+      electron?: string;
+      chrome?: string;
+      v8?: string;
+    };
+  };
+  workspace: {
+    hasWorkspace: boolean;
+    workspaceFolderCount: number;
+    workspaceFolders: string[];
+    hasSalesforceProject: boolean;
+    salesforceProjectRoot?: string;
+    salesforceProjectFile?: string;
+    sourceApiVersion?: string;
+  };
+  webview: {
+    retainContextWhenHidden: boolean;
+    stableVisibilityDelayMs: number;
+    readyTimeoutMs: number;
+    providers: WebviewProviderDiagnosticState[];
+    events: WebviewLifecycleEvent[];
+  };
+  recentLogs: LogEntry[];
+}
+
+export function formatDiagnosticsPackageMarkdown(pkg: DiagnosticsPackage): string {
+  const providers = pkg.webview.providers
+    .map(provider => {
+      const host = provider.hostKind ? `${provider.hostKind}, visible=${String(provider.visible)}` : 'unresolved';
+      return `- ${provider.surface}: ready=${provider.ready}, mounted=${provider.contentMounted}, host=${host}, mountSequence=${provider.mountSequence}`;
+    })
+    .join('\n');
+
+  const recentEvents = pkg.webview.events
+    .slice(-20)
+    .map(event => {
+      const host = event.hostKind ? ` ${event.hostKind}` : '';
+      const sequence = event.mountSequence === undefined ? '' : ` #${event.mountSequence}`;
+      return `- ${event.timestamp} ${event.surface}${host}${sequence}: ${event.event}`;
+    })
+    .join('\n');
+
+  return [
+    '# Electivus Apex Logs Diagnostics',
+    '',
+    `Generated: ${pkg.generatedAt}`,
+    `VS Code: ${pkg.vscode.version} (${pkg.vscode.appHost ?? 'unknown host'})`,
+    `Platform: ${pkg.process.platform}/${pkg.process.arch}, Node ${pkg.process.versions.node ?? 'unknown'}`,
+    `Workspace folders: ${pkg.workspace.workspaceFolderCount}`,
+    `Salesforce project detected: ${pkg.workspace.hasSalesforceProject}`,
+    '',
+    '## Webview State',
+    providers || '- No providers recorded.',
+    '',
+    '## Recent Webview Events',
+    recentEvents || '- No webview lifecycle events recorded.',
+    '',
+    '## JSON',
+    '```json',
+    JSON.stringify(pkg, null, 2),
+    '```'
+  ].join('\n');
+}

--- a/apps/vscode-extension/src/shared/webviewDiagnostics.ts
+++ b/apps/vscode-extension/src/shared/webviewDiagnostics.ts
@@ -1,0 +1,47 @@
+export type WebviewSurface = 'logs' | 'tail';
+export type WebviewHostKind = 'panel' | 'editor';
+
+export interface WebviewLifecycleEvent {
+  timestamp: string;
+  surface: WebviewSurface;
+  event: string;
+  hostKind?: WebviewHostKind;
+  mountSequence?: number;
+  messageType?: string;
+  visible?: boolean;
+  ready?: boolean;
+  contentMounted?: boolean;
+  details?: Record<string, string | number | boolean | undefined>;
+}
+
+export interface WebviewProviderDiagnosticState {
+  surface: WebviewSurface;
+  hasHost: boolean;
+  hostKind?: WebviewHostKind;
+  visible?: boolean;
+  ready: boolean;
+  disposed: boolean;
+  contentMounted: boolean;
+  mountSequence: number;
+  mountTimerActive: boolean;
+  readyTimerActive: boolean;
+  needsReplayOnVisible: boolean;
+  snapshots: Record<string, string | number | boolean | undefined>;
+}
+
+const MAX_WEBVIEW_EVENTS = 200;
+const webviewEvents: WebviewLifecycleEvent[] = [];
+
+export function recordWebviewEvent(event: Omit<WebviewLifecycleEvent, 'timestamp'>): void {
+  webviewEvents.push({
+    timestamp: new Date().toISOString(),
+    ...event
+  });
+  if (webviewEvents.length > MAX_WEBVIEW_EVENTS) {
+    webviewEvents.splice(0, webviewEvents.length - MAX_WEBVIEW_EVENTS);
+  }
+}
+
+export function getWebviewDiagnosticEvents(): WebviewLifecycleEvent[] {
+  return webviewEvents.slice();
+}

--- a/apps/vscode-extension/src/test/extension.activation.gating.test.ts
+++ b/apps/vscode-extension/src/test/extension.activation.gating.test.ts
@@ -55,11 +55,23 @@ function createExtensionHarness(options: {
   const tailRefreshViewStateCalls: number[] = [];
   const logsTailCalls: number[] = [];
   const logsRefreshCalls: number[] = [];
+  const webviewProviderRegistrations: Array<{ viewId: string; options?: any }> = [];
+  const clipboardWrites: string[] = [];
 
   const vscodeStub = {
     version: '1.90.0',
     env: {
-      appRoot: options.appRoot ?? '/usr/share/code'
+      appRoot: options.appRoot ?? '/usr/share/code',
+      appName: 'Visual Studio Code',
+      appHost: 'desktop',
+      language: 'en',
+      remoteName: undefined,
+      uiKind: 1,
+      clipboard: {
+        writeText: async (value: string) => {
+          clipboardWrites.push(value);
+        }
+      }
     },
     workspace: {
       workspaceFolders: options.salesforceProject ? [{ uri: { fsPath: options.salesforceProject.workspaceRoot } }] : [],
@@ -68,7 +80,10 @@ function createExtensionHarness(options: {
     },
     window: {
       activeTextEditor: options.activeDocument ? { document: options.activeDocument } : undefined,
-      registerWebviewViewProvider: () => createDisposable(),
+      registerWebviewViewProvider: (viewId: string, _provider: unknown, options?: any) => {
+        webviewProviderRegistrations.push({ viewId, options });
+        return createDisposable();
+      },
       showWarningMessage: async (message: string) => {
         warningMessages.push(message);
         return undefined;
@@ -106,6 +121,15 @@ function createExtensionHarness(options: {
       return options.logsViewResolved ?? false;
     }
 
+    public getWebviewDiagnosticState() {
+      return {
+        surface: 'logs',
+        hasHost: options.logsViewResolved ?? false,
+        visible: options.logsViewResolved ?? false,
+        ready: options.logsViewResolved ?? false
+      };
+    }
+
     public async refresh(): Promise<void> {
       logsRefreshCalls.push(1);
     }
@@ -137,6 +161,15 @@ function createExtensionHarness(options: {
 
     public getSelectedOrg(): string | undefined {
       return this.selectedOrg;
+    }
+
+    public getWebviewDiagnosticState() {
+      return {
+        surface: 'tail',
+        hasHost: false,
+        visible: false,
+        ready: false
+      };
     }
 
     public setSelectedOrg(username?: string): void {
@@ -178,6 +211,19 @@ function createExtensionHarness(options: {
     './panel/LogsEditorPanel': {
       LogsEditorPanel: {
         initialize: () => undefined,
+        getDiagnosticState: () => ({
+          surface: 'logs',
+          hasHost: true,
+          hostKind: 'editor',
+          ready: true,
+          disposed: false,
+          contentMounted: true,
+          mountSequence: 7,
+          mountTimerActive: false,
+          readyTimerActive: false,
+          needsReplayOnVisible: false,
+          snapshots: {}
+        }),
         show: async (options?: { selectedOrg?: string }) => {
           logsEditorShows.push(options ?? {});
         }
@@ -186,6 +232,7 @@ function createExtensionHarness(options: {
     './panel/TailEditorPanel': {
       TailEditorPanel: {
         initialize: () => undefined,
+        getDiagnosticState: () => undefined,
         show: async (options?: { selectedOrg?: string }) => {
           tailEditorShows.push(options ?? {});
         }
@@ -204,6 +251,7 @@ function createExtensionHarness(options: {
       logInfo: () => undefined,
       logWarn: () => undefined,
       logError: () => undefined,
+      getRecentLogEntries: () => [{ timestamp: '2026-04-29T12:00:00.000Z', level: 'warn', message: 'sample warn' }],
       showOutput: () => undefined,
       setTraceEnabled: () => undefined,
       disposeLogger: () => undefined
@@ -275,7 +323,9 @@ function createExtensionHarness(options: {
     tailSyncSelectedOrgCalls,
     tailRefreshViewStateCalls,
     logsTailCalls,
-    logsRefreshCalls
+    logsRefreshCalls,
+    webviewProviderRegistrations,
+    clipboardWrites
   };
 }
 
@@ -391,5 +441,36 @@ suite('extension activation gating', () => {
     const refreshEvent = harness.events.find(event => event.name === 'command.refresh');
     assert.deepEqual(refreshEvent?.props, { outcome: 'invoked' });
     assert.equal(typeof refreshEvent?.measurements?.durationMs, 'number');
+  });
+
+  test('registers retained sidebar webviews', async () => {
+    const harness = createExtensionHarness({});
+
+    await harness.extension.activate(createContext());
+
+    assert.deepEqual(
+      harness.webviewProviderRegistrations.map(registration => ({
+        viewId: registration.viewId,
+        retainContextWhenHidden: registration.options?.webviewOptions?.retainContextWhenHidden
+      })),
+      [
+        { viewId: 'sfLogViewer', retainContextWhenHidden: true },
+        { viewId: 'sfLogTail', retainContextWhenHidden: true }
+      ]
+    );
+  });
+
+  test('copy diagnostics command writes a markdown package with json evidence', async () => {
+    const harness = createExtensionHarness({ logsViewResolved: true });
+
+    await harness.extension.activate(createContext());
+    await harness.commands.get('sfLogs.copyDiagnostics')!();
+
+    const copied = harness.clipboardWrites[0] ?? '';
+    assert.ok(copied.includes('# Electivus Apex Logs Diagnostics'), 'should copy a markdown diagnostics package');
+    assert.ok(copied.includes('```json'), 'should include machine-readable JSON');
+    assert.ok(copied.includes('"logs"'), 'should include logs provider state');
+    assert.ok(copied.includes('"hostKind": "editor"'), 'should include active editor panel provider state');
+    assert.ok(copied.includes('sample warn'), 'should include recent extension output entries');
   });
 });

--- a/apps/vscode-extension/src/test/logger.showOutput.test.ts
+++ b/apps/vscode-extension/src/test/logger.showOutput.test.ts
@@ -27,4 +27,36 @@ suite('logger showOutput', () => {
     showOutput(true);
     assert.strictEqual(preserve, true, 'channel.show should be invoked');
   });
+
+  test('redacts token-shaped log values from recent diagnostic entries', () => {
+    const { getRecentLogEntries, logInfo } = proxyquire('../../../../src/utils/logger', {
+      vscode: {
+        window: {
+          createOutputChannel: () => ({
+            info: () => {},
+            warn: () => {},
+            error: () => {},
+            trace: () => {},
+            show: () => {},
+            dispose: () => {}
+          })
+        }
+      }
+    });
+
+    logInfo('Authorization: Bearer 00Dxx000000000001!secret-token', {
+      accessToken: 'raw-access-token',
+      refresh_token: 'raw-refresh-token',
+      sessionId: 'raw-session-id'
+    });
+
+    const recent = getRecentLogEntries();
+    const message = recent.at(-1)?.message ?? '';
+
+    assert.equal(message.includes('00Dxx000000000001!secret-token'), false);
+    assert.equal(message.includes('raw-access-token'), false);
+    assert.equal(message.includes('raw-refresh-token'), false);
+    assert.equal(message.includes('raw-session-id'), false);
+    assert.ok(message.includes('[redacted]'), 'sanitized log should keep redaction markers');
+  });
 });

--- a/apps/vscode-extension/src/test/logsEditorPanel.test.ts
+++ b/apps/vscode-extension/src/test/logsEditorPanel.test.ts
@@ -37,6 +37,7 @@ suite('LogsEditorPanel', () => {
   test('creates a panel once and syncs the selected org when reusing it', async () => {
     const createdProviders: any[] = [];
     const panel = createPanel();
+    const panelOptions: any[] = [];
 
     class FakeLogsProvider {
       selectedOrgs: Array<string | undefined> = [];
@@ -68,7 +69,10 @@ suite('LogsEditorPanel', () => {
 
     const vscodeStub = {
       window: {
-        createWebviewPanel: () => panel
+        createWebviewPanel: (_viewType: string, _title: string, _showOptions: unknown, options: unknown) => {
+          panelOptions.push(options);
+          return panel;
+        }
       },
       ViewColumn: {
         Active: 1
@@ -100,6 +104,7 @@ suite('LogsEditorPanel', () => {
     assert.deepEqual(createdProviders[0]?.syncedOrgs, ['second@example.com']);
     assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
     assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
+    assert.equal(panelOptions[0]?.retainContextWhenHidden, true, 'logs editor should retain context while hidden');
   });
 
   test('clears the singleton after dispose so a new editor panel can be created', async () => {

--- a/apps/vscode-extension/src/test/provider.webview.test.ts
+++ b/apps/vscode-extension/src/test/provider.webview.test.ts
@@ -16,10 +16,18 @@ class MockDisposable implements vscode.Disposable {
 }
 
 class MockWebview implements vscode.Webview {
-  html = '';
+  private _html = '';
+  readonly htmlAssignments: string[] = [];
   options: vscode.WebviewOptions = {};
   cspSource = 'vscode-resource://test';
   private messageHandler: ((e: any) => void) | undefined;
+  get html(): string {
+    return this._html;
+  }
+  set html(value: string) {
+    this._html = value;
+    this.htmlAssignments.push(value);
+  }
   asWebviewUri(uri: vscode.Uri): vscode.Uri {
     return uri;
   }
@@ -110,7 +118,36 @@ class MockWebviewPanel implements vscode.WebviewPanel {
   }
 }
 
+async function remountLogsSidebar(
+  provider: SfLogsViewProvider,
+  clock: TestClock,
+  posted: any[]
+): Promise<MockWebview> {
+  const webview = new MockWebview();
+  webview.postMessage = (message: any) => {
+    posted.push(message);
+    return Promise.resolve(true);
+  };
+  const view = new MockWebviewView(webview);
+  await provider.resolveWebviewView(view);
+  await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+  await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+  await clock.flushMicrotasks();
+  return webview;
+}
+
 suite('SfLogsViewProvider webview', () => {
+  test('uses corporate-friendly webview bootstrap timing windows', () => {
+    assert.ok(
+      WEBVIEW_STABLE_VISIBILITY_DELAY_MS >= 1000,
+      'visibility should be stable for at least 1s before mounting webview content'
+    );
+    assert.ok(
+      WEBVIEW_READY_TIMEOUT_MS >= 30000,
+      'webview ready watchdog should allow at least 30s for slow corporate machines'
+    );
+  });
+
   test('mounts the logs view after visibility stabilizes', async () => {
     const clock = new TestClock();
     try {
@@ -215,6 +252,200 @@ suite('SfLogsViewProvider webview', () => {
 
       await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
       assert.ok(webview.html.includes('Content-Security-Policy'), 'visible sidebar should auto-remount after timeout');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('accepts delayed logs ready messages from slow corporate webview startup', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const calls: string[] = [];
+
+      (provider as any).sendOrgs = async () => {
+        calls.push('sendOrgs');
+      };
+      (provider as any).refresh = async () => {
+        calls.push('refresh');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountSequence = (provider as any).mountSequence;
+      assert.ok(webview.html.includes('Content-Security-Policy'), 'initial mount should render real html');
+
+      await clock.advanceBy(20_000);
+      assert.ok(
+        webview.html.includes('Content-Security-Policy'),
+        'slow startup should not be replaced with placeholder before the ready timeout'
+      );
+
+      webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      assert.deepEqual(calls, ['sendOrgs', 'refresh']);
+      assert.equal(provider.isReady(), true, 'delayed ready should mark the provider ready');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('keeps a ready retained sidebar webview mounted across hide and show', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+
+      (provider as any).sendOrgs = async () => undefined;
+      (provider as any).refresh = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountedHtml = webview.html;
+      const mountedAssignments = webview.htmlAssignments.length;
+      const mountSequence = (provider as any).mountSequence;
+
+      await webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      view.fireVisible(false);
+      assert.equal(webview.html, mountedHtml, 'hiding a retained ready webview should not replace html');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hide should not write placeholder html');
+      assert.equal(provider.isReady(), true, 'ready retained webview should stay ready while hidden');
+
+      view.fireVisible(true);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'showing a retained ready webview should not remount html');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'show should not write a new html document');
+      assert.equal((provider as any).mountSequence, mountSequence, 'show should keep the same mount sequence');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('requeues retained sidebar replay when visible postMessage is dropped', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).sendOrgs = async () => undefined;
+      (provider as any).refresh = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      view.fireVisible(false);
+      (provider as any).post({
+        type: 'logs',
+        data: [{ Id: '07Lxx0000000001', StartTime: '2026-04-29T16:00:00.000Z', Status: 'Success' }],
+        hasMore: false
+      });
+      await clock.flushMicrotasks();
+
+      assert.equal((provider as any).needsReplayOnVisible, true, 'hidden update should request replay on show');
+
+      posted.length = 0;
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(false);
+      };
+      view.fireVisible(true);
+      await clock.flushMicrotasks();
+
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible transition should attempt init replay');
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'dropped visible replay should stay requested until a retry delivers it'
+      );
+
+      posted.length = 0;
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+      await clock.advanceBy(1000);
+
+      assert.equal((provider as any).needsReplayOnVisible, false, 'successful retry should clear replay request');
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend init');
+      assert.ok(posted.some(message => message?.type === 'logs'), 'visible retry should resend logs');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('keeps an initializing retained sidebar webview mounted while hidden', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const calls: string[] = [];
+
+      (provider as any).sendOrgs = async () => {
+        calls.push('sendOrgs');
+      };
+      (provider as any).refresh = async () => {
+        calls.push('refresh');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountedHtml = webview.html;
+      const mountedAssignments = webview.htmlAssignments.length;
+      const mountSequence = (provider as any).mountSequence;
+
+      view.fireVisible(false);
+      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS + WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'hidden initializing retained webview should not fall back to placeholder');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hidden initializing webview should not remount');
+
+      view.fireVisible(true);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'visible restore should reuse the initializing document');
+      assert.equal((provider as any).mountSequence, mountSequence, 'visible restore should not allocate a new mount');
+
+      await webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      assert.deepEqual(calls, ['sendOrgs', 'refresh']);
+      assert.equal(provider.isReady(), true);
     } finally {
       clock.dispose();
     }
@@ -329,11 +560,7 @@ suite('SfLogsViewProvider webview', () => {
       await clock.flushMicrotasks();
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'refreshCalled'),
@@ -545,11 +772,7 @@ suite('SfLogsViewProvider webview', () => {
       provider.setSelectedOrg('second@example.com');
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountLogsSidebar(provider, clock, posted);
 
       const replayedOrgs = posted.find(message => message?.type === 'orgs');
       assert.equal(replayedOrgs?.selected, 'second@example.com');
@@ -614,11 +837,7 @@ suite('SfLogsViewProvider webview', () => {
       (provider as any).post({ type: 'error', message: 'load failed' });
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'error' && message?.message === 'load failed'),
@@ -629,11 +848,7 @@ suite('SfLogsViewProvider webview', () => {
       (provider as any).post({ type: 'logs', data: [], hasMore: false });
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'error'),
@@ -672,11 +887,7 @@ suite('SfLogsViewProvider webview', () => {
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         posted.length = 0;
-        view.fireVisible(false);
-        view.fireVisible(true);
-        await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-        webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-        await clock.flushMicrotasks();
+        await remountLogsSidebar(provider, clock, posted);
 
         assert.equal(
           posted.some(message => message?.type === 'error' && message?.message === 'refresh failed'),
@@ -687,11 +898,7 @@ suite('SfLogsViewProvider webview', () => {
       (provider as any).post({ type: 'logs', data: [], hasMore: false });
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'error'),
@@ -753,6 +960,289 @@ suite('SfLogsViewProvider webview', () => {
         posted.some(message => message?.type === 'error'),
         false,
         'cleared loadMore errors should not replay on remount'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('replays an explicit logs error clear after hidden recovery', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropVisibleReplay = false;
+      webview.postMessage = (message: any) => {
+        if (!view.visible) {
+          return Promise.resolve(false);
+        }
+        if (dropVisibleReplay) {
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      (provider as any).post({ type: 'error', message: 'load more failed' });
+      posted.length = 0;
+
+      view.fireVisible(false);
+      (provider as any).post({
+        type: 'appendLogs',
+        data: [{ Id: '07L000000000005AA', StartTime: '2026-04-19T00:04:00.000Z' }],
+        hasMore: false
+      });
+      await clock.flushMicrotasks();
+
+      assert.equal(posted.length, 0, 'hidden clear is not delivered in this test harness');
+
+      dropVisibleReplay = true;
+      view.fireVisible(true);
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        false,
+        'dropped visible replay should not count as a delivered clear'
+      );
+
+      dropVisibleReplay = false;
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        true,
+        'visible retry should still include the stale retained logs error clear'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('retries a dropped visible logs error clear', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropVisibleClear = false;
+      webview.postMessage = (message: any) => {
+        if (dropVisibleClear && message?.type === 'error' && message?.message === undefined) {
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      (provider as any).post({ type: 'error', message: 'load more failed' });
+      posted.length = 0;
+
+      dropVisibleClear = true;
+      (provider as any).post({
+        type: 'appendLogs',
+        data: [{ Id: '07L000000000006AA', StartTime: '2026-04-19T00:05:00.000Z' }],
+        hasMore: false
+      });
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        false,
+        'dropped visible clear should not be treated as delivered'
+      );
+
+      dropVisibleClear = false;
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        true,
+        'visible retry should resend a dropped logs error clear'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('retries retained replay after a dropped visible appendLogs update', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropNextAppendLogs = false;
+      webview.postMessage = (message: any) => {
+        if (dropNextAppendLogs && message?.type === 'appendLogs') {
+          dropNextAppendLogs = false;
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      const logs = [{ Id: '07L000000000007AA', StartTime: '2026-04-19T00:06:00.000Z' }] as any[];
+      posted.length = 0;
+      dropNextAppendLogs = true;
+      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
+      (provider as any).setCurrentLogs(logs);
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'dropped visible appendLogs should request a retained replay'
+      );
+
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal((provider as any).needsReplayOnVisible, false, 'successful logs retry should clear replay request');
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend logs init');
+      assert.ok(
+        posted.some(message => message?.type === 'logs' && message?.data?.[0]?.Id === logs[0].Id),
+        'visible retry should replay the latest retained logs snapshot'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('resets visible replay retry budget after a successful logs retry', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropNextAppendLogs = false;
+      webview.postMessage = (message: any) => {
+        if (dropNextAppendLogs && message?.type === 'appendLogs') {
+          dropNextAppendLogs = false;
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      const logs = [{ Id: '07L000000000008AA', StartTime: '2026-04-19T00:07:00.000Z' }] as any[];
+      dropNextAppendLogs = true;
+      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
+      (provider as any).setCurrentLogs(logs);
+      await clock.flushMicrotasks();
+
+      assert.equal((provider as any).visibleReplayRetryAttempts, 1, 'dropped logs update should consume retry budget');
+
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        (provider as any).visibleReplayRetryAttempts,
+        0,
+        'successful logs replay retry should reset the retry budget'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('stops retrying visible logs replay after the retry budget is exhausted', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      let dropAppendThenAllReplay = false;
+      let dropAllReplay = false;
+      webview.postMessage = (message: any) => {
+        if (dropAppendThenAllReplay && message?.type === 'appendLogs') {
+          dropAppendThenAllReplay = false;
+          dropAllReplay = true;
+          return Promise.resolve(false);
+        }
+        if (dropAllReplay) {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      const logs = [{ Id: '07L000000000009AA', StartTime: '2026-04-19T00:08:00.000Z' }] as any[];
+      dropAppendThenAllReplay = true;
+      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
+      (provider as any).setCurrentLogs(logs);
+      await clock.flushMicrotasks();
+
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        (provider as any).visibleReplayRetryAttempts,
+        3,
+        'failed logs replay retries should consume the configured retry budget'
+      );
+      assert.equal(
+        (provider as any).visibleReplayRetryTimer,
+        undefined,
+        'logs replay should stop scheduling immediate retries after the budget is exhausted'
+      );
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'logs replay should remain pending for a future hide/show after immediate retries are exhausted'
       );
     } finally {
       clock.dispose();

--- a/apps/vscode-extension/src/test/tailEditorPanel.test.ts
+++ b/apps/vscode-extension/src/test/tailEditorPanel.test.ts
@@ -37,6 +37,7 @@ suite('TailEditorPanel', () => {
   test('creates a panel once and syncs the selected org when reusing it', async () => {
     const createdProviders: any[] = [];
     const panel = createPanel();
+    const panelOptions: any[] = [];
 
     class FakeTailProvider {
       selectedOrgs: Array<string | undefined> = [];
@@ -68,7 +69,10 @@ suite('TailEditorPanel', () => {
 
     const vscodeStub = {
       window: {
-        createWebviewPanel: () => panel
+        createWebviewPanel: (_viewType: string, _title: string, _showOptions: unknown, options: unknown) => {
+          panelOptions.push(options);
+          return panel;
+        }
       },
       ViewColumn: {
         Active: 1
@@ -100,6 +104,7 @@ suite('TailEditorPanel', () => {
     assert.deepEqual(createdProviders[0]?.syncedOrgs, ['tail-second@example.com']);
     assert.equal(createdProviders[0]?.resolvedPanels.length, 1, 'should bind the editor panel once');
     assert.equal(panel.revealCount, 1, 'should reveal the existing panel on reopen');
+    assert.equal(panelOptions[0]?.retainContextWhenHidden, true, 'tail editor should retain context while hidden');
   });
 
   test('clears the singleton after dispose so a new editor panel can be created', async () => {

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -96,10 +96,18 @@ class MockDisposable implements vscode.Disposable {
 }
 
 class MockWebview implements vscode.Webview {
-  html = '';
+  private _html = '';
+  readonly htmlAssignments: string[] = [];
   options: vscode.WebviewOptions = {};
   cspSource = 'vscode-resource://test';
   private handler: ((e: any) => any) | undefined;
+  get html(): string {
+    return this._html;
+  }
+  set html(value: string) {
+    this._html = value;
+    this.htmlAssignments.push(value);
+  }
   asWebviewUri(uri: vscode.Uri): vscode.Uri {
     return uri;
   }
@@ -187,6 +195,24 @@ class MockWebviewPanel implements vscode.WebviewPanel {
   }
 }
 
+async function remountTailSidebar(
+  provider: SfLogTailViewProvider,
+  clock: TestClock,
+  posted: any[]
+): Promise<MockWebview> {
+  const webview = new MockWebview();
+  webview.postMessage = (message: any) => {
+    posted.push(message);
+    return Promise.resolve(true);
+  };
+  const view = new MockWebviewView(webview);
+  await provider.resolveWebviewView(view);
+  await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+  await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+  await clock.flushMicrotasks();
+  return webview;
+}
+
 suite('TailService', () => {
   const originalDebugFlagsShow = DebugFlagsPanel.show;
 
@@ -196,6 +222,17 @@ suite('TailService', () => {
     jsforce.__resetConnectionFactoryForTests();
     __resetApiVersionFallbackStateForTests();
     setApiVersion('64.0');
+  });
+
+  test('tail webview uses corporate-friendly bootstrap timing windows', () => {
+    assert.ok(
+      WEBVIEW_STABLE_VISIBILITY_DELAY_MS >= 1000,
+      'visibility should be stable for at least 1s before mounting tail webview content'
+    );
+    assert.ok(
+      WEBVIEW_READY_TIMEOUT_MS >= 30000,
+      'tail webview ready watchdog should allow at least 30s for slow corporate machines'
+    );
   });
 
   test('requires debug level', async () => {
@@ -810,6 +847,510 @@ suite('TailService', () => {
     }
   });
 
+  test('tail sidebar accepts delayed ready messages from slow corporate webview startup', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const calls: string[] = [];
+
+      (provider as any).refreshViewState = async () => {
+        calls.push('refreshViewState');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountSequence = (provider as any).mountSequence;
+      assert.ok(webview.html.includes('media/tail.js'), 'initial mount should render the tail webview');
+
+      await clock.advanceBy(20_000);
+      assert.ok(
+        webview.html.includes('media/tail.js'),
+        'slow startup should not be replaced with placeholder before the ready timeout'
+      );
+
+      await webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      assert.deepEqual(calls, ['refreshViewState']);
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail keeps a ready retained sidebar webview mounted across hide and show', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountedHtml = webview.html;
+      const mountedAssignments = webview.htmlAssignments.length;
+      const mountSequence = (provider as any).mountSequence;
+
+      await webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      view.fireVisible(false);
+      assert.equal(webview.html, mountedHtml, 'hiding a retained ready tail webview should not replace html');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hide should not write placeholder html');
+      assert.equal(provider.isReady(), true, 'ready retained tail webview should stay ready while hidden');
+
+      view.fireVisible(true);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'showing a retained ready tail webview should not remount html');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'show should not write a new html document');
+      assert.equal((provider as any).mountSequence, mountSequence, 'show should keep the same mount sequence');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail requeues retained sidebar replay when visible postMessage is dropped', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      view.fireVisible(false);
+      (provider as any).post({ type: 'tailStatus', running: true });
+      await clock.flushMicrotasks();
+
+      assert.equal((provider as any).needsReplayOnVisible, true, 'hidden tail update should request replay on show');
+
+      posted.length = 0;
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(false);
+      };
+      view.fireVisible(true);
+      await clock.flushMicrotasks();
+
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible transition should attempt tail init replay');
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'dropped visible tail replay should stay requested until a retry delivers it'
+      );
+
+      posted.length = 0;
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+      await clock.advanceBy(1000);
+
+      assert.equal((provider as any).needsReplayOnVisible, false, 'successful tail retry should clear replay request');
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend tail init');
+      assert.ok(posted.some(message => message?.type === 'tailStatus'), 'visible retry should resend tail status');
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail retries retained replay after a dropped visible tailStatus update', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropNextTailStatus = false;
+      webview.postMessage = (message: any) => {
+        if (dropNextTailStatus && message?.type === 'tailStatus') {
+          dropNextTailStatus = false;
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      posted.length = 0;
+      dropNextTailStatus = true;
+      (provider as any).post({ type: 'tailStatus', running: true });
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'dropped visible tailStatus should request a retained replay'
+      );
+
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal((provider as any).needsReplayOnVisible, false, 'successful tail retry should clear replay request');
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend tail init');
+      assert.ok(
+        posted.some(message => message?.type === 'tailStatus' && message?.running === true),
+        'visible retry should replay the latest tail running status'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail retries retained reset after a dropped visible tailReset update', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropNextTailReset = false;
+      webview.postMessage = (message: any) => {
+        if (dropNextTailReset && message?.type === 'tailReset') {
+          dropNextTailReset = false;
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      posted.length = 0;
+      dropNextTailReset = true;
+      (provider as any).post({ type: 'tailReset' });
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'dropped visible tailReset should request a retained replay'
+      );
+
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal((provider as any).needsReplayOnVisible, false, 'successful tail reset retry should clear replay request');
+      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend tail init');
+      assert.ok(
+        posted.some(message => message?.type === 'tailReset'),
+        'visible retry should replay the retained tail reset'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail resets visible replay retry budget after a successful retry', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropNextTailStatus = false;
+      webview.postMessage = (message: any) => {
+        if (dropNextTailStatus && message?.type === 'tailStatus') {
+          dropNextTailStatus = false;
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      dropNextTailStatus = true;
+      (provider as any).post({ type: 'tailStatus', running: true });
+      await clock.flushMicrotasks();
+
+      assert.equal((provider as any).visibleReplayRetryAttempts, 1, 'dropped tail update should consume retry budget');
+
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        (provider as any).visibleReplayRetryAttempts,
+        0,
+        'successful tail replay retry should reset the retry budget'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail stops retrying visible replay after the retry budget is exhausted', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      let dropTailStatusThenAllReplay = false;
+      let dropAllReplay = false;
+      webview.postMessage = (message: any) => {
+        if (dropTailStatusThenAllReplay && message?.type === 'tailStatus') {
+          dropTailStatusThenAllReplay = false;
+          dropAllReplay = true;
+          return Promise.resolve(false);
+        }
+        if (dropAllReplay) {
+          return Promise.resolve(false);
+        }
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      dropTailStatusThenAllReplay = true;
+      (provider as any).post({ type: 'tailStatus', running: true });
+      await clock.flushMicrotasks();
+
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        (provider as any).visibleReplayRetryAttempts,
+        3,
+        'failed tail replay retries should consume the configured retry budget'
+      );
+      assert.equal(
+        (provider as any).visibleReplayRetryTimer,
+        undefined,
+        'tail replay should stop scheduling immediate retries after the budget is exhausted'
+      );
+      assert.equal(
+        (provider as any).needsReplayOnVisible,
+        true,
+        'tail replay should remain pending for a future hide/show after immediate retries are exhausted'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail replays an explicit error clear after hidden recovery', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropVisibleReplay = false;
+      webview.postMessage = (message: any) => {
+        if (!view.visible) {
+          return Promise.resolve(false);
+        }
+        if (dropVisibleReplay) {
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      (provider as any).post({ type: 'error', message: 'tail failed' });
+      posted.length = 0;
+
+      view.fireVisible(false);
+      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|recovered while hidden'] });
+      await clock.flushMicrotasks();
+
+      assert.equal(posted.length, 0, 'hidden recovery messages are not delivered in this test harness');
+
+      dropVisibleReplay = true;
+      view.fireVisible(true);
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        false,
+        'dropped visible tail replay should not count as a delivered clear'
+      );
+
+      dropVisibleReplay = false;
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        true,
+        'visible retry should still include the stale retained Tail error clear'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail retries a dropped visible error clear', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const posted: any[] = [];
+      let dropVisibleClear = false;
+      webview.postMessage = (message: any) => {
+        if (dropVisibleClear && message?.type === 'error' && message?.message === undefined) {
+          return Promise.resolve(false);
+        }
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.flushMicrotasks();
+
+      (provider as any).post({ type: 'error', message: 'tail failed' });
+      posted.length = 0;
+
+      dropVisibleClear = true;
+      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|recovered while visible'] });
+      await clock.flushMicrotasks();
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        false,
+        'dropped visible tail clear should not be treated as delivered'
+      );
+
+      dropVisibleClear = false;
+      posted.length = 0;
+      await clock.advanceBy(1000);
+
+      assert.equal(
+        posted.some(message => message?.type === 'error' && message?.message === undefined),
+        true,
+        'visible retry should resend a dropped tail error clear'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail keeps an initializing retained sidebar webview mounted while hidden', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const calls: string[] = [];
+
+      (provider as any).refreshViewState = async () => {
+        calls.push('refreshViewState');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      const mountedHtml = webview.html;
+      const mountedAssignments = webview.htmlAssignments.length;
+      const mountSequence = (provider as any).mountSequence;
+
+      view.fireVisible(false);
+      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS + WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'hidden initializing tail webview should not fall back to placeholder');
+      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hidden initializing tail webview should not remount');
+
+      view.fireVisible(true);
+      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+
+      assert.equal(webview.html, mountedHtml, 'visible restore should reuse the initializing tail document');
+      assert.equal((provider as any).mountSequence, mountSequence, 'visible restore should not allocate a new tail mount');
+
+      await webview.emit({ type: 'ready', mountSequence });
+      await clock.flushMicrotasks();
+
+      assert.deepEqual(calls, ['refreshViewState']);
+      assert.equal(provider.isReady(), true);
+    } finally {
+      clock.dispose();
+    }
+  });
+
   test('tail sidebar ignores stale ready events from a previous mount after timeout remounts', async () => {
     const clock = new TestClock();
     try {
@@ -871,11 +1412,7 @@ suite('TailService', () => {
       (provider as any).post({ type: 'error', message: 'tail failed' });
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountTailSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'error' && message?.message === 'tail failed'),
@@ -885,11 +1422,7 @@ suite('TailService', () => {
       (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|hello'] });
       posted.length = 0;
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountTailSidebar(provider, clock, posted);
 
       assert.equal(
         posted.some(message => message?.type === 'error'),
@@ -926,11 +1459,7 @@ suite('TailService', () => {
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         posted.length = 0;
-        view.fireVisible(false);
-        view.fireVisible(true);
-        await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-        await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-        await clock.flushMicrotasks();
+        await remountTailSidebar(provider, clock, posted);
 
         assert.equal(
           posted.some(message => message?.type === 'error' && message?.message === 'tail failed'),
@@ -1034,6 +1563,7 @@ suite('TailService', () => {
       const webview = new MockWebview();
       const view = new MockWebviewView(webview);
       const calls: Array<{ showLoading?: boolean }> = [];
+      const posted: any[] = [];
 
       (provider as any).post({ type: 'orgs', data: [], selected: undefined });
       (provider as any).post({ type: 'debugLevels', data: [] });
@@ -1048,11 +1578,7 @@ suite('TailService', () => {
 
       assert.deepEqual(calls, [], 'initial ready should rely on the cached snapshot');
 
-      view.fireVisible(false);
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
+      await remountTailSidebar(provider, clock, posted);
 
       assert.deepEqual(calls, [{ showLoading: false }], 'remount should silently refresh cached metadata');
     } finally {

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -4,6 +4,15 @@ import { stringifyUnknown } from './error';
 // Centralized LogOutputChannel for the extension
 const channel: vscode.LogOutputChannel = vscode.window.createOutputChannel('Electivus Apex Log Viewer', { log: true });
 let traceEnabled = false;
+const MAX_RECENT_LOG_ENTRIES = 300;
+
+export interface LogEntry {
+  timestamp: string;
+  level: 'info' | 'warn' | 'error' | 'trace';
+  message: string;
+}
+
+const recentLogEntries: LogEntry[] = [];
 
 function fmt(parts: unknown[]): string {
   const mapped = parts.map(p => {
@@ -15,16 +24,44 @@ function fmt(parts: unknown[]): string {
   return mapped.join(' ');
 }
 
+function redactSensitiveText(message: string): string {
+  const secretKeyNames = [
+    'accessToken',
+    'access_token',
+    'refreshToken',
+    'refresh_token',
+    'idToken',
+    'id_token',
+    'sessionId',
+    'session_id',
+    'sid',
+    'clientSecret',
+    'client_secret',
+    'authorization',
+    'authToken',
+    'auth_token',
+    'password'
+  ].join('|');
+  let redacted = message.replace(/(Authorization\s*[:=]\s*Bearer\s+)[^\s,;]+/gi, '$1[redacted]');
+  redacted = redacted.replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, 'Bearer [redacted]');
+  redacted = redacted.replace(
+    new RegExp(`(["']?(?:${secretKeyNames})["']?\\s*:\\s*["'])([^"']+)(["'])`, 'gi'),
+    '$1[redacted]$3'
+  );
+  redacted = redacted.replace(new RegExp(`(\\b(?:${secretKeyNames})\\b\\s*=\\s*)([^\\s,;]+)`, 'gi'), '$1[redacted]');
+  return redacted;
+}
+
 export function logInfo(...parts: unknown[]): void {
-  channel.info(fmt(parts));
+  writeLog('info', parts);
 }
 
 export function logWarn(...parts: unknown[]): void {
-  channel.warn(fmt(parts));
+  writeLog('warn', parts);
 }
 
 export function logError(...parts: unknown[]): void {
-  channel.error(fmt(parts));
+  writeLog('error', parts);
 }
 
 export function showOutput(preserveFocus: boolean = false): void {
@@ -37,7 +74,7 @@ export function disposeLogger(): void {
 
 export function setTraceEnabled(enabled: boolean): void {
   traceEnabled = !!enabled;
-  channel.info(`Trace logging ${traceEnabled ? 'enabled' : 'disabled'}`);
+  writeLog('info', [`Trace logging ${traceEnabled ? 'enabled' : 'disabled'}`]);
 }
 
 export function isTraceEnabled(): boolean {
@@ -48,5 +85,32 @@ export function logTrace(...parts: unknown[]): void {
   if (!traceEnabled) {
     return;
   }
-  channel.info(`[trace] ${fmt(parts)}`);
+  writeLog('trace', parts);
+}
+
+export function getRecentLogEntries(): LogEntry[] {
+  return recentLogEntries.slice();
+}
+
+function writeLog(level: LogEntry['level'], parts: unknown[]): void {
+  const message = redactSensitiveText(level === 'trace' ? `[trace] ${fmt(parts)}` : fmt(parts));
+  recentLogEntries.push({
+    timestamp: new Date().toISOString(),
+    level,
+    message
+  });
+  if (recentLogEntries.length > MAX_RECENT_LOG_ENTRIES) {
+    recentLogEntries.splice(0, recentLogEntries.length - MAX_RECENT_LOG_ENTRIES);
+  }
+  switch (level) {
+    case 'warn':
+      channel.warn(message);
+      break;
+    case 'error':
+      channel.error(message);
+      break;
+    default:
+      channel.info(message);
+      break;
+  }
 }

--- a/telemetry.json
+++ b/telemetry.json
@@ -143,6 +143,17 @@
         }
       }
     },
+    "command.copyDiagnostics": {
+      "description": "Copy-diagnostics command outcome.",
+      "properties": {
+        "outcome": {
+          "classification": "SystemMetaData",
+          "purpose": "FeatureInsight",
+          "required": true,
+          "values": ["ok", "error"]
+        }
+      }
+    },
     "command.resetCliCache": {
       "description": "Reset-CLI-cache command outcome.",
       "properties": {


### PR DESCRIPTION
## Summary
- Increase webview bootstrap timing windows and retain webview context across hidden sidebar/editor transitions.
- Avoid aggressive hide/show remount loops that can invalidate VS Code webview documents while service worker registration is still starting.
- Add a copyable diagnostics package with webview lifecycle state, recent redacted logs, environment details, and provider state evidence.

## Root Cause / Notes
- The VS Code service worker error is produced inside VS Code's webview bootstrap, not directly by the extension timeout itself.
- The previous 5s ready timeout and placeholder remount loop made slow corporate environments more likely to dispose/recreate the document during VS Code's webview/service-worker startup path.
- `retainContextWhenHidden` is now used, but state replay remains in place as a defensive recovery path for true remounts, dropped hidden messages, and reloads.

## Test Plan
- [x] `node --version` -> `v22.15.1`
- [x] `npm run compile`
- [x] `npm run compile-tests`
- [x] `VSCODE_TEST_MOCHA_TIMEOUT_MS=120000 node scripts/run-tests-cli.js --scope=unit --vscode=stable --timeout=240000` -> `357 passing`
- [x] `git diff --check`
