### PR TITLE
fix(release): sync prerelease version across marketplaces

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -402,7 +402,18 @@ jobs:
           fi
           for FILE in "${FILES[@]}"; do
             echo "Publishing ${FILE} to Open VSX"
-            npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release
+            set +e
+            OUTPUT=$(npx --yes ovsx publish --pat "${OVSX_PAT}" --packagePath "${FILE}" --pre-release 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -F "is already published." >/dev/null 2>&1; then
+                echo "Skipping ${FILE}; Open VSX already has this version and target."
+                continue
+              fi
+              exit "$STATUS"
+            fi
           done
 
   rollback_prerelease:

--- a/scripts/compute-prerelease-version.mjs
+++ b/scripts/compute-prerelease-version.mjs
@@ -62,10 +62,10 @@ export function readExtensionManifest(manifestPath) {
   };
 }
 
-export function findLatestPublishedPrereleasePatch(marketplaceVersions, { major, minor }) {
+export function findLatestPublishedPrereleasePatch(publishedVersions, { major, minor }) {
   let latestPatch = -1;
 
-  for (const entry of marketplaceVersions) {
+  for (const entry of publishedVersions) {
     const parsed = parseSemver(entry?.version);
     if (!parsed) {
       continue;
@@ -84,14 +84,14 @@ export function findLatestPublishedPrereleasePatch(marketplaceVersions, { major,
   return latestPatch;
 }
 
-export function computeNextPrereleaseVersion({ baseVersion, marketplaceVersions }) {
+export function computeNextPrereleaseVersion({ baseVersion, publishedVersions }) {
   const parsedBase = parseSemver(baseVersion);
   if (!parsedBase) {
     throw new Error(`expected a plain semver extension version, got ${JSON.stringify(baseVersion)}`);
   }
 
   const targetMinor = normalizePrereleaseMinor(parsedBase.minor);
-  const latestPublishedPatch = findLatestPublishedPrereleasePatch(marketplaceVersions, {
+  const latestPublishedPatch = findLatestPublishedPrereleasePatch(publishedVersions, {
     major: parsedBase.major,
     minor: targetMinor
   });
@@ -224,6 +224,7 @@ export async function main(
   {
     cwd = process.cwd(),
     stdout = process.stdout,
+    stderr = process.stderr,
     spawnSyncImpl = spawnSync,
     vsceCliPath,
     processExecPath = process.execPath,
@@ -239,10 +240,16 @@ export async function main(
     processExecPath,
     cwd
   });
-  const openVsxVersions = await fetchOpenVsxVersions(extensionId, { fetchImpl });
+  let openVsxVersions = [];
+  try {
+    openVsxVersions = await fetchOpenVsxVersions(extensionId, { fetchImpl });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stderr.write(`Warning: ${message}; continuing with VS Code Marketplace versions only.\n`);
+  }
   const nextVersion = computeNextPrereleaseVersion({
     baseVersion,
-    marketplaceVersions: [...marketplaceVersions, ...openVsxVersions]
+    publishedVersions: [...marketplaceVersions, ...openVsxVersions]
   });
 
   stdout.write(nextVersion);

--- a/scripts/compute-prerelease-version.mjs
+++ b/scripts/compute-prerelease-version.mjs
@@ -26,6 +26,21 @@ function normalizePrereleaseMinor(minor) {
   return minor % 2 === 0 ? minor + 1 : minor;
 }
 
+function isVscePrerelease(entry) {
+  return (
+    Array.isArray(entry?.properties) &&
+    entry.properties.some(
+      property =>
+        property?.key === 'Microsoft.VisualStudio.Code.PreRelease' &&
+        String(property?.value) === 'true'
+    )
+  );
+}
+
+function isOpenVsxPrerelease(entry) {
+  return entry?.preRelease === true;
+}
+
 function formatSpawnError(prefix, result) {
   const details = [result.stdout, result.stderr]
     .filter(value => typeof value === 'string' && value.trim().length > 0)
@@ -51,18 +66,13 @@ export function findLatestPublishedPrereleasePatch(marketplaceVersions, { major,
   let latestPatch = -1;
 
   for (const entry of marketplaceVersions) {
-    const isPrerelease = Array.isArray(entry?.properties)
-      && entry.properties.some(
-        property =>
-          property?.key === 'Microsoft.VisualStudio.Code.PreRelease'
-          && String(property?.value) === 'true'
-      );
-    if (!isPrerelease) {
+    const parsed = parseSemver(entry?.version);
+    if (!parsed) {
       continue;
     }
 
-    const parsed = parseSemver(entry?.version);
-    if (!parsed) {
+    const isPrerelease = isVscePrerelease(entry) || isOpenVsxPrerelease(entry);
+    if (!isPrerelease) {
       continue;
     }
 
@@ -129,6 +139,61 @@ export function fetchMarketplaceVersions(
   return Array.isArray(payload.versions) ? payload.versions : [];
 }
 
+export function openVsxApiUrlForExtension(extensionId) {
+  const separatorIndex = String(extensionId).indexOf('.');
+  if (separatorIndex <= 0 || separatorIndex === String(extensionId).length - 1) {
+    throw new Error(`expected extension id in publisher.name form, got ${JSON.stringify(extensionId)}`);
+  }
+  const namespace = encodeURIComponent(String(extensionId).slice(0, separatorIndex));
+  const name = encodeURIComponent(String(extensionId).slice(separatorIndex + 1));
+  return `https://open-vsx.org/api/${namespace}/${name}`;
+}
+
+export function versionsFromOpenVsxPayload(payload) {
+  const versions = new Set();
+  if (payload?.allVersions && typeof payload.allVersions === 'object') {
+    for (const version of Object.keys(payload.allVersions)) {
+      versions.add(version);
+    }
+  }
+  if (typeof payload?.version === 'string' && payload.version.trim()) {
+    versions.add(payload.version.trim());
+  }
+
+  return Array.from(versions).map(version => {
+    const parsed = parseSemver(version);
+    return {
+      version,
+      preRelease: parsed ? parsed.minor % 2 === 1 : false,
+      source: 'open-vsx'
+    };
+  });
+}
+
+export async function fetchOpenVsxVersions(
+  extensionId,
+  {
+    fetchImpl = globalThis.fetch
+  } = {}
+) {
+  if (typeof fetchImpl !== 'function') {
+    throw new Error('fetch is unavailable; cannot query Open VSX versions');
+  }
+
+  const url = openVsxApiUrlForExtension(extensionId);
+  const response = await fetchImpl(url, {
+    headers: {
+      accept: 'application/json'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`Open VSX version query failed for ${extensionId}: HTTP ${response.status}`);
+  }
+
+  return versionsFromOpenVsxPayload(await response.json());
+}
+
 function parseArgs(argv) {
   const options = {
     manifestPath: 'apps/vscode-extension/package.json'
@@ -154,14 +219,15 @@ function parseArgs(argv) {
   return options;
 }
 
-export function main(
+export async function main(
   argv = process.argv.slice(2),
   {
     cwd = process.cwd(),
     stdout = process.stdout,
     spawnSyncImpl = spawnSync,
     vsceCliPath,
-    processExecPath = process.execPath
+    processExecPath = process.execPath,
+    fetchImpl = globalThis.fetch
   } = {}
 ) {
   const { manifestPath } = parseArgs(argv);
@@ -173,7 +239,11 @@ export function main(
     processExecPath,
     cwd
   });
-  const nextVersion = computeNextPrereleaseVersion({ baseVersion, marketplaceVersions });
+  const openVsxVersions = await fetchOpenVsxVersions(extensionId, { fetchImpl });
+  const nextVersion = computeNextPrereleaseVersion({
+    baseVersion,
+    marketplaceVersions: [...marketplaceVersions, ...openVsxVersions]
+  });
 
   stdout.write(nextVersion);
   return nextVersion;
@@ -185,7 +255,7 @@ export function isDirectExecution(argvEntry, moduleUrl = import.meta.url) {
 
 if (isDirectExecution(process.argv[1])) {
   try {
-    main();
+    await main();
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     process.exitCode = 1;

--- a/scripts/compute-prerelease-version.test.js
+++ b/scripts/compute-prerelease-version.test.js
@@ -16,7 +16,7 @@ test('computeNextPrereleaseVersion increments from the latest published prerelea
 
   const nextVersion = mod.computeNextPrereleaseVersion({
     baseVersion: '0.42.0',
-    marketplaceVersions: [
+    publishedVersions: [
       { version: '0.43.1', targetPlatform: 'linux-x64', properties: prereleaseProperties() },
       { version: '0.43.1', targetPlatform: 'linux-arm64', properties: prereleaseProperties() },
       { version: '0.43.1', targetPlatform: 'win32-x64', properties: prereleaseProperties() },
@@ -33,7 +33,7 @@ test('computeNextPrereleaseVersion advances beyond Open VSX prerelease patches',
 
   const nextVersion = mod.computeNextPrereleaseVersion({
     baseVersion: '0.48.1',
-    marketplaceVersions: [
+    publishedVersions: [
       { version: '0.49.2', properties: prereleaseProperties() },
       { version: '0.49.3', preRelease: true, source: 'open-vsx' },
       { version: '0.48.2', preRelease: false, source: 'open-vsx' }
@@ -48,7 +48,7 @@ test('computeNextPrereleaseVersion advances from the manifest patch when it is a
 
   const nextVersion = mod.computeNextPrereleaseVersion({
     baseVersion: '0.43.5',
-    marketplaceVersions: [
+    publishedVersions: [
       { version: '0.43.4', targetPlatform: 'linux-x64', properties: prereleaseProperties() }
     ]
   });
@@ -180,6 +180,69 @@ test('main reads the extension manifest and writes the computed version', async 
 
     assert.equal(nextVersion, '0.43.3');
     assert.equal(stdout, '0.43.3');
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});
+
+test('main warns and continues with Marketplace versions when Open VSX lookup fails', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-prerelease-version-'));
+  let stdout = '';
+  let stderr = '';
+
+  try {
+    fs.mkdirSync(path.join(repoRoot, 'apps', 'vscode-extension'), { recursive: true });
+    fs.writeFileSync(
+      path.join(repoRoot, 'apps', 'vscode-extension', 'package.json'),
+      JSON.stringify({
+        name: 'apex-log-viewer',
+        publisher: 'electivus',
+        version: '0.42.0'
+      }, null, 2)
+    );
+
+    const nextVersion = await mod.main(
+      ['--manifest', 'apps/vscode-extension/package.json'],
+      {
+        cwd: repoRoot,
+        stdout: {
+          write(chunk) {
+            stdout += chunk;
+          }
+        },
+        stderr: {
+          write(chunk) {
+            stderr += chunk;
+          }
+        },
+        processExecPath: '/usr/bin/node',
+        vsceCliPath: '/repo/node_modules/@vscode/vsce/vsce',
+        async fetchImpl() {
+          return {
+            ok: false,
+            status: 503,
+            async json() {
+              return {};
+            }
+          };
+        },
+        spawnSyncImpl() {
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              versions: [{ version: '0.43.1', properties: prereleaseProperties() }]
+            }),
+            stderr: ''
+          };
+        }
+      }
+    );
+
+    assert.equal(nextVersion, '0.43.2');
+    assert.equal(stdout, '0.43.2');
+    assert.match(stderr, /Warning: Open VSX version query failed for electivus\.apex-log-viewer: HTTP 503/);
+    assert.match(stderr, /continuing with VS Code Marketplace versions only/);
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/scripts/compute-prerelease-version.test.js
+++ b/scripts/compute-prerelease-version.test.js
@@ -28,6 +28,21 @@ test('computeNextPrereleaseVersion increments from the latest published prerelea
   assert.equal(nextVersion, '0.43.2');
 });
 
+test('computeNextPrereleaseVersion advances beyond Open VSX prerelease patches', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+
+  const nextVersion = mod.computeNextPrereleaseVersion({
+    baseVersion: '0.48.1',
+    marketplaceVersions: [
+      { version: '0.49.2', properties: prereleaseProperties() },
+      { version: '0.49.3', preRelease: true, source: 'open-vsx' },
+      { version: '0.48.2', preRelease: false, source: 'open-vsx' }
+    ]
+  });
+
+  assert.equal(nextVersion, '0.49.4');
+});
+
 test('computeNextPrereleaseVersion advances from the manifest patch when it is already ahead of the marketplace', async () => {
   const mod = await import(pathToFileURL(modulePath).href);
 
@@ -72,6 +87,45 @@ test('fetchMarketplaceVersions invokes vsce show via node with a larger max buff
   });
 });
 
+test('fetchOpenVsxVersions reads all Open VSX versions and marks odd minors as prereleases', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  let requestedUrl;
+
+  const versions = await mod.fetchOpenVsxVersions('electivus.apex-log-viewer', {
+    async fetchImpl(url, options) {
+      requestedUrl = { url, options };
+      return {
+        ok: true,
+        status: 200,
+        async json() {
+          return {
+            version: '0.49.3',
+            allVersions: {
+              '0.48.1': 'https://open-vsx.org/api/electivus/apex-log-viewer/0.48.1',
+              '0.49.2': 'https://open-vsx.org/api/electivus/apex-log-viewer/0.49.2',
+              '0.49.3': 'https://open-vsx.org/api/electivus/apex-log-viewer/0.49.3'
+            }
+          };
+        }
+      };
+    }
+  });
+
+  assert.deepEqual(requestedUrl, {
+    url: 'https://open-vsx.org/api/electivus/apex-log-viewer',
+    options: {
+      headers: {
+        accept: 'application/json'
+      }
+    }
+  });
+  assert.deepEqual(versions, [
+    { version: '0.48.1', preRelease: false, source: 'open-vsx' },
+    { version: '0.49.2', preRelease: true, source: 'open-vsx' },
+    { version: '0.49.3', preRelease: true, source: 'open-vsx' }
+  ]);
+});
+
 test('main reads the extension manifest and writes the computed version', async () => {
   const mod = await import(pathToFileURL(modulePath).href);
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-prerelease-version-'));
@@ -88,7 +142,7 @@ test('main reads the extension manifest and writes the computed version', async 
       }, null, 2)
     );
 
-    const nextVersion = mod.main(
+    const nextVersion = await mod.main(
       ['--manifest', 'apps/vscode-extension/package.json'],
       {
         cwd: repoRoot,
@@ -99,6 +153,19 @@ test('main reads the extension manifest and writes the computed version', async 
         },
         processExecPath: '/usr/bin/node',
         vsceCliPath: '/repo/node_modules/@vscode/vsce/vsce',
+        async fetchImpl() {
+          return {
+            ok: true,
+            status: 200,
+            async json() {
+              return {
+                allVersions: {
+                  '0.43.2': 'https://open-vsx.org/api/electivus/apex-log-viewer/0.43.2'
+                }
+              };
+            }
+          };
+        },
         spawnSyncImpl() {
           return {
             status: 0,
@@ -111,8 +178,8 @@ test('main reads the extension manifest and writes the computed version', async 
       }
     );
 
-    assert.equal(nextVersion, '0.43.2');
-    assert.equal(stdout, '0.43.2');
+    assert.equal(nextVersion, '0.43.3');
+    assert.equal(stdout, '0.43.3');
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -119,7 +119,7 @@ for (const workflowPath of ['.github/workflows/prerelease.yml', '.github/workflo
   });
 }
 
-test('prerelease workflow computes the next Marketplace version via the dedicated helper script', () => {
+test('prerelease workflow computes the next publish version via the dedicated helper script', () => {
   const workflowSource = readFile('.github/workflows/prerelease.yml');
 
   assert.match(
@@ -131,6 +131,21 @@ test('prerelease workflow computes the next Marketplace version via the dedicate
     workflowSource,
     /spawnSync\('\.\/node_modules\/\.bin\/vsce'/,
     'expected the prerelease workflow to stop embedding the vsce Marketplace query inline in YAML'
+  );
+});
+
+test('prerelease Open VSX publish skips already published target artifacts', () => {
+  const publishJob = readWorkflowJob('.github/workflows/prerelease.yml', 'publish_open_vsx');
+
+  assert.match(
+    publishJob,
+    /OUTPUT=\$\(npx --yes ovsx publish --pat "\$\{OVSX_PAT\}" --packagePath "\$\{FILE\}" --pre-release 2>&1\)/,
+    'expected Open VSX publish output to be captured for duplicate-version handling'
+  );
+  assert.match(
+    publishJob,
+    /grep -F "is already published\."[\s\S]*?Skipping \$\{FILE\}; Open VSX already has this version and target\./,
+    'expected duplicate Open VSX target publishes to be skipped instead of failing the workflow'
   );
 });
 


### PR DESCRIPTION
## Summary
- compute nightly pre-release versions from both VS Code Marketplace and Open VSX published versions
- treat Open VSX odd-minor versions as pre-release candidates so the next nightly uses the highest published prerelease patch + 1 across registries
- make the pre-release Open VSX publish step idempotent by skipping per-target artifacts that are already published

## Validation
- node --test scripts/compute-prerelease-version.test.js scripts/packaging-ci.test.js
- node scripts/compute-prerelease-version.mjs --manifest apps/vscode-extension/package.json -> 0.49.4

## Context
Run 25969171921 failed because Open VSX already had electivus.apex-log-viewer 0.49.3 for darwin-arm64 while the workflow selected 0.49.3 from Marketplace-only version discovery. This change lets the next run advance to the highest prerelease patch known by either marketplace and keeps reruns from failing on already-published Open VSX target artifacts.