### PR TITLE
[codex] test(extension): tighten Open VSX metadata regression

### DIFF
--- a/apps/vscode-extension/src/test/packageManifest.test.ts
+++ b/apps/vscode-extension/src/test/packageManifest.test.ts
@@ -3,14 +3,16 @@ import { readFile } from 'node:fs/promises';
 import path from 'node:path';
 
 suite('package manifest', () => {
-  test('uses literal extension marketplace metadata for Open VSX compatibility', async () => {
+  test('uses literal default extension metadata for Open VSX compatibility', async () => {
     const repoRoot = path.resolve(__dirname, '..', '..', '..', '..');
-    const raw = await readFile(path.join(repoRoot, 'apps', 'vscode-extension', 'package.json'), 'utf8');
+    const appRoot = path.join(repoRoot, 'apps', 'vscode-extension');
+    const raw = await readFile(path.join(appRoot, 'package.json'), 'utf8');
+    const nlsRaw = await readFile(path.join(appRoot, 'package.nls.json'), 'utf8');
     const manifest = JSON.parse(raw) as { displayName?: string; description?: string };
+    const defaultNls = JSON.parse(nlsRaw) as { 'extension.displayName'?: string; 'extension.description'?: string };
 
-    assert.equal(manifest.displayName, 'Electivus Apex Log Viewer');
-    assert.equal(manifest.description?.startsWith('%'), false);
-    assert.equal(manifest.description?.endsWith('%'), false);
+    assert.equal(manifest.displayName, defaultNls['extension.displayName']);
+    assert.equal(manifest.description, defaultNls['extension.description']);
   });
 
   test('does not require Apex Replay Debugger as an extension dependency', async () => {


### PR DESCRIPTION
## Summary

- tighten the Open VSX metadata regression test so the extension manifest literals must match the default NLS strings
- cover the description value exactly instead of only checking that it is not wrapped in percent placeholders

## Why

The recent Open VSX metadata fix made `displayName` and `description` literal in `apps/vscode-extension/package.json`. The existing regression could still pass with a wrong literal description, so this keeps the packaged marketplace metadata aligned with the canonical default NLS values.

## Validation

- targeted Mocha run for `apps/vscode-extension/src/test/packageManifest.test.ts`: 5 passing
- `npx --yes --package node@22.15.1 node ./node_modules/typescript/bin/tsc --noEmit -p tsconfig.extension.json`

Note: `npm ci` with lifecycle scripts hit a local native `tree-sitter-sfapex`/`node-gyp` Visual Studio toolchain error, so dependencies were installed with `npm ci --ignore-scripts` for this manifest-only validation.