### PR TITLE
fix(cli-release): set npm package repository metadata

### DIFF
--- a/packages/cli-npm/templates/package.meta.json
+++ b/packages/cli-npm/templates/package.meta.json
@@ -2,6 +2,10 @@
   "name": "@electivus/apex-log-viewer",
   "version": "__VERSION__",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
   "bin": {
     "alv": "bin/apex-log-viewer.js",
     "apex-log-viewer": "bin/apex-log-viewer.js"

--- a/packages/cli-npm/templates/package.native.json
+++ b/packages/cli-npm/templates/package.native.json
@@ -1,6 +1,10 @@
 {
   "name": "__PACKAGE_NAME__",
   "version": "__VERSION__",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Electivus/Apex-Log-Viewer"
+  },
   "os": ["__OS__"],
   "cpu": ["__CPU__"],
   "bin": {

--- a/scripts/build-cli-npm-packages.test.js
+++ b/scripts/build-cli-npm-packages.test.js
@@ -37,6 +37,10 @@ test('buildCliNpmPackages generates the meta package with all native optionalDep
 
   assert.equal(metaPackage.name, '@electivus/apex-log-viewer');
   assert.equal(metaPackage.version, '1.2.3');
+  assert.deepEqual(metaPackage.repository, {
+    type: 'git',
+    url: 'https://github.com/Electivus/Apex-Log-Viewer'
+  });
   assert.deepEqual(metaPackage.bin, {
     alv: 'bin/apex-log-viewer.js',
     'apex-log-viewer': 'bin/apex-log-viewer.js'
@@ -49,6 +53,10 @@ test('buildCliNpmPackages generates the meta package with all native optionalDep
     'expected meta package launcher to be copied'
   );
   assert.equal(linuxNativePackage.name, '@electivus/apex-log-viewer-linux-x64');
+  assert.deepEqual(linuxNativePackage.repository, {
+    type: 'git',
+    url: 'https://github.com/Electivus/Apex-Log-Viewer'
+  });
   assert.deepEqual(linuxNativePackage.os, ['linux']);
   assert.deepEqual(linuxNativePackage.cpu, ['x64']);
   assert.equal(


### PR DESCRIPTION
## Summary
- Add `repository.url` metadata to generated CLI npm meta and native package manifests.
- Cover the generated metadata in `build-cli-npm-packages` tests.

## Why
The `rust-v0.1.14` Trusted Publisher retry reached npm OIDC/provenance signing, but npm rejected the native package publish with:

```text
Error verifying sigstore provenance bundle: Failed to validate repository information: package.json: "repository.url" is "", expected to match "https://github.com/Electivus/Apex-Log-Viewer" from provenance
```

Setting the generated package `repository.url` to the GitHub repository should satisfy npm provenance validation for both native packages and the meta package.

## Validation
- `node --test scripts/build-cli-npm-packages.test.js scripts/packaging-ci.test.js scripts/publish-npm-package-if-needed.test.js`
- `git diff --check`

## Release follow-up
After merge, recreate/move `rust-v0.1.14` to the updated `main` commit again so the release workflow rebuilds tarballs with this metadata.