### PR TITLE
chore(deps): ignore sf-plugins-core major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,6 +74,9 @@ updates:
           - 'version-update:semver-major'
           - 'version-update:semver-minor'
           - 'version-update:semver-patch'
+      - dependency-name: '@salesforce/sf-plugins-core'
+        update-types:
+          - 'version-update:semver-major'
   - package-ecosystem: 'cargo'
     directory: '/'
     schedule:


### PR DESCRIPTION
## Summary
- Adds a Dependabot ignore rule for semver-major updates of @salesforce/sf-plugins-core.

## Why
The 12.x update was triaged and reverted because it introduces @oclif/table -> ink -> react-reconciler, which breaks `oclif manifest` in this repository's React 19 dependency tree with `ReactCurrentOwner`.

## Verification
- Parsed .github/dependabot.yml with the yaml package.
