### PR TITLE
fix(release): install sf plugin workspace during publish staging

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -173,7 +173,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Download runtime binaries
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -270,6 +270,21 @@ test('rust-release workflow verifies the packaged linux-x64 release artifact bef
   );
 });
 
+test('rust-release package job installs sf plugin workspace dependencies before building the plugin', () => {
+  const packageReleaseJob = readWorkflowJob('.github/workflows/rust-release.yml', 'package_release');
+
+  assert.match(
+    packageReleaseJob,
+    /- name:\s+Install dependencies\s+run:\s+npm ci\s+- name:\s+Download runtime binaries/,
+    'expected release packaging to install workspace dependencies before building @electivus/plugin-electivus'
+  );
+  assert.doesNotMatch(
+    packageReleaseJob,
+    /- name:\s+Install dependencies\s+run:\s+npm ci --workspaces=false\s+- name:\s+Download runtime binaries/,
+    'expected release packaging not to omit workspace dependencies needed by @electivus/plugin-electivus'
+  );
+});
+
 test('rust-release workflow publishes npm packages through trusted publishers', () => {
   const workflowSource = readFile('.github/workflows/rust-release.yml');
   const nativePublishJob = readWorkflowJob('.github/workflows/rust-release.yml', 'publish_npm_native');


### PR DESCRIPTION
## Summary
- install workspace dependencies in the Rust release packaging job before building @electivus/plugin-electivus
- add a packaging guard so the release job does not omit sf-plugin workspace dependencies again

## Verification
- npm run build:sf-plugin
- npm run check-types
- npm run test:scripts

This fixes the rust-v0.1.17 workflow failure before npm publication.