### PR TITLE
[codex] chore(cli): prepare 0.1.16 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 ### Chores
 
-- CLI/Runtime: bump the standalone runtime train to `0.1.15` so the CLI release packages the agent-friendly runtime commands and shared runtime fixes.
+- CLI/Runtime: bump the standalone runtime train to `0.1.16` so the CLI release packages the Codex skill installer, local org-state startup path, and shared runtime fixes.
 - Release/CLI: publish npm CLI packages through npm Trusted Publishers/OIDC instead of long-lived `NPM_TOKEN` credentials.
 - Build: migrate the development, CI, and packaging Node.js baseline to Node.js 24 LTS.
 - Telemetry/Azure Monitor: fix usage-report KQL generation and docs for workspace-backed Application Insights queries.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.15"
+version = "0.1.16"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.15",
-  "tag": "rust-v0.1.15",
+  "cliVersion": "0.1.16",
+  "tag": "rust-v0.1.16",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.15", path = "../alv-core" }
-alv-protocol = { version = "0.1.15", path = "../alv-protocol" }
+alv-core = { version = "0.1.16", path = "../alv-core" }
+alv-protocol = { version = "0.1.16", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.52", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.15", path = "../alv-app-server" }
-alv-core = { version = "0.1.15", path = "../alv-core" }
+alv-app-server = { version = "0.1.16", path = "../alv-app-server" }
+alv-core = { version = "0.1.16", path = "../alv-core" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.15"
+version = "0.1.16"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -223,8 +223,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.15',
-    tag: 'rust-v0.1.15',
+    cliVersion: '0.1.16',
+    tag: 'rust-v0.1.16',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary

- Bump the standalone Rust CLI/runtime train from `0.1.15` to `0.1.16` across first-party runtime crates and internal dependency constraints.
- Pin `config/runtime-bundle.json` and the packaging guard test to `rust-v0.1.16`.
- Update the Unreleased changelog chore entry for the CLI release.

## Validation

- `cargo check -p apex-log-viewer-cli`
- `node --test scripts/packaging-ci.test.js scripts/fetch-runtime-release.test.js scripts/build-cli-npm-packages.test.js`
- `npm run test:rust:smoke`