### PR TITLE
[codex] remove unsupported E2E concurrency queue

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -26,7 +26,6 @@ on:
 
 concurrency:
   group: ${{ vars.SF_SCRATCH_POOL_NAME != '' && format('e2e-playwright-pool-{0}', vars.SF_SCRATCH_POOL_NAME) || 'sf-e2e-scratch-global' }}
-  queue: max
   cancel-in-progress: false
 
 permissions:

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -23,7 +23,7 @@ Build & Test basics:
 - Extension packaging consumes `config/runtime-bundle.json` so the bundled runtime stays pinned to a tested CLI release instead of building workspace HEAD during extension packaging.
 - The Rust workspace supply-chain policy is committed in `deny.toml` and evaluated against the checked-in root `Cargo.lock`.
 
-Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref, except the real-org Playwright workflow when `SF_SCRATCH_POOL_NAME` is configured. That workflow queues by scratch-org pool name with `queue: max` and `cancel-in-progress: false` so dependency bursts do not over-lease the shared Dev Hub pool or replace older pending E2E runs.
+Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref, except the real-org Playwright workflow when `SF_SCRATCH_POOL_NAME` is configured. That workflow keys concurrency by scratch-org pool name with `cancel-in-progress: false` so active E2E runs are not canceled by dependency bursts or allowed to over-lease the shared Dev Hub pool.
 
 ## Workflow Supply Chain Controls
 
@@ -73,7 +73,7 @@ Key behavior in pool mode:
 - The Ubuntu CLI real-org step runs `npm run test:e2e:cli` through the proxy lab with the same scratch-org env contract as the extension step, then uploads `output/playwright-cli/` as a dedicated artifact.
 - The Ubuntu extension step then runs `npm run test:e2e:telemetry` or `npm run test:e2e` through the proxy lab and uploads `output/playwright/`.
 - The Windows/macOS direct matrix runs `npm run test:e2e:cli` and `npm run test:e2e` without proxy-lab, then uploads artifacts with OS suffixes such as `playwright-cli-e2e-windows` and `playwright-e2e-macos`.
-- The workflow-level concurrency lock uses the configured `SF_SCRATCH_POOL_NAME` when pool mode is active, with `queue: max` and `cancel-in-progress: false`, so all PRs sharing the same Dev Hub pool queue behind one another instead of exhausting pool leases or replacing earlier pending runs during dependency bursts.
+- The workflow-level concurrency lock uses the configured `SF_SCRATCH_POOL_NAME` when pool mode is active, with `cancel-in-progress: false`, so active runs sharing the same Dev Hub pool are not canceled or allowed to over-lease the pool during dependency bursts.
 - The helper still keeps `fullyParallel: false`, but multiple Playwright workers can now run in parallel because each worker acquires its own scratch org slot.
 - Manual `workflow_dispatch` runs use the same pool-only path as `pull_request`, so dispatch validation exercises the same concurrency and lease behavior as CI.
 

--- a/docs/SCRATCH_ORG_POOL.md
+++ b/docs/SCRATCH_ORG_POOL.md
@@ -117,7 +117,7 @@ Repository variables for pool mode:
 
 When pool mode is active, the workflow lets each Playwright worker acquire its own scratch org slot and reuse the stored `sfdxAuthUrl` for future runs. The repository workflow defaults to `1` Playwright worker for CI PR runs; manual `workflow_dispatch` runs can override that with the `playwright_workers` input.
 
-The workflow-level concurrency group is keyed by `SF_SCRATCH_POOL_NAME` with `queue: max` and `cancel-in-progress: false`. Multiple PRs that share the same Dev Hub pool are queued instead of running every PR ref at once, and older pending E2E runs are not replaced by newer dependency PRs. This prevents Dependabot bursts from producing spurious lease-exhaustion failures or canceled intermediate validations.
+The workflow-level concurrency group is keyed by `SF_SCRATCH_POOL_NAME` with `cancel-in-progress: false`. Active runs that share the same Dev Hub pool are not canceled or allowed to run every PR ref at once. This prevents Dependabot bursts from producing spurious lease-exhaustion failures.
 
 ## Codex Cloud
 

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -164,12 +164,7 @@ test('real-org Playwright workflow serializes CI runs by scratch-org pool', () =
   assert.equal(
     concurrency['cancel-in-progress'],
     false,
-    'expected queued E2E runs to wait for the shared pool instead of canceling each other'
-  );
-  assert.equal(
-    concurrency.queue,
-    'max',
-    'expected Dependabot bursts to keep all shared-pool E2E runs pending instead of replacing older pending runs'
+    'expected an active E2E run to finish instead of being canceled by another shared-pool run'
   );
   assert.doesNotMatch(
     String(concurrency.group || ''),


### PR DESCRIPTION
## Summary

- remove unsupported `concurrency.queue: max` from the real-org Playwright workflow
- keep the scratch-pool concurrency group keyed by `SF_SCRATCH_POOL_NAME` with `cancel-in-progress: false`
- update the workflow guard and docs so they no longer describe unsupported queue behavior

## Root Cause

PR #905 added `queue: max` under GitHub Actions `concurrency`. GitHub Actions only supports `group` and `cancel-in-progress` in that section, and `actionlint` reports the workflow as invalid.

## Validation

- `actionlint .github/workflows/e2e-playwright.yml`
- `/usr/bin/node --test scripts/cli-e2e-workflow.test.js scripts/scratch-pool-admin.test.js`
- `/usr/bin/npm run check-types`
