### PR TITLE
chore(cli): prepare 0.1.12 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Runtime/Orgs: avoid slow `sf org list` startup/plugin work by reading local Salesforce org state first, and cache/coalesce shared runtime auth resolution to reduce repeated `sf org display` calls during refresh and sync.
 
+### Chores
+
+- CLI/Runtime: bump the standalone runtime train to `0.1.12` so the CLI release packages the sf CLI performance and auth-refresh fixes.
+
 ## [0.48.1](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.0...v0.48.1) (2026-05-08)
 
 ### Bug Fixes

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,7 +25,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -36,7 +36,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "chrono",
  "grep",
@@ -53,11 +53,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.11"
+version = "0.1.12"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "serde",
  "serde_json",
@@ -124,7 +124,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.11"
+version = "0.1.12"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.11",
-  "tag": "rust-v0.1.11",
+  "cliVersion": "0.1.12",
+  "tag": "rust-v0.1.12",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.11", path = "../alv-core" }
-alv-protocol = { version = "0.1.11", path = "../alv-protocol" }
+alv-core = { version = "0.1.12", path = "../alv-core" }
+alv-protocol = { version = "0.1.12", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.52", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.11", path = "../alv-app-server" }
-alv-core = { version = "0.1.11", path = "../alv-core" }
+alv-app-server = { version = "0.1.12", path = "../alv-app-server" }
+alv-core = { version = "0.1.12", path = "../alv-core" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.11"
+version = "0.1.12"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -188,8 +188,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.11',
-    tag: 'rust-v0.1.11',
+    cliVersion: '0.1.12',
+    tag: 'rust-v0.1.12',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary
- Bump the Rust runtime/CLI workspace crates and lockfile from `0.1.11` to `0.1.12`.
- Update `config/runtime-bundle.json` to pin extension packaging to `rust-v0.1.12`.
- Refresh the packaging CI expectation and changelog entry for the CLI release.
- After merge, push tag `rust-v0.1.12` to trigger the CLI release workflow.

## Linked Issues
- Relates-to #792

## Screenshots / GIFs (UI)
- N/A, release metadata only.

## Verification Steps
- `cargo check -p apex-log-viewer-cli`
- `git diff --check`
- `npm run test:scripts`
- `npm run test:rust:smoke`

## Risk / Rollback
- Low risk: metadata/version bump only. Roll back by reverting this commit before creating the `rust-v0.1.12` tag.

## Checklist
- [ ] `npm run build` passes
- [ ] `npm test` (or `npm run test:all`) passes; integration tests prefixed with `integration`
- [ ] Lint/Types: `npm run lint` and `npm run check-types`
- [ ] Docs updated (AGENTS.md/README snippets if applicable)
- [x] No secrets or org-sensitive data added