### PR TITLE
[codex] Prepare 0.48.1 Open VSX metadata fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## [0.48.1](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.0...v0.48.1) (2026-05-08)
+
+### Bug Fixes
+
+- Packaging/Open VSX: keep the packaged extension display name and description literal in `package.json` so Open VSX accepts the generated VSIX metadata.
+
 ## [0.48.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.46.0...v0.48.0) (2026-05-08)
 
 ### Features

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -1,8 +1,8 @@
 {
   "name": "apex-log-viewer",
-  "displayName": "%extension.displayName%",
-  "description": "%extension.description%",
-  "version": "0.48.0",
+  "displayName": "Electivus Apex Log Viewer",
+  "description": "Fast, searchable Salesforce Apex logs in VS Code — browse, filter, tail, and debug with Apex Replay.",
+  "version": "0.48.1",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",

--- a/apps/vscode-extension/src/test/packageManifest.test.ts
+++ b/apps/vscode-extension/src/test/packageManifest.test.ts
@@ -3,6 +3,16 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 suite('package manifest', () => {
+  test('uses literal extension marketplace metadata for Open VSX compatibility', async () => {
+    const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
+    const raw = await readFile(path.join(repoRoot, 'apps', 'vscode-extension', 'package.json'), 'utf8');
+    const manifest = JSON.parse(raw) as { displayName?: string; description?: string };
+
+    assert.equal(manifest.displayName, 'Electivus Apex Log Viewer');
+    assert.equal(manifest.description?.startsWith('%'), false);
+    assert.equal(manifest.description?.endsWith('%'), false);
+  });
+
   test('does not require Apex Replay Debugger as an extension dependency', async () => {
     const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
     const raw = await readFile(path.join(repoRoot, 'package.json'), 'utf8');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "apex-log-viewer",
-  "version": "0.48.0",
+  "version": "0.48.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -81,7 +81,7 @@
     },
     "apps/vscode-extension": {
       "name": "apex-log-viewer",
-      "version": "0.48.0",
+      "version": "0.48.1",
       "license": "MIT",
       "engines": {
         "node": ">=22.15.1",


### PR DESCRIPTION
## Summary

- Prepare patch release `0.48.1` after the `v0.48.0` release workflow failed only in the Open VSX publish job.
- Replace localized placeholder values for the extension `displayName` and `description` in the packaged `package.json` with the literal public metadata that `vsce` already writes into `extension.vsixmanifest`.
- Add a package manifest regression test so marketplace metadata does not go back to placeholder values.

## Root Cause

Open VSX rejected the `0.48.0` VSIX with:

```text
Display name in extension.vsixmanifest and package.json does not match.
```

The VSIX had `extension.vsixmanifest` display name resolved to `Electivus Apex Log Viewer`, while the packaged `package.json` still had `%extension.displayName%`.

## Release Notes

After this PR merges, create and push tag `v0.48.1`. Do not retag `v0.48.0`; that version already published to the VS Code Marketplace and has GitHub release artifacts.

## Validation

- `git diff --check`
- `npx --yes -p node@22.15.1 -p npm@10.9.2 npm run check-types`
- `npx --yes -p node@22.15.1 -p npm@10.9.2 npm run compile-tests`
- `npx --yes -p node@22.15.1 -p npm@10.9.2 npm run test:extension:node`