### PR TITLE
chore: use Cargo target dir config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,4 @@
+[build]
+# In linked worktrees under .worktrees/<branch>, this resolves to
+# .worktrees/.cargo-target/Apex-Log-Viewer and is shared by those worktrees.
+target-dir = "../.cargo-target/Apex-Log-Viewer"

--- a/.envrc
+++ b/.envrc
@@ -1,2 +1,0 @@
-# Share Cargo build artifacts across worktrees of this project.
-export CARGO_TARGET_DIR="$HOME/.cache/cargo-target/Apex-Log-Viewer"

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -107,14 +107,6 @@ jobs:
       - name: Install Linux deps for Electron (best-effort)
         run: INSTALL_LINUX_DEPS=true bash scripts/install-linux-deps.sh
 
-      - name: Azure login for dedicated App Insights validation
-        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
-        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48
-        with:
-          client-id: ${{ env.AZURE_CLIENT_ID }}
-          tenant-id: ${{ env.AZURE_TENANT_ID }}
-          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
-
       - name: Run CLI real-org E2E
         shell: bash
         run: |
@@ -144,6 +136,14 @@ jobs:
           name: playwright-cli-e2e
           path: output/playwright-cli/
           if-no-files-found: ignore
+
+      - name: Azure login for dedicated App Insights validation
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
+        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
       - name: Run Playwright E2E
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.envrc
 out
 media/*.js
 media/webview.css

--- a/apps/vscode-extension/scripts/copy-runtime-binary.mjs
+++ b/apps/vscode-extension/scripts/copy-runtime-binary.mjs
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const CARGO_TARGETS = {
@@ -38,24 +39,51 @@ export function resolveArguments(argv) {
   return { target, profile };
 }
 
-export function resolveSourceCandidates(repoRoot, target, profile) {
+export function resolveCargoTargetDirectory(repoRoot, spawnSyncImpl = spawnSync) {
+  const result = spawnSyncImpl('cargo', ['metadata', '--format-version=1', '--no-deps'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (result.status !== 0) {
+    throw new Error(
+      `Failed to resolve Cargo target directory: cargo metadata exited with status ${result.status}. ${result.stderr ?? ''}`.trim()
+    );
+  }
+
+  const metadata = JSON.parse(result.stdout);
+  if (!metadata.target_directory) {
+    throw new Error('Failed to resolve Cargo target directory: cargo metadata did not return target_directory.');
+  }
+
+  return metadata.target_directory;
+}
+
+export function resolveSourceCandidates(repoRoot, target, profile, cargoTargetDir = path.join(repoRoot, 'target')) {
   const binaryName = resolveBinaryName(target);
   const candidates = [];
   const cargoTarget = CARGO_TARGETS[target];
   if (cargoTarget) {
-    candidates.push(path.join(repoRoot, 'target', cargoTarget, profile, binaryName));
+    candidates.push(path.join(cargoTargetDir, cargoTarget, profile, binaryName));
   }
-  candidates.push(path.join(repoRoot, 'target', profile, binaryName));
+  candidates.push(path.join(cargoTargetDir, profile, binaryName));
   return candidates;
 }
 
 export function copyRuntimeBinary({
   repoRoot,
   target,
-  profile
+  profile,
+  cargoTargetDir,
+  spawnSyncImpl = spawnSync
 }) {
   const binaryName = resolveBinaryName(target);
-  const sourceCandidates = resolveSourceCandidates(repoRoot, target, profile);
+  const effectiveCargoTargetDir = cargoTargetDir ?? resolveCargoTargetDirectory(repoRoot, spawnSyncImpl);
+  const sourceCandidates = resolveSourceCandidates(repoRoot, target, profile, effectiveCargoTargetDir);
   const source = sourceCandidates.find(candidate => fs.existsSync(candidate));
   const destinationDir = path.join(repoRoot, 'apps', 'vscode-extension', 'bin', target);
   const destination = path.join(destinationDir, binaryName);

--- a/docs/superpowers/plans/2026-05-06-cli-e2e-cargo-target-dir.md
+++ b/docs/superpowers/plans/2026-05-06-cli-e2e-cargo-target-dir.md
@@ -1,0 +1,634 @@
+# CLI E2E Cargo Target Dir Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make CLI Playwright E2E locate the standalone debug CLI binary from Cargo's effective target directory.
+
+**Architecture:** The Node E2E wrapper resolves Cargo's `target_directory`, checks that directory plus the legacy `target/debug` path, and passes the selected binary path to Playwright through `ALV_CLI_BINARY_PATH`. The TypeScript CLI test helper treats that env var as an explicit binary override and keeps its current fallback behavior when the env var is absent.
+
+**Tech Stack:** Node.js CommonJS test runner, Playwright TypeScript helpers, Cargo metadata.
+
+---
+
+## File structure
+
+- Modify `scripts/run-playwright-cli-e2e.js`
+  - Resolve Cargo target-dir candidates.
+  - Return the selected CLI binary path from `ensureBuildArtifacts()`.
+  - Pass `ALV_CLI_BINARY_PATH` into the Playwright child process.
+- Modify `scripts/run-playwright-cli-e2e.test.js`
+  - Add focused tests for Cargo target-dir discovery and env propagation.
+  - Adjust existing tests only when needed for the returned binary path.
+- Modify `test/e2e/cli/utils/cli.ts`
+  - Prefer `ALV_CLI_BINARY_PATH` when present.
+  - Fail clearly if the explicit env path is missing.
+  - Preserve legacy fallback and Windows command shim behavior.
+- Modify `test/e2e/cli/specs/cliHelper.e2e.spec.ts`
+  - Add helper tests for the env-var override success and missing-path diagnostics.
+
+## Task 1: Add failing tests for the E2E wrapper target-dir lookup
+
+**Files:**
+- Modify: `scripts/run-playwright-cli-e2e.test.js`
+- Test target: `scripts/run-playwright-cli-e2e.js`
+
+- [ ] **Step 1: Add a helper for fake Cargo metadata responses**
+
+Insert this helper after `readPackageScripts()`:
+
+```js
+function cargoMetadataSpawnSync(cargoTargetDir) {
+  return function spawnSyncImpl(command, args, options) {
+    assert.equal(command, 'cargo');
+    assert.deepEqual(args, ['metadata', '--format-version=1', '--no-deps']);
+    assert.equal(options.encoding, 'utf8');
+
+    return {
+      status: 0,
+      stdout: JSON.stringify({ target_directory: cargoTargetDir })
+    };
+  };
+}
+```
+
+- [ ] **Step 2: Add a failing test for configured Cargo target-dir discovery**
+
+Insert this test after `findMissingBuildArtifacts still requires the host debug binary when CARGO_BUILD_TARGET is set`:
+
+```js
+test('findMissingBuildArtifacts accepts the debug CLI binary from Cargo target_directory', () => {
+  const repoRoot = createTempRepo();
+  const cargoTargetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cargo-target-'));
+  try {
+    const runner = loadRunner();
+    const cliBinaryName = path.basename(runner.resolveCliBinaryRelativePath(process.platform));
+    const cliBinaryPath = path.join(cargoTargetDir, 'debug', cliBinaryName);
+    fs.mkdirSync(path.dirname(cliBinaryPath), { recursive: true });
+    fs.writeFileSync(cliBinaryPath, '', 'utf8');
+
+    assert.deepEqual(
+      runner.findMissingBuildArtifacts(repoRoot, {
+        spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir)
+      }),
+      []
+    );
+    assert.equal(
+      runner.resolveBuiltCliBinaryPath(repoRoot, {
+        spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir)
+      }),
+      cliBinaryPath
+    );
+  } finally {
+    cleanupTempRepo(repoRoot);
+    fs.rmSync(cargoTargetDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 3: Add a failing test for build preparation returning the target-dir binary**
+
+Insert this test after `ensureBuildArtifacts runs npm run build:runtime when the CLI binary is missing`:
+
+```js
+test('ensureBuildArtifacts returns the configured Cargo target-dir CLI binary after building', async () => {
+  const repoRoot = createTempRepo();
+  const cargoTargetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cargo-target-'));
+  try {
+    const runner = loadRunner();
+    const cliBinaryName = path.basename(runner.resolveCliBinaryRelativePath(process.platform));
+    const cliBinaryPath = path.join(cargoTargetDir, 'debug', cliBinaryName);
+    let recordedCall;
+
+    const result = await runner.ensureBuildArtifacts(repoRoot, {
+      spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir),
+      spawnImpl(command, args, options) {
+        recordedCall = { command, args, options };
+        const child = new EventEmitter();
+        process.nextTick(() => {
+          fs.mkdirSync(path.dirname(cliBinaryPath), { recursive: true });
+          fs.writeFileSync(cliBinaryPath, '', 'utf8');
+          child.emit('exit', 0, null);
+        });
+        return child;
+      }
+    });
+
+    assert.ok(recordedCall, 'expected ensureBuildArtifacts to invoke the build command');
+    assert.equal(result, cliBinaryPath);
+  } finally {
+    cleanupTempRepo(repoRoot);
+    fs.rmSync(cargoTargetDir, { recursive: true, force: true });
+  }
+});
+```
+
+- [ ] **Step 4: Add a failing test for Playwright env propagation**
+
+Insert this test near the `resolvePlaywrightInvocation` tests:
+
+```js
+test('resolvePlaywrightEnv passes the selected CLI binary path to Playwright', () => {
+  const runner = loadRunner();
+  const env = runner.resolvePlaywrightEnv('/tmp/alv/bin/apex-log-viewer', { EXISTING: '1' });
+
+  assert.equal(env.EXISTING, '1');
+  assert.equal(env.ALV_CLI_BINARY_PATH, '/tmp/alv/bin/apex-log-viewer');
+});
+```
+
+- [ ] **Step 5: Run the focused tests and verify they fail for missing exports/behavior**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-cli-e2e.test.js
+```
+
+Expected: FAIL with messages mentioning `resolveBuiltCliBinaryPath` or `resolvePlaywrightEnv` is not a function, or failing target-dir assertions.
+
+## Task 2: Implement the E2E wrapper target-dir lookup
+
+**Files:**
+- Modify: `scripts/run-playwright-cli-e2e.js`
+- Test: `scripts/run-playwright-cli-e2e.test.js`
+
+- [ ] **Step 1: Import `spawnSync` and add binary/candidate helpers**
+
+Change the first import and add these functions after `resolveCliBinaryRelativePath()`:
+
+```js
+const { spawn, spawnSync } = require('child_process');
+```
+
+```js
+function resolveCliBinaryName(targetPlatform = process.platform) {
+  return targetPlatform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+}
+
+function normalizeCargoTargetDirectory(repoRoot, cargoTargetDirectory) {
+  if (!cargoTargetDirectory) {
+    return undefined;
+  }
+  return path.isAbsolute(cargoTargetDirectory)
+    ? cargoTargetDirectory
+    : path.resolve(repoRoot, cargoTargetDirectory);
+}
+
+function resolveCargoTargetDirectory(repoRoot, options = {}) {
+  const spawnSyncImpl = options.spawnSyncImpl || spawnSync;
+  const result = spawnSyncImpl('cargo', ['metadata', '--format-version=1', '--no-deps'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+
+  if (result.error || result.status !== 0) {
+    return undefined;
+  }
+
+  try {
+    const metadata = JSON.parse(result.stdout || '{}');
+    return normalizeCargoTargetDirectory(repoRoot, metadata.target_directory);
+  } catch {
+    return undefined;
+  }
+}
+
+function displayCandidatePath(repoRoot, candidatePath) {
+  const relativePath = path.relative(repoRoot, candidatePath);
+  return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+    ? relativePath
+    : candidatePath;
+}
+
+function resolveCliBinaryCandidatePaths(repoRoot, options = {}) {
+  const targetPlatform = options.targetPlatform || process.platform;
+  const binaryName = resolveCliBinaryName(targetPlatform);
+  const cargoTargetDirectory =
+    options.cargoTargetDirectory === undefined
+      ? resolveCargoTargetDirectory(repoRoot, options)
+      : normalizeCargoTargetDirectory(repoRoot, options.cargoTargetDirectory);
+  const candidates = [];
+
+  if (cargoTargetDirectory) {
+    candidates.push(path.join(cargoTargetDirectory, 'debug', binaryName));
+  }
+
+  candidates.push(path.join(repoRoot, resolveCliBinaryRelativePath(targetPlatform)));
+  return [...new Set(candidates)];
+}
+
+function resolveBuiltCliBinaryPath(repoRoot, options = {}) {
+  return resolveCliBinaryCandidatePaths(repoRoot, options).find(candidate => existsSync(candidate));
+}
+```
+
+- [ ] **Step 2: Replace accepted-path and missing-artifact logic**
+
+Replace `resolveAcceptedCliBinaryRelativePaths()` and `findMissingBuildArtifacts()` with:
+
+```js
+function resolveAcceptedCliBinaryRelativePaths(targetPlatform = process.platform) {
+  return [resolveCliBinaryRelativePath(targetPlatform)];
+}
+
+function findMissingBuildArtifacts(repoRoot, options = {}) {
+  if (resolveBuiltCliBinaryPath(repoRoot, options)) {
+    return [];
+  }
+
+  return [
+    resolveCliBinaryCandidatePaths(repoRoot, options)
+      .map(candidate => displayCandidatePath(repoRoot, candidate))
+      .join(' or ')
+  ];
+}
+```
+
+- [ ] **Step 3: Return the selected binary from `ensureBuildArtifacts()`**
+
+Replace `ensureBuildArtifacts()` with:
+
+```js
+async function ensureBuildArtifacts(repoRoot, options = {}) {
+  const existingCliBinaryPath = resolveBuiltCliBinaryPath(repoRoot, options);
+  if (existingCliBinaryPath) {
+    return existingCliBinaryPath;
+  }
+
+  const missingArtifacts = findMissingBuildArtifacts(repoRoot, options);
+  console.log(
+    `[e2e:cli] Missing build artifacts (${missingArtifacts.join(', ')}). Running npm run build:runtime before Playwright...`
+  );
+  const buildInvocation = resolveBuildInvocation();
+  const buildEnv = { ...process.env };
+  delete buildEnv.CARGO_BUILD_TARGET;
+  const result = await spawnAsync(
+    buildInvocation.command,
+    buildInvocation.args,
+    { cwd: repoRoot, env: buildEnv, stdio: 'inherit' },
+    options.spawnImpl
+  );
+
+  if (result.code !== 0) {
+    const details =
+      typeof result.code === 'number' ? `exit code ${result.code}` : `signal ${result.signal || 'unknown'}`;
+    throw new Error(`npm run build:runtime failed while preparing CLI Playwright E2E (${details}).`);
+  }
+
+  const builtCliBinaryPath = resolveBuiltCliBinaryPath(repoRoot, options);
+  if (!builtCliBinaryPath) {
+    const remainingMissingArtifacts = findMissingBuildArtifacts(repoRoot, options);
+    throw new Error(
+      `npm run build:runtime did not produce required CLI artifact(s): ${remainingMissingArtifacts.join(', ')}.`
+    );
+  }
+  return builtCliBinaryPath;
+}
+```
+
+- [ ] **Step 4: Add Playwright env propagation**
+
+Add this helper before `main()`:
+
+```js
+function resolvePlaywrightEnv(cliBinaryPath, env = process.env) {
+  return {
+    ...env,
+    ALV_CLI_BINARY_PATH: cliBinaryPath
+  };
+}
+```
+
+Then replace the start of `main()` and the child `env` option with:
+
+```js
+async function main() {
+  const repoRoot = path.join(__dirname, '..');
+  const cliBinaryPath = await ensureBuildArtifacts(repoRoot);
+  const invocation = resolvePlaywrightInvocation(process.argv.slice(2));
+  const child = spawn(invocation.command, invocation.args, {
+    stdio: 'inherit',
+    cwd: repoRoot,
+    env: resolvePlaywrightEnv(cliBinaryPath)
+  });
+  child.on('exit', exitWithChildResult);
+}
+```
+
+- [ ] **Step 5: Export the new helper functions**
+
+Add these properties to `module.exports`:
+
+```js
+  resolveBuiltCliBinaryPath,
+  resolveCargoTargetDirectory,
+  resolveCliBinaryCandidatePaths,
+  resolvePlaywrightEnv
+```
+
+- [ ] **Step 6: Run the focused tests and verify Task 1 now passes**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-cli-e2e.test.js
+```
+
+Expected: PASS for all tests in `scripts/run-playwright-cli-e2e.test.js`.
+
+- [ ] **Step 7: Commit Task 1 and Task 2**
+
+Run:
+
+```bash
+git add scripts/run-playwright-cli-e2e.js scripts/run-playwright-cli-e2e.test.js
+git commit -m "fix(e2e): resolve CLI binary from Cargo target dir"
+```
+
+## Task 3: Add failing tests for the CLI helper env override
+
+**Files:**
+- Modify: `test/e2e/cli/specs/cliHelper.e2e.spec.ts`
+- Test target: `test/e2e/cli/utils/cli.ts`
+
+- [ ] **Step 1: Add an explicit binary helper**
+
+Insert this helper after `writeFakeStandaloneBinary()`:
+
+```ts
+async function writeFakeStandaloneBinaryAtPath(binaryPath: string, scriptBody: string): Promise<string> {
+  await mkdir(path.dirname(binaryPath), { recursive: true });
+  await writeFile(binaryPath, scriptBody, 'utf8');
+  if (process.platform !== 'win32') {
+    await chmod(binaryPath, 0o755);
+  }
+  return binaryPath;
+}
+```
+
+- [ ] **Step 2: Add a failing env-var success test**
+
+Insert this test after `resolveAlvCliBinaryPath rejects extension runtime fallback when standalone binary is missing`:
+
+```ts
+test('resolveAlvCliBinaryPath prefers ALV_CLI_BINARY_PATH when it exists', async () => {
+  await withTempRepo(async repoRoot => {
+    const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+    const configuredBinaryPath = await writeFakeStandaloneBinaryAtPath(
+      path.join(repoRoot, '..', '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName),
+      '#!/bin/sh\nexit 0\n'
+    );
+
+    const env = { ALV_CLI_BINARY_PATH: configuredBinaryPath };
+
+    expect(resolveAlvCliBinaryPath({ repoRoot, env })).toBe(configuredBinaryPath);
+    expect(resolveAlvCliInvocation({ repoRoot, env })).toEqual({
+      command: configuredBinaryPath,
+      args: []
+    });
+  });
+});
+```
+
+- [ ] **Step 3: Add a failing missing explicit path test**
+
+Insert this test after the env-var success test:
+
+```ts
+test('resolveAlvCliBinaryPath fails clearly when ALV_CLI_BINARY_PATH is missing', async () => {
+  await withTempRepo(async repoRoot => {
+    const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+    const missingBinaryPath = path.join(repoRoot, '..', '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName);
+    await writeFakeStandaloneBinary(repoRoot, '#!/bin/sh\nexit 0\n');
+
+    expect(() =>
+      resolveAlvCliBinaryPath({
+        repoRoot,
+        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+      })
+    ).toThrow(/ALV_CLI_BINARY_PATH/);
+    expect(() =>
+      resolveAlvCliInvocation({
+        repoRoot,
+        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+      })
+    ).toThrow(/ALV_CLI_BINARY_PATH/);
+  });
+});
+```
+
+- [ ] **Step 4: Run the CLI helper tests and verify they fail for unsupported options**
+
+Run:
+
+```bash
+npx playwright test test/e2e/cli/specs/cliHelper.e2e.spec.ts --config=playwright.cli.config.ts
+```
+
+Expected: FAIL because `ResolveAlvCliBinaryPathOptions` does not yet accept `env`, or because the helper ignores `ALV_CLI_BINARY_PATH`.
+
+## Task 4: Implement CLI helper env override
+
+**Files:**
+- Modify: `test/e2e/cli/utils/cli.ts`
+- Test: `test/e2e/cli/specs/cliHelper.e2e.spec.ts`
+
+- [ ] **Step 1: Add `env` to the resolver option type**
+
+Replace `ResolveAlvCliBinaryPathOptions` with:
+
+```ts
+type ResolveAlvCliBinaryPathOptions = {
+  repoRoot?: string;
+  cargoBuildTarget?: string;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+};
+```
+
+- [ ] **Step 2: Add explicit env-var helpers**
+
+Insert these functions after `resolveBinaryCandidates()`:
+
+```ts
+function resolveConfiguredCliBinaryPath(options: ResolveAlvCliBinaryPathOptions = {}): string | undefined {
+  const rawPath = String((options.env ?? process.env).ALV_CLI_BINARY_PATH ?? '').trim();
+  if (!rawPath) {
+    return undefined;
+  }
+
+  const repoRoot = options.repoRoot || resolveRepoRoot();
+  return path.isAbsolute(rawPath) ? rawPath : path.resolve(repoRoot, rawPath);
+}
+
+function formatMissingBinaryMessage(
+  configuredBinaryPath: string | undefined,
+  fallbackCandidates: string[]
+): string {
+  if (configuredBinaryPath) {
+    return `Unable to locate apex-log-viewer standalone binary from ALV_CLI_BINARY_PATH. Checked: ${[
+      configuredBinaryPath,
+      ...fallbackCandidates
+    ].join(', ')}`;
+  }
+
+  return `Unable to locate apex-log-viewer standalone binary. Checked: ${fallbackCandidates.join(', ')}`;
+}
+```
+
+- [ ] **Step 3: Update `resolveAlvCliBinaryPath()`**
+
+Replace the function body with:
+
+```ts
+export function resolveAlvCliBinaryPath(options: ResolveAlvCliBinaryPathOptions = {}): string {
+  const configuredBinaryPath = resolveConfiguredCliBinaryPath(options);
+  const candidates = resolveBinaryCandidates(options);
+
+  if (configuredBinaryPath) {
+    if (existsSync(configuredBinaryPath)) {
+      return configuredBinaryPath;
+    }
+    throw new Error(formatMissingBinaryMessage(configuredBinaryPath, candidates));
+  }
+
+  const binaryPath = candidates.find(candidate => existsSync(candidate));
+  if (!binaryPath) {
+    throw new Error(formatMissingBinaryMessage(undefined, candidates));
+  }
+  return binaryPath;
+}
+```
+
+- [ ] **Step 4: Update `resolveAlvCliInvocation()`**
+
+Replace the first part of the function with this code, keeping the Windows command-shim fallback after it:
+
+```ts
+export function resolveAlvCliInvocation(options: ResolveAlvCliInvocationOptions = {}): CliInvocation {
+  const configuredBinaryPath = resolveConfiguredCliBinaryPath(options);
+  const candidates = resolveBinaryCandidates(options);
+
+  if (configuredBinaryPath) {
+    if (existsSync(configuredBinaryPath)) {
+      return {
+        command: configuredBinaryPath,
+        args: []
+      };
+    }
+    throw new Error(formatMissingBinaryMessage(configuredBinaryPath, candidates));
+  }
+
+  const binaryPath = candidates.find(candidate => existsSync(candidate));
+  if (binaryPath) {
+    return {
+      command: binaryPath,
+      args: []
+    };
+  }
+```
+
+The final throw at the end of `resolveAlvCliInvocation()` should become:
+
+```ts
+  throw new Error(formatMissingBinaryMessage(undefined, resolveBinaryCandidates(options)));
+```
+
+- [ ] **Step 5: Pass `options.env` into CLI invocation resolution**
+
+In `runAlvCli()`, replace the `resolveAlvCliInvocation()` call with:
+
+```ts
+  const invocation = resolveAlvCliInvocation({
+    repoRoot: options.repoRoot,
+    allowWindowsCommandShim: options.allowWindowsCommandShim,
+    env: options.env
+  });
+```
+
+- [ ] **Step 6: Run the CLI helper tests and verify Task 3 now passes**
+
+Run:
+
+```bash
+npx playwright test test/e2e/cli/specs/cliHelper.e2e.spec.ts --config=playwright.cli.config.ts
+```
+
+Expected: PASS for `cliHelper.e2e.spec.ts`.
+
+- [ ] **Step 7: Commit Task 3 and Task 4**
+
+Run:
+
+```bash
+git add test/e2e/cli/utils/cli.ts test/e2e/cli/specs/cliHelper.e2e.spec.ts
+git commit -m "fix(e2e): pass resolved CLI binary to Playwright helpers"
+```
+
+## Task 5: Verify, push, and resume babysitting
+
+**Files:**
+- No code changes expected.
+- Read: `docs/superpowers/specs/2026-05-06-cli-e2e-cargo-target-dir-design.md`
+
+- [ ] **Step 1: Run focused Node script tests**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-cli-e2e.test.js
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run focused Playwright helper tests**
+
+Run:
+
+```bash
+npx playwright test test/e2e/cli/specs/cliHelper.e2e.spec.ts --config=playwright.cli.config.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run broader script regressions**
+
+Run:
+
+```bash
+npm run test:scripts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Commit any verification-only doc updates**
+
+Run only if `git status --short` shows intentional doc or test-result updates:
+
+```bash
+git add <intentional-files>
+git commit -m "docs: update cli e2e target-dir notes"
+```
+
+Expected: Either no commit is needed, or the commit contains only intentional files.
+
+- [ ] **Step 5: Push the PR branch**
+
+Run:
+
+```bash
+git status --short
+git push origin chore/cargo-target-dir-no-direnv
+```
+
+Expected: Push succeeds and updates PR #783.
+
+- [ ] **Step 6: Resume PR watcher**
+
+Run from the babysit-pr skill directory:
+
+```bash
+python3 scripts/gh_pr_watch.py --pr https://github.com/Electivus/Apex-Log-Viewer/pull/783 --watch
+```
+
+Expected: The watcher stays attached during passive states or exits with the next actionable/terminal snapshot.

--- a/docs/superpowers/plans/2026-05-06-e2e-azure-oidc-token-lifetime.md
+++ b/docs/superpowers/plans/2026-05-06-e2e-azure-oidc-token-lifetime.md
@@ -1,0 +1,490 @@
+# E2E Azure OIDC Token Lifetime Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prevent the real-org Playwright telemetry validation job from failing when Azure's OIDC federated assertion expires before the Log Analytics query.
+
+**Architecture:** Move Azure login later in the GitHub Actions job and pre-resolve the Log Analytics workspace before the long Playwright child run starts. The telemetry runner will pass the prepared workspace context into the existing validation loop so query targeting remains unchanged while token acquisition happens while the assertion is fresh.
+
+**Tech Stack:** GitHub Actions YAML, Node.js CommonJS scripts, `node:test`, Azure CLI helper functions.
+
+---
+
+## File structure
+
+- Modify `scripts/cli-e2e-workflow.test.js`
+  - Owns static workflow guard tests for `.github/workflows/e2e-playwright.yml`.
+  - Add order assertions that place `Azure login for dedicated App Insights validation` after CLI E2E artifacts and before extension Playwright E2E.
+- Modify `.github/workflows/e2e-playwright.yml`
+  - Move the existing Azure login step without changing its `if`, `uses`, or `with` fields.
+- Modify `scripts/run-playwright-e2e-telemetry.test.js`
+  - Owns unit tests for the telemetry wrapper.
+  - Add a regression test for pre-warming workspace metadata before spawning Playwright.
+- Modify `scripts/run-playwright-e2e-telemetry.js`
+  - Add `prepareTelemetryValidationContext`.
+  - Add an injectable `runTelemetryE2e` orchestration helper for order testing.
+  - Update `waitForTelemetry` to accept a prepared validation context.
+
+---
+
+### Task 1: Add failing workflow ordering guard
+
+**Files:**
+- Modify: `scripts/cli-e2e-workflow.test.js`
+- Test: `scripts/cli-e2e-workflow.test.js`
+
+- [ ] **Step 1: Update the Azure login workflow test**
+
+Replace the existing test named `real-org Playwright workflow uses the org-allowlisted Azure login pin` with:
+
+```js
+test('real-org Playwright workflow logs into Azure immediately before telemetry-capable extension E2E', () => {
+  const workflow = readWorkflow();
+  const azureLoginStep = getWorkflowStep(workflow, 'Azure login for dedicated App Insights validation');
+  const cliStep = getWorkflowStep(workflow, 'Run CLI real-org E2E');
+  const uploadArtifactsStep = getWorkflowStep(workflow, 'Upload CLI E2E artifacts');
+  const extensionStep = getWorkflowStep(workflow, 'Run Playwright E2E');
+
+  assert.equal(
+    azureLoginStep.step.uses,
+    'azure/login@93381592711f247e165c389ebb30b596c84cdc48',
+    'expected azure/login to stay pinned to the SHA currently allowed by the Electivus org action policy'
+  );
+  assert.ok(
+    cliStep.index < azureLoginStep.index,
+    'expected Azure login to run after the CLI real-org step so the OIDC assertion is fresher for telemetry validation'
+  );
+  assert.ok(
+    uploadArtifactsStep.index < azureLoginStep.index,
+    'expected Azure login to run after CLI artifact upload and immediately before the extension Playwright step'
+  );
+  assert.ok(
+    azureLoginStep.index < extensionStep.index,
+    'expected Azure login to run before the telemetry-capable extension Playwright step'
+  );
+});
+```
+
+- [ ] **Step 2: Run the workflow guard and verify it fails**
+
+Run:
+
+```bash
+node --test scripts/cli-e2e-workflow.test.js
+```
+
+Expected: FAIL with the message `expected Azure login to run after the CLI real-org step so the OIDC assertion is fresher for telemetry validation`, because the current workflow logs into Azure before the CLI step.
+
+- [ ] **Step 3: Commit the failing workflow test**
+
+```bash
+git add scripts/cli-e2e-workflow.test.js
+git commit -m "test(e2e): guard Azure login ordering"
+```
+
+---
+
+### Task 2: Add failing telemetry pre-warm regression test
+
+**Files:**
+- Modify: `scripts/run-playwright-e2e-telemetry.test.js`
+- Test: `scripts/run-playwright-e2e-telemetry.test.js`
+
+- [ ] **Step 1: Update telemetry test imports**
+
+Change the import block in `scripts/run-playwright-e2e-telemetry.test.js` to include `runTelemetryE2e`:
+
+```js
+const {
+  buildRunValidationQuery,
+  resolveConfig,
+  resolvePlaywrightChildInvocation,
+  runTelemetryE2e,
+  spawnAsync,
+  summarizeTelemetry
+} = require('./run-playwright-e2e-telemetry');
+```
+
+- [ ] **Step 2: Add the orchestration order test**
+
+Add this test after `spawnAsync rejects when the child process cannot be started`:
+
+```js
+test('runTelemetryE2e prepares Log Analytics context before spawning Playwright', async () => {
+  const calls = [];
+  const validationContext = {
+    componentResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/appi-e2e',
+    workspaceCustomerId: 'workspace-customer-id'
+  };
+
+  const result = await runTelemetryE2e({
+    env: {
+      ALV_E2E_TELEMETRY_APP: 'appi-e2e',
+      ALV_E2E_TELEMETRY_BASE_APP: 'appi-base',
+      ALV_E2E_TELEMETRY_RESOURCE_GROUP: 'rg-telemetry',
+      AZURE_SUBSCRIPTION_ID: 'sub-123'
+    },
+    extraArgs: ['--grep', 'logs'],
+    repoRoot: path.join('/repo', 'apex-log-viewer'),
+    logger: { log() {} },
+    randomUUIDImpl: () => 'run-123',
+    ensureTelemetryComponentImpl: async config => {
+      calls.push(['ensure', config.appName]);
+      return {
+        component: {
+          connectionString: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+          id: validationContext.componentResourceId,
+          name: 'appi-e2e',
+          resourceGroup: 'rg-telemetry',
+          workspaceResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.operationalinsights/workspaces/law-e2e'
+        },
+        created: false
+      };
+    },
+    prepareTelemetryValidationContextImpl: async (config, component) => {
+      calls.push(['prepare', component.id]);
+      assert.equal(config.appName, 'appi-e2e');
+      return validationContext;
+    },
+    resolvePlaywrightChildInvocationImpl: extraArgs => {
+      calls.push(['resolve-child', extraArgs.join(' ')]);
+      return { command: 'node', args: ['child.js'] };
+    },
+    spawnAsyncImpl: async (command, args) => {
+      calls.push(['spawn', command, args.join(' ')]);
+      return { code: 0, signal: null };
+    },
+    waitForTelemetryImpl: async (_config, _component, runId, options) => {
+      calls.push(['wait', runId, options.validationContext.workspaceCustomerId]);
+      return {
+        attempt: 1,
+        rows: [{ name: 'electivus.apex-log-viewer/extension.activate', events: 5 }],
+        summary: { distinctNames: 3, hasActivation: true, totalEvents: 5 }
+      };
+    }
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(calls, [
+    ['ensure', 'appi-e2e'],
+    ['prepare', validationContext.componentResourceId],
+    ['resolve-child', '--grep logs'],
+    ['spawn', 'node', 'child.js'],
+    ['wait', 'run-123', 'workspace-customer-id']
+  ]);
+});
+```
+
+- [ ] **Step 3: Run the telemetry test and verify it fails**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-e2e-telemetry.test.js
+```
+
+Expected: FAIL with `runTelemetryE2e is not a function`, because the orchestration helper does not exist yet.
+
+- [ ] **Step 4: Commit the failing telemetry test**
+
+```bash
+git add scripts/run-playwright-e2e-telemetry.test.js
+git commit -m "test(e2e): require telemetry context prewarm"
+```
+
+---
+
+### Task 3: Implement telemetry context pre-warm
+
+**Files:**
+- Modify: `scripts/run-playwright-e2e-telemetry.js`
+- Test: `scripts/run-playwright-e2e-telemetry.test.js`
+
+- [ ] **Step 1: Add the prepared validation context helper**
+
+In `scripts/run-playwright-e2e-telemetry.js`, add this helper after `async function queryTelemetryForRun(...)`:
+
+```js
+async function prepareTelemetryValidationContext(
+  config,
+  component,
+  resolveWorkspaceInfoImpl = resolveWorkspaceInfo
+) {
+  const workspace = await resolveWorkspaceInfoImpl({
+    ...config,
+    workspaceResourceId: component.workspaceResourceId || config.workspaceResourceId
+  });
+
+  return {
+    componentResourceId: component.id,
+    workspaceCustomerId: workspace.workspaceCustomerId
+  };
+}
+```
+
+- [ ] **Step 2: Update `waitForTelemetry` to accept prepared context**
+
+Replace the current `waitForTelemetry` function with:
+
+```js
+async function waitForTelemetry(config, component, runId, options = {}) {
+  const attempts = Math.max(1, Number(process.env.ALV_E2E_TELEMETRY_QUERY_ATTEMPTS || 18) || 18);
+  const delayMs = Math.max(1000, Number(process.env.ALV_E2E_TELEMETRY_QUERY_DELAY_MS || 10000) || 10000);
+  const lookback = String(process.env.ALV_E2E_TELEMETRY_LOOKBACK || '2h').trim() || '2h';
+  const validationContext =
+    options.validationContext ||
+    (await prepareTelemetryValidationContext(config, component, options.resolveWorkspaceInfoImpl));
+
+  for (let attempt = 1; attempt <= attempts; attempt++) {
+    const result = await queryTelemetryForRun(
+      validationContext.workspaceCustomerId,
+      validationContext.componentResourceId,
+      runId,
+      lookback
+    );
+    const rows = toRows(result);
+    const summary = summarizeTelemetry(rows);
+    if (summary.hasActivation && summary.totalEvents >= 5 && summary.distinctNames >= 3) {
+      return { rows, summary, attempt };
+    }
+    if (attempt < attempts) {
+      console.log(
+        `[e2e] Waiting for Log Analytics ingestion (${attempt}/${attempts}) -> ${summary.totalEvents} events, ${summary.distinctNames} names`
+      );
+      await sleep(delayMs);
+    }
+  }
+
+  const finalResult = await queryTelemetryForRun(
+    validationContext.workspaceCustomerId,
+    validationContext.componentResourceId,
+    runId,
+    lookback
+  );
+  const finalRows = toRows(finalResult);
+  const finalSummary = summarizeTelemetry(finalRows);
+  throw new Error(
+    `Telemetry validation failed for run ${runId}. Expected at least one activation event, 5 total events, and 3 distinct names, but observed ${finalSummary.totalEvents} events across ${finalSummary.distinctNames} names.`
+  );
+}
+```
+
+- [ ] **Step 3: Add the injectable orchestration helper**
+
+Replace the current `async function main()` with these two functions:
+
+```js
+async function runTelemetryE2e(options = {}) {
+  const env = options.env || process.env;
+  const extraArgs = options.extraArgs || process.argv.slice(2);
+  const repoRoot = options.repoRoot || REPO_ROOT;
+  const logger = options.logger || console;
+  const randomUUIDImpl = options.randomUUIDImpl || randomUUID;
+  const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
+  const prepareTelemetryValidationContextImpl =
+    options.prepareTelemetryValidationContextImpl || prepareTelemetryValidationContext;
+  const resolvePlaywrightChildInvocationImpl =
+    options.resolvePlaywrightChildInvocationImpl || resolvePlaywrightChildInvocation;
+  const spawnAsyncImpl = options.spawnAsyncImpl || spawnAsync;
+  const waitForTelemetryImpl = options.waitForTelemetryImpl || waitForTelemetry;
+
+  const config = resolveConfig(env);
+
+  const { component, created } = await ensureTelemetryComponentImpl(config);
+  const runId = randomUUIDImpl();
+
+  logger.log(
+    `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
+  );
+  logger.log(`[e2e] Test telemetry run id: ${runId}`);
+
+  const validationContext = await prepareTelemetryValidationContextImpl(config, component);
+
+  const childEnv = {
+    ...env,
+    ALV_ENABLE_TEST_TELEMETRY: '1',
+    ALV_TEST_TELEMETRY_CONNECTION_STRING: component.connectionString,
+    ALV_TEST_TELEMETRY_RUN_ID: runId
+  };
+
+  const childInvocation = resolvePlaywrightChildInvocationImpl(extraArgs, childEnv, repoRoot);
+  const child = await spawnAsyncImpl(childInvocation.command, childInvocation.args, {
+    cwd: repoRoot,
+    env: childEnv,
+    stdio: 'inherit'
+  });
+
+  if (typeof child.code === 'number' && child.code !== 0) {
+    return { exitCode: child.code };
+  }
+  if (child.signal) {
+    throw new Error(`Playwright E2E process exited via signal ${child.signal}.`);
+  }
+
+  logger.log('[e2e] Playwright suite passed. Validating telemetry arrival in the linked Log Analytics workspace...');
+  const validation = await waitForTelemetryImpl(config, component, runId, { validationContext });
+  logger.log(
+    `[e2e] Telemetry validated after ${validation.attempt} query attempt(s): ${validation.summary.totalEvents} events across ${validation.summary.distinctNames} event names.`
+  );
+  for (const row of validation.rows) {
+    logger.log(`[e2e] ${row.name}: ${row.events}`);
+  }
+
+  return { exitCode: 0, validation };
+}
+
+async function main() {
+  const result = await runTelemetryE2e();
+  if (typeof result.exitCode === 'number' && result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}
+```
+
+- [ ] **Step 4: Export the new helper**
+
+Replace the `module.exports` block with:
+
+```js
+module.exports = {
+  buildRunValidationQuery,
+  prepareTelemetryValidationContext,
+  resolveConfig,
+  resolvePlaywrightChildInvocation,
+  runTelemetryE2e,
+  spawnAsync,
+  summarizeTelemetry
+};
+```
+
+- [ ] **Step 5: Run the focused telemetry test and verify it passes**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-e2e-telemetry.test.js
+```
+
+Expected: PASS with all telemetry wrapper tests passing.
+
+- [ ] **Step 6: Commit the telemetry pre-warm implementation**
+
+```bash
+git add scripts/run-playwright-e2e-telemetry.js scripts/run-playwright-e2e-telemetry.test.js
+git commit -m "fix(e2e): prewarm telemetry workspace context"
+```
+
+---
+
+### Task 4: Move Azure login immediately before extension E2E
+
+**Files:**
+- Modify: `.github/workflows/e2e-playwright.yml`
+- Test: `scripts/cli-e2e-workflow.test.js`
+
+- [ ] **Step 1: Move the Azure login step**
+
+In `.github/workflows/e2e-playwright.yml`, remove this step from its current position before `Run CLI real-org E2E`:
+
+```yaml
+      - name: Azure login for dedicated App Insights validation
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
+        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+```
+
+Paste the same step immediately after the `Upload CLI E2E artifacts` step and immediately before `Run Playwright E2E`.
+
+- [ ] **Step 2: Run the focused workflow guard and verify it passes**
+
+Run:
+
+```bash
+node --test scripts/cli-e2e-workflow.test.js
+```
+
+Expected: PASS with all workflow guard tests passing.
+
+- [ ] **Step 3: Run both focused regression tests**
+
+Run:
+
+```bash
+node --test scripts/run-playwright-e2e-telemetry.test.js scripts/cli-e2e-workflow.test.js
+```
+
+Expected: PASS with both focused regression files passing.
+
+- [ ] **Step 4: Commit the workflow reorder**
+
+```bash
+git add .github/workflows/e2e-playwright.yml scripts/cli-e2e-workflow.test.js
+git commit -m "fix(e2e): refresh Azure login before telemetry run"
+```
+
+---
+
+### Task 5: Final verification, push, and resume PR babysitting
+
+**Files:**
+- Verify all files changed in Tasks 1-4.
+
+- [ ] **Step 1: Run the script regression suite**
+
+Run:
+
+```bash
+npm run test:scripts
+```
+
+Expected: PASS with `# fail 0`.
+
+- [ ] **Step 2: Confirm the worktree is clean except committed branch history**
+
+Run:
+
+```bash
+git status --short --branch
+```
+
+Expected: no modified or untracked files.
+
+- [ ] **Step 3: Push the branch**
+
+Run:
+
+```bash
+git push origin HEAD:chore/cargo-target-dir-no-direnv
+```
+
+Expected: push succeeds and updates PR #783.
+
+- [ ] **Step 4: Resume PR babysitting**
+
+Run from the babysit skill directory:
+
+```bash
+python3 scripts/gh_pr_watch.py --pr https://github.com/Electivus/Apex-Log-Viewer/pull/783 --watch
+```
+
+Expected: The watcher remains attached through passive states and exits only for an actionable or terminal PR state.
+
+- [ ] **Step 5: Handle the watcher result**
+
+If the watcher exits with `diagnose_ci_failure`, inspect `ci_diagnostics` first and continue the debugging workflow. If it exits with `stop_ready_for_human_approval`, report that PR #783 is green, mergeable, and waiting only for required human review approval. If it exits with `stop_ready_to_merge`, report that the PR is ready to merge.
+
+---
+
+## Self-review checklist
+
+- Spec coverage:
+  - Azure login moved later: Task 4.
+  - Telemetry context pre-warm before Playwright child process: Tasks 2 and 3.
+  - Regression coverage: Tasks 1 and 2.
+  - Verification and babysit loop: Task 5.
+- Placeholder scan: no placeholder steps remain; every code and command step includes exact content.
+- Type consistency:
+  - `runTelemetryE2e`, `prepareTelemetryValidationContext`, `validationContext`, and injected implementation names are used consistently between test and implementation steps.

--- a/docs/superpowers/plans/2026-05-06-e2e-azure-oidc-token-lifetime.md
+++ b/docs/superpowers/plans/2026-05-06-e2e-azure-oidc-token-lifetime.md
@@ -4,7 +4,7 @@
 
 **Goal:** Prevent the real-org Playwright telemetry validation job from failing when Azure's OIDC federated assertion expires before the Log Analytics query.
 
-**Architecture:** Move Azure login later in the GitHub Actions job and pre-resolve the Log Analytics workspace before the long Playwright child run starts. The telemetry runner will pass the prepared workspace context into the existing validation loop so query targeting remains unchanged while token acquisition happens while the assertion is fresh.
+**Architecture:** Move Azure login later in the GitHub Actions job, pre-resolve the Log Analytics workspace, and run a harmless Log Analytics query before the long Playwright child run starts. The telemetry runner will pass the prepared workspace context into the existing validation loop so query targeting remains unchanged while the same query-token path used by validation is acquired while the assertion is fresh.
 
 **Tech Stack:** GitHub Actions YAML, Node.js CommonJS scripts, `node:test`, Azure CLI helper functions.
 
@@ -19,9 +19,10 @@
   - Move the existing Azure login step without changing its `if`, `uses`, or `with` fields.
 - Modify `scripts/run-playwright-e2e-telemetry.test.js`
   - Owns unit tests for the telemetry wrapper.
-  - Add a regression test for pre-warming workspace metadata before spawning Playwright.
+  - Add a regression test for preflighting a real Log Analytics query before spawning Playwright.
 - Modify `scripts/run-playwright-e2e-telemetry.js`
   - Add `prepareTelemetryValidationContext`.
+  - Add `prewarmTelemetryQueryToken`.
   - Add an injectable `runTelemetryE2e` orchestration helper for order testing.
   - Update `waitForTelemetry` to accept a prepared validation context.
 
@@ -110,7 +111,7 @@ const {
 Add this test after `spawnAsync rejects when the child process cannot be started`:
 
 ```js
-test('runTelemetryE2e prepares Log Analytics context before spawning Playwright', async () => {
+test('runTelemetryE2e preflights a Log Analytics query before spawning Playwright', async () => {
   const calls = [];
   const validationContext = {
     componentResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/appi-e2e',
@@ -146,6 +147,10 @@ test('runTelemetryE2e prepares Log Analytics context before spawning Playwright'
       assert.equal(config.appName, 'appi-e2e');
       return validationContext;
     },
+    queryTelemetryForRunImpl: async (workspaceCustomerId, componentResourceId, runId, lookback) => {
+      calls.push(['query-preflight', workspaceCustomerId, componentResourceId, runId, lookback]);
+      return [];
+    },
     resolvePlaywrightChildInvocationImpl: extraArgs => {
       calls.push(['resolve-child', extraArgs.join(' ')]);
       return { command: 'node', args: ['child.js'] };
@@ -168,6 +173,13 @@ test('runTelemetryE2e prepares Log Analytics context before spawning Playwright'
   assert.deepEqual(calls, [
     ['ensure', 'appi-e2e'],
     ['prepare', validationContext.componentResourceId],
+    [
+      'query-preflight',
+      validationContext.workspaceCustomerId,
+      validationContext.componentResourceId,
+      'run-123',
+      '5m'
+    ],
     ['resolve-child', '--grep logs'],
     ['spawn', 'node', 'child.js'],
     ['wait', 'run-123', 'workspace-customer-id']
@@ -219,6 +231,23 @@ async function prepareTelemetryValidationContext(
     componentResourceId: component.id,
     workspaceCustomerId: workspace.workspaceCustomerId
   };
+}
+```
+
+- [ ] **Step 1.5: Add the Log Analytics query preflight helper**
+
+Add this helper after `prepareTelemetryValidationContext`:
+
+```js
+async function prewarmTelemetryQueryToken(validationContext, runId, options = {}) {
+  const queryTelemetryForRunImpl = options.queryTelemetryForRunImpl || queryTelemetryForRun;
+  const lookback = String(options.lookback || '5m').trim() || '5m';
+  await queryTelemetryForRunImpl(
+    validationContext.workspaceCustomerId,
+    validationContext.componentResourceId,
+    runId,
+    lookback
+  );
 }
 ```
 
@@ -283,6 +312,8 @@ async function runTelemetryE2e(options = {}) {
   const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
   const prepareTelemetryValidationContextImpl =
     options.prepareTelemetryValidationContextImpl || prepareTelemetryValidationContext;
+  const prewarmTelemetryQueryTokenImpl = options.prewarmTelemetryQueryTokenImpl || prewarmTelemetryQueryToken;
+  const queryTelemetryForRunImpl = options.queryTelemetryForRunImpl || queryTelemetryForRun;
   const resolvePlaywrightChildInvocationImpl =
     options.resolvePlaywrightChildInvocationImpl || resolvePlaywrightChildInvocation;
   const spawnAsyncImpl = options.spawnAsyncImpl || spawnAsync;
@@ -299,6 +330,7 @@ async function runTelemetryE2e(options = {}) {
   logger.log(`[e2e] Test telemetry run id: ${runId}`);
 
   const validationContext = await prepareTelemetryValidationContextImpl(config, component);
+  await prewarmTelemetryQueryTokenImpl(validationContext, runId, { queryTelemetryForRunImpl });
 
   const childEnv = {
     ...env,
@@ -349,6 +381,7 @@ Replace the `module.exports` block with:
 module.exports = {
   buildRunValidationQuery,
   prepareTelemetryValidationContext,
+  prewarmTelemetryQueryToken,
   resolveConfig,
   resolvePlaywrightChildInvocation,
   runTelemetryE2e,
@@ -482,9 +515,9 @@ If the watcher exits with `diagnose_ci_failure`, inspect `ci_diagnostics` first 
 
 - Spec coverage:
   - Azure login moved later: Task 4.
-  - Telemetry context pre-warm before Playwright child process: Tasks 2 and 3.
+  - Telemetry validation context and Log Analytics query-token preflight before Playwright child process: Tasks 2 and 3.
   - Regression coverage: Tasks 1 and 2.
   - Verification and babysit loop: Task 5.
 - Placeholder scan: no placeholder steps remain; every code and command step includes exact content.
 - Type consistency:
-  - `runTelemetryE2e`, `prepareTelemetryValidationContext`, `validationContext`, and injected implementation names are used consistently between test and implementation steps.
+  - `runTelemetryE2e`, `prepareTelemetryValidationContext`, `prewarmTelemetryQueryToken`, `validationContext`, and injected implementation names are used consistently between test and implementation steps.

--- a/docs/superpowers/specs/2026-05-06-cli-e2e-cargo-target-dir-design.md
+++ b/docs/superpowers/specs/2026-05-06-cli-e2e-cargo-target-dir-design.md
@@ -1,0 +1,71 @@
+# CLI E2E Cargo target-dir compatibility design
+
+## Context
+
+PR #783 moves Cargo build output away from the default `target/` directory by
+adding `.cargo/config.toml` with `build.target-dir = "../.cargo-target/Apex-Log-Viewer"`.
+The runtime binary copy script already resolves Cargo's effective target
+directory with `cargo metadata`, but the CLI Playwright E2E bootstrap still
+expects the standalone debug binary at `target/debug/apex-log-viewer`.
+
+The failing GitHub Actions check is `Playwright E2E (scratch org)`. Its log
+shows that `npm run build:runtime` finished compiling the CLI, then
+`scripts/run-playwright-cli-e2e.js` failed because `target/debug/apex-log-viewer`
+did not exist.
+
+## Goal
+
+Make the CLI E2E bootstrap and helper utilities locate the standalone CLI binary
+from Cargo's effective target directory while preserving the legacy
+`target/debug` lookup for existing local workflows.
+
+## Non-goals
+
+- Do not change the new Cargo target directory strategy.
+- Do not copy or symlink Cargo artifacts back into `target/debug`.
+- Do not change scratch-org allocation, proxy-lab behavior, or Playwright test
+  coverage beyond binary resolution.
+
+## Design
+
+Update `scripts/run-playwright-cli-e2e.js` so it can resolve Cargo's effective
+target directory by running:
+
+```bash
+cargo metadata --format-version=1 --no-deps
+```
+
+The wrapper will build the accepted standalone binary paths from that
+`target_directory`, using the host debug binary name (`apex-log-viewer` or
+`apex-log-viewer.exe`). It will keep `target/debug/<binary>` as a fallback so
+older layouts and simple test fixtures continue to work.
+
+When `ensureBuildArtifacts()` invokes `npm run build:runtime`, it will continue
+to clear `CARGO_BUILD_TARGET` so the build produces a host debug binary. After a
+successful build, it will re-check the accepted paths. Before launching
+Playwright, the wrapper will pass the resolved CLI binary path through an
+environment variable such as `ALV_CLI_BINARY_PATH`.
+
+Update `test/e2e/cli/utils/cli.ts` to prefer `ALV_CLI_BINARY_PATH` when present
+and otherwise fall back to its existing `target/debug` lookup. The helper should
+validate that the env-var path exists before using it, and error messages should
+include both the explicit path and fallback candidates when resolution fails.
+
+## Error handling
+
+- If `cargo metadata` fails before the build, the wrapper may fall back to the
+  legacy `target/debug` candidate so tests in minimal fixtures remain cheap.
+- If `npm run build:runtime` succeeds but no accepted binary exists, fail with a
+  diagnostic listing all checked paths.
+- If `ALV_CLI_BINARY_PATH` is set but missing, the CLI helper fails clearly
+  rather than silently using a different binary.
+
+## Verification
+
+- Add focused Node tests for `scripts/run-playwright-cli-e2e.js` covering Cargo
+  target-dir candidates and `ALV_CLI_BINARY_PATH` propagation.
+- Add focused CLI helper tests covering `ALV_CLI_BINARY_PATH` success and
+  missing-path diagnostics.
+- Run `node --test scripts/run-playwright-cli-e2e.test.js`.
+- Run the broader script regression command if the focused tests pass.
+- Push the fix and resume the PR watcher.

--- a/docs/superpowers/specs/2026-05-06-e2e-azure-oidc-token-lifetime-design.md
+++ b/docs/superpowers/specs/2026-05-06-e2e-azure-oidc-token-lifetime-design.md
@@ -1,0 +1,80 @@
+# E2E Azure OIDC token lifetime CI fix design
+
+## Context
+
+PR #783 moved Cargo build outputs to Cargo's native `build.target-dir`. After the CLI E2E target-dir fix was pushed, the `Playwright E2E (scratch org)` GitHub Actions job still failed.
+
+The failure was not in the CLI path:
+
+- `Run CLI real-org E2E` completed successfully.
+- The extension Playwright suite completed successfully with `7 passed`.
+- The job failed during the post-suite telemetry validation query.
+
+The failing log line was:
+
+```text
+AADSTS700024: Client assertion is not within its valid time range. Current time: 2026-05-06T17:49:02Z, assertion valid from 2026-05-06T17:38:34Z, expiry time of assertion 2026-05-06T17:43:34Z.
+```
+
+## Root cause
+
+The workflow authenticates with `azure/login` before the CLI E2E and extension E2E steps. The Azure federated assertion used by Azure CLI is short-lived. The telemetry wrapper only needs Log Analytics access after the long Playwright child process finishes, so the first Log Analytics query can occur after the original assertion has expired.
+
+## Goals
+
+- Keep the existing telemetry validation behavior enabled when Azure OIDC and telemetry variables are configured.
+- Avoid changing the real-org Playwright test coverage or proxy-lab architecture.
+- Make the telemetry validation path robust against the observed Azure OIDC assertion lifetime failure.
+- Add regression coverage so future workflow or telemetry runner changes do not reintroduce the same timing issue.
+
+## Non-goals
+
+- Replace Azure OIDC with stored credentials.
+- Change scratch-org allocation or proxy-lab behavior.
+- Broaden Playwright retries or hide real telemetry failures.
+- Change production telemetry resources or event contracts.
+
+## Recommended approach
+
+Use a two-part fix:
+
+1. Move the `Azure login for dedicated App Insights validation` step in `.github/workflows/e2e-playwright.yml` so it runs after the CLI E2E step and immediately before the extension Playwright/telemetry step.
+2. In `scripts/run-playwright-e2e-telemetry.js`, resolve the Log Analytics workspace before launching the long Playwright child process. This pre-warms the Azure CLI access token while the federated assertion is still fresh, then the final telemetry validation can reuse that cached access token.
+
+This keeps the Playwright child run inside the existing telemetry wrapper and proxy-lab flow, while reducing the time between Azure login and the first Log Analytics token acquisition.
+
+## Alternatives considered
+
+### Rerun the failed job only
+
+This might pass if timing is favorable, but it leaves a deterministic timing hazard in the workflow. The previous run shows the suite can outlive the assertion window, so retrying alone is not a durable fix.
+
+### Only move the Azure login step
+
+Moving login later reduces the window, but the telemetry wrapper still may not ask Azure CLI for a Log Analytics token until after a long extension run. Pre-warming the workspace/token before Playwright is the safer small change.
+
+### Re-authenticate after Playwright
+
+Adding a second `azure/login` step after the Playwright child process would require splitting the telemetry wrapper's play/run and validation phases or duplicating logic in workflow shell. That is more invasive than keeping the behavior inside the telemetry runner.
+
+## Implementation shape
+
+- Add a telemetry runner helper that prepares workspace validation metadata before spawning Playwright.
+- Reuse the prepared workspace metadata in `waitForTelemetry` instead of resolving the workspace again.
+- Add a focused unit test proving the pre-warm step occurs before child spawn.
+- Update the workflow guard test to assert Azure login occurs after `Run CLI real-org E2E` and before `Run Playwright E2E`.
+
+## Verification plan
+
+- `node --test scripts/run-playwright-e2e-telemetry.test.js scripts/cli-e2e-workflow.test.js`
+- `npm run test:scripts`
+- Push the PR branch and resume `babysit-pr` until PR #783 reaches a terminal state.
+
+## Risks and mitigations
+
+- **Risk:** The final Log Analytics token could still expire during a very long ingestion wait.
+  - **Mitigation:** The observed failure was the federated assertion before first token acquisition. Pre-warming obtains the access token early. Existing validation attempts remain bounded by the runner's retry settings.
+- **Risk:** Workflow ordering regressions could reintroduce the issue.
+  - **Mitigation:** Add a workflow guard test for the Azure login step position.
+- **Risk:** Refactoring telemetry workspace resolution could change query targeting.
+  - **Mitigation:** Keep the existing query construction and add only a small prepared-context path around `resolveWorkspaceInfo`.

--- a/docs/superpowers/specs/2026-05-06-e2e-azure-oidc-token-lifetime-design.md
+++ b/docs/superpowers/specs/2026-05-06-e2e-azure-oidc-token-lifetime-design.md
@@ -39,7 +39,7 @@ The workflow authenticates with `azure/login` before the CLI E2E and extension E
 Use a two-part fix:
 
 1. Move the `Azure login for dedicated App Insights validation` step in `.github/workflows/e2e-playwright.yml` so it runs after the CLI E2E step and immediately before the extension Playwright/telemetry step.
-2. In `scripts/run-playwright-e2e-telemetry.js`, resolve the Log Analytics workspace before launching the long Playwright child process. This pre-warms the Azure CLI access token while the federated assertion is still fresh, then the final telemetry validation can reuse that cached access token.
+2. In `scripts/run-playwright-e2e-telemetry.js`, resolve the Log Analytics workspace and run a harmless Log Analytics query before launching the long Playwright child process. This pre-warms the same Azure CLI query-token path used by final telemetry validation while the federated assertion is still fresh, then the final telemetry validation can reuse the cached access token.
 
 This keeps the Playwright child run inside the existing telemetry wrapper and proxy-lab flow, while reducing the time between Azure login and the first Log Analytics token acquisition.
 
@@ -51,7 +51,7 @@ This might pass if timing is favorable, but it leaves a deterministic timing haz
 
 ### Only move the Azure login step
 
-Moving login later reduces the window, but the telemetry wrapper still may not ask Azure CLI for a Log Analytics token until after a long extension run. Pre-warming the workspace/token before Playwright is the safer small change.
+Moving login later reduces the window, but the telemetry wrapper still may not ask Azure CLI for a Log Analytics query token until after a long extension run. Running a harmless preflight query before Playwright is the safer small change.
 
 ### Re-authenticate after Playwright
 
@@ -60,9 +60,10 @@ Adding a second `azure/login` step after the Playwright child process would requ
 ## Implementation shape
 
 - Add a telemetry runner helper that prepares workspace validation metadata before spawning Playwright.
+- Add a telemetry runner helper that preflights a harmless Log Analytics query before spawning Playwright.
 - Reuse the prepared workspace metadata in `waitForTelemetry` instead of resolving the workspace again.
-- Add a focused unit test proving the pre-warm step occurs before child spawn.
-- Update the workflow guard test to assert Azure login occurs after `Run CLI real-org E2E` and before `Run Playwright E2E`.
+- Add a focused unit test proving the query preflight occurs before child spawn.
+- Update the workflow guard test to assert Azure login occurs after `Run CLI real-org E2E` and immediately before `Run Playwright E2E`.
 
 ## Verification plan
 
@@ -73,8 +74,8 @@ Adding a second `azure/login` step after the Playwright child process would requ
 ## Risks and mitigations
 
 - **Risk:** The final Log Analytics token could still expire during a very long ingestion wait.
-  - **Mitigation:** The observed failure was the federated assertion before first token acquisition. Pre-warming obtains the access token early. Existing validation attempts remain bounded by the runner's retry settings.
+  - **Mitigation:** The observed failure was the federated assertion before first Log Analytics query-token acquisition. The preflight query obtains that access token early through the same `az monitor log-analytics query` path used by validation. Existing validation attempts remain bounded by the runner's retry settings.
 - **Risk:** Workflow ordering regressions could reintroduce the issue.
   - **Mitigation:** Add a workflow guard test for the Azure login step position.
 - **Risk:** Refactoring telemetry workspace resolution could change query targeting.
-  - **Mitigation:** Keep the existing query construction and add only a small prepared-context path around `resolveWorkspaceInfo`.
+  - **Mitigation:** Keep the existing query construction and pass the prepared context into the same query helper used by validation.

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -166,4 +166,9 @@ test('real-org Playwright workflow logs into Azure immediately before telemetry-
     azureLoginStep.index < extensionStep.index,
     'expected Azure login to run before the telemetry-capable extension Playwright step'
   );
+  assert.equal(
+    azureLoginStep.index + 1,
+    extensionStep.index,
+    'expected Azure login to run immediately before the telemetry-capable extension Playwright step'
+  );
 });

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -142,13 +142,28 @@ test('real-org Playwright workflow disables Playwright retries for the expensive
   );
 });
 
-test('real-org Playwright workflow uses the org-allowlisted Azure login pin', () => {
+test('real-org Playwright workflow logs into Azure immediately before telemetry-capable extension E2E', () => {
   const workflow = readWorkflow();
-  const { step } = getWorkflowStep(workflow, 'Azure login for dedicated App Insights validation');
+  const azureLoginStep = getWorkflowStep(workflow, 'Azure login for dedicated App Insights validation');
+  const cliStep = getWorkflowStep(workflow, 'Run CLI real-org E2E');
+  const uploadArtifactsStep = getWorkflowStep(workflow, 'Upload CLI E2E artifacts');
+  const extensionStep = getWorkflowStep(workflow, 'Run Playwright E2E');
 
   assert.equal(
-    step.uses,
+    azureLoginStep.step.uses,
     'azure/login@93381592711f247e165c389ebb30b596c84cdc48',
     'expected azure/login to stay pinned to the SHA currently allowed by the Electivus org action policy'
+  );
+  assert.ok(
+    cliStep.index < azureLoginStep.index,
+    'expected Azure login to run after the CLI real-org step so the OIDC assertion is fresher for telemetry validation'
+  );
+  assert.ok(
+    uploadArtifactsStep.index < azureLoginStep.index,
+    'expected Azure login to run after CLI artifact upload and immediately before the extension Playwright step'
+  );
+  assert.ok(
+    azureLoginStep.index < extensionStep.index,
+    'expected Azure login to run before the telemetry-capable extension Playwright step'
   );
 });

--- a/scripts/copy-runtime-binary.test.js
+++ b/scripts/copy-runtime-binary.test.js
@@ -30,7 +30,8 @@ test('copyRuntimeBinary falls back to the host cargo output when a target-specif
   const result = mod.copyRuntimeBinary({
     repoRoot,
     target: 'linux-arm64',
-    profile: 'release'
+    profile: 'release',
+    cargoTargetDir: path.join(repoRoot, 'target')
   });
 
   assert.equal(result.source, source);
@@ -41,6 +42,42 @@ test('copyRuntimeBinary falls back to the host cargo output when a target-specif
   assert.equal(fs.existsSync(result.destination), true);
 
   fs.rmSync(repoRoot, { recursive: true, force: true });
+});
+
+test('copyRuntimeBinary reads artifacts from the configured Cargo target directory', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-copy-runtime-'));
+  const cargoTargetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cargo-target-'));
+  const source = path.join(cargoTargetDir, 'debug', 'apex-log-viewer');
+  fs.mkdirSync(path.dirname(source), { recursive: true });
+  fs.writeFileSync(source, 'binary');
+
+  const result = mod.copyRuntimeBinary({
+    repoRoot,
+    target: 'linux-x64',
+    profile: 'debug',
+    spawnSyncImpl(command, args, options) {
+      assert.equal(command, 'cargo');
+      assert.deepEqual(args, ['metadata', '--format-version=1', '--no-deps']);
+      assert.equal(options.cwd, repoRoot);
+      assert.equal(options.encoding, 'utf8');
+
+      return {
+        status: 0,
+        stdout: JSON.stringify({ target_directory: cargoTargetDir })
+      };
+    }
+  });
+
+  assert.equal(result.source, source);
+  assert.equal(
+    result.destination,
+    path.join(repoRoot, 'apps', 'vscode-extension', 'bin', 'linux-x64', 'apex-log-viewer')
+  );
+  assert.equal(fs.existsSync(result.destination), true);
+
+  fs.rmSync(repoRoot, { recursive: true, force: true });
+  fs.rmSync(cargoTargetDir, { recursive: true, force: true });
 });
 
 test('resolveCargoBuildArgs includes the packaged runtime target triple', async () => {

--- a/scripts/run-playwright-cli-e2e.js
+++ b/scripts/run-playwright-cli-e2e.js
@@ -1,13 +1,73 @@
 #!/usr/bin/env node
 'use strict';
 
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 const { existsSync } = require('fs');
 const path = require('path');
 
 function resolveCliBinaryRelativePath(targetPlatform = process.platform) {
-  const bin = targetPlatform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+  const bin = resolveCliBinaryName(targetPlatform);
   return path.posix.join('target', 'debug', bin);
+}
+
+function resolveCliBinaryName(targetPlatform = process.platform) {
+  return targetPlatform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+}
+
+function normalizeCargoTargetDirectory(repoRoot, cargoTargetDirectory) {
+  if (!cargoTargetDirectory) {
+    return undefined;
+  }
+  return path.isAbsolute(cargoTargetDirectory)
+    ? cargoTargetDirectory
+    : path.resolve(repoRoot, cargoTargetDirectory);
+}
+
+function resolveCargoTargetDirectory(repoRoot, options = {}) {
+  const spawnSyncImpl = options.spawnSyncImpl || spawnSync;
+  const result = spawnSyncImpl('cargo', ['metadata', '--format-version=1', '--no-deps'], {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  });
+
+  if (result.error || result.status !== 0) {
+    return undefined;
+  }
+
+  try {
+    const metadata = JSON.parse(result.stdout || '{}');
+    return normalizeCargoTargetDirectory(repoRoot, metadata.target_directory);
+  } catch {
+    return undefined;
+  }
+}
+
+function displayCandidatePath(repoRoot, candidatePath) {
+  const relativePath = path.relative(repoRoot, candidatePath);
+  return relativePath && !relativePath.startsWith('..') && !path.isAbsolute(relativePath)
+    ? relativePath
+    : candidatePath;
+}
+
+function resolveCliBinaryCandidatePaths(repoRoot, options = {}) {
+  const targetPlatform = options.targetPlatform || process.platform;
+  const binaryName = resolveCliBinaryName(targetPlatform);
+  const cargoTargetDirectory =
+    options.cargoTargetDirectory === undefined
+      ? resolveCargoTargetDirectory(repoRoot, options)
+      : normalizeCargoTargetDirectory(repoRoot, options.cargoTargetDirectory);
+  const candidates = [];
+
+  if (cargoTargetDirectory) {
+    candidates.push(path.join(cargoTargetDirectory, 'debug', binaryName));
+  }
+
+  candidates.push(path.join(repoRoot, resolveCliBinaryRelativePath(targetPlatform)));
+  return [...new Set(candidates)];
+}
+
+function resolveBuiltCliBinaryPath(repoRoot, options = {}) {
+  return resolveCliBinaryCandidatePaths(repoRoot, options).find(candidate => existsSync(candidate));
 }
 
 const requiredBuildArtifacts = [resolveCliBinaryRelativePath()];
@@ -34,11 +94,16 @@ function resolveBuildInvocation(targetPlatform = process.platform) {
   };
 }
 
-function findMissingBuildArtifacts(repoRoot) {
-  const acceptedCliPaths = resolveAcceptedCliBinaryRelativePaths();
-  return acceptedCliPaths.some(relativePath => existsSync(path.join(repoRoot, relativePath)))
-    ? []
-    : [acceptedCliPaths.join(' or ')];
+function findMissingBuildArtifacts(repoRoot, options = {}) {
+  if (resolveBuiltCliBinaryPath(repoRoot, options)) {
+    return [];
+  }
+
+  return [
+    resolveCliBinaryCandidatePaths(repoRoot, options)
+      .map(candidate => displayCandidatePath(repoRoot, candidate))
+      .join(' or ')
+  ];
 }
 
 function spawnAsync(command, args, options = {}, spawnImpl = spawn) {
@@ -50,11 +115,12 @@ function spawnAsync(command, args, options = {}, spawnImpl = spawn) {
 }
 
 async function ensureBuildArtifacts(repoRoot, options = {}) {
-  const missingArtifacts = findMissingBuildArtifacts(repoRoot);
-  if (!missingArtifacts.length) {
-    return;
+  const existingCliBinaryPath = resolveBuiltCliBinaryPath(repoRoot, options);
+  if (existingCliBinaryPath) {
+    return existingCliBinaryPath;
   }
 
+  const missingArtifacts = findMissingBuildArtifacts(repoRoot, options);
   console.log(
     `[e2e:cli] Missing build artifacts (${missingArtifacts.join(', ')}). Running npm run build:runtime before Playwright...`
   );
@@ -74,12 +140,14 @@ async function ensureBuildArtifacts(repoRoot, options = {}) {
     throw new Error(`npm run build:runtime failed while preparing CLI Playwright E2E (${details}).`);
   }
 
-  const remainingMissingArtifacts = findMissingBuildArtifacts(repoRoot);
-  if (remainingMissingArtifacts.length) {
+  const builtCliBinaryPath = resolveBuiltCliBinaryPath(repoRoot, options);
+  if (!builtCliBinaryPath) {
+    const remainingMissingArtifacts = findMissingBuildArtifacts(repoRoot, options);
     throw new Error(
       `npm run build:runtime did not produce required CLI artifact(s): ${remainingMissingArtifacts.join(', ')}.`
     );
   }
+  return builtCliBinaryPath;
 }
 
 function resolvePlaywrightInvocation(extraArgs, options = {}) {
@@ -116,14 +184,21 @@ function exitWithChildResult(code, signal) {
   process.exit(1);
 }
 
+function resolvePlaywrightEnv(cliBinaryPath, env = process.env) {
+  return {
+    ...env,
+    ALV_CLI_BINARY_PATH: cliBinaryPath
+  };
+}
+
 async function main() {
   const repoRoot = path.join(__dirname, '..');
-  await ensureBuildArtifacts(repoRoot);
+  const cliBinaryPath = await ensureBuildArtifacts(repoRoot);
   const invocation = resolvePlaywrightInvocation(process.argv.slice(2));
   const child = spawn(invocation.command, invocation.args, {
     stdio: 'inherit',
     cwd: repoRoot,
-    env: process.env
+    env: resolvePlaywrightEnv(cliBinaryPath)
   });
   child.on('exit', exitWithChildResult);
 }
@@ -139,9 +214,13 @@ module.exports = {
   ensureBuildArtifacts,
   findMissingBuildArtifacts,
   requiredBuildArtifacts,
+  resolveBuiltCliBinaryPath,
   resolveBuildInvocation,
+  resolveCargoTargetDirectory,
+  resolveCliBinaryCandidatePaths,
   resolveCliBinaryRelativePath,
   resolveAcceptedCliBinaryRelativePaths,
   resolveCliSuiteRelativePath,
+  resolvePlaywrightEnv,
   resolvePlaywrightInvocation
 };

--- a/scripts/run-playwright-cli-e2e.test.js
+++ b/scripts/run-playwright-cli-e2e.test.js
@@ -26,6 +26,19 @@ function readPackageScripts() {
   return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8')).scripts;
 }
 
+function cargoMetadataSpawnSync(cargoTargetDir) {
+  return function spawnSyncImpl(command, args, options) {
+    assert.equal(command, 'cargo');
+    assert.deepEqual(args, ['metadata', '--format-version=1', '--no-deps']);
+    assert.equal(options.encoding, 'utf8');
+
+    return {
+      status: 0,
+      stdout: JSON.stringify({ target_directory: cargoTargetDir })
+    };
+  };
+}
+
 test('resolveCliBinaryRelativePath targets the debug CLI binary on Linux', () => {
   const runner = loadRunner();
 
@@ -63,6 +76,34 @@ test('findMissingBuildArtifacts still requires the host debug binary when CARGO_
   }
 });
 
+test('findMissingBuildArtifacts accepts the debug CLI binary from Cargo target_directory', () => {
+  const repoRoot = createTempRepo();
+  const cargoTargetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cargo-target-'));
+  try {
+    const runner = loadRunner();
+    const cliBinaryName = path.basename(runner.resolveCliBinaryRelativePath(process.platform));
+    const cliBinaryPath = path.join(cargoTargetDir, 'debug', cliBinaryName);
+    fs.mkdirSync(path.dirname(cliBinaryPath), { recursive: true });
+    fs.writeFileSync(cliBinaryPath, '', 'utf8');
+
+    assert.deepEqual(
+      runner.findMissingBuildArtifacts(repoRoot, {
+        spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir)
+      }),
+      []
+    );
+    assert.equal(
+      runner.resolveBuiltCliBinaryPath(repoRoot, {
+        spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir)
+      }),
+      cliBinaryPath
+    );
+  } finally {
+    cleanupTempRepo(repoRoot);
+    fs.rmSync(cargoTargetDir, { recursive: true, force: true });
+  }
+});
+
 test('ensureBuildArtifacts runs npm run build:runtime when the CLI binary is missing', async () => {
   const repoRoot = createTempRepo();
   try {
@@ -97,6 +138,37 @@ test('ensureBuildArtifacts runs npm run build:runtime when the CLI binary is mis
     assert.equal(recordedCall.options.stdio, 'inherit');
   } finally {
     cleanupTempRepo(repoRoot);
+  }
+});
+
+test('ensureBuildArtifacts returns the configured Cargo target-dir CLI binary after building', async () => {
+  const repoRoot = createTempRepo();
+  const cargoTargetDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-cargo-target-'));
+  try {
+    const runner = loadRunner();
+    const cliBinaryName = path.basename(runner.resolveCliBinaryRelativePath(process.platform));
+    const cliBinaryPath = path.join(cargoTargetDir, 'debug', cliBinaryName);
+    let recordedCall;
+
+    const result = await runner.ensureBuildArtifacts(repoRoot, {
+      spawnSyncImpl: cargoMetadataSpawnSync(cargoTargetDir),
+      spawnImpl(command, args, options) {
+        recordedCall = { command, args, options };
+        const child = new EventEmitter();
+        process.nextTick(() => {
+          fs.mkdirSync(path.dirname(cliBinaryPath), { recursive: true });
+          fs.writeFileSync(cliBinaryPath, '', 'utf8');
+          child.emit('exit', 0, null);
+        });
+        return child;
+      }
+    });
+
+    assert.ok(recordedCall, 'expected ensureBuildArtifacts to invoke the build command');
+    assert.equal(result, cliBinaryPath);
+  } finally {
+    cleanupTempRepo(repoRoot);
+    fs.rmSync(cargoTargetDir, { recursive: true, force: true });
   }
 });
 
@@ -154,6 +226,14 @@ test('ensureBuildArtifacts clears CARGO_BUILD_TARGET and requires a host debug b
     }
     cleanupTempRepo(repoRoot);
   }
+});
+
+test('resolvePlaywrightEnv passes the selected CLI binary path to Playwright', () => {
+  const runner = loadRunner();
+  const env = runner.resolvePlaywrightEnv('/tmp/alv/bin/apex-log-viewer', { EXISTING: '1' });
+
+  assert.equal(env.EXISTING, '1');
+  assert.equal(env.ALV_CLI_BINARY_PATH, '/tmp/alv/bin/apex-log-viewer');
 });
 
 test('resolvePlaywrightInvocation throws when @playwright/test/cli cannot be resolved instead of falling back to npx', () => {

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -103,6 +103,22 @@ async function queryTelemetryForRun(workspaceCustomerId, componentResourceId, ru
   return queryWorkspace(workspaceCustomerId, query);
 }
 
+async function prepareTelemetryValidationContext(
+  config,
+  component,
+  resolveWorkspaceInfoImpl = resolveWorkspaceInfo
+) {
+  const workspace = await resolveWorkspaceInfoImpl({
+    ...config,
+    workspaceResourceId: component.workspaceResourceId || config.workspaceResourceId
+  });
+
+  return {
+    componentResourceId: component.id,
+    workspaceCustomerId: workspace.workspaceCustomerId
+  };
+}
+
 function summarizeTelemetry(rows) {
   const totalEvents = rows.reduce((sum, row) => sum + Number(row.events || 0), 0);
   const distinctNames = rows.length;
@@ -167,17 +183,21 @@ function resolveConfig(env = process.env) {
   return config;
 }
 
-async function waitForTelemetry(config, component, runId) {
+async function waitForTelemetry(config, component, runId, options = {}) {
   const attempts = Math.max(1, Number(process.env.ALV_E2E_TELEMETRY_QUERY_ATTEMPTS || 18) || 18);
   const delayMs = Math.max(1000, Number(process.env.ALV_E2E_TELEMETRY_QUERY_DELAY_MS || 10000) || 10000);
   const lookback = String(process.env.ALV_E2E_TELEMETRY_LOOKBACK || '2h').trim() || '2h';
-  const workspace = await resolveWorkspaceInfo({
-    ...config,
-    workspaceResourceId: component.workspaceResourceId || config.workspaceResourceId
-  });
+  const validationContext =
+    options.validationContext ||
+    (await prepareTelemetryValidationContext(config, component, options.resolveWorkspaceInfoImpl));
 
   for (let attempt = 1; attempt <= attempts; attempt++) {
-    const result = await queryTelemetryForRun(workspace.workspaceCustomerId, component.id, runId, lookback);
+    const result = await queryTelemetryForRun(
+      validationContext.workspaceCustomerId,
+      validationContext.componentResourceId,
+      runId,
+      lookback
+    );
     const rows = toRows(result);
     const summary = summarizeTelemetry(rows);
     if (summary.hasActivation && summary.totalEvents >= 5 && summary.distinctNames >= 3) {
@@ -191,7 +211,12 @@ async function waitForTelemetry(config, component, runId) {
     }
   }
 
-  const finalResult = await queryTelemetryForRun(workspace.workspaceCustomerId, component.id, runId, lookback);
+  const finalResult = await queryTelemetryForRun(
+    validationContext.workspaceCustomerId,
+    validationContext.componentResourceId,
+    runId,
+    lookback
+  );
   const finalRows = toRows(finalResult);
   const finalSummary = summarizeTelemetry(finalRows);
   throw new Error(
@@ -199,46 +224,69 @@ async function waitForTelemetry(config, component, runId) {
   );
 }
 
-async function main() {
-  const config = resolveConfig(process.env);
+async function runTelemetryE2e(options = {}) {
+  const env = options.env || process.env;
+  const extraArgs = options.extraArgs || process.argv.slice(2);
+  const repoRoot = options.repoRoot || REPO_ROOT;
+  const logger = options.logger || console;
+  const randomUUIDImpl = options.randomUUIDImpl || randomUUID;
+  const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
+  const prepareTelemetryValidationContextImpl =
+    options.prepareTelemetryValidationContextImpl || prepareTelemetryValidationContext;
+  const resolvePlaywrightChildInvocationImpl =
+    options.resolvePlaywrightChildInvocationImpl || resolvePlaywrightChildInvocation;
+  const spawnAsyncImpl = options.spawnAsyncImpl || spawnAsync;
+  const waitForTelemetryImpl = options.waitForTelemetryImpl || waitForTelemetry;
 
-  const { component, created } = await ensureTelemetryComponent(config);
-  const runId = randomUUID();
+  const config = resolveConfig(env);
 
-  console.log(
+  const { component, created } = await ensureTelemetryComponentImpl(config);
+  const runId = randomUUIDImpl();
+
+  logger.log(
     `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
   );
-  console.log(`[e2e] Test telemetry run id: ${runId}`);
+  logger.log(`[e2e] Test telemetry run id: ${runId}`);
+
+  const validationContext = await prepareTelemetryValidationContextImpl(config, component);
 
   const childEnv = {
-    ...process.env,
+    ...env,
     ALV_ENABLE_TEST_TELEMETRY: '1',
     ALV_TEST_TELEMETRY_CONNECTION_STRING: component.connectionString,
     ALV_TEST_TELEMETRY_RUN_ID: runId
   };
 
-  const childInvocation = resolvePlaywrightChildInvocation(process.argv.slice(2), childEnv, REPO_ROOT);
-  const child = await spawnAsync(childInvocation.command, childInvocation.args, {
-    cwd: REPO_ROOT,
+  const childInvocation = resolvePlaywrightChildInvocationImpl(extraArgs, childEnv, repoRoot);
+  const child = await spawnAsyncImpl(childInvocation.command, childInvocation.args, {
+    cwd: repoRoot,
     env: childEnv,
     stdio: 'inherit'
   });
 
   if (typeof child.code === 'number' && child.code !== 0) {
-    process.exit(child.code);
-    return;
+    return { exitCode: child.code };
   }
   if (child.signal) {
     throw new Error(`Playwright E2E process exited via signal ${child.signal}.`);
   }
 
-  console.log('[e2e] Playwright suite passed. Validating telemetry arrival in the linked Log Analytics workspace...');
-  const validation = await waitForTelemetry(config, component, runId);
-  console.log(
+  logger.log('[e2e] Playwright suite passed. Validating telemetry arrival in the linked Log Analytics workspace...');
+  const validation = await waitForTelemetryImpl(config, component, runId, { validationContext });
+  logger.log(
     `[e2e] Telemetry validated after ${validation.attempt} query attempt(s): ${validation.summary.totalEvents} events across ${validation.summary.distinctNames} event names.`
   );
   for (const row of validation.rows) {
-    console.log(`[e2e] ${row.name}: ${row.events}`);
+    logger.log(`[e2e] ${row.name}: ${row.events}`);
+  }
+
+  return { exitCode: 0, validation };
+}
+
+async function main() {
+  const result = await runTelemetryE2e();
+  if (typeof result.exitCode === 'number' && result.exitCode !== 0) {
+    process.exit(result.exitCode);
   }
 }
 
@@ -251,8 +299,10 @@ if (require.main === module) {
 
 module.exports = {
   buildRunValidationQuery,
+  prepareTelemetryValidationContext,
   resolveConfig,
   resolvePlaywrightChildInvocation,
+  runTelemetryE2e,
   spawnAsync,
   summarizeTelemetry
 };

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -119,6 +119,17 @@ async function prepareTelemetryValidationContext(
   };
 }
 
+async function prewarmTelemetryQueryToken(validationContext, runId, options = {}) {
+  const queryTelemetryForRunImpl = options.queryTelemetryForRunImpl || queryTelemetryForRun;
+  const lookback = String(options.lookback || '5m').trim() || '5m';
+  await queryTelemetryForRunImpl(
+    validationContext.workspaceCustomerId,
+    validationContext.componentResourceId,
+    runId,
+    lookback
+  );
+}
+
 function summarizeTelemetry(rows) {
   const totalEvents = rows.reduce((sum, row) => sum + Number(row.events || 0), 0);
   const distinctNames = rows.length;
@@ -233,6 +244,8 @@ async function runTelemetryE2e(options = {}) {
   const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
   const prepareTelemetryValidationContextImpl =
     options.prepareTelemetryValidationContextImpl || prepareTelemetryValidationContext;
+  const prewarmTelemetryQueryTokenImpl = options.prewarmTelemetryQueryTokenImpl || prewarmTelemetryQueryToken;
+  const queryTelemetryForRunImpl = options.queryTelemetryForRunImpl || queryTelemetryForRun;
   const resolvePlaywrightChildInvocationImpl =
     options.resolvePlaywrightChildInvocationImpl || resolvePlaywrightChildInvocation;
   const spawnAsyncImpl = options.spawnAsyncImpl || spawnAsync;
@@ -249,6 +262,7 @@ async function runTelemetryE2e(options = {}) {
   logger.log(`[e2e] Test telemetry run id: ${runId}`);
 
   const validationContext = await prepareTelemetryValidationContextImpl(config, component);
+  await prewarmTelemetryQueryTokenImpl(validationContext, runId, { queryTelemetryForRunImpl });
 
   const childEnv = {
     ...env,
@@ -300,6 +314,7 @@ if (require.main === module) {
 module.exports = {
   buildRunValidationQuery,
   prepareTelemetryValidationContext,
+  prewarmTelemetryQueryToken,
   resolveConfig,
   resolvePlaywrightChildInvocation,
   runTelemetryE2e,

--- a/scripts/run-playwright-e2e-telemetry.test.js
+++ b/scripts/run-playwright-e2e-telemetry.test.js
@@ -6,6 +6,7 @@ const {
   buildRunValidationQuery,
   resolveConfig,
   resolvePlaywrightChildInvocation,
+  runTelemetryE2e,
   spawnAsync,
   summarizeTelemetry
 } = require('./run-playwright-e2e-telemetry');
@@ -79,6 +80,71 @@ test('spawnAsync rejects when the child process cannot be started', async () => 
       })),
     /spawn ENOENT/
   );
+});
+
+test('runTelemetryE2e prepares Log Analytics context before spawning Playwright', async () => {
+  const calls = [];
+  const validationContext = {
+    componentResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/appi-e2e',
+    workspaceCustomerId: 'workspace-customer-id'
+  };
+
+  const result = await runTelemetryE2e({
+    env: {
+      ALV_E2E_TELEMETRY_APP: 'appi-e2e',
+      ALV_E2E_TELEMETRY_BASE_APP: 'appi-base',
+      ALV_E2E_TELEMETRY_RESOURCE_GROUP: 'rg-telemetry',
+      AZURE_SUBSCRIPTION_ID: 'sub-123'
+    },
+    extraArgs: ['--grep', 'logs'],
+    repoRoot: path.join('/repo', 'apex-log-viewer'),
+    logger: { log() {} },
+    randomUUIDImpl: () => 'run-123',
+    ensureTelemetryComponentImpl: async config => {
+      calls.push(['ensure', config.appName]);
+      return {
+        component: {
+          connectionString: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+          id: validationContext.componentResourceId,
+          name: 'appi-e2e',
+          resourceGroup: 'rg-telemetry',
+          workspaceResourceId:
+            '/subscriptions/sub/resourceGroups/rg/providers/microsoft.operationalinsights/workspaces/law-e2e'
+        },
+        created: false
+      };
+    },
+    prepareTelemetryValidationContextImpl: async (config, component) => {
+      calls.push(['prepare', component.id]);
+      assert.equal(config.appName, 'appi-e2e');
+      return validationContext;
+    },
+    resolvePlaywrightChildInvocationImpl: extraArgs => {
+      calls.push(['resolve-child', extraArgs.join(' ')]);
+      return { command: 'node', args: ['child.js'] };
+    },
+    spawnAsyncImpl: async (command, args) => {
+      calls.push(['spawn', command, args.join(' ')]);
+      return { code: 0, signal: null };
+    },
+    waitForTelemetryImpl: async (_config, _component, runId, options) => {
+      calls.push(['wait', runId, options.validationContext.workspaceCustomerId]);
+      return {
+        attempt: 1,
+        rows: [{ name: 'electivus.apex-log-viewer/extension.activate', events: 5 }],
+        summary: { distinctNames: 3, hasActivation: true, totalEvents: 5 }
+      };
+    }
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(calls, [
+    ['ensure', 'appi-e2e'],
+    ['prepare', validationContext.componentResourceId],
+    ['resolve-child', '--grep logs'],
+    ['spawn', 'node', 'child.js'],
+    ['wait', 'run-123', 'workspace-customer-id']
+  ]);
 });
 
 test('resolvePlaywrightChildInvocation runs Playwright directly by default', () => {

--- a/scripts/run-playwright-e2e-telemetry.test.js
+++ b/scripts/run-playwright-e2e-telemetry.test.js
@@ -82,7 +82,7 @@ test('spawnAsync rejects when the child process cannot be started', async () => 
   );
 });
 
-test('runTelemetryE2e prepares Log Analytics context before spawning Playwright', async () => {
+test('runTelemetryE2e preflights a Log Analytics query before spawning Playwright', async () => {
   const calls = [];
   const validationContext = {
     componentResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/appi-e2e',
@@ -119,6 +119,10 @@ test('runTelemetryE2e prepares Log Analytics context before spawning Playwright'
       assert.equal(config.appName, 'appi-e2e');
       return validationContext;
     },
+    queryTelemetryForRunImpl: async (workspaceCustomerId, componentResourceId, runId, lookback) => {
+      calls.push(['query-preflight', workspaceCustomerId, componentResourceId, runId, lookback]);
+      return [];
+    },
     resolvePlaywrightChildInvocationImpl: extraArgs => {
       calls.push(['resolve-child', extraArgs.join(' ')]);
       return { command: 'node', args: ['child.js'] };
@@ -141,6 +145,13 @@ test('runTelemetryE2e prepares Log Analytics context before spawning Playwright'
   assert.deepEqual(calls, [
     ['ensure', 'appi-e2e'],
     ['prepare', validationContext.componentResourceId],
+    [
+      'query-preflight',
+      validationContext.workspaceCustomerId,
+      validationContext.componentResourceId,
+      'run-123',
+      '5m'
+    ],
     ['resolve-child', '--grep logs'],
     ['spawn', 'node', 'child.js'],
     ['wait', 'run-123', 'workspace-customer-id']

--- a/test/e2e/cli/specs/cliHelper.e2e.spec.ts
+++ b/test/e2e/cli/specs/cliHelper.e2e.spec.ts
@@ -13,6 +13,10 @@ async function withTempRepo<T>(fn: (repoRoot: string) => Promise<T>): Promise<T>
   }
 }
 
+function withoutConfiguredCliBinaryEnv(): NodeJS.ProcessEnv {
+  return { ALV_CLI_BINARY_PATH: '' };
+}
+
 async function writeFakeStandaloneBinary(repoRoot: string, scriptBody: string): Promise<string> {
   const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
   const binaryDir = path.join(repoRoot, 'target', 'debug');
@@ -84,7 +88,7 @@ test('resolveAlvCliBinaryPath rejects extension runtime fallback when standalone
     await mkdir(extensionRuntimeDir, { recursive: true });
     await writeFile(path.join(extensionRuntimeDir, binaryName), 'not-a-real-binary', 'utf8');
 
-    expect(() => resolveAlvCliBinaryPath({ repoRoot, env: {} })).toThrow(
+    expect(() => resolveAlvCliBinaryPath({ repoRoot, env: withoutConfiguredCliBinaryEnv() })).toThrow(
       /Unable to locate apex-log-viewer standalone binary/
     );
   });
@@ -112,20 +116,25 @@ test('resolveAlvCliBinaryPath fails clearly when ALV_CLI_BINARY_PATH is missing'
   await withTempRepo(async repoRoot => {
     const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
     const missingBinaryPath = path.join(repoRoot, '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName);
+    const fallbackBinaryPath = path.join(repoRoot, 'target', 'debug', binaryName);
     await writeFakeStandaloneBinary(repoRoot, '#!/bin/sh\nexit 0\n');
 
-    expect(() =>
-      resolveAlvCliBinaryPath({
-        repoRoot,
-        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
-      })
-    ).toThrow(/ALV_CLI_BINARY_PATH/);
-    expect(() =>
-      resolveAlvCliInvocation({
-        repoRoot,
-        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
-      })
-    ).toThrow(/ALV_CLI_BINARY_PATH/);
+    for (const resolve of [
+      () =>
+        resolveAlvCliBinaryPath({
+          repoRoot,
+          env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+        }),
+      () =>
+        resolveAlvCliInvocation({
+          repoRoot,
+          env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+        })
+    ]) {
+      expect(resolve).toThrow(/ALV_CLI_BINARY_PATH/);
+      expect(resolve).toThrow(missingBinaryPath);
+      expect(resolve).toThrow(fallbackBinaryPath);
+    }
   });
 });
 
@@ -146,12 +155,43 @@ test('runAlvCli parses stdoutJson separately from stderrJson', async () => {
     const result = await runAlvCli([], {
       repoRoot,
       allowWindowsCommandShim: process.platform === 'win32',
-      env: {}
+      env: withoutConfiguredCliBinaryEnv()
     });
 
     expect(result.exitCode).toBe(0);
     expect(result.stdoutJson).toEqual({ stream: 'stdout', status: 'success' });
     expect(result.stderrJson).toEqual({ stream: 'stderr', status: 'warning' });
+  });
+});
+
+test('runAlvCli resolves ALV_CLI_BINARY_PATH from process env when an env overlay is provided', async () => {
+  await withTempRepo(async repoRoot => {
+    const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+    const configuredBinaryPath = await writeFakeStandaloneBinaryAtPath(
+      path.join(repoRoot, '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName),
+      '#!/bin/sh\nprintf \'{"source":"configured"}\\n\'\n'
+    );
+    await writeFakeStandaloneBinary(repoRoot, '#!/bin/sh\nprintf \'{"source":"fallback"}\\n\'\n');
+
+    const originalConfiguredBinaryPath = process.env.ALV_CLI_BINARY_PATH;
+    process.env.ALV_CLI_BINARY_PATH = configuredBinaryPath;
+
+    try {
+      const result = await runAlvCli([], {
+        repoRoot,
+        env: { ALV_TEST_MARKER: '1' }
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.command).toBe(configuredBinaryPath);
+      expect(result.stdoutJson).toEqual({ source: 'configured' });
+    } finally {
+      if (originalConfiguredBinaryPath === undefined) {
+        delete process.env.ALV_CLI_BINARY_PATH;
+      } else {
+        process.env.ALV_CLI_BINARY_PATH = originalConfiguredBinaryPath;
+      }
+    }
   });
 });
 
@@ -165,7 +205,12 @@ test('runAlvCli returns diagnostics on timeout instead of rejecting', async () =
 
     const result = await runAlvCli(
       [],
-      { repoRoot, timeoutMs: 50, allowWindowsCommandShim: process.platform === 'win32', env: {} }
+      {
+        repoRoot,
+        timeoutMs: 50,
+        allowWindowsCommandShim: process.platform === 'win32',
+        env: withoutConfiguredCliBinaryEnv()
+      }
     );
 
     expect(result.exitCode).toBe(-1);
@@ -177,9 +222,9 @@ test('resolveAlvCliBinaryPath stays strict when only a Windows command shim exis
   await withTempRepo(async repoRoot => {
     await writeFakeWindowsCommandShim(repoRoot, '@echo off\r\nexit /b 0\r\n');
 
-    expect(() => resolveAlvCliBinaryPath({ repoRoot, platform: 'win32', env: {} })).toThrow(
-      /Unable to locate apex-log-viewer standalone binary/
-    );
+    expect(() =>
+      resolveAlvCliBinaryPath({ repoRoot, platform: 'win32', env: withoutConfiguredCliBinaryEnv() })
+    ).toThrow(/Unable to locate apex-log-viewer standalone binary/);
   });
 });
 
@@ -188,7 +233,14 @@ test('resolveAlvCliInvocation can use a Windows command shim for helper-only cov
     const shimPath = await writeFakeWindowsCommandShim(repoRoot, '@echo off\r\nexit /b 0\r\n');
     const quotedShimPath = `"${shimPath.replace(/"/g, '""')}"`;
 
-    expect(resolveAlvCliInvocation({ repoRoot, platform: 'win32', allowWindowsCommandShim: true, env: {} })).toEqual({
+    expect(
+      resolveAlvCliInvocation({
+        repoRoot,
+        platform: 'win32',
+        allowWindowsCommandShim: true,
+        env: withoutConfiguredCliBinaryEnv()
+      })
+    ).toEqual({
       command: process.env.ComSpec || 'cmd.exe',
       args: ['/d', '/s', '/c', quotedShimPath]
     });
@@ -209,8 +261,10 @@ test('resolveAlvCliBinaryPath prefers the host debug binary when CARGO_BUILD_TAR
         '#!/bin/sh\nexit 0\n'
       );
 
-      expect(resolveAlvCliBinaryPath({ repoRoot, env: {} })).toBe(hostBinaryPath);
-      expect(resolveAlvCliInvocation({ repoRoot, env: {} })).toEqual({
+      expect(resolveAlvCliBinaryPath({ repoRoot, env: withoutConfiguredCliBinaryEnv() })).toBe(
+        hostBinaryPath
+      );
+      expect(resolveAlvCliInvocation({ repoRoot, env: withoutConfiguredCliBinaryEnv() })).toEqual({
         command: hostBinaryPath,
         args: []
       });
@@ -238,10 +292,10 @@ test('resolveAlvCliBinaryPath ignores cross-target debug binaries when the host 
         '#!/bin/sh\nexit 0\n'
       );
 
-      expect(() => resolveAlvCliBinaryPath({ repoRoot, env: {} })).toThrow(
+      expect(() => resolveAlvCliBinaryPath({ repoRoot, env: withoutConfiguredCliBinaryEnv() })).toThrow(
         /Unable to locate apex-log-viewer standalone binary/
       );
-      expect(() => resolveAlvCliInvocation({ repoRoot, env: {} })).toThrow(
+      expect(() => resolveAlvCliInvocation({ repoRoot, env: withoutConfiguredCliBinaryEnv() })).toThrow(
         /Unable to locate apex-log-viewer standalone binary/
       );
     } finally {

--- a/test/e2e/cli/specs/cliHelper.e2e.spec.ts
+++ b/test/e2e/cli/specs/cliHelper.e2e.spec.ts
@@ -27,6 +27,15 @@ async function writeFakeStandaloneBinary(repoRoot: string, scriptBody: string): 
   return binaryPath;
 }
 
+async function writeFakeStandaloneBinaryAtPath(binaryPath: string, scriptBody: string): Promise<string> {
+  await mkdir(path.dirname(binaryPath), { recursive: true });
+  await writeFile(binaryPath, scriptBody, 'utf8');
+  if (process.platform !== 'win32') {
+    await chmod(binaryPath, 0o755);
+  }
+  return binaryPath;
+}
+
 async function writeFakeWindowsCommandShim(repoRoot: string, scriptBody: string): Promise<string> {
   const binaryDir = path.join(repoRoot, 'target', 'debug');
   const shimPath = path.join(binaryDir, 'apex-log-viewer.cmd');
@@ -76,6 +85,45 @@ test('resolveAlvCliBinaryPath rejects extension runtime fallback when standalone
     await writeFile(path.join(extensionRuntimeDir, binaryName), 'not-a-real-binary', 'utf8');
 
     expect(() => resolveAlvCliBinaryPath({ repoRoot })).toThrow(/Unable to locate apex-log-viewer standalone binary/);
+  });
+});
+
+test('resolveAlvCliBinaryPath prefers ALV_CLI_BINARY_PATH when it exists', async () => {
+  await withTempRepo(async repoRoot => {
+    const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+    const configuredBinaryPath = await writeFakeStandaloneBinaryAtPath(
+      path.join(repoRoot, '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName),
+      '#!/bin/sh\nexit 0\n'
+    );
+
+    const env = { ALV_CLI_BINARY_PATH: configuredBinaryPath };
+
+    expect(resolveAlvCliBinaryPath({ repoRoot, env })).toBe(configuredBinaryPath);
+    expect(resolveAlvCliInvocation({ repoRoot, env })).toEqual({
+      command: configuredBinaryPath,
+      args: []
+    });
+  });
+});
+
+test('resolveAlvCliBinaryPath fails clearly when ALV_CLI_BINARY_PATH is missing', async () => {
+  await withTempRepo(async repoRoot => {
+    const binaryName = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
+    const missingBinaryPath = path.join(repoRoot, '.cargo-target', 'Apex-Log-Viewer', 'debug', binaryName);
+    await writeFakeStandaloneBinary(repoRoot, '#!/bin/sh\nexit 0\n');
+
+    expect(() =>
+      resolveAlvCliBinaryPath({
+        repoRoot,
+        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+      })
+    ).toThrow(/ALV_CLI_BINARY_PATH/);
+    expect(() =>
+      resolveAlvCliInvocation({
+        repoRoot,
+        env: { ALV_CLI_BINARY_PATH: missingBinaryPath }
+      })
+    ).toThrow(/ALV_CLI_BINARY_PATH/);
   });
 });
 

--- a/test/e2e/cli/specs/cliHelper.e2e.spec.ts
+++ b/test/e2e/cli/specs/cliHelper.e2e.spec.ts
@@ -84,7 +84,9 @@ test('resolveAlvCliBinaryPath rejects extension runtime fallback when standalone
     await mkdir(extensionRuntimeDir, { recursive: true });
     await writeFile(path.join(extensionRuntimeDir, binaryName), 'not-a-real-binary', 'utf8');
 
-    expect(() => resolveAlvCliBinaryPath({ repoRoot })).toThrow(/Unable to locate apex-log-viewer standalone binary/);
+    expect(() => resolveAlvCliBinaryPath({ repoRoot, env: {} })).toThrow(
+      /Unable to locate apex-log-viewer standalone binary/
+    );
   });
 });
 
@@ -141,7 +143,11 @@ test('runAlvCli parses stdoutJson separately from stderrJson', async () => {
       );
     }
 
-    const result = await runAlvCli([], { repoRoot, allowWindowsCommandShim: process.platform === 'win32' });
+    const result = await runAlvCli([], {
+      repoRoot,
+      allowWindowsCommandShim: process.platform === 'win32',
+      env: {}
+    });
 
     expect(result.exitCode).toBe(0);
     expect(result.stdoutJson).toEqual({ stream: 'stdout', status: 'success' });
@@ -159,7 +165,7 @@ test('runAlvCli returns diagnostics on timeout instead of rejecting', async () =
 
     const result = await runAlvCli(
       [],
-      { repoRoot, timeoutMs: 50, allowWindowsCommandShim: process.platform === 'win32' }
+      { repoRoot, timeoutMs: 50, allowWindowsCommandShim: process.platform === 'win32', env: {} }
     );
 
     expect(result.exitCode).toBe(-1);
@@ -171,7 +177,7 @@ test('resolveAlvCliBinaryPath stays strict when only a Windows command shim exis
   await withTempRepo(async repoRoot => {
     await writeFakeWindowsCommandShim(repoRoot, '@echo off\r\nexit /b 0\r\n');
 
-    expect(() => resolveAlvCliBinaryPath({ repoRoot, platform: 'win32' })).toThrow(
+    expect(() => resolveAlvCliBinaryPath({ repoRoot, platform: 'win32', env: {} })).toThrow(
       /Unable to locate apex-log-viewer standalone binary/
     );
   });
@@ -182,7 +188,7 @@ test('resolveAlvCliInvocation can use a Windows command shim for helper-only cov
     const shimPath = await writeFakeWindowsCommandShim(repoRoot, '@echo off\r\nexit /b 0\r\n');
     const quotedShimPath = `"${shimPath.replace(/"/g, '""')}"`;
 
-    expect(resolveAlvCliInvocation({ repoRoot, platform: 'win32', allowWindowsCommandShim: true })).toEqual({
+    expect(resolveAlvCliInvocation({ repoRoot, platform: 'win32', allowWindowsCommandShim: true, env: {} })).toEqual({
       command: process.env.ComSpec || 'cmd.exe',
       args: ['/d', '/s', '/c', quotedShimPath]
     });
@@ -203,8 +209,8 @@ test('resolveAlvCliBinaryPath prefers the host debug binary when CARGO_BUILD_TAR
         '#!/bin/sh\nexit 0\n'
       );
 
-      expect(resolveAlvCliBinaryPath({ repoRoot })).toBe(hostBinaryPath);
-      expect(resolveAlvCliInvocation({ repoRoot })).toEqual({
+      expect(resolveAlvCliBinaryPath({ repoRoot, env: {} })).toBe(hostBinaryPath);
+      expect(resolveAlvCliInvocation({ repoRoot, env: {} })).toEqual({
         command: hostBinaryPath,
         args: []
       });
@@ -232,8 +238,12 @@ test('resolveAlvCliBinaryPath ignores cross-target debug binaries when the host 
         '#!/bin/sh\nexit 0\n'
       );
 
-      expect(() => resolveAlvCliBinaryPath({ repoRoot })).toThrow(/Unable to locate apex-log-viewer standalone binary/);
-      expect(() => resolveAlvCliInvocation({ repoRoot })).toThrow(/Unable to locate apex-log-viewer standalone binary/);
+      expect(() => resolveAlvCliBinaryPath({ repoRoot, env: {} })).toThrow(
+        /Unable to locate apex-log-viewer standalone binary/
+      );
+      expect(() => resolveAlvCliInvocation({ repoRoot, env: {} })).toThrow(
+        /Unable to locate apex-log-viewer standalone binary/
+      );
     } finally {
       if (originalCargoBuildTarget === undefined) {
         delete process.env.CARGO_BUILD_TARGET;

--- a/test/e2e/cli/specs/runtimeDaemon.e2e.spec.ts
+++ b/test/e2e/cli/specs/runtimeDaemon.e2e.spec.ts
@@ -1,7 +1,7 @@
 import { access } from 'node:fs/promises';
-import path from 'node:path';
 import { createDaemonProcess, type DaemonProcess } from '../../../../packages/app-server-client-ts/src/daemonProcess';
 import { expect, test } from '../fixtures/alvCliE2E';
+import { resolveAlvCliBinaryPath } from '../utils/cli';
 
 type JsonRpcResponse = {
   id?: string;
@@ -16,8 +16,7 @@ type JsonRpcResponse = {
 let nextRuntimeRequestId = 0;
 
 function resolveRuntimeExecutable(): string {
-  const binary = process.platform === 'win32' ? 'apex-log-viewer.exe' : 'apex-log-viewer';
-  return path.join(process.cwd(), 'target', 'debug', binary);
+  return resolveAlvCliBinaryPath();
 }
 
 function redactedProxySummary(): Record<string, boolean> {

--- a/test/e2e/cli/utils/cli.ts
+++ b/test/e2e/cli/utils/cli.ts
@@ -34,6 +34,7 @@ type ResolveAlvCliBinaryPathOptions = {
   repoRoot?: string;
   cargoBuildTarget?: string;
   platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
 };
 
 type ResolveAlvCliInvocationOptions = ResolveAlvCliBinaryPathOptions & {
@@ -52,6 +53,30 @@ function resolveBinaryCandidatesForName(binaryName: string, options: ResolveAlvC
 
 function resolveBinaryCandidates(options: ResolveAlvCliBinaryPathOptions = {}): string[] {
   return resolveBinaryCandidatesForName(resolveBinaryName(options.platform), options);
+}
+
+function resolveConfiguredCliBinaryPath(options: ResolveAlvCliBinaryPathOptions = {}): string | undefined {
+  const rawPath = String((options.env ?? process.env).ALV_CLI_BINARY_PATH ?? '').trim();
+  if (!rawPath) {
+    return undefined;
+  }
+
+  const repoRoot = options.repoRoot || resolveRepoRoot();
+  return path.isAbsolute(rawPath) ? rawPath : path.resolve(repoRoot, rawPath);
+}
+
+function formatMissingBinaryMessage(
+  configuredBinaryPath: string | undefined,
+  fallbackCandidates: string[]
+): string {
+  if (configuredBinaryPath) {
+    return `Unable to locate apex-log-viewer standalone binary from ALV_CLI_BINARY_PATH. Checked: ${[
+      configuredBinaryPath,
+      ...fallbackCandidates
+    ].join(', ')}`;
+  }
+
+  return `Unable to locate apex-log-viewer standalone binary. Checked: ${fallbackCandidates.join(', ')}`;
 }
 
 function tryParseCliJson(raw: string): any | undefined {
@@ -81,18 +106,38 @@ function tryParseCliJson(raw: string): any | undefined {
 }
 
 export function resolveAlvCliBinaryPath(options: ResolveAlvCliBinaryPathOptions = {}): string {
+  const configuredBinaryPath = resolveConfiguredCliBinaryPath(options);
   const candidates = resolveBinaryCandidates(options);
+
+  if (configuredBinaryPath) {
+    if (existsSync(configuredBinaryPath)) {
+      return configuredBinaryPath;
+    }
+    throw new Error(formatMissingBinaryMessage(configuredBinaryPath, candidates));
+  }
+
   const binaryPath = candidates.find(candidate => existsSync(candidate));
   if (!binaryPath) {
-    throw new Error(
-      `Unable to locate apex-log-viewer standalone binary. Checked: ${candidates.join(', ')}`
-    );
+    throw new Error(formatMissingBinaryMessage(undefined, candidates));
   }
   return binaryPath;
 }
 
 export function resolveAlvCliInvocation(options: ResolveAlvCliInvocationOptions = {}): CliInvocation {
-  const binaryPath = resolveBinaryCandidates(options).find(candidate => existsSync(candidate));
+  const configuredBinaryPath = resolveConfiguredCliBinaryPath(options);
+  const candidates = resolveBinaryCandidates(options);
+
+  if (configuredBinaryPath) {
+    if (existsSync(configuredBinaryPath)) {
+      return {
+        command: configuredBinaryPath,
+        args: []
+      };
+    }
+    throw new Error(formatMissingBinaryMessage(configuredBinaryPath, candidates));
+  }
+
+  const binaryPath = candidates.find(candidate => existsSync(candidate));
   if (binaryPath) {
     return {
       command: binaryPath,
@@ -111,15 +156,14 @@ export function resolveAlvCliInvocation(options: ResolveAlvCliInvocationOptions 
     }
   }
 
-  throw new Error(
-    `Unable to locate apex-log-viewer standalone binary. Checked: ${resolveBinaryCandidates(options).join(', ')}`
-  );
+  throw new Error(formatMissingBinaryMessage(undefined, resolveBinaryCandidates(options)));
 }
 
 export async function runAlvCli(args: string[], options: CliExecOptions = {}): Promise<CliRunResult> {
   const invocation = resolveAlvCliInvocation({
     repoRoot: options.repoRoot,
-    allowWindowsCommandShim: options.allowWindowsCommandShim
+    allowWindowsCommandShim: options.allowWindowsCommandShim,
+    env: options.env
   });
   const finalArgs = [...invocation.args, ...args.map(value => String(value ?? ''))];
 

--- a/test/e2e/cli/utils/cli.ts
+++ b/test/e2e/cli/utils/cli.ts
@@ -55,8 +55,15 @@ function resolveBinaryCandidates(options: ResolveAlvCliBinaryPathOptions = {}): 
   return resolveBinaryCandidatesForName(resolveBinaryName(options.platform), options);
 }
 
+function resolveCliEnvironment(options: ResolveAlvCliBinaryPathOptions = {}): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...options.env
+  };
+}
+
 function resolveConfiguredCliBinaryPath(options: ResolveAlvCliBinaryPathOptions = {}): string | undefined {
-  const rawPath = String((options.env ?? process.env).ALV_CLI_BINARY_PATH ?? '').trim();
+  const rawPath = String(resolveCliEnvironment(options).ALV_CLI_BINARY_PATH ?? '').trim();
   if (!rawPath) {
     return undefined;
   }
@@ -160,10 +167,11 @@ export function resolveAlvCliInvocation(options: ResolveAlvCliInvocationOptions 
 }
 
 export async function runAlvCli(args: string[], options: CliExecOptions = {}): Promise<CliRunResult> {
+  const env = resolveCliEnvironment({ env: options.env });
   const invocation = resolveAlvCliInvocation({
     repoRoot: options.repoRoot,
     allowWindowsCommandShim: options.allowWindowsCommandShim,
-    env: options.env
+    env
   });
   const finalArgs = [...invocation.args, ...args.map(value => String(value ?? ''))];
 
@@ -173,10 +181,7 @@ export async function runAlvCli(args: string[], options: CliExecOptions = {}): P
       finalArgs,
       {
         cwd: options.cwd,
-        env: {
-          ...process.env,
-          ...options.env
-        },
+        env,
         encoding: 'utf8',
         timeout: options.timeoutMs ?? 120_000,
         maxBuffer: 1024 * 1024 * 20


### PR DESCRIPTION
## Summary
- replace the tracked `.envrc` with Cargo's native `build.target-dir` config
- ignore future local `.envrc` files to avoid reintroducing direnv approval prompts
- make the runtime binary copy script read Cargo's effective `target_directory` from `cargo metadata`

## Verification
- `git diff --check origin/main..HEAD`
- `env -u CARGO_TARGET_DIR cargo metadata --format-version=1 --no-deps`
- `node --test scripts/copy-runtime-binary.test.js`
- `npm run build:runtime`
