### PR TITLE
[codex] test ci e2e concurrency queue guard

### DIFF
--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -166,6 +166,11 @@ test('real-org Playwright workflow serializes CI runs by scratch-org pool', () =
     false,
     'expected an active E2E run to finish instead of being canceled by another shared-pool run'
   );
+  assert.equal(
+    Object.hasOwn(concurrency, 'queue'),
+    false,
+    'expected workflow concurrency to avoid the unsupported queue key'
+  );
   assert.doesNotMatch(
     String(concurrency.group || ''),
     /github\.ref/,


### PR DESCRIPTION
## What changed

- Added a focused workflow-contract assertion that the real-org Playwright workflow concurrency block does not define the unsupported `queue` key.

## Why

GitHub Actions rejected the recently added `concurrency.queue` setting, and PR #906 removed it. The existing test kept checking the scratch-pool group and `cancel-in-progress`, but did not pin the absence of the invalid key, leaving the regression easy to reintroduce.

## Validation

- `PATH=/usr/bin:$PATH /usr/bin/node --test scripts/cli-e2e-workflow.test.js`
- `PATH=/usr/bin:$PATH /usr/bin/node scripts/check-dependency-sources.mjs scripts/cli-e2e-workflow.test.js`
- Verified the new assertion fails against the prior workflow from `fabf4df` with `expected workflow concurrency to avoid the unsupported queue key`.

Note: this worktree needed `npm ci --legacy-peer-deps` for local dependency installation because npm 11 reports the current lockfile as missing an optional peer entry for `conventional-commits-parser@6.4.0`; no lockfile changes were included.