### PR TITLE
[codex] Prepare 0.48.0 extension release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 
 ## Unreleased
 
+## [0.48.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.46.0...v0.48.0) (2026-05-08)
+
 ### Features
 
 - Runtime/Logs: share the Rust `logs/sync` path between CLI and extension, index synced log bodies in `apexlogs/.alv/log-index.sqlite`, add `logs index rebuild`, and let Refresh Logs start sync in the background before rerunning triage/search.
 
 ### Bug Fixes
 
+- Telemetry/Azure Monitor: emit path-safe daemon request method names and ignore legacy redacted method aggregates in the daemon degradation alert so alerts identify actionable runtime methods. ([#785](https://github.com/Electivus/Apex-Log-Viewer/pull/785))
 - Logs/Tail: increase webview startup timing windows so slow corporate machines can finish VS Code webview/service-worker bootstrap before the extension retries the mount.
 - Logs/Tail: retain webview context while hidden, avoid placeholder remounts during hide/show, and add a diagnostics package command with lifecycle evidence for service-worker/bootstrap failures.
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "0.46.0",
+  "version": "0.48.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.46.0",
+  "version": "0.48.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -81,7 +81,7 @@
     },
     "apps/vscode-extension": {
       "name": "apex-log-viewer",
-      "version": "0.46.0",
+      "version": "0.48.0",
       "license": "MIT",
       "engines": {
         "node": ">=22.15.1",


### PR DESCRIPTION
## Summary

- Prepare the stable VS Code extension release `0.48.0`.
- Move current `Unreleased` entries into the `0.48.0` changelog section, including the Azure Monitor telemetry fix from #785.
- Bump the extension package version and lockfile metadata from `0.46.0` to `0.48.0`.

## Notes

- This is an extension release only; the standalone CLI/npm runtime train is unchanged.
- After this PR merges, create and push tag `v0.48.0` to trigger the release workflow.

## Validation

- `git diff --check`
- `npx --yes -p node@22.15.1 -p npm@10.9.2 npm run check-types`