### PR TITLE
chore(cli): prepare 0.1.17 release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,7 +13,7 @@ dependencies = [
 
 [[package]]
 name = "alv-app-server"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "alv-core",
  "alv-protocol",
@@ -24,7 +24,7 @@ dependencies = [
 
 [[package]]
 name = "alv-core"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "chrono",
  "grep",
@@ -40,11 +40,11 @@ dependencies = [
 
 [[package]]
 name = "alv-mcp"
-version = "0.1.16"
+version = "0.1.17"
 
 [[package]]
 name = "alv-protocol"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "serde",
  "serde_json",
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "apex-log-viewer-cli"
-version = "0.1.16"
+version = "0.1.17"
 dependencies = [
  "alv-app-server",
  "alv-core",

--- a/config/runtime-bundle.json
+++ b/config/runtime-bundle.json
@@ -1,6 +1,6 @@
 {
-  "cliVersion": "0.1.16",
-  "tag": "rust-v0.1.16",
+  "cliVersion": "0.1.17",
+  "tag": "rust-v0.1.17",
   "channel": "stable",
   "protocolVersion": "1"
 }

--- a/crates/alv-app-server/Cargo.toml
+++ b/crates/alv-app-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-app-server"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "JSON-RPC app server for the Apex Log Viewer runtime"
 license = "MIT"
@@ -11,8 +11,8 @@ homepage = "https://github.com/Electivus/Apex-Log-Viewer"
 path = "src/lib.rs"
 
 [dependencies]
-alv-core = { version = "0.1.16", path = "../alv-core" }
-alv-protocol = { version = "0.1.16", path = "../alv-protocol" }
+alv-core = { version = "0.1.17", path = "../alv-core" }
+alv-protocol = { version = "0.1.17", path = "../alv-protocol" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.52", features = ["sync"] }

--- a/crates/alv-cli/Cargo.toml
+++ b/crates/alv-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apex-log-viewer-cli"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "Rust CLI for Apex Log Viewer"
 license = "MIT"
@@ -12,8 +12,8 @@ name = "apex-log-viewer"
 path = "src/main.rs"
 
 [dependencies]
-alv-app-server = { version = "0.1.16", path = "../alv-app-server" }
-alv-core = { version = "0.1.16", path = "../alv-core" }
+alv-app-server = { version = "0.1.17", path = "../alv-app-server" }
+alv-core = { version = "0.1.17", path = "../alv-core" }
 clap = { version = "4.6", features = ["derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/crates/alv-core/Cargo.toml
+++ b/crates/alv-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-core"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "Core runtime services for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-mcp/Cargo.toml
+++ b/crates/alv-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-mcp"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "MCP integration crate for Apex Log Viewer"
 license = "MIT"

--- a/crates/alv-protocol/Cargo.toml
+++ b/crates/alv-protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "alv-protocol"
-version = "0.1.16"
+version = "0.1.17"
 edition = "2021"
 description = "Protocol types for the Apex Log Viewer runtime"
 license = "MIT"

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -223,8 +223,8 @@ test('runtime bundle stays pinned to the current tested CLI release', () => {
   const runtimeBundle = JSON.parse(readFile('config/runtime-bundle.json'));
 
   assert.deepEqual(runtimeBundle, {
-    cliVersion: '0.1.16',
-    tag: 'rust-v0.1.16',
+    cliVersion: '0.1.17',
+    tag: 'rust-v0.1.17',
     channel: 'stable',
     protocolVersion: '1'
   });


### PR DESCRIPTION
## Summary
- bump Rust runtime crates and npm runtime bundle metadata to 0.1.17
- update packaging guard expectations for rust-v0.1.17

## Verification
- npm run check-types
- npm run test:scripts
- cargo check --workspace

After merge, publish through the repository Trusted Publisher path by pushing tag rust-v0.1.17.