### PR TITLE
feat(logs): share sync runtime with extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Runtime/Logs: share the Rust `logs/sync` path between CLI and extension, index synced log bodies in `apexlogs/.alv/log-index.sqlite`, add `logs index rebuild`, and let Refresh Logs start sync in the background before rerunning triage/search.
+
 ### Bug Fixes
 
 - Logs/Tail: increase webview startup timing windows so slow corporate machines can finish VS Code webview/service-worker bootstrap before the extension retries the mount.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -32,6 +44,7 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "reqwest",
+ "rusqlite",
  "serde",
  "serde_json",
  "tiny_http",
@@ -314,6 +327,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +503,24 @@ dependencies = [
  "log",
  "memchr",
  "memmap2",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
 ]
 
 [[package]]
@@ -768,6 +811,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -849,6 +903,12 @@ name = "pin-project-lite"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -1044,6 +1104,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -1491,6 +1565,18 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"

--- a/README.md
+++ b/README.md
@@ -66,9 +66,10 @@ The standalone Rust CLI now exposes a local-first `logs` surface for humans and 
 apex-log-viewer logs sync --target-org my-org --concurrency 6
 apex-log-viewer logs status --target-org my-org
 apex-log-viewer logs search "NullPointerException" --target-org my-org
+apex-log-viewer logs index rebuild --target-org my-org
 ```
 
-`logs sync` reuses `sf org display` for auth, then lists `ApexLog` rows and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `6` and `1` keeps the old serial-style troubleshooting mode. The VS Code extension and the CLI remain separate surfaces over the same shared runtime architecture, so the runtime still tolerates the legacy flat cache layout during the transition.
+`logs sync` reuses `sf org display` for auth, then lists `ApexLog` rows and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/sync-state.json`, updates the local SQLite/FTS search index at `apexlogs/.alv/log-index.sqlite`, and writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, where `<safe-target-org>` is the sanitized directory name derived from the resolved org username. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `6` and `1` keeps the old serial-style troubleshooting mode. The VS Code extension and the CLI remain separate surfaces over the same shared Rust runtime architecture, and both can reuse the same local bodies, sync checkpoints, and index.
 
 ## Usage
 
@@ -82,8 +83,8 @@ The extension activates automatically when the workspace contains `sfdx-project.
 
 ### Search Downloaded Logs
 
-- Run **Refresh Logs** to populate the list and download the bodies used by local search.
-- Use the search box to search visible metadata plus those saved log bodies.
+- Run **Refresh Logs** to populate the list immediately while the shared runtime syncs bodies and the local index in the background.
+- Use the search box to search visible metadata plus locally synced log bodies.
 - Match snippets appear in the `Match` column when the hit comes from the saved log file.
 - Scroll to load more rows from the current list when you want to keep widening the search incrementally.
 - Use **Download all logs** when the refreshed and scrolled set still is not enough, or when you want to pull all logs from the selected org into local search in one action.

--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -136,6 +136,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   private lastSearchQuery = '';
   private searchToken = 0;
   private searchAbortController: AbortController | undefined;
+  private backgroundSyncAbortController: AbortController | undefined;
   private purgePromise: Promise<void> | undefined;
   private readonly logCacheMaxAgeMs = 1000 * 60 * 60 * 24;
   private logsColumns: NormalizedLogsColumnsConfig = DEFAULT_LOGS_COLUMNS_CONFIG;
@@ -253,6 +254,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       this.searchAbortController.abort();
       this.searchAbortController = undefined;
     }
+    if (this.backgroundSyncAbortController) {
+      this.backgroundSyncAbortController.abort();
+      this.backgroundSyncAbortController = undefined;
+    }
     this.readyTimeoutListeners.clear();
     vscode.Disposable.from(...this.hostDisposables).dispose();
     this.hostDisposables = [];
@@ -337,7 +342,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           this.purgeLogCache(controller.signal);
           const authPromise = authHandle.handoff();
           this.startAuthHydration(logs, authPromise, token, selectedOrg, controller.signal);
-          this.startErrorScanForCurrentLogs(token, controller.signal);
+          this.startBackgroundSync(selectedOrg, false, token, controller.signal);
           if (this.lastSearchQuery.trim()) {
             this.rerunActiveSearch();
           } else {
@@ -407,7 +412,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       this.purgeLogCache();
       const authPromise = authHandle.handoff();
       this.startAuthHydration(logs, authPromise, token, selectedOrg);
-      this.startErrorScanForCurrentLogs(token);
+      this.startBackgroundSync(selectedOrg, false, token);
       this.rerunActiveSearch();
       try {
         const durationMs = Date.now() - t0;
@@ -442,7 +447,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         if (warning) {
           this.post({ type: 'warning', message: warning });
         }
-        this.preloadFullLogBodies(logs, auth, refreshToken, signal, selectedOrg);
         this.logService.loadLogHeads(
           logs,
           auth,
@@ -466,6 +470,92 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       });
   }
 
+  private getBackgroundSyncConcurrency(): number {
+    return Math.max(1, Math.min(3, this.configManager.getHeadConcurrency()));
+  }
+
+  private startBackgroundSync(
+    selectedOrg: string | undefined,
+    forceFull: boolean,
+    refreshToken: number,
+    parentSignal?: AbortSignal
+  ): void {
+    if (this.bulkDownloadInProgress || parentSignal?.aborted) {
+      return;
+    }
+    if (this.backgroundSyncAbortController) {
+      this.backgroundSyncAbortController.abort();
+    }
+    const controller = new AbortController();
+    this.backgroundSyncAbortController = controller;
+    if (parentSignal) {
+      const onAbort = () => controller.abort();
+      parentSignal.addEventListener('abort', onAbort, { once: true });
+      controller.signal.addEventListener(
+        'abort',
+        () => {
+          try {
+            parentSignal.removeEventListener('abort', onAbort);
+          } catch {}
+        },
+        { once: true }
+      );
+    }
+
+    const workspaceRoot = getWorkspaceRoot();
+    void runtimeClient
+      .logsSync(
+        {
+          targetOrg: selectedOrg,
+          workspaceRoot,
+          forceFull,
+          concurrency: this.getBackgroundSyncConcurrency()
+        },
+        controller.signal
+      )
+      .then(result => {
+        if (
+          controller.signal.aborted ||
+          refreshToken !== this.refreshToken ||
+          this.disposed ||
+          this.backgroundSyncAbortController !== controller
+        ) {
+          return;
+        }
+        logInfo('Logs: background sync finished', {
+          status: result.status,
+          downloaded: result.downloaded,
+          cached: result.cached,
+          indexed: result.indexed,
+          failed: result.failed
+        });
+        if (result.index_error) {
+          logWarn('Logs: background sync index warning ->', result.index_error);
+        }
+        this.startErrorScanForCurrentLogs(refreshToken, controller.signal);
+        this.rerunActiveSearch();
+      })
+      .catch(error => {
+        if (controller.signal.aborted) {
+          return;
+        }
+        logWarn('Logs: background sync failed ->', getErrorMessage(error));
+        if (
+          refreshToken !== this.refreshToken ||
+          this.disposed ||
+          this.backgroundSyncAbortController !== controller
+        ) {
+          return;
+        }
+        this.startErrorScanForCurrentLogs(refreshToken, controller.signal);
+      })
+      .finally(() => {
+        if (this.backgroundSyncAbortController === controller) {
+          this.backgroundSyncAbortController = undefined;
+        }
+      });
+  }
+
   private observeDeferredAuth(params: { username?: string }): { handoff: () => Promise<OrgAuth> } {
     const observed = runtimeClient.getOrgAuth(params).then(
       auth => ({ ok: true as const, auth }),
@@ -481,94 +571,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           throw result.error;
         })
     };
-  }
-
-  private preloadFullLogBodies(
-    logs: ApexLogRow[],
-    auth: OrgAuth,
-    refreshToken: number,
-    signal?: AbortSignal,
-    selectedOrg?: string
-  ): void {
-    if (!this.configManager.shouldLoadFullLogBodies()) {
-      return;
-    }
-    if (!Array.isArray(logs) || logs.length === 0) {
-      return;
-    }
-    const logsById = new Map(
-      logs
-        .filter((log): log is ApexLogRow & { Id: string } => typeof log?.Id === 'string' && log.Id.length > 0)
-        .map(log => [log.Id, log] as const)
-    );
-    let searchRerunTimer: ReturnType<typeof setTimeout> | undefined;
-    const scheduleSearchRerun = () => {
-      if (searchRerunTimer) {
-        return;
-      }
-      searchRerunTimer = setTimeout(() => {
-        searchRerunTimer = undefined;
-        if (!signal?.aborted && !this.disposed) {
-          logTrace('Logs: rerunning active search after body preload');
-          this.rerunActiveSearch();
-        }
-      }, 150);
-    };
-    void this.logService
-      .ensureLogsSaved(logs, selectedOrg, signal, {
-        authHint: auth,
-        onItemComplete: result => {
-          if (signal?.aborted || this.disposed) {
-            return;
-          }
-          if (result.status !== 'downloaded' && result.status !== 'existing') {
-            return;
-          }
-          logTrace('Logs: preload body completed', { logId: result.logId, status: result.status });
-          const log = logsById.get(result.logId);
-          if (!log) {
-            return;
-          }
-          this.logService.loadLogHeads(
-            [log],
-            auth,
-            refreshToken,
-            (logId, codeUnit) => {
-              if (refreshToken === this.refreshToken && !this.disposed && this.currentLogIds.has(logId)) {
-                this.post({ type: 'logHead', logId, codeUnitStarted: codeUnit });
-              }
-            },
-            signal,
-            {
-              preferLocalBodies: true,
-              selectedOrg
-            }
-          );
-          scheduleSearchRerun();
-        }
-      })
-      .then(summary => {
-        if (searchRerunTimer) {
-          clearTimeout(searchRerunTimer);
-          searchRerunTimer = undefined;
-        }
-        if (signal?.aborted || this.disposed) {
-          return;
-        }
-        if (summary.success > 0) {
-          logTrace('Logs: rerunning active search after preload summary', summary);
-          this.rerunActiveSearch();
-        }
-      })
-      .catch(e => {
-        if (searchRerunTimer) {
-          clearTimeout(searchRerunTimer);
-          searchRerunTimer = undefined;
-        }
-        if (!signal?.aborted) {
-          logWarn('Logs: preload full log bodies failed ->', getErrorMessage(e));
-        }
-      });
   }
 
   private rerunActiveSearch(): void {
@@ -765,6 +767,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             this.post({
               type: 'logHead',
               logId: entry.logId,
+              codeUnitStarted: entry.codeUnitStarted,
               hasErrors: summary.hasErrors,
               primaryReason: summary.primaryReason,
               reasons: summary.reasons
@@ -984,49 +987,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     } catch {}
   }
 
-  private async fetchAllOrgLogs(selectedOrg: string | undefined, signal?: AbortSignal): Promise<ApexLogRow[]> {
-    const all: ApexLogRow[] = [];
-    const seen = new Set<string>();
-    let cursorStartTime: string | undefined;
-    let cursorId: string | undefined;
-    let lastCursorKey: string | undefined;
-    while (!signal?.aborted) {
-      const batch = (await runtimeClient.logsList(
-        {
-          username: selectedOrg,
-          limit: this.pageLimit,
-          cursor: cursorStartTime && cursorId ? { beforeStartTime: cursorStartTime, beforeId: cursorId } : undefined
-        },
-        signal
-      )) as ApexLogRow[];
-      if (!Array.isArray(batch) || batch.length === 0) {
-        break;
-      }
-      for (const log of batch) {
-        if (!log?.Id || seen.has(log.Id)) {
-          continue;
-        }
-        seen.add(log.Id);
-        all.push(log);
-      }
-      if (batch.length < this.pageLimit) {
-        break;
-      }
-      const last = batch[batch.length - 1];
-      if (!last?.StartTime || !last?.Id) {
-        break;
-      }
-      const cursorKey = `${last.StartTime}|${last.Id}`;
-      if (cursorKey === lastCursorKey) {
-        break;
-      }
-      lastCursorKey = cursorKey;
-      cursorStartTime = last.StartTime;
-      cursorId = last.Id;
-    }
-    return all;
-  }
-
   private async clearLogs(scope: 'all' | 'mine'): Promise<void> {
     if (this.clearLogsInProgress) {
       void vscode.window.showInformationMessage(
@@ -1230,9 +1190,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         return;
       }
 
-      this.pageLimit = this.configManager.getPageLimit();
       type BulkDownloadRunResult =
-        | { kind: 'cancelled-before-download'; listed: number }
+        | { kind: 'cancelled'; processed: number }
         | { kind: 'empty' }
         | {
             kind: 'done';
@@ -1251,52 +1210,60 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           ct.onCancellationRequested(() => controller.abort());
 
           progress.report({
-            message: localize('downloadAllLogsProgressListing', 'Listing logs from the selected org…')
+            message: localize('downloadAllLogsProgressSyncing', 'Syncing logs from the selected org…')
           });
-          let logs: ApexLogRow[] = [];
+          let result: Awaited<ReturnType<typeof runtimeClient.logsSync>>;
           try {
-            logs = await this.fetchAllOrgLogs(selectedOrg, controller.signal);
+            result = await runtimeClient.logsSync(
+              {
+                targetOrg: selectedOrg,
+                workspaceRoot: getWorkspaceRoot(),
+                forceFull: true,
+                concurrency: this.getBackgroundSyncConcurrency()
+              },
+              controller.signal
+            );
           } catch (e) {
             const msg = getErrorMessage(e);
             if (controller.signal.aborted || this.isAbortLikeError(e, msg)) {
-              return { kind: 'cancelled-before-download', listed: 0 };
+              return { kind: 'cancelled', processed: 0 };
             }
             throw e;
           }
-          if (controller.signal.aborted) {
-            return { kind: 'cancelled-before-download', listed: logs.length };
+          const processed = result.downloaded + result.cached + result.failed;
+          const success = result.downloaded + result.cached;
+          const summary: EnsureLogsSavedSummary = {
+            total: processed,
+            success,
+            downloaded: result.downloaded,
+            existing: result.cached,
+            missing: 0,
+            failed: result.failed,
+            cancelled: result.status === 'cancelled' ? processed : 0,
+            failedLogIds: []
+          };
+          progress.report({
+            increment: 100,
+            message: localize('downloadAllLogsProgressMessage', 'Processed {0}/{1} logs…', processed, processed)
+          });
+          if (result.index_error) {
+            logWarn('Logs: downloadAllLogs index warning ->', result.index_error);
           }
-          if (logs.length === 0) {
+          if (result.status === 'cancelled') {
+            return { kind: 'cancelled', processed };
+          }
+          if (processed === 0) {
             return { kind: 'empty' };
           }
-
-          let processed = 0;
-          let progressPct = 0;
-          const total = logs.length;
-          progress.report({
-            message: localize('downloadAllLogsProgressMessage', 'Processed {0}/{1} logs…', processed, total)
-          });
-          const summary = await this.logService.ensureLogsSaved(logs, selectedOrg, controller.signal, {
-            onItemComplete: () => {
-              processed += 1;
-              const nextPct = Math.floor((processed / total) * 100);
-              const increment = nextPct > progressPct ? nextPct - progressPct : undefined;
-              progressPct = Math.max(progressPct, nextPct);
-              progress.report({
-                increment,
-                message: localize('downloadAllLogsProgressMessage', 'Processed {0}/{1} logs…', processed, total)
-              });
-            }
-          });
-          return { kind: 'done', total, processed, summary };
+          return { kind: 'done', total: processed, processed, summary };
         }
       );
 
-      if (runResult.kind === 'cancelled-before-download') {
+      if (runResult.kind === 'cancelled') {
         void vscode.window.showWarningMessage(
           localize(
-            'downloadAllLogsSummaryCancelledBeforeDownload',
-            'Bulk download cancelled while listing logs for the selected org.'
+            'downloadAllLogsSummaryCancelledDuringSync',
+            'Bulk download cancelled while syncing logs for the selected org.'
           )
         );
         try {
@@ -1305,10 +1272,10 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             { outcome: 'cancelled', sourceView: 'logs' },
             {
               durationMs: Date.now() - t0,
-              total: runResult.listed,
+              total: runResult.processed,
               success: 0,
               failed: 0,
-              cancelled: runResult.listed
+              cancelled: runResult.processed
             }
           );
         } catch {}

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -7,6 +7,8 @@ import type {
   JsonRpcSuccessResponse,
   InitializeResult,
   LogsListParams,
+  LogsSyncParams,
+  LogsSyncResult,
   ResolveCachedLogPathParams,
   ResolveCachedLogPathResult,
   LogsTriageEntry,
@@ -33,7 +35,15 @@ import {
 
 type TimerHandle = ReturnType<typeof setTimeout>;
 const RUNTIME_EXIT_MESSAGE_PREFIX = 'runtime exited (';
-const RUNTIME_TELEMETRY_METHODS = new Set(['initialize', 'org/list', 'org/auth', 'logs/list', 'search/query', 'logs/triage']);
+const RUNTIME_TELEMETRY_METHODS = new Set([
+  'initialize',
+  'org/list',
+  'org/auth',
+  'logs/list',
+  'logs/sync',
+  'search/query',
+  'logs/triage'
+]);
 const RUNTIME_TRACE_REDACTED = '[redacted]';
 const RUNTIME_TRACE_MAX_STRING_LENGTH = 8192;
 const RUNTIME_TRACE_SECRET_KEYS = new Set([
@@ -293,6 +303,13 @@ export class RuntimeClient extends EventEmitter {
       await this.initialize();
     }
     return this.request<RuntimeLogRow[]>('logs/list', params, signal);
+  }
+
+  async logsSync(params: LogsSyncParams = {}, signal?: AbortSignal): Promise<LogsSyncResult> {
+    if (!this.requestHandler) {
+      await this.initialize();
+    }
+    return this.request<LogsSyncResult>('logs/sync', params, signal);
   }
 
   async searchQuery(params: SearchQueryParams, signal?: AbortSignal): Promise<SearchQueryResult> {

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -55,11 +55,21 @@ function createProviderHarness() {
   };
   const runtimeClientStub: any = {
     orgList: async () => [],
-    getOrgAuth: async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' }),
-    logsList: async () => [],
-    searchQuery: async () => ({ logIds: [], snippets: {}, pendingLogIds: [] }),
-    logsTriage: async () => []
-  };
+	    getOrgAuth: async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' }),
+	    logsList: async () => [],
+	    searchQuery: async () => ({ logIds: [], snippets: {}, pendingLogIds: [] }),
+	    logsTriage: async () => [],
+	    logsSync: async () => ({
+	      status: 'success',
+	      downloaded: 0,
+	      cached: 0,
+	      failed: 0,
+	      indexed: 0,
+	      checkpoint_advanced: false,
+	      state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	      index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	    })
+	  };
   const cliStub: any = runtimeClientStub;
   const vscodeMock: any = {
     Uri: {
@@ -344,11 +354,11 @@ suite('SfLogsViewProvider behavior', () => {
     }
   });
 
-  test('refresh preloads full log bodies when enabled', async () => {
-    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
-    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
-    cli.logsList = async () => [
-      { Id: '07L000000000001AA' },
+	  test('refresh starts shared background sync after listing logs', async () => {
+	    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    cli.logsList = async () => [
+	      { Id: '07L000000000001AA' },
       { Id: '07L000000000002AA' }
     ];
 
@@ -359,37 +369,41 @@ suite('SfLogsViewProvider behavior', () => {
       webview: {
         postMessage: () => Promise.resolve(true)
       }
-    } as any;
-    (provider as any).logService.loadLogHeads = () => {};
+	    } as any;
+	    (provider as any).logService.loadLogHeads = () => {};
 
-    const calls: Array<{ logs: any[]; signal?: AbortSignal; options?: any }> = [];
-    (provider as any).logService.ensureLogsSaved = async (
-      logs: any[],
-      _org: string | undefined,
-      signal?: AbortSignal,
-      options?: any
-    ) => {
-      calls.push({ logs, signal, options });
-    };
-    const purged: Array<{ keepIds?: Set<string>; maxAgeMs?: number; signal?: AbortSignal }> = [];
-    workspace.purgeSavedLogs = async (opts: any) => {
-      purged.push(opts);
-      return 3;
-    };
+	    const syncCalls: Array<{ params: any; signal?: AbortSignal }> = [];
+	    cli.logsSync = async (params: any, signal?: AbortSignal) => {
+	      syncCalls.push({ params, signal });
+	      return {
+	        status: 'success',
+	        downloaded: 2,
+	        cached: 0,
+	        failed: 0,
+	        indexed: 2,
+	        checkpoint_advanced: true,
+	        state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	        index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	      };
+	    };
+	    const purged: Array<{ keepIds?: Set<string>; maxAgeMs?: number; signal?: AbortSignal }> = [];
+	    workspace.purgeSavedLogs = async (opts: any) => {
+	      purged.push(opts);
+	      return 3;
+	    };
 
-    await provider.refresh();
-    await new Promise(resolve => setTimeout(resolve, 20));
+	    await provider.refresh();
+	    await waitForCondition(() => syncCalls.length === 1);
 
-    assert.equal(calls.length, 1, 'should preload log bodies once');
-    assert.deepEqual(
-      calls[0]?.logs.map(l => l.Id),
-      ['07L000000000001AA', '07L000000000002AA'],
-      'should pass fetched logs to ensureLogsSaved'
-    );
-    assert.equal(typeof calls[0]?.signal?.aborted, 'boolean', 'should pass abort signal to ensureLogsSaved');
-    assert.equal(calls[0]?.options?.authHint?.username, 'u', 'should pass auth hint to ensureLogsSaved');
-    assert.equal(purged.length, 1, 'should purge cached logs after refresh');
-    const keepIds = Array.from(purged[0]?.keepIds ?? []);
+	    assert.deepEqual(syncCalls[0]?.params, {
+	      targetOrg: undefined,
+	      workspaceRoot: '/tmp/alv-workspace',
+	      forceFull: false,
+	      concurrency: 3
+	    });
+	    assert.equal(typeof syncCalls[0]?.signal?.aborted, 'boolean', 'should pass abort signal to runtime sync');
+	    assert.equal(purged.length, 1, 'should purge cached logs after refresh');
+	    const keepIds = Array.from(purged[0]?.keepIds ?? []);
     assert.deepEqual(
       keepIds.sort(),
       ['07L000000000001AA', '07L000000000002AA'],
@@ -397,10 +411,10 @@ suite('SfLogsViewProvider behavior', () => {
     );
   });
 
-  test('refresh posts progressive error scan status and marks visible logs with errors', async () => {
-    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
-    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
-    cli.logsList = async () => [
+	  test('refresh scans visible logs for errors after background sync completes', async () => {
+	    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    cli.logsList = async () => [
       { Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z', LogLength: 10 },
       { Id: '07L000000000002AA', StartTime: '2026-03-30T18:40:58.000Z', LogLength: 20 }
     ];
@@ -430,10 +444,24 @@ suite('SfLogsViewProvider behavior', () => {
             hasErrors: false,
             reasons: []
           }
-        }
-      ];
-    };
-    workspace.purgeSavedLogs = async () => 0;
+	        }
+	      ];
+	    };
+	    const syncCalls: any[] = [];
+	    cli.logsSync = async (params: any) => {
+	      syncCalls.push(params);
+	      return {
+	        status: 'success',
+	        downloaded: 2,
+	        cached: 0,
+	        failed: 0,
+	        indexed: 2,
+	        checkpoint_advanced: true,
+	        state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	        index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	      };
+	    };
+	    workspace.purgeSavedLogs = async () => 0;
 
     const context = makeContext();
     const posted: any[] = [];
@@ -449,29 +477,77 @@ suite('SfLogsViewProvider behavior', () => {
       }
     } as any;
 
-    await provider.refresh();
-    await new Promise(resolve => setTimeout(resolve, 30));
+	    await provider.refresh();
+	    await waitForCondition(() => triageCalls.length === 1);
 
-    const scanRunning = posted.find(m => m?.type === 'errorScanStatus' && m?.state === 'running');
+	    const scanRunning = posted.find(m => m?.type === 'errorScanStatus' && m?.state === 'running');
     const scanIdle = posted.find(m => m?.type === 'errorScanStatus' && m?.state === 'idle' && m?.total === 2);
     const errorHead = posted.find(m => m?.type === 'logHead' && m?.logId === '07L000000000001AA' && m?.hasErrors === true);
 
-    assert.ok(scanRunning, 'should post running scan status');
-    assert.ok(scanIdle, 'should post idle scan status after completion');
-    assert.ok(errorHead, 'should mark visible error log in logHead stream');
-    assert.equal(errorHead?.primaryReason, 'Fatal exception');
+	    assert.ok(scanRunning, 'should post running scan status');
+	    assert.ok(scanIdle, 'should post idle scan status after completion');
+	    assert.ok(errorHead, 'should mark visible error log in logHead stream');
+	    assert.equal(syncCalls.length, 1, 'should complete shared sync before triage');
+	    assert.equal(errorHead?.primaryReason, 'Fatal exception');
     assert.equal(errorHead?.reasons?.[0]?.code, 'fatal_exception');
     assert.equal(triageCalls[0]?.workspaceRoot, '/tmp/alv-workspace');
     assert.deepEqual(triageCalls[0]?.logStartTimes, {
       '07L000000000001AA': '2026-03-30T18:39:58.000Z',
       '07L000000000002AA': '2026-03-30T18:40:58.000Z'
     });
-  });
+	  });
 
-  test('refresh cancellation aborts background error scan', async () => {
-    const { SfLogsViewProvider, cli, workspace, vscode: vscodeMock } = createProviderHarness();
-    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
-    cli.logsList = async () => [{ Id: '07L000000000001AA', LogLength: 10 }];
+	  test('refresh scans visible logs for errors when background sync fails', async () => {
+	    const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    cli.logsList = async () => [
+	      { Id: '07L000000000001AA', StartTime: '2026-03-30T18:39:58.000Z', LogLength: 10 }
+	    ];
+	    cli.logsSync = async () => {
+	      throw new Error('sync failed');
+	    };
+	    const triageCalls: any[] = [];
+	    cli.logsTriage = async (params: any) => {
+	      triageCalls.push(params);
+	      return [
+	        {
+	          logId: params.logIds[0],
+	          summary: {
+	            hasErrors: true,
+	            primaryReason: 'Fatal exception',
+	            reasons: [{ code: 'fatal_exception', severity: 'error', summary: 'Fatal exception' }]
+	          }
+	        }
+	      ];
+	    };
+	    workspace.purgeSavedLogs = async () => 0;
+
+	    const context = makeContext();
+	    const posted: any[] = [];
+	    const provider = new SfLogsViewProvider(context);
+	    (provider as any).logService.loadLogHeads = () => {};
+	    (provider as any).view = {
+	      webview: {
+	        postMessage: (m: any) => {
+	          posted.push(m);
+	          return Promise.resolve(true);
+	        }
+	      }
+	    } as any;
+
+	    await provider.refresh();
+	    await waitForCondition(() => triageCalls.length === 1);
+
+	    assert.ok(
+	      posted.some(m => m?.type === 'logHead' && m?.logId === '07L000000000001AA' && m?.hasErrors === true),
+	      'should still mark visible logs after sync failure'
+	    );
+	  });
+
+	  test('refresh cancellation aborts background sync', async () => {
+	    const { SfLogsViewProvider, cli, workspace, vscode: vscodeMock } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    cli.logsList = async () => [{ Id: '07L000000000001AA', LogLength: 10 }];
     workspace.purgeSavedLogs = async () => 0;
 
     const context = makeContext();
@@ -487,21 +563,30 @@ suite('SfLogsViewProvider behavior', () => {
           return Promise.resolve(true);
         }
       }
-    } as any;
+	    } as any;
 
-    let triageSignal: AbortSignal | undefined;
-    let triageStarted!: () => void;
-    const started = new Promise<void>(resolve => {
-      triageStarted = resolve;
-    });
-    cli.logsTriage = async (_params: { logIds: string[] }, signal?: AbortSignal) => {
-      if (signal) {
-        triageSignal = signal;
-      }
-      triageStarted();
-      await new Promise(resolve => setTimeout(resolve, 30));
-      return [];
-    };
+	    let syncSignal: AbortSignal | undefined;
+	    let syncStarted!: () => void;
+	    const started = new Promise<void>(resolve => {
+	      syncStarted = resolve;
+	    });
+	    cli.logsSync = async (_params: any, signal?: AbortSignal) => {
+	      if (signal) {
+	        syncSignal = signal;
+	      }
+	      syncStarted();
+	      await new Promise(resolve => setTimeout(resolve, 30));
+	      return {
+	        status: signal?.aborted ? 'cancelled' : 'success',
+	        downloaded: 0,
+	        cached: 0,
+	        failed: 0,
+	        indexed: 0,
+	        checkpoint_advanced: false,
+	        state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	        index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	      };
+	    };
 
     vscodeMock.window.withProgress = async (_opts: any, task: any) => {
       let cancel: (() => void) | undefined;
@@ -518,13 +603,17 @@ suite('SfLogsViewProvider behavior', () => {
       return resultPromise;
     };
 
-    await provider.refresh();
-    await new Promise(resolve => setTimeout(resolve, 60));
+	    await provider.refresh();
+	    await new Promise(resolve => setTimeout(resolve, 60));
 
-    assert.ok(triageSignal, 'should start runtime triage');
-    assert.equal(triageSignal?.aborted, true, 'scan signal should be aborted when refresh is cancelled');
-    assert.ok(posted.some(m => m?.type === 'errorScanStatus' && m?.state === 'running'), 'should have started scan status');
-  });
+	    assert.ok(syncSignal, 'should start shared runtime sync');
+	    assert.equal(syncSignal?.aborted, true, 'sync signal should be aborted when refresh is cancelled');
+	    assert.equal(
+	      posted.some(m => m?.type === 'errorScanStatus' && m?.state === 'running'),
+	      false,
+	      'should not scan when refresh cancellation aborts sync first'
+	    );
+	  });
 
   test('refresh posts logs before org auth completes', async () => {
     const { SfLogsViewProvider, cli, workspace } = createProviderHarness();
@@ -583,183 +672,6 @@ suite('SfLogsViewProvider behavior', () => {
     await provider.sendOrgs();
 
     assert.equal(progressOptions?.cancellable, false, 'org listing progress should not advertise cancellation');
-  });
-
-  test('preloadFullLogBodies re-runs active search after downloads complete', async () => {
-    const { SfLogsViewProvider } = createProviderHarness();
-    const context = makeContext();
-    const provider = new SfLogsViewProvider(context);
-    (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).lastSearchQuery = 'error';
-
-    const searchCalls: string[] = [];
-    (provider as any).executeSearch = async (query: string) => {
-      searchCalls.push(query);
-    };
-    (provider as any).logService.ensureLogsSaved = async (
-      _logs: any[],
-      _selectedOrg?: string,
-      _signal?: AbortSignal,
-      options?: { onItemComplete?: (result: { logId: string; status: string }) => void }
-    ) => {
-      options?.onItemComplete?.({ logId: '07L000000000001AA', status: 'downloaded' });
-      return {
-        total: 1,
-        success: 1,
-        downloaded: 1,
-        existing: 0,
-        missing: 0,
-        failed: 0,
-        cancelled: 0,
-        failedLogIds: []
-      };
-    };
-
-    (provider as any).preloadFullLogBodies(
-      [{ Id: '07L000000000001AA' }],
-      { username: 'u', instanceUrl: 'i', accessToken: 't' },
-      0
-    );
-    await new Promise(resolve => setTimeout(resolve, 20));
-
-    assert.deepEqual(searchCalls, ['error'], 'should re-run active search after preload saves logs');
-  });
-
-  test('preloadFullLogBodies re-runs active search when bodies became available via a parallel cache writer', async () => {
-    const { SfLogsViewProvider } = createProviderHarness();
-    const context = makeContext();
-    const provider = new SfLogsViewProvider(context);
-    (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).lastSearchQuery = 'error';
-
-    const searchCalls: string[] = [];
-    (provider as any).executeSearch = async (query: string) => {
-      searchCalls.push(query);
-    };
-    (provider as any).logService.ensureLogsSaved = async () => ({
-      total: 1,
-      success: 1,
-      downloaded: 0,
-      existing: 1,
-      missing: 0,
-      failed: 0,
-      cancelled: 0,
-      failedLogIds: []
-    });
-
-    (provider as any).preloadFullLogBodies(
-      [{ Id: '07L000000000001AA' }],
-      { username: 'u', instanceUrl: 'i', accessToken: 't' },
-      0
-    );
-    await new Promise(resolve => setTimeout(resolve, 20));
-
-    assert.deepEqual(
-      searchCalls,
-      ['error'],
-      'should re-run active search when preload confirms files already exist locally'
-    );
-  });
-
-  test('preloadFullLogBodies re-runs active search before the full save batch finishes', async () => {
-    const { SfLogsViewProvider } = createProviderHarness();
-    const context = makeContext();
-    const provider = new SfLogsViewProvider(context);
-    (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).lastSearchQuery = 'error';
-
-    const searchCalls: string[] = [];
-    let batchFinished = false;
-    (provider as any).executeSearch = async (query: string) => {
-      searchCalls.push(query);
-    };
-    (provider as any).logService.loadLogHeads = () => {};
-    (provider as any).logService.ensureLogsSaved = async (
-      _logs: any[],
-      _selectedOrg?: string,
-      _signal?: AbortSignal,
-      options?: { onItemComplete?: (result: { logId: string; status: string }) => void }
-    ) => {
-      options?.onItemComplete?.({ logId: '07L000000000001AA', status: 'downloaded' });
-      await new Promise(resolve => setTimeout(resolve, 400));
-      batchFinished = true;
-      return {
-        total: 1,
-        success: 1,
-        downloaded: 1,
-        existing: 0,
-        missing: 0,
-        failed: 0,
-        cancelled: 0,
-        failedLogIds: []
-      };
-    };
-
-    (provider as any).preloadFullLogBodies(
-      [{ Id: '07L000000000001AA' }],
-      { username: 'u', instanceUrl: 'i', accessToken: 't' },
-      0
-    );
-
-    await waitForCondition(() => searchCalls.length === 1, { timeoutMs: 300, intervalMs: 20 });
-    assert.equal(batchFinished, false, 'should not wait for the full save batch before re-running search');
-  });
-
-  test('preloadFullLogBodies re-hydrates code unit metadata from the saved full bodies', async () => {
-    const { SfLogsViewProvider } = createProviderHarness();
-    const context = makeContext();
-    const provider = new SfLogsViewProvider(context);
-    (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
-    (provider as any).setCurrentLogs([{ Id: '07L000000000001AA' }]);
-
-    const loadHeadCalls: any[] = [];
-    (provider as any).logService.ensureLogsSaved = async (
-      _logs: any[],
-      _selectedOrg?: string,
-      _signal?: AbortSignal,
-      options?: { onItemComplete?: (result: { logId: string; status: string }) => void }
-    ) => {
-      options?.onItemComplete?.({ logId: '07L000000000001AA', status: 'downloaded' });
-      return {
-        total: 1,
-        success: 1,
-        downloaded: 1,
-        existing: 0,
-        missing: 0,
-        failed: 0,
-        cancelled: 0,
-        failedLogIds: []
-      };
-    };
-    (provider as any).logService.loadLogHeads = (
-      logs: any[],
-      auth: any,
-      refreshToken: number,
-      post: (logId: string, codeUnit: string) => void
-    ) => {
-      loadHeadCalls.push({ logs, auth, refreshToken });
-      post('07L000000000001AA', 'AccountService.handle');
-    };
-
-    const posted: any[] = [];
-    (provider as any).post = (message: any) => {
-      posted.push(message);
-    };
-
-    (provider as any).preloadFullLogBodies(
-      [{ Id: '07L000000000001AA' }],
-      { username: 'u', instanceUrl: 'i', accessToken: 't' },
-      0
-    );
-    await new Promise(resolve => setTimeout(resolve, 20));
-
-    assert.equal(loadHeadCalls.length, 1, 'should refresh code unit metadata after bodies are saved');
-    assert.equal(posted.some(m => m?.type === 'logHead' && m?.codeUnitStarted === 'AccountService.handle'), true);
   });
 
   test('refresh posts API version fallback warning when available', async () => {
@@ -1097,65 +1009,39 @@ suite('SfLogsViewProvider behavior', () => {
     assert.equal(executed[0], 'abc');
   });
 
-  test('downloadAllLogs message performs explicit bulk download flow', async () => {
-    const { SfLogsViewProvider, cli, vscode: vscodeMock } = createProviderHarness();
-    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
-    const context = makeContext();
+	  test('downloadAllLogs message performs explicit bulk download flow', async () => {
+	    const { SfLogsViewProvider, cli, vscode: vscodeMock } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    const context = makeContext();
     const provider = new SfLogsViewProvider(context);
     (provider as any).lastSearchQuery = 'error';
-    (provider as any).configManager.getPageLimit = () => 2;
+	    (provider as any).configManager.getPageLimit = () => 2;
 
-    const callOrder: string[] = [];
-    const listSignals: AbortSignal[] = [];
-    const listCalls: any[] = [];
-    cli.logsList = async (params: any, signal?: AbortSignal) => {
-      callOrder.push('list');
-      listCalls.push(params);
-      if (signal) {
-        listSignals.push(signal);
-      }
-      if (listCalls.length === 1) {
-        return [
-          { Id: '07L000000000001AA', StartTime: '2026-01-01T00:00:00.000Z', LogLength: 10 },
-          { Id: '07L000000000002AA', StartTime: '2025-12-31T23:59:59.000Z', LogLength: 20 }
-        ] as any;
-      }
-      if (listCalls.length === 2) {
-        return [
-          { Id: '07L000000000003AA', StartTime: '2025-12-31T23:59:58.000Z', LogLength: 30 }
-        ] as any;
-      }
-      return [] as any;
-    };
-    const searchCalls: string[] = [];
-    (provider as any).executeSearch = async (query: string) => {
-      searchCalls.push(query);
-    };
+	    const callOrder: string[] = [];
+	    const syncCalls: Array<{ params: any; signal?: AbortSignal }> = [];
+	    cli.logsSync = async (params: any, signal?: AbortSignal) => {
+	      callOrder.push('sync');
+	      syncCalls.push({ params, signal });
+	      if (signal) {
+	        assert.equal(typeof signal.aborted, 'boolean');
+	      }
+	      return {
+	        status: 'success',
+	        downloaded: 2,
+	        cached: 1,
+	        failed: 0,
+	        indexed: 3,
+	        checkpoint_advanced: true,
+	        state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	        index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	      };
+	    };
+	    const searchCalls: string[] = [];
+	    (provider as any).executeSearch = async (query: string) => {
+	      searchCalls.push(query);
+	    };
 
-    const ensureCalls: Array<{ count: number; selectedOrg?: string }> = [];
-    (provider as any).logService.ensureLogsSaved = async (
-      logs: any[],
-      selectedOrg?: string,
-      _signal?: AbortSignal,
-      options?: { onItemComplete?: (result: { logId: string; status: string }) => void }
-    ) => {
-      ensureCalls.push({ count: logs.length, selectedOrg });
-      for (const log of logs) {
-        options?.onItemComplete?.({ logId: log.Id, status: 'downloaded' });
-      }
-      return {
-        total: logs.length,
-        success: logs.length,
-        downloaded: logs.length,
-        existing: 0,
-        missing: 0,
-        failed: 0,
-        cancelled: 0,
-        failedLogIds: []
-      };
-    };
-
-    const warningCalls: any[] = [];
+	    const warningCalls: any[] = [];
     vscodeMock.window.showWarningMessage = async (...args: any[]) => {
       callOrder.push('confirm');
       warningCalls.push(args);
@@ -1198,64 +1084,59 @@ suite('SfLogsViewProvider behavior', () => {
     }
     const webview = new MockWebview();
     const view = new MockWebviewView(webview);
-    await provider.resolveWebviewView(view);
-    await (webview as any).emit({ type: 'downloadAllLogs' });
-    await new Promise(resolve => setTimeout(resolve, 20));
+	    await provider.resolveWebviewView(view);
+	    await (webview as any).emit({ type: 'downloadAllLogs' });
+	    await new Promise(resolve => setTimeout(resolve, 20));
 
-    assert.equal(ensureCalls.length, 1, 'should perform one bulk save run');
-    assert.equal(ensureCalls[0]?.count, 3, 'should include all paged logs fetched for the org');
-    assert.ok(warningCalls.length >= 1, 'should request user confirmation');
-    assert.ok(infoCalls.length >= 1, 'should show completion summary');
-    assert.equal(callOrder[0], 'confirm', 'should confirm before listing org logs');
-    assert.equal(typeof listSignals[0]?.aborted, 'boolean', 'should pass cancellation signal while listing logs');
-    assert.ok(searchCalls.includes('error'), 'should re-run active search query after bulk download');
-    assert.deepEqual(listCalls[0], { username: undefined, limit: 2, cursor: undefined });
-    assert.deepEqual(listCalls[1], {
-      username: undefined,
-      limit: 2,
-      cursor: {
-        beforeStartTime: '2025-12-31T23:59:59.000Z',
-        beforeId: '07L000000000002AA'
-      }
-    });
-  });
+	    assert.equal(syncCalls.length, 1, 'should perform one shared runtime sync');
+	    assert.deepEqual(syncCalls[0]?.params, {
+	      targetOrg: undefined,
+	      workspaceRoot: '/tmp/alv-workspace',
+	      forceFull: true,
+	      concurrency: 3
+	    });
+	    assert.ok(warningCalls.length >= 1, 'should request user confirmation');
+	    assert.ok(infoCalls.length >= 1, 'should show completion summary');
+	    assert.deepEqual(callOrder, ['confirm', 'sync'], 'should confirm before starting shared sync');
+	    assert.equal(typeof syncCalls[0]?.signal?.aborted, 'boolean', 'should pass cancellation signal to shared sync');
+	    assert.ok(searchCalls.includes('error'), 'should re-run active search query after bulk download');
+	  });
 
-  test('downloadAllLogs supports cancellation while listing org logs', async () => {
-    const { SfLogsViewProvider, cli, vscode: vscodeMock } = createProviderHarness();
-    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
-    const context = makeContext();
-    const provider = new SfLogsViewProvider(context);
+	  test('downloadAllLogs supports cancellation while shared sync is running', async () => {
+	    const { SfLogsViewProvider, cli, vscode: vscodeMock } = createProviderHarness();
+	    cli.getOrgAuth = async () => ({ username: 'u', instanceUrl: 'i', accessToken: 't' });
+	    const context = makeContext();
+	    const provider = new SfLogsViewProvider(context);
 
-    const listSignals: AbortSignal[] = [];
-    cli.logsList = async (_params: any, signal?: AbortSignal) => {
-      if (signal) {
-        listSignals.push(signal);
-      }
-      await new Promise(resolve => setTimeout(resolve, 30));
-      if (signal?.aborted) {
-        const error = new Error('The operation was aborted');
-        (error as { name?: string }).name = 'AbortError';
-        throw error;
-      }
-      return [
-        { Id: '07L000000000001AA', StartTime: '2026-01-01T00:00:00.000Z', LogLength: 10 }
-      ] as any;
-    };
-
-    let ensureCalled = false;
-    (provider as any).logService.ensureLogsSaved = async () => {
-      ensureCalled = true;
-      return {
-        total: 0,
-        success: 0,
-        downloaded: 0,
-        existing: 0,
-        missing: 0,
-        failed: 0,
-        cancelled: 0,
-        failedLogIds: []
-      };
-    };
+	    const syncSignals: AbortSignal[] = [];
+	    cli.logsSync = async (_params: any, signal?: AbortSignal) => {
+	      if (signal) {
+	        syncSignals.push(signal);
+	      }
+	      await new Promise(resolve => setTimeout(resolve, 30));
+	      if (signal?.aborted) {
+	        return {
+	          status: 'cancelled',
+	          downloaded: 0,
+	          failed: 0,
+	          cached: 0,
+	          indexed: 0,
+	          checkpoint_advanced: false,
+	          state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	          index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	        };
+	      }
+	      return {
+	        status: 'success',
+	        downloaded: 0,
+	        failed: 0,
+	        cached: 0,
+	        indexed: 0,
+	        checkpoint_advanced: false,
+	        state_file: '/tmp/alv-workspace/apexlogs/.alv/sync-state.json',
+	        index_file: '/tmp/alv-workspace/apexlogs/.alv/log-index.sqlite'
+	      };
+	    };
 
     const warningCalls: string[] = [];
     const errorCalls: string[] = [];
@@ -1309,18 +1190,17 @@ suite('SfLogsViewProvider behavior', () => {
     const webview = new MockWebview();
     const view = new MockWebviewView(webview);
     await provider.resolveWebviewView(view);
-    await (webview as any).emit({ type: 'downloadAllLogs' });
-    await new Promise(resolve => setTimeout(resolve, 50));
+	    await (webview as any).emit({ type: 'downloadAllLogs' });
+	    await new Promise(resolve => setTimeout(resolve, 50));
 
-    assert.equal(ensureCalled, false, 'should not start downloads when cancelled during listing');
-    assert.equal(listSignals.length >= 1, true, 'should pass signal to listing calls');
-    assert.equal(listSignals[0]?.aborted, true, 'listing signal should be aborted after cancellation');
-    assert.ok(
-      warningCalls.some(msg => msg.includes('cancelled while listing logs')),
-      'should show cancellation summary for listing stage'
-    );
-    assert.equal(errorCalls.length, 0, 'should not show hard error toast for listing abort');
-  });
+	    assert.equal(syncSignals.length >= 1, true, 'should pass signal to shared sync');
+	    assert.equal(syncSignals[0]?.aborted, true, 'sync signal should be aborted after cancellation');
+	    assert.ok(
+	      warningCalls.some(msg => msg.includes('cancelled while syncing logs')),
+	      'should show cancellation summary for sync setup stage'
+	    );
+	    assert.equal(errorCalls.length, 0, 'should not show hard error toast for listing abort');
+	  });
 
   test('openDebugFlags opens debug flags panel', async () => {
     const { SfLogsViewProvider, DebugFlagsPanel } = createProviderHarness();

--- a/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
+++ b/apps/vscode-extension/src/test/runtime/runtimeClient.test.ts
@@ -724,7 +724,7 @@ suite('runtime client', () => {
     assert.equal(seenEnv?.Path, 'C:\\custom\\sf\\bin');
   });
 
-  test('logsList, searchQuery, and logsTriage use runtime request methods', async () => {
+  test('logsList, logsSync, searchQuery, and logsTriage use runtime request methods', async () => {
     const methods: string[] = [];
     const client = new RuntimeClient({
       requestHandler: async (method, params) => {
@@ -750,6 +750,24 @@ suite('runtime client', () => {
               LogLength: 123
             }
           ] as never;
+        }
+        if (method === 'logs/sync') {
+          assert.deepEqual(params, {
+            targetOrg: 'demo@example.com',
+            workspaceRoot: '/workspace/project',
+            forceFull: true,
+            concurrency: 3
+          });
+          return {
+            status: 'success',
+            downloaded: 12,
+            cached: 5,
+            failed: 0,
+            indexed: 17,
+            checkpoint_advanced: true,
+            state_file: '/workspace/project/apexlogs/.alv/sync-state.json',
+            index_file: '/workspace/project/apexlogs/.alv/log-index.sqlite'
+          } as never;
         }
         if (method === 'search/query') {
           assert.deepEqual(params, {
@@ -804,6 +822,12 @@ suite('runtime client', () => {
         beforeId: '07L000000000001AA'
       }
     });
+    const syncResult = await client.logsSync({
+      targetOrg: 'demo@example.com',
+      workspaceRoot: '/workspace/project',
+      forceFull: true,
+      concurrency: 3
+    });
     const searchResult = await client.searchQuery({
       username: 'demo@example.com',
       query: 'NullPointerException',
@@ -814,8 +838,9 @@ suite('runtime client', () => {
       logIds: ['07L000000000001AA']
     });
 
-    assert.deepEqual(methods, ['logs/list', 'search/query', 'logs/triage']);
+    assert.deepEqual(methods, ['logs/list', 'logs/sync', 'search/query', 'logs/triage']);
     assert.equal(logs[0]?.Id, '07L000000000001AA');
+    assert.equal(syncResult.indexed, 17);
     assert.equal(searchResult.logIds[0], '07L000000000001AA');
     assert.equal(searchResult.snippets?.['07L000000000001AA']?.ranges[0]?.[0], 7);
     assert.equal(triageEntries[0]?.summary.primaryReason, 'Fatal exception');

--- a/crates/alv-app-server/src/handlers/logs.rs
+++ b/crates/alv-app-server/src/handlers/logs.rs
@@ -1,5 +1,6 @@
 use alv_core::{
     logs::{list_logs_detailed_with_cancel, CancellationToken, LogsListParams, LogsRuntimeError},
+    logs_sync::{sync_logs_detailed_with_cancel, LogsSyncParams},
     search::{search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs_with_cancel, LogsTriageParams},
 };
@@ -26,6 +27,16 @@ pub fn handle_logs_list_with_cancel(
     let rows = list_logs_detailed_with_cancel(&params, cancellation)?;
     serde_json::to_string(&rows).map_err(|error| {
         LogsRuntimeError::from_message(format!("failed to serialize logs/list response: {error}"))
+    })
+}
+
+pub fn handle_logs_sync_with_cancel(
+    params: LogsSyncParams,
+    cancellation: &CancellationToken,
+) -> Result<String, LogsRuntimeError> {
+    let result = sync_logs_detailed_with_cancel(&params, cancellation)?;
+    serde_json::to_string(&result).map_err(|error| {
+        LogsRuntimeError::from_message(format!("failed to serialize logs/sync response: {error}"))
     })
 }
 

--- a/crates/alv-app-server/src/server.rs
+++ b/crates/alv-app-server/src/server.rs
@@ -1,5 +1,6 @@
 use alv_core::{
     logs::{CancellationToken, LogsCursor, LogsListParams, LogsRuntimeError},
+    logs_sync::LogsSyncParams,
     search::SearchQueryParams,
     triage::LogsTriageParams,
 };
@@ -82,6 +83,7 @@ enum ServerOperation {
     OrgList { force_refresh: bool },
     OrgAuth { username: Option<String> },
     LogsList(LogsListParams),
+    LogsSync(LogsSyncParams),
     SearchQuery(SearchQueryParams),
     LogsTriage(LogsTriageParams),
     ResolveCachedPath(logs_handler::ResolveCachedLogPathParams),
@@ -300,6 +302,10 @@ fn execute_call(call: ServerCall, cancellation: &CancellationToken) -> Result<St
             let payload = logs_handler::handle_logs_list_with_cancel(params, cancellation)?;
             Ok(jsonrpc_result(&call.id, &payload))
         }
+        ServerOperation::LogsSync(params) => {
+            let payload = logs_handler::handle_logs_sync_with_cancel(params, cancellation)?;
+            Ok(jsonrpc_result(&call.id, &payload))
+        }
         ServerOperation::SearchQuery(params) => {
             let payload = logs_handler::handle_search_query_with_cancel(params, cancellation)?;
             Ok(jsonrpc_result(&call.id, &payload))
@@ -414,6 +420,27 @@ fn parse_request_line(request: &str) -> Result<ParsedRequest, String> {
                     .map(|value| value as usize),
             })
         }
+        "logs/sync" => ServerOperation::LogsSync(LogsSyncParams {
+            target_org: params
+                .get("targetOrg")
+                .and_then(Value::as_str)
+                .or_else(|| params.get("target_org").and_then(Value::as_str))
+                .map(str::to_string),
+            workspace_root: params
+                .get("workspaceRoot")
+                .and_then(Value::as_str)
+                .or_else(|| params.get("workspace_root").and_then(Value::as_str))
+                .map(str::to_string),
+            force_full: params
+                .get("forceFull")
+                .and_then(Value::as_bool)
+                .or_else(|| params.get("force_full").and_then(Value::as_bool))
+                .unwrap_or(false),
+            concurrency: params
+                .get("concurrency")
+                .and_then(Value::as_u64)
+                .map(|value| value as usize),
+        }),
         "search/query" => ServerOperation::SearchQuery(SearchQueryParams {
             query: params
                 .get("query")
@@ -648,5 +675,36 @@ mod tests {
                 .map(String::as_str),
             Some("2026-03-30T18:39:58.000Z")
         );
+    }
+
+    #[test]
+    fn parse_request_line_reads_logs_sync_params() {
+        let parsed = parse_request_line(
+            r#"{
+              "jsonrpc":"2.0",
+              "id":"sync:1",
+              "method":"logs/sync",
+              "params":{
+                "targetOrg":"selected@example.com",
+                "workspaceRoot":"/tmp/demo",
+                "forceFull":true,
+                "concurrency":3
+              }
+            }"#,
+        )
+        .expect("logs/sync request should parse");
+
+        let ParsedRequest::Call(call) = parsed else {
+            panic!("expected a normal call");
+        };
+
+        let ServerOperation::LogsSync(params) = call.operation else {
+            panic!("expected logs/sync operation");
+        };
+
+        assert_eq!(params.target_org.as_deref(), Some("selected@example.com"));
+        assert_eq!(params.workspace_root.as_deref(), Some("/tmp/demo"));
+        assert!(params.force_full);
+        assert_eq!(params.concurrency, Some(3));
     }
 }

--- a/crates/alv-cli/src/cli.rs
+++ b/crates/alv-cli/src/cli.rs
@@ -35,6 +35,7 @@ pub enum LogsCommand {
     Sync(LogSyncArgs),
     Status(LogStatusArgs),
     Search(LogSearchArgs),
+    Index(LogIndexArgs),
 }
 
 #[derive(Debug, Args)]
@@ -60,6 +61,25 @@ pub struct LogStatusArgs {
 #[derive(Debug, Args)]
 pub struct LogSearchArgs {
     pub query: String,
+    #[arg(long = "target-org")]
+    pub target_org: Option<String>,
+    #[arg(long)]
+    pub json: bool,
+}
+
+#[derive(Debug, Args)]
+pub struct LogIndexArgs {
+    #[command(subcommand)]
+    pub command: LogIndexCommand,
+}
+
+#[derive(Debug, Subcommand)]
+pub enum LogIndexCommand {
+    Rebuild(LogIndexRebuildArgs),
+}
+
+#[derive(Debug, Args)]
+pub struct LogIndexRebuildArgs {
     #[arg(long = "target-org")]
     pub target_org: Option<String>,
     #[arg(long)]

--- a/crates/alv-cli/src/commands/logs.rs
+++ b/crates/alv-cli/src/commands/logs.rs
@@ -1,6 +1,9 @@
-use crate::cli::{LogSearchArgs, LogStatusArgs, LogSyncArgs, LogsArgs, LogsCommand};
+use crate::cli::{
+    LogIndexArgs, LogIndexCommand, LogIndexRebuildArgs, LogSearchArgs, LogStatusArgs, LogSyncArgs,
+    LogsArgs, LogsCommand,
+};
 use alv_core::{
-    auth,
+    auth, log_index,
     log_store::{self, OrgMetadata, SyncState},
     logs::{CancellationToken, LogsRuntimeError, RuntimeErrorData},
     logs_sync::{sync_logs_detailed_with_cancel, LogsSyncParams, LogsSyncResult},
@@ -24,6 +27,8 @@ struct StatusResult {
     last_synced_start_time: Option<String>,
     downloaded_count: usize,
     cached_count: usize,
+    indexed_count: usize,
+    index_file: String,
     last_error: Option<String>,
 }
 
@@ -44,6 +49,15 @@ struct SearchResult {
     pending_log_ids: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize)]
+struct IndexRebuildResult {
+    target_org: String,
+    safe_target_org: String,
+    workspace_root: String,
+    index_file: String,
+    indexed_count: usize,
+}
+
 #[derive(Debug, Serialize)]
 struct CommandErrorResult<'a> {
     status: &'static str,
@@ -57,6 +71,7 @@ pub fn run(args: LogsArgs) -> Result<i32, String> {
         LogsCommand::Sync(sync) => run_sync(sync),
         LogsCommand::Status(status) => run_status(status),
         LogsCommand::Search(search) => run_search(search),
+        LogsCommand::Index(index) => run_index(index),
     }
 }
 
@@ -100,9 +115,11 @@ fn run_status(args: LogStatusArgs) -> Result<i32, String> {
     let apexlogs_root = log_store::resolve_apexlogs_root(Some(&workspace_root));
     let entry = sync_state.orgs.get(&resolved_username);
     let log_count = discover_local_log_ids(Some(&workspace_root), Some(&resolved_username))?.len();
+    let indexed_count =
+        log_index::count_indexed_logs(Some(&workspace_root), &resolved_username).unwrap_or(0);
 
     let result = StatusResult {
-        target_org: resolved_username,
+        target_org: resolved_username.clone(),
         safe_target_org,
         workspace_root: workspace_root.clone(),
         apexlogs_root: apexlogs_root.display().to_string(),
@@ -117,6 +134,10 @@ fn run_status(args: LogStatusArgs) -> Result<i32, String> {
         last_synced_start_time: entry.and_then(|value| value.last_synced_start_time.clone()),
         downloaded_count: entry.map(|value| value.downloaded_count).unwrap_or(0),
         cached_count: entry.map(|value| value.cached_count).unwrap_or(0),
+        indexed_count,
+        index_file: log_index::index_path(Some(&workspace_root))
+            .display()
+            .to_string(),
         last_error: entry.and_then(|value| value.last_error.clone()),
     };
 
@@ -124,6 +145,48 @@ fn run_status(args: LogStatusArgs) -> Result<i32, String> {
         print_json(&result)?;
     } else {
         print_status_summary(&result);
+    }
+
+    Ok(0)
+}
+
+fn run_index(args: LogIndexArgs) -> Result<i32, String> {
+    match args.command {
+        LogIndexCommand::Rebuild(rebuild) => run_index_rebuild(rebuild),
+    }
+}
+
+fn run_index_rebuild(args: LogIndexRebuildArgs) -> Result<i32, String> {
+    let workspace_root = workspace_root_string()?;
+    let sync_state = log_store::read_sync_state(Some(&workspace_root))?;
+    let target_org = resolve_search_target_org(
+        args.target_org.as_deref(),
+        Some(&workspace_root),
+        &sync_state,
+    )?
+    .or_else(|| sync_state.orgs.keys().next().cloned())
+    .unwrap_or_else(|| "default".to_string());
+    let indexed_count = log_index::rebuild_org_index(
+        Some(&workspace_root),
+        &target_org,
+        &CancellationToken::new(),
+    )?;
+    let result = IndexRebuildResult {
+        safe_target_org: log_store::safe_target_org(&target_org),
+        target_org,
+        workspace_root: workspace_root.clone(),
+        index_file: log_index::index_path(Some(&workspace_root))
+            .display()
+            .to_string(),
+        indexed_count,
+    };
+
+    if args.json {
+        print_json(&result)?;
+    } else {
+        println!("Rebuilt Apex log index");
+        println!("Indexed: {}", result.indexed_count);
+        println!("Index file: {}", result.index_file);
     }
 
     Ok(0)
@@ -252,9 +315,14 @@ fn print_sync_summary(result: &LogsSyncResult) {
     println!("Status: {}", result.status);
     println!("Downloaded: {}", result.downloaded);
     println!("Cached: {}", result.cached);
+    println!("Indexed: {}", result.indexed);
     println!("Failed: {}", result.failed);
     println!("Checkpoint advanced: {}", result.checkpoint_advanced);
     println!("State file: {}", result.state_file);
+    println!("Index file: {}", result.index_file);
+    if let Some(error) = result.index_error.as_deref() {
+        println!("Index warning: {error}");
+    }
 }
 
 fn print_status_summary(result: &StatusResult) {
@@ -262,7 +330,9 @@ fn print_status_summary(result: &StatusResult) {
     println!("Workspace: {}", result.workspace_root);
     println!("Apex logs root: {}", result.apexlogs_root);
     println!("State file: {}", result.state_file);
+    println!("Index file: {}", result.index_file);
     println!("Local logs: {}", result.log_count);
+    println!("Indexed logs: {}", result.indexed_count);
     if result.has_state {
         println!("Last sync completed: {:?}", result.last_sync_completed_at);
     } else {

--- a/crates/alv-cli/tests/cli_smoke.rs
+++ b/crates/alv-cli/tests/cli_smoke.rs
@@ -193,6 +193,7 @@ fn cli_smoke_shows_logs_subcommands_in_help() {
     assert!(stdout.contains("sync"));
     assert!(stdout.contains("status"));
     assert!(stdout.contains("search"));
+    assert!(stdout.contains("index"));
 }
 
 #[test]
@@ -247,14 +248,73 @@ fn cli_smoke_logs_sync_json_emits_structured_result_and_writes_state() {
     assert_eq!(json["status"], "success");
     assert_eq!(json["target_org"], "default@example.com");
     assert_eq!(json["downloaded"], 1);
+    assert_eq!(json["indexed"], 1);
+    assert!(json["index_file"]
+        .as_str()
+        .is_some_and(|value| value.ends_with("apexlogs/.alv/log-index.sqlite")));
     assert!(workspace_root
         .join("apexlogs")
         .join(".alv")
         .join("sync-state.json")
         .is_file());
+    assert!(workspace_root
+        .join("apexlogs")
+        .join(".alv")
+        .join("log-index.sqlite")
+        .is_file());
 
     fs::remove_dir_all(workspace_root).expect("workspace should be removable");
     fs::remove_dir_all(fixture_dir).expect("fixture dir should be removable");
+}
+
+#[test]
+fn cli_smoke_logs_index_rebuild_json_indexes_existing_org_logs() {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("clock should be after unix epoch")
+        .as_nanos();
+    let workspace_root = std::env::temp_dir().join(format!("alv-cli-index-{unique}"));
+    let log_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join("default")
+        .join("logs")
+        .join("unknown-date");
+    fs::create_dir_all(&log_dir).expect("log dir should exist");
+    fs::write(
+        log_dir.join("07L000000000003AA.log"),
+        "09:00:00.0|USER_INFO|indexed body\n",
+    )
+    .expect("fixture log should be writable");
+
+    let output = apex_log_viewer_command()
+        .current_dir(&workspace_root)
+        .args([
+            "logs",
+            "index",
+            "rebuild",
+            "--target-org",
+            "default",
+            "--json",
+        ])
+        .output()
+        .expect("index rebuild should execute");
+
+    assert!(
+        output.status.success(),
+        "index rebuild should exit successfully: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: Value = serde_json::from_slice(&output.stdout).expect("stdout should be valid json");
+    assert_eq!(json["target_org"], "default");
+    assert_eq!(json["indexed_count"], 1);
+    assert!(workspace_root
+        .join("apexlogs")
+        .join(".alv")
+        .join("log-index.sqlite")
+        .is_file());
+
+    fs::remove_dir_all(workspace_root).expect("workspace should be removable");
 }
 
 #[test]

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -16,6 +16,7 @@ grep = "0.4"
 grep-matcher = "0.1"
 grep-regex = "0.1"
 grep-searcher = "0.1"
+rusqlite = { version = "0.32", features = ["bundled"] }
 # Keep native roots and system proxy support enabled so corporate TLS interception
 # works through the OS trust store on Windows, macOS, and Linux.
 reqwest = { version = "0.12", default-features = false, features = [

--- a/crates/alv-core/src/lib.rs
+++ b/crates/alv-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod cache;
 pub(crate) mod cli;
 pub(crate) mod cli_json;
 pub mod debug_flags;
+pub mod log_index;
 pub mod log_store;
 pub mod logs;
 pub mod logs_sync;

--- a/crates/alv-core/src/log_index.rs
+++ b/crates/alv-core/src/log_index.rs
@@ -1,0 +1,578 @@
+use crate::{
+    log_store,
+    logs::{CancellationToken, LogRow},
+};
+use rusqlite::{params, Connection, OptionalExtension};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    path::{Path, PathBuf},
+};
+
+const INDEX_SCHEMA_VERSION: u32 = 1;
+const INDEX_FILE_NAME: &str = "log-index.sqlite";
+const MAX_SQL_PARAMS: usize = 900;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LogIndexRecord {
+    pub row: LogRow,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct LogIndexSearchResult {
+    pub matched_lines: BTreeMap<String, String>,
+    pub indexed_log_ids: BTreeSet<String>,
+}
+
+pub fn index_path(workspace_root: Option<&str>) -> PathBuf {
+    log_store::resolve_apexlogs_root(workspace_root)
+        .join(".alv")
+        .join(INDEX_FILE_NAME)
+}
+
+pub fn count_indexed_logs(workspace_root: Option<&str>, target_org: &str) -> Result<usize, String> {
+    let path = index_path(workspace_root);
+    if !path.is_file() {
+        return Ok(0);
+    }
+    let conn = open_index(workspace_root)?;
+    let count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM logs WHERE target_org = ?1",
+            params![target_org],
+            |row| row.get(0),
+        )
+        .map_err(|error| format!("failed to read log index count: {error}"))?;
+    Ok(count.max(0) as usize)
+}
+
+pub fn index_synced_logs(
+    workspace_root: Option<&str>,
+    target_org: &str,
+    safe_target_org: &str,
+    records: &[LogIndexRecord],
+    cancellation: &CancellationToken,
+) -> Result<usize, String> {
+    if records.is_empty() {
+        return Ok(0);
+    }
+
+    let mut conn = open_index(workspace_root)?;
+    let tx = conn
+        .transaction()
+        .map_err(|error| format!("failed to start log index transaction: {error}"))?;
+    let indexed_at = timestamp_now();
+    let mut indexed = 0usize;
+
+    for record in records {
+        cancellation.check_cancelled()?;
+        let body = fs::read_to_string(&record.path).map_err(|error| {
+            format!(
+                "failed to read {} for indexing: {error}",
+                record.path.display()
+            )
+        })?;
+        upsert_log(
+            &tx,
+            target_org,
+            safe_target_org,
+            &record.row,
+            &record.path,
+            &body,
+            &indexed_at,
+        )?;
+        indexed += 1;
+    }
+
+    tx.commit()
+        .map_err(|error| format!("failed to commit log index transaction: {error}"))?;
+    Ok(indexed)
+}
+
+pub fn rebuild_org_index(
+    workspace_root: Option<&str>,
+    target_org: &str,
+    cancellation: &CancellationToken,
+) -> Result<usize, String> {
+    let safe_target_org = log_store::safe_target_org(target_org);
+    let logs_root = log_store::org_dir(workspace_root, target_org).join("logs");
+    let mut paths = Vec::new();
+    collect_log_paths(&logs_root, cancellation, &mut paths)?;
+
+    let mut conn = open_index(workspace_root)?;
+    let tx = conn
+        .transaction()
+        .map_err(|error| format!("failed to start log index rebuild transaction: {error}"))?;
+    clear_org_index(&tx, target_org)?;
+    if paths.is_empty() {
+        tx.commit()
+            .map_err(|error| format!("failed to commit empty log index rebuild: {error}"))?;
+        return Ok(0);
+    }
+    let indexed_at = timestamp_now();
+    let mut indexed = 0usize;
+
+    for path in paths {
+        cancellation.check_cancelled()?;
+        let Some(log_id) = log_id_from_path(&path) else {
+            continue;
+        };
+        let body = fs::read_to_string(&path)
+            .map_err(|error| format!("failed to read {} for indexing: {error}", path.display()))?;
+        let row = rebuilt_row(&log_id, start_time_from_path(&path));
+        upsert_log(
+            &tx,
+            target_org,
+            &safe_target_org,
+            &row,
+            &path,
+            &body,
+            &indexed_at,
+        )?;
+        indexed += 1;
+    }
+
+    tx.commit()
+        .map_err(|error| format!("failed to commit log index rebuild: {error}"))?;
+    Ok(indexed)
+}
+
+pub fn search_index_lines(
+    workspace_root: Option<&str>,
+    target_org: &str,
+    query: &str,
+    log_ids: &[String],
+    cancellation: &CancellationToken,
+) -> Result<Option<LogIndexSearchResult>, String> {
+    let path = index_path(workspace_root);
+    if !path.is_file() {
+        return Ok(None);
+    }
+    let query = query.trim();
+    if query.chars().count() < 3 || log_ids.is_empty() {
+        return Ok(None);
+    }
+
+    let conn = open_index(workspace_root)?;
+    let requested = log_ids
+        .iter()
+        .map(|value| value.trim())
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+        .collect::<BTreeSet<_>>();
+    if requested.is_empty() {
+        return Ok(Some(LogIndexSearchResult::default()));
+    }
+
+    let indexed_log_ids = indexed_log_ids(&conn, target_org, &requested, cancellation)?;
+    let mut result = LogIndexSearchResult {
+        indexed_log_ids,
+        matched_lines: BTreeMap::new(),
+    };
+
+    let fts_query = fts_phrase_query(query);
+    let mut stmt = conn
+        .prepare("SELECT id, body FROM log_fts WHERE target_org = ?1 AND body MATCH ?2")
+        .map_err(|error| format!("failed to prepare log index search: {error}"))?;
+    let mut rows = stmt
+        .query(params![target_org, fts_query])
+        .map_err(|error| format!("failed to search log index: {error}"))?;
+    while let Some(row) = rows
+        .next()
+        .map_err(|error| format!("failed to read log index search row: {error}"))?
+    {
+        cancellation.check_cancelled()?;
+        let log_id: String = row
+            .get(0)
+            .map_err(|error| format!("failed to read indexed log id: {error}"))?;
+        if !requested.contains(&log_id) || result.matched_lines.contains_key(&log_id) {
+            continue;
+        }
+        let body: String = row
+            .get(1)
+            .map_err(|error| format!("failed to read indexed log body: {error}"))?;
+        if let Some(line) = find_matching_line(&body, query) {
+            result.matched_lines.insert(log_id, line);
+        }
+    }
+
+    Ok(Some(result))
+}
+
+fn open_index(workspace_root: Option<&str>) -> Result<Connection, String> {
+    let path = index_path(workspace_root);
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|error| format!("failed to create {}: {error}", parent.display()))?;
+    }
+
+    let conn = Connection::open(&path)
+        .map_err(|error| format!("failed to open log index {}: {error}", path.display()))?;
+    conn.pragma_update(None, "journal_mode", "WAL")
+        .map_err(|error| format!("failed to enable WAL for log index: {error}"))?;
+    conn.pragma_update(None, "busy_timeout", 5000i64)
+        .map_err(|error| format!("failed to set log index busy timeout: {error}"))?;
+    ensure_schema(&conn)?;
+    Ok(conn)
+}
+
+fn ensure_schema(conn: &Connection) -> Result<(), String> {
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS metadata (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        INSERT OR IGNORE INTO metadata (key, value)
+          VALUES ('schema_version', '1');
+        CREATE TABLE IF NOT EXISTS logs (
+          target_org TEXT NOT NULL,
+          id TEXT NOT NULL,
+          safe_target_org TEXT NOT NULL,
+          start_time TEXT,
+          operation TEXT,
+          application TEXT,
+          status TEXT,
+          request TEXT,
+          log_length INTEGER,
+          log_user_name TEXT,
+          path TEXT NOT NULL,
+          body_size INTEGER NOT NULL DEFAULT 0,
+          indexed_at TEXT NOT NULL,
+          PRIMARY KEY (target_org, id)
+        );
+        "#,
+    )
+    .map_err(|error| format!("failed to initialize log index schema: {error}"))?;
+
+    ensure_fts_table(conn)?;
+    let version: Option<String> = conn
+        .query_row(
+            "SELECT value FROM metadata WHERE key = 'schema_version'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()
+        .map_err(|error| format!("failed to read log index schema version: {error}"))?;
+    if version.as_deref() != Some(&INDEX_SCHEMA_VERSION.to_string()) {
+        return Err("unsupported log index schema version".to_string());
+    }
+    Ok(())
+}
+
+fn ensure_fts_table(conn: &Connection) -> Result<(), String> {
+    match conn.execute_batch(
+        r#"
+        CREATE VIRTUAL TABLE IF NOT EXISTS log_fts
+        USING fts5(target_org UNINDEXED, id UNINDEXED, body, tokenize='trigram');
+        "#,
+    ) {
+        Ok(()) => Ok(()),
+        Err(first_error) => conn
+            .execute_batch(
+                r#"
+                CREATE VIRTUAL TABLE IF NOT EXISTS log_fts
+                USING fts5(target_org UNINDEXED, id UNINDEXED, body);
+                "#,
+            )
+            .map_err(|second_error| {
+                format!(
+                    "failed to initialize log FTS table: {first_error}; fallback failed: {second_error}"
+                )
+            }),
+    }
+}
+
+fn upsert_log(
+    conn: &Connection,
+    target_org: &str,
+    safe_target_org: &str,
+    row: &LogRow,
+    path: &Path,
+    body: &str,
+    indexed_at: &str,
+) -> Result<(), String> {
+    conn.execute(
+        r#"
+        INSERT INTO logs (
+          target_org, id, safe_target_org, start_time, operation, application,
+          status, request, log_length, log_user_name, path, body_size, indexed_at
+        )
+        VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)
+        ON CONFLICT(target_org, id) DO UPDATE SET
+          safe_target_org = excluded.safe_target_org,
+          start_time = excluded.start_time,
+          operation = excluded.operation,
+          application = excluded.application,
+          status = excluded.status,
+          request = excluded.request,
+          log_length = excluded.log_length,
+          log_user_name = excluded.log_user_name,
+          path = excluded.path,
+          body_size = excluded.body_size,
+          indexed_at = excluded.indexed_at
+        "#,
+        params![
+            target_org,
+            row.id,
+            safe_target_org,
+            row.start_time,
+            row.operation,
+            row.application,
+            row.status,
+            row.request,
+            row.log_length as i64,
+            row.log_user.as_ref().and_then(|user| user.name.as_deref()),
+            path.display().to_string(),
+            body.len() as i64,
+            indexed_at,
+        ],
+    )
+    .map_err(|error| format!("failed to upsert log metadata into index: {error}"))?;
+    conn.execute(
+        "DELETE FROM log_fts WHERE target_org = ?1 AND id = ?2",
+        params![target_org, row.id],
+    )
+    .map_err(|error| format!("failed to replace indexed log body: {error}"))?;
+    conn.execute(
+        "INSERT INTO log_fts (target_org, id, body) VALUES (?1, ?2, ?3)",
+        params![target_org, row.id, body],
+    )
+    .map_err(|error| format!("failed to index log body: {error}"))?;
+    Ok(())
+}
+
+fn clear_org_index(conn: &Connection, target_org: &str) -> Result<(), String> {
+    conn.execute(
+        "DELETE FROM log_fts WHERE target_org = ?1",
+        params![target_org],
+    )
+    .map_err(|error| format!("failed to clear indexed log bodies: {error}"))?;
+    conn.execute(
+        "DELETE FROM logs WHERE target_org = ?1",
+        params![target_org],
+    )
+    .map_err(|error| format!("failed to clear indexed log metadata: {error}"))?;
+    Ok(())
+}
+
+fn indexed_log_ids(
+    conn: &Connection,
+    target_org: &str,
+    requested: &BTreeSet<String>,
+    cancellation: &CancellationToken,
+) -> Result<BTreeSet<String>, String> {
+    let mut indexed = BTreeSet::new();
+    let requested = requested.iter().collect::<Vec<_>>();
+    for chunk in requested.chunks(MAX_SQL_PARAMS) {
+        cancellation.check_cancelled()?;
+        let placeholders = (0..chunk.len()).map(|_| "?").collect::<Vec<_>>().join(",");
+        let sql = format!("SELECT id FROM logs WHERE target_org = ? AND id IN ({placeholders})");
+        let mut params: Vec<&dyn rusqlite::ToSql> = Vec::with_capacity(chunk.len() + 1);
+        params.push(&target_org);
+        for log_id in chunk {
+            params.push(*log_id);
+        }
+        let mut stmt = conn
+            .prepare(&sql)
+            .map_err(|error| format!("failed to prepare indexed log lookup: {error}"))?;
+        let mut rows = stmt
+            .query(params.as_slice())
+            .map_err(|error| format!("failed to query indexed log ids: {error}"))?;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| format!("failed to read indexed log lookup row: {error}"))?
+        {
+            let log_id: String = row
+                .get(0)
+                .map_err(|error| format!("failed to read indexed log lookup id: {error}"))?;
+            indexed.insert(log_id);
+        }
+    }
+    Ok(indexed)
+}
+
+fn collect_log_paths(
+    logs_root: &Path,
+    cancellation: &CancellationToken,
+    paths: &mut Vec<PathBuf>,
+) -> Result<(), String> {
+    if !logs_root.is_dir() {
+        return Ok(());
+    }
+    let entries = fs::read_dir(logs_root)
+        .map_err(|error| format!("failed to read {}: {error}", logs_root.display()))?;
+    for entry in entries.flatten() {
+        cancellation.check_cancelled()?;
+        let path = entry.path();
+        if path.is_dir() {
+            if log_store::is_supported_log_day_dir_name(
+                entry.file_name().to_string_lossy().as_ref(),
+            ) {
+                collect_log_paths(&path, cancellation, paths)?;
+            }
+            continue;
+        }
+        if path.is_file() && log_id_from_path(&path).is_some() {
+            paths.push(path);
+        }
+    }
+    paths.sort();
+    Ok(())
+}
+
+fn log_id_from_path(path: &Path) -> Option<String> {
+    path.file_name()
+        .and_then(|value| value.to_str())
+        .and_then(|value| value.strip_suffix(".log"))
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToOwned::to_owned)
+}
+
+fn start_time_from_path(path: &Path) -> String {
+    path.parent()
+        .and_then(|parent| parent.file_name())
+        .and_then(|value| value.to_str())
+        .filter(|value| log_store::is_supported_log_day_dir_name(value))
+        .filter(|value| *value != "unknown-date")
+        .map(|day| format!("{day}T00:00:00.000Z"))
+        .unwrap_or_default()
+}
+
+fn rebuilt_row(log_id: &str, start_time: String) -> LogRow {
+    LogRow {
+        id: log_id.to_string(),
+        start_time,
+        operation: String::new(),
+        application: String::new(),
+        duration_milliseconds: 0,
+        status: String::new(),
+        request: String::new(),
+        log_length: 0,
+        log_user: None,
+    }
+}
+
+fn find_matching_line(body: &str, query: &str) -> Option<String> {
+    let needle = query.to_lowercase();
+    body.lines()
+        .find(|line| line.to_lowercase().contains(&needle))
+        .map(ToOwned::to_owned)
+}
+
+fn fts_phrase_query(query: &str) -> String {
+    format!("\"{}\"", query.replace('"', "\"\""))
+}
+
+fn timestamp_now() -> String {
+    chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn temp_workspace(label: &str) -> PathBuf {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!("alv-log-index-{label}-{nonce}"));
+        fs::create_dir_all(&root).expect("temp workspace should be creatable");
+        root
+    }
+
+    #[test]
+    fn rebuild_org_index_clears_existing_rows_when_no_logs_remain() {
+        let workspace_root = temp_workspace("rebuild-empty");
+        let target_org = "selected@example.com";
+        let log_dir = log_store::org_dir(
+            Some(
+                workspace_root
+                    .to_str()
+                    .expect("workspace path should be utf8"),
+            ),
+            target_org,
+        )
+        .join("logs")
+        .join("2026-03-30");
+        fs::create_dir_all(&log_dir).expect("log dir should be creatable");
+        let log_path = log_dir.join("07L000000000001AA.log");
+        fs::write(&log_path, "09:00:00.0|USER_INFO|stale indexed body\n")
+            .expect("log file should be writable");
+
+        let workspace_text = workspace_root
+            .to_str()
+            .expect("workspace path should be utf8")
+            .to_string();
+        let token = CancellationToken::new();
+        assert_eq!(
+            rebuild_org_index(Some(&workspace_text), target_org, &token)
+                .expect("initial rebuild should succeed"),
+            1
+        );
+        assert_eq!(
+            count_indexed_logs(Some(&workspace_text), target_org)
+                .expect("indexed count should be readable"),
+            1
+        );
+
+        fs::remove_file(&log_path).expect("log file should be removable");
+        assert_eq!(
+            rebuild_org_index(Some(&workspace_text), target_org, &token)
+                .expect("empty rebuild should succeed"),
+            0
+        );
+        assert_eq!(
+            count_indexed_logs(Some(&workspace_text), target_org)
+                .expect("indexed count should be readable after empty rebuild"),
+            0
+        );
+        let search = search_index_lines(
+            Some(&workspace_text),
+            target_org,
+            "stale indexed body",
+            &["07L000000000001AA".to_string()],
+            &token,
+        )
+        .expect("search should query index")
+        .expect("index should exist");
+        assert!(search.indexed_log_ids.is_empty());
+        assert!(search.matched_lines.is_empty());
+
+        fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    }
+
+    #[test]
+    fn open_index_rejects_existing_unsupported_schema_version() {
+        let workspace_root = temp_workspace("unsupported-version");
+        let workspace_text = workspace_root
+            .to_str()
+            .expect("workspace path should be utf8")
+            .to_string();
+        let path = index_path(Some(&workspace_text));
+        fs::create_dir_all(path.parent().expect("index path should have parent"))
+            .expect("index parent should be creatable");
+        let conn = Connection::open(&path).expect("sqlite index should be creatable");
+        conn.execute_batch(
+            r#"
+            CREATE TABLE metadata (
+              key TEXT PRIMARY KEY,
+              value TEXT NOT NULL
+            );
+            INSERT INTO metadata (key, value) VALUES ('schema_version', '999');
+            "#,
+        )
+        .expect("unsupported metadata should be writable");
+        drop(conn);
+
+        let error = count_indexed_logs(Some(&workspace_text), "selected@example.com")
+            .expect_err("unsupported schema version should be rejected");
+        assert!(error.contains("unsupported log index schema version"));
+
+        fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+    }
+}

--- a/crates/alv-core/src/logs_sync.rs
+++ b/crates/alv-core/src/logs_sync.rs
@@ -1,6 +1,7 @@
 use crate::{
     auth,
     auth::OrgAuth,
+    log_index::{self, LogIndexRecord},
     log_store::{
         log_file_path_for_start_time, read_sync_state, safe_target_org, write_org_metadata,
         write_sync_state, write_version_file, OrgMetadata, SyncStateOrgEntry,
@@ -39,9 +40,13 @@ pub struct LogsSyncResult {
     pub safe_target_org: String,
     pub downloaded: usize,
     pub cached: usize,
+    pub indexed: usize,
     pub failed: usize,
     pub checkpoint_advanced: bool,
     pub state_file: String,
+    pub index_file: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index_error: Option<String>,
     pub last_synced_log_id: Option<String>,
 }
 
@@ -94,10 +99,15 @@ pub fn sync_logs_detailed_with_cancel(
         .map_err(LogsRuntimeError::from_message)?;
     let mut downloaded = 0usize;
     let mut cached = 0usize;
+    let mut indexed = 0usize;
     let mut failed = 0usize;
+    let mut index_error: Option<String> = None;
     let mut newest: Option<(String, String)> = None;
     let mut cursor: Option<LogsCursor> = None;
     let sync_concurrency = normalize_sync_concurrency(params.concurrency);
+    let index_count_before =
+        log_index::count_indexed_logs(params.workspace_root.as_deref(), &resolved_username)
+            .unwrap_or(0);
 
     loop {
         let mut rows = match list_logs_for_auth_detailed_with_cancel(
@@ -147,6 +157,22 @@ pub fn sync_logs_detailed_with_cancel(
         downloaded += outcome.downloaded;
         cached += outcome.cached;
         failed += outcome.failed;
+        if !outcome.synced.is_empty() {
+            match log_index::index_synced_logs(
+                params.workspace_root.as_deref(),
+                &resolved_username,
+                &safe_org,
+                &outcome.synced,
+                cancellation,
+            ) {
+                Ok(count) => indexed += count,
+                Err(error) => {
+                    if index_error.is_none() {
+                        index_error = Some(error);
+                    }
+                }
+            }
+        }
         if newest.is_none() {
             newest = outcome.newest_synced.clone();
         }
@@ -170,6 +196,21 @@ pub fn sync_logs_detailed_with_cancel(
         "success".to_string()
     };
     let finished_at = timestamp_now();
+
+    if indexed == 0 && index_count_before == 0 && !cancellation.is_cancelled() {
+        match log_index::rebuild_org_index(
+            params.workspace_root.as_deref(),
+            &resolved_username,
+            cancellation,
+        ) {
+            Ok(count) => indexed += count,
+            Err(error) => {
+                if index_error.is_none() {
+                    index_error = Some(error);
+                }
+            }
+        }
+    }
 
     let checkpoint = newest.clone().or_else(|| {
         previous.as_ref().map(|entry| {
@@ -202,7 +243,7 @@ pub fn sync_logs_detailed_with_cancel(
                 },
                 downloaded_count: downloaded,
                 cached_count: cached,
-                last_error: None,
+                last_error: index_error.clone(),
             },
         );
         write_sync_state(params.workspace_root.as_deref(), &state)
@@ -231,11 +272,16 @@ pub fn sync_logs_detailed_with_cancel(
         safe_target_org: safe_org,
         downloaded,
         cached,
+        indexed,
         failed,
         checkpoint_advanced: status == "success",
         state_file: crate::log_store::sync_state_path(params.workspace_root.as_deref())
             .display()
             .to_string(),
+        index_file: crate::log_index::index_path(params.workspace_root.as_deref())
+            .display()
+            .to_string(),
+        index_error,
         last_synced_log_id: if status == "success" {
             checkpoint.map(|(log_id, _)| log_id)
         } else {
@@ -304,6 +350,7 @@ struct PageSyncOutcome {
     cached: usize,
     failed: usize,
     newest_synced: Option<(String, String)>,
+    synced: Vec<LogIndexRecord>,
 }
 
 fn process_sync_page(
@@ -321,7 +368,7 @@ fn process_sync_page(
     let queue = Arc::new(Mutex::new(
         rows.into_iter().enumerate().collect::<VecDeque<_>>(),
     ));
-    let (tx, rx) = mpsc::channel::<(usize, String, String, SyncItemStatus)>();
+    let (tx, rx) = mpsc::channel::<(usize, LogRow, std::path::PathBuf, SyncItemStatus)>();
     let auth = auth.clone();
     let workspace_root = workspace_root.map(str::to_string);
     let resolved_username = resolved_username.to_string();
@@ -376,7 +423,7 @@ fn process_sync_page(
                     }
                 };
 
-                let _ = tx.send((index, row.id, row.start_time, status));
+                let _ = tx.send((index, row, target_path, status));
                 if status == SyncItemStatus::Cancelled {
                     break;
                 }
@@ -386,7 +433,7 @@ fn process_sync_page(
 
         let mut outcome = PageSyncOutcome::default();
         let mut best_index: Option<usize> = None;
-        for (index, row_id, start_time, item) in rx {
+        for (index, row, path, item) in rx {
             match item {
                 SyncItemStatus::Downloaded | SyncItemStatus::Cached => {
                     if item == SyncItemStatus::Downloaded {
@@ -396,8 +443,9 @@ fn process_sync_page(
                     }
                     if best_index.is_none_or(|best| index < best) {
                         best_index = Some(index);
-                        outcome.newest_synced = Some((row_id, start_time));
+                        outcome.newest_synced = Some((row.id.clone(), row.start_time.clone()));
                     }
+                    outcome.synced.push(LogIndexRecord { row, path });
                 }
                 SyncItemStatus::Failed => outcome.failed += 1,
                 SyncItemStatus::Cancelled => {}

--- a/crates/alv-core/src/search.rs
+++ b/crates/alv-core/src/search.rs
@@ -1,4 +1,4 @@
-use crate::{auth, log_store, logs::CancellationToken};
+use crate::{auth, log_index, log_store, logs::CancellationToken};
 use grep_matcher::Matcher;
 use grep_regex::RegexMatcherBuilder;
 use serde::{Deserialize, Serialize};
@@ -74,6 +74,44 @@ pub fn search_query_with_cancel(
         .raw_username
         .as_deref()
         .or(params.username.as_deref());
+
+    let target_org_for_index = canonical_username
+        .as_deref()
+        .or(raw_username_hint)
+        .map(str::trim)
+        .filter(|value| !value.is_empty());
+    let mut scan_log_ids = log_ids.clone();
+    if let Some(target_org) = target_org_for_index {
+        if let Some(index_result) = log_index::search_index_lines(
+            params.workspace_root.as_deref(),
+            target_org,
+            query,
+            &log_ids,
+            cancellation,
+        )
+        .unwrap_or(None)
+        {
+            scan_log_ids.clear();
+            for log_id in &log_ids {
+                cancellation.check_cancelled()?;
+                if !index_result.indexed_log_ids.contains(log_id) {
+                    scan_log_ids.push(log_id.clone());
+                    continue;
+                }
+                let Some(line) = index_result.matched_lines.get(log_id) else {
+                    continue;
+                };
+                result.log_ids.push(log_id.clone());
+                if let Some(snippet) = build_snippet(&matcher, line) {
+                    result.snippets.insert(log_id.clone(), snippet);
+                }
+            }
+            if scan_log_ids.is_empty() {
+                return Ok(result);
+            }
+        }
+    }
+
     let path_index = build_cached_log_path_index(
         params.workspace_root.as_deref(),
         raw_username_hint,
@@ -81,7 +119,7 @@ pub fn search_query_with_cancel(
         cancellation,
     )?;
 
-    for log_id in log_ids {
+    for log_id in scan_log_ids {
         cancellation.check_cancelled()?;
         let Some(paths) = path_index.get(&log_id) else {
             result.pending_log_ids.push(log_id);

--- a/crates/alv-core/tests/logs_runtime_smoke.rs
+++ b/crates/alv-core/tests/logs_runtime_smoke.rs
@@ -13,10 +13,12 @@ use std::{
 
 use alv_core::{
     auth::TEST_ORG_DISPLAY_JSON_ENV,
+    log_index::{self, LogIndexRecord},
+    log_store,
     logs::{
         ensure_log_file_cached, extract_code_unit_started, find_cached_log_path,
-        list_logs_detailed_with_cancel, list_logs_with_cancel, CancellationToken, LogsListParams,
-        TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV,
+        list_logs_detailed_with_cancel, list_logs_with_cancel, CancellationToken, LogRow,
+        LogsListParams, TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV,
     },
     search::{search_query, search_query_with_cancel, SearchQueryParams},
     triage::{triage_logs, triage_logs_with_cancel, LogsTriageParams},
@@ -541,6 +543,77 @@ fn logs_runtime_smoke_search_with_blank_log_ids_short_circuits_before_cache_inde
     assert!(result.log_ids.is_empty());
     assert!(result.pending_log_ids.is_empty());
     assert!(result.snippets.is_empty());
+
+    fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
+}
+
+#[test]
+fn logs_runtime_smoke_search_falls_back_to_files_for_unindexed_local_logs() {
+    let _guard = lock_test_guard();
+
+    let workspace_root = make_temp_workspace("search-partial-index");
+    let target_org = "selected@example.com";
+    let log_dir = workspace_root
+        .join("apexlogs")
+        .join("orgs")
+        .join(target_org)
+        .join("logs")
+        .join("2026-03-30");
+    fs::create_dir_all(&log_dir).expect("selected org log dir should exist");
+    let indexed_path = log_dir.join("07L000000000001AA.log");
+    let unindexed_path = log_dir.join("07L000000000002AA.log");
+    fs::write(
+        &indexed_path,
+        "09:00:00.0|USER_INFO|indexed body without the searched token\n",
+    )
+    .expect("indexed log should be writable");
+    fs::write(
+        &unindexed_path,
+        "09:00:00.0|FATAL_ERROR|PartialIndexNeedle\n",
+    )
+    .expect("unindexed log should be writable");
+
+    let row = LogRow {
+        id: "07L000000000001AA".to_string(),
+        start_time: "2026-03-30T18:39:58.000Z".to_string(),
+        operation: "ExecuteAnonymous".to_string(),
+        application: "Developer Console".to_string(),
+        duration_milliseconds: 0,
+        status: "Success".to_string(),
+        request: "REQ-1".to_string(),
+        log_length: 64,
+        log_user: None,
+    };
+    log_index::index_synced_logs(
+        Some(
+            workspace_root
+                .to_str()
+                .expect("workspace path should be utf8"),
+        ),
+        target_org,
+        &log_store::safe_target_org(target_org),
+        &[LogIndexRecord {
+            row,
+            path: indexed_path,
+        }],
+        &CancellationToken::new(),
+    )
+    .expect("partial index should be writable");
+
+    let result = search_query(&SearchQueryParams {
+        query: "PartialIndexNeedle".to_string(),
+        log_ids: vec![
+            "07L000000000001AA".to_string(),
+            "07L000000000002AA".to_string(),
+        ],
+        username: Some(target_org.to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search/query should fall back to file scan for unindexed logs");
+
+    assert_eq!(result.log_ids, vec!["07L000000000002AA".to_string()]);
+    assert!(result.pending_log_ids.is_empty());
 
     fs::remove_dir_all(workspace_root).expect("temp workspace should be removable");
 }

--- a/crates/alv-core/tests/logs_sync_smoke.rs
+++ b/crates/alv-core/tests/logs_sync_smoke.rs
@@ -10,6 +10,7 @@ use alv_core::{
     log_store::{org_metadata_path, read_sync_state, resolve_apexlogs_root, OrgMetadata},
     logs::{TEST_APEX_LOG_FIXTURE_DIR_ENV, TEST_SF_LOG_LIST_JSON_ENV},
     logs_sync::{sync_logs_with_cancel, LogsSyncParams},
+    search::{search_query, SearchQueryParams},
 };
 use serde_json::{json, Value};
 use tiny_http::{Header, Response, Server, StatusCode};
@@ -118,6 +119,11 @@ fn logs_sync_smoke_writes_new_layout_and_updates_checkpoint() {
 
     assert_eq!(result.status, "success");
     assert_eq!(result.downloaded, 1);
+    assert_eq!(result.indexed, 1);
+    assert!(
+        PathBuf::from(&result.index_file).is_file(),
+        "sync should create the shared SQLite search index"
+    );
     assert!(resolve_apexlogs_root(Some(
         workspace_root
             .to_str()
@@ -142,6 +148,16 @@ fn logs_sync_smoke_writes_new_layout_and_updates_checkpoint() {
             .as_deref(),
         Some("07L000000000003AA")
     );
+    let search_result = search_query(&SearchQueryParams {
+        query: "synced body".to_string(),
+        log_ids: vec!["07L000000000003AA".to_string()],
+        username: Some("default@example.com".to_string()),
+        raw_username: None,
+        workspace_root: Some(workspace_root.display().to_string()),
+    })
+    .expect("search should read synced bodies through the shared index");
+    assert_eq!(search_result.log_ids, vec!["07L000000000003AA".to_string()]);
+    assert!(search_result.pending_log_ids.is_empty());
 
     std::env::remove_var(TEST_APEX_LOG_FIXTURE_DIR_ENV);
     std::env::remove_var(TEST_SF_LOG_LIST_JSON_ENV);

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,7 +6,7 @@ This document explains the internal structure of the Apex Log Viewer extension a
 
 The extension has two main sides:
 
-1. **Extension host** – runs in Node.js inside VS Code and handles commands, log retrieval, and runtime communication with Salesforce via jsforce-backed API calls.
+1. **Extension host** – runs in Node.js inside VS Code and handles commands, webview orchestration, and runtime communication with Salesforce through the shared Rust sidecar plus remaining jsforce-backed flows.
 2. **Webview UI** – a React application bundled to `media/main.js` and rendered inside a VS Code webview. It presents logs, filters, and user interactions.
 
 Both sides exchange messages using the `vscode` webview API with shared TypeScript interfaces defined in `src/shared`.
@@ -18,7 +18,7 @@ The activation entry point is `src/extension.ts`. It registers commands such as 
 Key responsibilities:
 
 - Use Salesforce CLI (`sf` or legacy `sfdx`) to discover authenticated orgs and reuse existing auth.
-- Use jsforce-backed REST/Tooling/Streaming API calls for runtime log retrieval, tailing, and debug-flag management.
+- Use the shared Rust runtime for log list, sync, search, triage, and cached-path lookup, while jsforce-backed flows continue to handle tailing and debug-flag management.
 - Maintain per-org state such as selected org and log cache.
 - Forward trace output to the "Electivus Apex Log Viewer" output channel when `electivus.apexLogs.trace` is enabled.
 
@@ -47,10 +47,11 @@ The standalone CLI and the VS Code extension are separate surfaces over the same
 
 - `apexlogs/.alv/version.json` stores the local layout version.
 - `apexlogs/.alv/sync-state.json` stores incremental sync checkpoints by org.
+- `apexlogs/.alv/log-index.sqlite` stores a local SQLite/FTS index for synced log body search.
 - `apexlogs/orgs/<safe-target-org>/org.json` stores resolved org metadata.
 - `apexlogs/orgs/<safe-target-org>/logs/<YYYY-MM-DD>/<logId>.log` stores full log bodies.
 
-The Rust CLI is the first consumer of that shared storage through `apex-log-viewer logs sync`, `logs status`, and `logs search`, while the runtime still reads the legacy flat cache layout during the transition so the extension remains compatible. For `logs sync`, the CLI still reuses `sf org display` for org auth, but the actual list/body fetches now go straight to the Salesforce Tooling REST API and can download bodies concurrently per page via `--concurrency`.
+The Rust CLI exposes that shared storage through `apex-log-viewer logs sync`, `logs status`, `logs search`, and `logs index rebuild`. The VS Code Logs panel uses the same app-server contract for `logs/list`, starts `logs/sync` in the background after refresh/load-more, and reruns triage/search after synced bodies have been indexed. For `logs sync`, the runtime still reuses `sf org display` for org auth, but the actual list/body fetches go straight to the Salesforce Tooling REST API and can download bodies concurrently per page.
 
 ## Testing and build tooling
 
@@ -60,7 +61,7 @@ The Rust CLI is the first consumer of that shared storage through `apex-log-view
 ## Data flow summary
 
 1. The user triggers a command (e.g., refresh).
-2. The extension resolves the selected org via Salesforce CLI-backed auth reuse and then queries Salesforce through jsforce.
-3. Results are sent to the webview over the messaging channel.
+2. The extension asks the shared runtime for the visible log rows and posts them to the webview as soon as they arrive.
+3. The runtime syncs full log bodies and updates the local index in the background.
 4. The React UI updates the table and exposes actions like open or tail.
-5. Actions from the UI send messages back to the extension for further processing.
+5. Search and error triage reuse synced bodies through the shared runtime/index instead of re-downloading rows already present locally.

--- a/packages/app-server-client-ts/src/index.ts
+++ b/packages/app-server-client-ts/src/index.ts
@@ -48,6 +48,28 @@ export type LogsListParams = {
   cursor?: LogsListCursor;
 };
 
+export type LogsSyncParams = {
+  targetOrg?: string;
+  workspaceRoot?: string;
+  forceFull?: boolean;
+  concurrency?: number;
+};
+
+export type LogsSyncResult = {
+  status: string;
+  target_org: string;
+  safe_target_org: string;
+  downloaded: number;
+  cached: number;
+  indexed: number;
+  failed: number;
+  checkpoint_advanced: boolean;
+  state_file: string;
+  index_file: string;
+  index_error?: string;
+  last_synced_log_id?: string;
+};
+
 export type SearchSnippet = {
   text: string;
   ranges: [number, number][];
@@ -89,6 +111,7 @@ export type LogsTriageParams = {
 
 export type LogsTriageEntry = {
   logId: string;
+  codeUnitStarted?: string;
   summary: RuntimeLogTriageSummary;
 };
 

--- a/telemetry.json
+++ b/telemetry.json
@@ -614,7 +614,7 @@
           "classification": "SystemMetaData",
           "purpose": "PerformanceAndHealth",
           "required": true,
-          "values": ["initialize", "org/list", "org/auth", "logs/list", "search/query", "logs/triage", "other"]
+          "values": ["initialize", "org/list", "org/auth", "logs/list", "logs/sync", "search/query", "logs/triage", "other"]
         }
       },
       "measurements": {


### PR DESCRIPTION
## Summary
- add a shared Rust SQLite/FTS log index that is updated by `logs sync` and used by runtime search before falling back to file scans
- expose `logs/sync` through the app-server and TypeScript runtime client, then use it from the VS Code Logs refresh/background sync and Download all logs flows
- add `logs index rebuild`, sync/status index reporting, telemetry contract coverage, and docs/changelog updates

## Verification
- cargo check -p alv-core -p alv-app-server -p apex-log-viewer-cli
- cargo test -p alv-core logs_sync_smoke -- --nocapture
- cargo test -p alv-core search -- --nocapture
- cargo test -p alv-app-server app_server_smoke -- --nocapture
- cargo test -p alv-app-server parse_request_line_reads_logs_sync_params -- --nocapture
- cargo test -p apex-log-viewer-cli cli_smoke -- --nocapture
- npm run test:rust:smoke
- npm run check-types
- npm run compile-tests
- npm run lint
- npm run test:unit
- git diff --check