### PR TITLE
[codex] Sync plugin manifest version

### DIFF
--- a/scripts/build-cli-npm-packages.mjs
+++ b/scripts/build-cli-npm-packages.mjs
@@ -78,6 +78,12 @@ function copyDirectory(source, destination) {
   }
 }
 
+function copyPluginManifest(source, destination, version) {
+  const manifest = JSON.parse(readText(source));
+  manifest.version = version;
+  writeJson(destination, manifest);
+}
+
 export function discoverBinaries(rootDir = repoRoot) {
   const binaries = {};
   const baseDir = path.join(rootDir, 'apps', 'vscode-extension', 'bin');
@@ -141,11 +147,14 @@ function buildPluginPackage({ version, outDir, pluginRoot = sfPluginRoot }) {
   copyDirectory(pluginLibDir, path.join(pluginDir, 'lib'));
   copyDirectory(path.join(pluginRoot, 'messages'), path.join(pluginDir, 'messages'));
 
-  for (const fileName of ['oclif.manifest.json', 'oclif.lock']) {
-    const source = path.join(pluginRoot, fileName);
-    if (fs.existsSync(source)) {
-      copyFile(source, path.join(pluginDir, fileName));
-    }
+  const manifestSource = path.join(pluginRoot, 'oclif.manifest.json');
+  if (fs.existsSync(manifestSource)) {
+    copyPluginManifest(manifestSource, path.join(pluginDir, 'oclif.manifest.json'), version);
+  }
+
+  const lockSource = path.join(pluginRoot, 'oclif.lock');
+  if (fs.existsSync(lockSource)) {
+    copyFile(lockSource, path.join(pluginDir, 'oclif.lock'));
   }
 
   return pluginDir;

--- a/scripts/build-cli-npm-packages.test.js
+++ b/scripts/build-cli-npm-packages.test.js
@@ -60,7 +60,10 @@ function makePluginRoot(rootDir) {
   fs.writeFileSync(path.join(pluginRoot, 'lib', 'index.js'), 'export {};\n');
   fs.writeFileSync(path.join(pluginRoot, 'lib', 'commands', 'electivus.js'), 'export default class {}\n');
   fs.writeFileSync(path.join(pluginRoot, 'messages', 'electivus.md'), '# summary\n');
-  fs.writeFileSync(path.join(pluginRoot, 'oclif.manifest.json'), '{}\n');
+  fs.writeFileSync(
+    path.join(pluginRoot, 'oclif.manifest.json'),
+    JSON.stringify({ commands: { electivus: { id: 'electivus' } }, version: '0.0.0' }, null, 2)
+  );
   return pluginRoot;
 }
 
@@ -82,6 +85,7 @@ test('buildCliNpmPackages stages the sf plugin with all native optionalDependenc
   });
 
   const pluginPackage = JSON.parse(fs.readFileSync(path.join(result.pluginDir, 'package.json'), 'utf8'));
+  const pluginManifest = JSON.parse(fs.readFileSync(path.join(result.pluginDir, 'oclif.manifest.json'), 'utf8'));
   const linuxNativePackage = JSON.parse(
     fs.readFileSync(path.join(result.nativeDirs['linux-x64'], 'package.json'), 'utf8')
   );
@@ -99,6 +103,8 @@ test('buildCliNpmPackages stages the sf plugin with all native optionalDependenc
   assert.equal(pluginPackage.oclif.bin, 'sf');
   assert.equal(pluginPackage.oclif.topicSeparator, ' ');
   assert.equal(pluginPackage.oclif.flexibleTaxonomy, true);
+  assert.equal(pluginManifest.version, '1.2.3');
+  assert.deepEqual(pluginManifest.commands.electivus, { id: 'electivus' });
   assert.equal(pluginPackage.optionalDependencies['@electivus/apex-log-viewer-linux-x64'], '1.2.3');
   assert.equal(pluginPackage.optionalDependencies['@electivus/apex-log-viewer-darwin-arm64'], '1.2.3');
   assert.equal(


### PR DESCRIPTION
## Summary

- Rewrite the staged `oclif.manifest.json` version to match the CLI/plugin release version.
- Keep the rest of the oclif manifest intact while copying `oclif.lock` unchanged.
- Add regression coverage so staged plugin packages no longer ship a `0.0.0` manifest version.

## Validation

- `node --test scripts/build-cli-npm-packages.test.js`
- `npm run build:cli:npm`
- `npm run test:scripts`
