### PR TITLE
[codex] Wrap long log status text

### DIFF
--- a/docs/superpowers/plans/2026-05-19-status-column-wrap.md
+++ b/docs/superpowers/plans/2026-05-19-status-column-wrap.md
@@ -1,0 +1,139 @@
+# Status Column Wrap Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Keep long Salesforce `ApexLog.Status` messages inside the logs table `Status` column by allowing the text to wrap.
+
+**Architecture:** This is a presentation-only webview change. `LogRow` will keep rendering the raw `r.Status` string, but the status text span will be shrinkable and wrapping-friendly inside the existing grid/flex cell. Existing error and triage reason badges remain unchanged.
+
+**Tech Stack:** TypeScript, React, Tailwind utility classes, Jest, React Testing Library.
+
+---
+
+## File Map
+
+- `packages/webview/src/components/table/LogRow.tsx`: change the status text span classes and add a stable test id.
+- `packages/webview/src/__tests__/LogRow.test.tsx`: add a focused regression test for long status text wrapping classes.
+
+---
+
+## Task 1: Wrap Raw Salesforce Status Text In The Logs Table
+
+**Files:**
+- Modify: `packages/webview/src/__tests__/LogRow.test.tsx`
+- Modify: `packages/webview/src/components/table/LogRow.tsx`
+
+- [ ] **Step 1: Write the failing regression test**
+
+Add this test to `packages/webview/src/__tests__/LogRow.test.tsx` after `shows error badge on status column when error is detected`:
+
+```tsx
+  it('lets long Salesforce status text wrap inside the status column', () => {
+    const row: ApexLogRow = {
+      Id: 'long-status-1',
+      StartTime: new Date().toISOString(),
+      Operation: 'Op',
+      Application: 'App',
+      DurationMilliseconds: 1,
+      Status:
+        "Insert failed. First exception on row 0; first error: INVALID_INPUT, The selected language isn't currently supported. Apex error: List has no rows for assignment to SObject",
+      Request: '',
+      LogLength: 2048,
+      LogUser: { Name: 'User' }
+    };
+
+    render(
+      <LogRow
+        r={row}
+        logHead={{ 'long-status-1': { hasErrors: true, primaryReason: 'Validation failure' } as any }}
+        locale="en-US"
+        t={{ open: 'Open', replay: 'Replay', filters: { errorDetectedBadge: 'Error' } }}
+        columns={['status']}
+        loading={false}
+        onOpen={() => {}}
+        onReplay={() => {}}
+        gridTemplate="220px 96px"
+        style={{}}
+        index={0}
+        setRowHeight={() => {}}
+      />
+    );
+
+    const statusText = screen.getByTestId('logs-status-text');
+    expect(statusText).toHaveTextContent('List has no rows for assignment to SObject');
+    expect(statusText.className).toContain('min-w-0');
+    expect(statusText.className).toContain('max-w-full');
+    expect(statusText.className).toContain('whitespace-normal');
+    expect(statusText.className).toContain('break-words');
+    expect(statusText.className).not.toContain('shrink-0');
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('Validation failure')).toBeInTheDocument();
+  });
+```
+
+- [ ] **Step 2: Run the focused test and verify it fails**
+
+Run:
+
+```bash
+npm run test:webview -- --runTestsByPath packages/webview/src/__tests__/LogRow.test.tsx --runInBand
+```
+
+Expected: FAIL because `logs-status-text` does not exist yet and the current status span uses `shrink-0`.
+
+- [ ] **Step 3: Implement the minimal rendering change**
+
+In `packages/webview/src/components/table/LogRow.tsx`, replace the status text span in the `status` case:
+
+```tsx
+                  <span className="shrink-0">{r.Status}</span>
+```
+
+with:
+
+```tsx
+                  <span data-testid="logs-status-text" className="min-w-0 max-w-full whitespace-normal break-words">
+                    {r.Status}
+                  </span>
+```
+
+Leave the `Error` badge and the `primaryReason` badge unchanged.
+
+- [ ] **Step 4: Run the focused test and verify it passes**
+
+Run:
+
+```bash
+npm run test:webview -- --runTestsByPath packages/webview/src/__tests__/LogRow.test.tsx --runInBand
+```
+
+Expected: PASS for `LogRow.test.tsx`.
+
+- [ ] **Step 5: Run the full webview suite**
+
+Run:
+
+```bash
+npm run test:webview -- --runInBand
+```
+
+Expected: PASS for the webview Jest suite.
+
+- [ ] **Step 6: Review the diff**
+
+Run:
+
+```bash
+git diff -- packages/webview/src/components/table/LogRow.tsx packages/webview/src/__tests__/LogRow.test.tsx
+```
+
+Expected: The only implementation behavior change is the status text wrapping classes and test id; the test only covers this regression and existing badges.
+
+- [ ] **Step 7: Commit the implementation**
+
+Run:
+
+```bash
+git add packages/webview/src/components/table/LogRow.tsx packages/webview/src/__tests__/LogRow.test.tsx
+git commit -m "fix(logs): wrap long status text"
+```

--- a/docs/superpowers/specs/2026-05-19-status-column-wrap-design.md
+++ b/docs/superpowers/specs/2026-05-19-status-column-wrap-design.md
@@ -1,0 +1,73 @@
+# Status column text wrapping design
+
+## Context
+
+The logs table renders the Salesforce `ApexLog.Status` value directly in the `Status` column. For failed Apex logs, Salesforce can return a long exception message in that field instead of a short value such as `Success`.
+
+The current status text is rendered as a non-shrinking inline item inside a flex cell. When the status value is long, it can overflow across adjacent columns, making the row hard to read.
+
+## Goals
+
+- Preserve the raw `ApexLog.Status` value returned by Salesforce.
+- Keep the status text visually contained inside the `Status` column.
+- Let long status text wrap automatically instead of crossing into other columns.
+- Keep the existing `Error` and triage reason badges visible.
+- Avoid changing Salesforce API queries, triage logic, sorting, filtering, or log storage.
+
+## Non-goals
+
+- Do not normalize long Salesforce status values into `Failed`, `Error`, or another derived label.
+- Do not remove the existing error badge.
+- Do not remove the existing triage reason badge.
+- Do not redesign the full logs table or change the default column order.
+
+## Design
+
+Update only the webview rendering for the logs table `Status` cell. The cell should still display:
+
+1. the raw Salesforce status string;
+2. the `Error` badge when log triage reports an error;
+3. the primary triage reason badge when available.
+
+The raw status string should be rendered in an element that can shrink within the CSS grid/flex layout and wrap long text. The important layout constraints are:
+
+- the status text element must not use `shrink-0`;
+- the status text element should allow wrapping and breaking long words;
+- the status cell should keep `min-width: 0` behavior inherited from the shared cell class;
+- badges may remain non-shrinking so they stay readable.
+
+This preserves Salesforce data while preventing long exception text from overlaying neighboring columns.
+
+## Components affected
+
+- `packages/webview/src/components/table/LogRow.tsx`
+  - status text classes inside the `status` column case.
+- `packages/webview/src/__tests__/LogRow.test.tsx`
+  - focused regression coverage that long status text is rendered with wrapping-friendly classes instead of `shrink-0`.
+
+No runtime, CLI, extension host, or Rust changes are expected.
+
+## Data flow
+
+No data flow changes are required. `ApexLog.Status` continues to come from the existing log list response and arrives in `LogRow` as `r.Status`.
+
+Only presentation changes. Filtering and sorting by status continue to use the original `r.Status` string.
+
+## Testing and validation
+
+Automated coverage should assert that:
+
+- a long status value is rendered in the status column;
+- the status text uses wrapping-friendly classes;
+- the status text no longer uses the non-shrinking class that causes overflow risk;
+- existing error and reason badges still render when triage data is present.
+
+Expected verification:
+
+- Run the focused webview test for `LogRow`.
+- Run `npm run test:webview` if the focused test passes.
+
+## Risks
+
+- JSDOM cannot prove actual pixel-level table overflow, so the regression test should focus on the class contract that controls layout.
+- Very long Salesforce status messages will make affected rows taller. The logs table already measures variable row height with `ResizeObserver`, so this is an expected outcome.

--- a/packages/webview/src/__tests__/LogRow.test.tsx
+++ b/packages/webview/src/__tests__/LogRow.test.tsx
@@ -87,6 +87,48 @@ describe('LogRow', () => {
     expect(screen.getByText('Error')).toBeInTheDocument();
   });
 
+  it('lets long Salesforce status text wrap inside the status column', () => {
+    const row: ApexLogRow = {
+      Id: 'long-status-1',
+      StartTime: new Date().toISOString(),
+      Operation: 'Op',
+      Application: 'App',
+      DurationMilliseconds: 1,
+      Status:
+        "Insert failed. First exception on row 0; first error: INVALID_INPUT, The selected language isn't currently supported. Apex error: List has no rows for assignment to SObject",
+      Request: '',
+      LogLength: 2048,
+      LogUser: { Name: 'User' }
+    };
+
+    render(
+      <LogRow
+        r={row}
+        logHead={{ 'long-status-1': { hasErrors: true, primaryReason: 'Validation failure' } as any }}
+        locale="en-US"
+        t={{ open: 'Open', replay: 'Replay', filters: { errorDetectedBadge: 'Error' } }}
+        columns={['status']}
+        loading={false}
+        onOpen={() => {}}
+        onReplay={() => {}}
+        gridTemplate="220px 96px"
+        style={{}}
+        index={0}
+        setRowHeight={() => {}}
+      />
+    );
+
+    const statusText = screen.getByTestId('logs-status-text');
+    expect(statusText).toHaveTextContent('List has no rows for assignment to SObject');
+    expect(statusText.className).toContain('min-w-0');
+    expect(statusText.className).toContain('max-w-full');
+    expect(statusText.className).toContain('whitespace-normal');
+    expect(statusText.className).toContain('break-words');
+    expect(statusText.className).not.toContain('shrink-0');
+    expect(screen.getByText('Error')).toBeInTheDocument();
+    expect(screen.getByText('Validation failure')).toBeInTheDocument();
+  });
+
   it('shows a compact reason label next to the error badge', () => {
     const row: ApexLogRow = {
       Id: 'err-2',

--- a/packages/webview/src/components/table/LogRow.tsx
+++ b/packages/webview/src/components/table/LogRow.tsx
@@ -188,7 +188,9 @@ export function LogRow({
             case 'status':
               return (
                 <div key={key} className={cn(cellClass, 'flex flex-wrap items-center content-start gap-2 gap-y-1')}>
-                  <span className="shrink-0">{r.Status}</span>
+                  <span data-testid="logs-status-text" className="min-w-0 max-w-full whitespace-normal break-words">
+                    {r.Status}
+                  </span>
                   {hasErrors && (
                     <Badge
                       data-testid="logs-error-badge"


### PR DESCRIPTION
## Summary
- Preserve raw Salesforce `ApexLog.Status` values while allowing long status text to wrap inside the logs table Status column.
- Keep the existing Error and triage reason badges unchanged.
- Add focused webview regression coverage for long status text and badge visibility.

## Why
Salesforce can return full exception text in `ApexLog.Status`. The previous non-shrinking status span could visually cross into neighboring columns instead of staying contained in the Status column.

## Test Plan
- [x] `npm run test:webview -- --runTestsByPath packages/webview/src/__tests__/LogRow.test.tsx --runInBand`
- [x] `npm run test:webview -- --runInBand --no-cache`

## Notes
- Design/spec: `docs/superpowers/specs/2026-05-19-status-column-wrap-design.md`
- Plan: `docs/superpowers/plans/2026-05-19-status-column-wrap.md`
- The worktree branch was reviewed by Superpowers spec, quality, and final reviewers.