### PR TITLE
chore(runtime): prepare 0.1.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
 - Logs/Tail: increase webview startup timing windows so slow corporate machines can finish VS Code webview/service-worker bootstrap before the extension retries the mount.
 - Logs/Tail: retain webview context while hidden, avoid placeholder remounts during hide/show, and add a diagnostics package command with lifecycle evidence for service-worker/bootstrap failures.
 
+### Chores
+
+- CLI/Runtime: bump the standalone runtime train to `0.1.11` so extension prereleases package the SQLite-backed log sync/index runtime.
+
 ## [0.46.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.44.0...v0.46.0) (2026-04-29)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "chrono",
  "grep",
@@ -53,11 +53,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.10"
+version = "0.1.11"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "serde",
  "serde_json",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.10"
+version = "0.1.11"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.10",
-  "tag": "rust-v0.1.10",
+  "cliVersion": "0.1.11",
+  "tag": "rust-v0.1.11",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.10", path = "../alv-core" }
-alv-protocol = { version = "0.1.10", path = "../alv-protocol" }
+alv-core = { version = "0.1.11", path = "../alv-core" }
+alv-protocol = { version = "0.1.11", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.47", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.10", path = "../alv-app-server" }
-alv-core = { version = "0.1.10", path = "../alv-core" }
+alv-app-server = { version = "0.1.11", path = "../alv-app-server" }
+alv-core = { version = "0.1.11", path = "../alv-core" }
 clap = { version = "4.5", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.10"
+version = "0.1.11"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -188,8 +188,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.10',
-    tag: 'rust-v0.1.10',
+    cliVersion: '0.1.11',
+    tag: 'rust-v0.1.11',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary
- Bump the Rust runtime crate train from 0.1.10 to 0.1.11.
- Point config/runtime-bundle.json at rust-v0.1.11 so extension packaging fetches the runtime with SQLite-backed log sync/indexing.
- Update the runtime packaging regression test and changelog entry.

## Verification
- cargo check --workspace
- node --test scripts/packaging-ci.test.js scripts/fetch-runtime-release.test.js scripts/package-cli-release.test.js scripts/build-cli-npm-packages.test.js

## Release order
After this PR merges, push tag rust-v0.1.11 so the CLI release workflow publishes the runtime assets before the next extension pre-release is packaged.