### PR TITLE
[codex] Skip duplicate Marketplace publishes

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -350,6 +350,7 @@ jobs:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
         shell: bash
         run: |
+          set -euo pipefail
           if [ -z "${VSCE_PAT}" ]; then
             echo "VSCE_PAT not set; skipping publish." && exit 0
           fi
@@ -361,7 +362,18 @@ jobs:
           fi
           for FILE in "${FILES[@]}"; do
             echo "Publishing ${FILE}"
-            npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
+            set +e
+            OUTPUT=$(npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release 2>&1)
+            STATUS=$?
+            set -e
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -F "already exists." >/dev/null 2>&1; then
+                echo "Skipping ${FILE}; VS Code Marketplace already has this version and target."
+                continue
+              fi
+              exit "$STATUS"
+            fi
           done
 
   publish_open_vsx:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -381,10 +381,24 @@ jobs:
           for FILE in "${FILES[@]}"; do
             if [ "${PRE_RELEASE}" = "true" ]; then
               echo "Publishing pre-release ${VERSION} from ${FILE}"
-              npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release
+              set +e
+              OUTPUT=$(npx --yes @vscode/vsce publish --packagePath "${FILE}" --pre-release 2>&1)
+              STATUS=$?
+              set -e
             else
               echo "Publishing stable ${VERSION} from ${FILE}"
-              npx --yes @vscode/vsce publish --packagePath "${FILE}"
+              set +e
+              OUTPUT=$(npx --yes @vscode/vsce publish --packagePath "${FILE}" 2>&1)
+              STATUS=$?
+              set -e
+            fi
+            echo "$OUTPUT"
+            if [ "$STATUS" -ne 0 ]; then
+              if echo "$OUTPUT" | grep -F "already exists." >/dev/null 2>&1; then
+                echo "Skipping ${FILE}; VS Code Marketplace already has this version and target."
+                continue
+              fi
+              exit "$STATUS"
             fi
           done
 

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -149,6 +149,26 @@ test('prerelease Open VSX publish skips already published target artifacts', () 
   );
 });
 
+for (const [workflowPath, jobName] of [
+  ['.github/workflows/prerelease.yml', 'publish_marketplace'],
+  ['.github/workflows/release.yml', 'publish_marketplace']
+]) {
+  test(`${workflowPath} Marketplace publish skips already published target artifacts`, () => {
+    const publishJob = readWorkflowJob(workflowPath, jobName);
+
+    assert.match(
+      publishJob,
+      /OUTPUT=\$\(npx --yes @vscode\/vsce publish --packagePath "\$\{FILE\}"(?: --pre-release)? 2>&1\)/,
+      'expected Marketplace publish output to be captured for duplicate-version handling'
+    );
+    assert.match(
+      publishJob,
+      /grep -F "already exists\."[\s\S]*?Skipping \$\{FILE\}; VS Code Marketplace already has this version and target\./,
+      'expected duplicate Marketplace target publishes to be skipped instead of failing the workflow'
+    );
+  });
+}
+
 test('rust-release workflow bootstrap skips crates.io publishing', () => {
   const workflowSource = readFile('.github/workflows/rust-release.yml');
 


### PR DESCRIPTION
## Summary
- Make VS Code Marketplace publish jobs idempotent when a target/version already exists
- Apply the same duplicate-publish handling to nightly prereleases and tagged releases
- Add workflow regression coverage matching the existing Open VSX duplicate handling

## Root Cause
The nightly publish run failed after the Marketplace rejected an already-published target artifact:

```text
electivus.apex-log-viewer (darwin-arm64) v0.49.10 already exists.
```

The Open VSX job already captured publish output and skipped duplicate target publishes, but the VS Code Marketplace job exited immediately on the same class of retry/rerun failure.

## Validation
- `npm ci --workspaces=false`
- `npm run test:scripts -- scripts/packaging-ci.test.js scripts/compute-prerelease-version.test.js`