### PR TITLE
chore(sf-plugin): prepare 0.1.18 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 
 ### Chores
 
+- Release/SF Plugin: bump `@electivus/plugin-electivus` to `0.1.18` for the next independent Salesforce CLI plugin npm release.
 - CLI/Runtime: bump the standalone runtime train to `0.1.16` so the CLI release packages the Codex skill installer, local org-state startup path, and shared runtime fixes.
 - Release/CLI: publish npm CLI packages through npm Trusted Publishers/OIDC instead of long-lived `NPM_TOKEN` credentials.
 - Build: migrate the development, CI, and packaging Node.js baseline to Node.js 24 LTS.

--- a/package-lock.json
+++ b/package-lock.json
@@ -25378,7 +25378,7 @@
     },
     "packages/sf-plugin": {
       "name": "@electivus/plugin-electivus",
-      "version": "0.0.0",
+      "version": "0.1.18",
       "license": "MIT",
       "dependencies": {
         "@jsforce/jsforce-node": "3.9.0",

--- a/packages/sf-plugin/package.json
+++ b/packages/sf-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electivus/plugin-electivus",
-  "version": "0.0.0",
+  "version": "0.1.18",
   "private": true,
   "description": "Salesforce CLI plugin for Electivus Apex Log Viewer workflows.",
   "type": "module",


### PR DESCRIPTION
## Summary

- Bump `@electivus/plugin-electivus` from `0.0.0` to `0.1.18` for the next independent Salesforce CLI plugin npm release.
- Keep `package-lock.json` aligned with the workspace package version.
- Add an `Unreleased` changelog note for the sf plugin release prep.

## Validation

- `npm run test:sf-plugin`
- `npm run build:sf-plugin`
- `npm run stage:sf-plugin-npm`
- `git diff --check`
- Confirmed `npm view @electivus/plugin-electivus@0.1.18 version --json` returns `E404`, so the target version is not published yet.

## Release Notes

After merge, publish with the documented plugin npm flow from `main`, for example `npm run publish:sf-plugin:npm` or publish the staged `dist/sf-plugin-npm` package.
