### PR TITLE
[codex] fix proxy-lab Dev Hub auth preflight

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -121,7 +121,7 @@ Useful env vars:
 - The proxy requires Basic authentication using test-only credentials in the proxy URL, matching the corporate shape `http://username:pwd@proxy.company.com:8080`.
 - The lab waits for mitmproxy to generate its CA, then proves that authenticated HTTPS through the proxy fails before that CA is trusted.
 - The runner installs the mitmproxy CA into the container trust store, exports `NODE_USE_SYSTEM_CA=1`, `ALV_E2E_USE_SYSTEM_CA=1`, `NODE_EXTRA_CA_CERTS`, and `SSL_CERT_FILE`, and keeps VS Code `http.proxyStrictSSL` enabled.
-- The lab verifies that `curl` and a dependency-free Node HTTPS check can reach the internet through the authenticated MITM proxy after CA trust is installed. When `SF_DEVHUB_AUTH_URL` is provided, it also verifies Salesforce CLI traffic can reach Salesforce through the proxy; otherwise `run.sh` skips that preflight.
+- The lab verifies that `curl` and a dependency-free Node HTTPS check can reach the internet through the authenticated MITM proxy after CA trust is installed. Real-org commands fail fast when `SF_DEVHUB_AUTH_URL` is missing; explicit non-real-org smoke commands skip the Salesforce CLI preflight.
 - Real-org proxy-lab runs require `SF_DEVHUB_AUTH_URL`; a host `SF_DEVHUB_ALIAS` is not sufficient inside the clean runner container.
 - After logging in from `SF_DEVHUB_AUTH_URL`, the lab uses `ConfiguredDevHub` as the container-local Dev Hub alias by default. `ALV_E2E_PROXY_LAB_DEVHUB_ALIAS` only changes that container-local alias.
 - The lab sets `SFDX_DISABLE_DNS_CHECK=true` because the runner has no direct DNS/egress path to Salesforce; Salesforce CLI traffic must be validated through the proxy instead.
@@ -131,6 +131,13 @@ By default the lab runs `npm run test:e2e`. To run another E2E command inside th
 
 ```bash
 npm run test:e2e:proxy-lab -- npm run test:e2e:cli
+```
+
+For local real-org proxy-lab runs, derive an auth URL from an already-authenticated Dev Hub on the host and pass it into the clean container:
+
+```bash
+ALV_LOCAL_DEVHUB_AUTH_URL="$(sf org display --verbose -o <dev-hub-alias> --json | jq -r '.result.sfdxAuthUrl')"
+SF_DEVHUB_AUTH_URL="${ALV_LOCAL_DEVHUB_AUTH_URL}" SF_TEST_KEEP_ORG=1 npm run test:e2e:proxy-lab
 ```
 
 To target the extension runtime/daemon path that powers `logs/list` without paying the full VS Code UI startup cost:

--- a/scripts/run-e2e-proxy-lab.test.js
+++ b/scripts/run-e2e-proxy-lab.test.js
@@ -144,6 +144,18 @@ test('proxy lab runner script validates MITM trust before running E2E commands',
   assert.match(script, /preflight_salesforce_cli/);
 });
 
+test('proxy lab runner requires Dev Hub auth for real-org commands only', () => {
+  const script = readProxyLabScript();
+
+  assert.match(script, /requested_command_requires_devhub\(\)/);
+  assert.match(script, /SF_DEVHUB_AUTH_URL is required for real-org proxy-lab commands/);
+  assert.match(script, /clean runner container cannot use host Salesforce CLI aliases/);
+  assert.match(script, /if \[\[ "\$#" -eq 0 && -z "\$\{ALV_E2E_PROXY_LAB_COMMAND:-\}" \]\]; then/);
+  assert.match(script, /\*"test:e2e"\*/);
+  assert.match(script, /requested command does not look like a real-org E2E run/);
+  assert.match(script, /preflight_salesforce_cli "\$@"/);
+});
+
 test('proxy lab sf preflight preserves failed command exit status', () => {
   const script = readProxyLabScript();
   const body = script.match(/run_sf_preflight_command\(\) \{(?<body>[\s\S]*?)\n\}/)?.groups.body;

--- a/test/e2e/proxy-lab/run.sh
+++ b/test/e2e/proxy-lab/run.sh
@@ -367,9 +367,27 @@ run_sf_preflight_command() {
   return "${status}"
 }
 
+requested_command_requires_devhub() {
+  if [[ "$#" -eq 0 && -z "${ALV_E2E_PROXY_LAB_COMMAND:-}" ]]; then
+    return 0
+  fi
+
+  local requested_command="$* ${ALV_E2E_PROXY_LAB_COMMAND:-}"
+  case "${requested_command}" in
+    *"test:e2e"*)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
 preflight_salesforce_cli() {
   if [[ -z "${SF_DEVHUB_AUTH_URL:-}" ]]; then
-    echo "[proxy-lab] Skipping Salesforce CLI network preflight because SF_DEVHUB_AUTH_URL is not set."
+    if requested_command_requires_devhub "$@"; then
+      fail "SF_DEVHUB_AUTH_URL is required for real-org proxy-lab commands because the clean runner container cannot use host Salesforce CLI aliases. Export a Dev Hub SFDX auth URL or pass an explicit non-real-org smoke command after '--'."
+    fi
+    echo "[proxy-lab] Skipping Salesforce CLI network preflight because SF_DEVHUB_AUTH_URL is not set and the requested command does not look like a real-org E2E run."
     return 0
   fi
 
@@ -414,5 +432,5 @@ install_mitm_ca
 verify_authenticated_mitm_proxy
 install_dependencies
 verify_node_https_proxy
-preflight_salesforce_cli
+preflight_salesforce_cli "$@"
 run_requested_command "$@"


### PR DESCRIPTION
## Summary
- fail fast when real-org proxy-lab commands run without `SF_DEVHUB_AUTH_URL`
- keep explicit non-real-org smoke commands working without Dev Hub auth
- document how to derive a local Dev Hub auth URL for the clean Docker runner

## Root cause
`npm run test:e2e:proxy-lab` skipped the Salesforce CLI preflight when `SF_DEVHUB_AUTH_URL` was missing, then continued into the default `npm run test:e2e` command. The clean Docker runner cannot see host `sf` aliases, so Playwright failed later with `ConfiguredDevHub` not authenticated.

## Validation
- `node --test scripts/run-e2e-proxy-lab.test.js`
- `ALV_E2E_PROXY_LAB_SKIP_NPM_CI=1 npm run test:e2e:proxy-lab -- bash -lc 'echo proxy-lab-smoke'`\n- `ALV_E2E_PROXY_LAB_SKIP_NPM_CI=1 npm run test:e2e:proxy-lab` now fails fast with the new missing `SF_DEVHUB_AUTH_URL` message\n- local Dev Hub auth URL smoke through proxy-lab: `sf org display -o ConfiguredDevHub --json >/dev/null` inside the runner\n- `npm run test:scripts`