### PR TITLE
ci(sf-plugin): publish releases from tags

### DIFF
--- a/.github/workflows/sf-plugin-release.yml
+++ b/.github/workflows/sf-plugin-release.yml
@@ -1,0 +1,185 @@
+name: SF Plugin Release
+
+on:
+  push:
+    tags:
+      - 'sf-plugin-v*'
+  workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Existing sf-plugin-vX.Y.Z tag to publish'
+        required: false
+        type: string
+
+concurrency:
+  group: sf-plugin-release-${{ inputs.tag_name || github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  validate_tag:
+    name: Validate release tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.release_meta.outputs.version }}
+      tag_name: ${{ steps.release_meta.outputs.tag_name }}
+      pre_release: ${{ steps.release_meta.outputs.pre_release }}
+      npm_dist_tag: ${{ steps.release_meta.outputs.npm_dist_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ inputs.tag_name || github.ref }}
+
+      - name: Validate sf plugin release tag
+        id: release_meta
+        shell: bash
+        env:
+          REQUESTED_TAG: ${{ inputs.tag_name || github.ref_name }}
+        run: |
+          set -euo pipefail
+          TAG_NAME="${REQUESTED_TAG}"
+          if [[ ! "${TAG_NAME}" =~ ^sf-plugin-v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "Expected sf plugin release tag sf-plugin-vX.Y.Z, got ${TAG_NAME}" >&2
+            exit 1
+          fi
+
+          PKG_VERSION=$(node -e "const fs=require('fs');const p=JSON.parse(fs.readFileSync('packages/sf-plugin/package.json','utf8'));process.stdout.write(p.version)")
+          TAG_VERSION="${TAG_NAME#sf-plugin-v}"
+          if [ "${PKG_VERSION}" != "${TAG_VERSION}" ]; then
+            echo "Tag ${TAG_NAME} != packages/sf-plugin/package.json version ${PKG_VERSION}" >&2
+            exit 1
+          fi
+
+          PRE_RELEASE=false
+          NPM_DIST_TAG=latest
+          if [[ "${PKG_VERSION}" == *-* ]]; then
+            PRE_RELEASE=true
+            NPM_DIST_TAG=next
+          fi
+
+          {
+            echo "version=${PKG_VERSION}"
+            echo "tag_name=${TAG_NAME}"
+            echo "pre_release=${PRE_RELEASE}"
+            echo "npm_dist_tag=${NPM_DIST_TAG}"
+          } >> "${GITHUB_OUTPUT}"
+
+  package_plugin:
+    name: Test and stage npm package
+    needs: validate_tag
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ needs.validate_tag.outputs.tag_name }}
+
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - name: Enforce dependency source policy
+        run: node scripts/check-dependency-sources.mjs
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test sf plugin
+        run: npm run test:sf-plugin
+
+      - name: Build sf plugin
+        run: npm run build:sf-plugin
+
+      - name: Stage sf plugin npm package
+        run: npm run stage:sf-plugin-npm
+
+      - name: Verify staged package version
+        env:
+          VERSION: ${{ needs.validate_tag.outputs.version }}
+        run: |
+          node -e "const p=require('./dist/sf-plugin-npm/package.json'); if (p.version !== process.env.VERSION) { throw new Error('staged package version ' + p.version + ' != ' + process.env.VERSION); } if (p.private !== undefined) { throw new Error('staged package must not be private'); }"
+
+      - name: Upload staged npm package
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: sf-plugin-npm-package
+          path: dist/sf-plugin-npm/**
+          if-no-files-found: error
+
+  publish_npm:
+    name: Publish npm package
+    needs: [validate_tag, package_plugin]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      NPM_DIST_TAG: ${{ needs.validate_tag.outputs.npm_dist_tag }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ needs.validate_tag.outputs.tag_name }}
+
+      - name: Setup Node.js from .nvmrc
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+
+      - name: Download staged npm package
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: sf-plugin-npm-package
+          path: dist/sf-plugin-npm
+
+      - name: Publish sf plugin package
+        run: node scripts/publish-npm-package-if-needed.mjs dist/sf-plugin-npm --tag "${NPM_DIST_TAG}" --access public
+
+  github_release:
+    name: Create GitHub release
+    needs: [validate_tag, publish_npm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+      PRE_RELEASE: ${{ needs.validate_tag.outputs.pre_release }}
+      TAG_NAME: ${{ needs.validate_tag.outputs.tag_name }}
+      VERSION: ${{ needs.validate_tag.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+        with:
+          ref: ${{ needs.validate_tag.outputs.tag_name }}
+
+      - name: Create or update GitHub release
+        shell: bash
+        run: |
+          set -euo pipefail
+          TITLE="${TAG_NAME}"
+          NOTES="Automated Salesforce CLI plugin release for @electivus/plugin-electivus@${VERSION}."
+          if gh release view "${TAG_NAME}" >/dev/null 2>&1; then
+            if [ "${PRE_RELEASE}" = "true" ]; then
+              gh release edit "${TAG_NAME}" --title "${TITLE}" --notes "${NOTES}" --prerelease
+            else
+              gh release edit "${TAG_NAME}" --title "${TITLE}" --notes "${NOTES}"
+            fi
+          else
+            if [ "${PRE_RELEASE}" = "true" ]; then
+              gh release create "${TAG_NAME}" --title "${TITLE}" --notes "${NOTES}" --prerelease
+            else
+              gh release create "${TAG_NAME}" --title "${TITLE}" --notes "${NOTES}"
+            fi
+          fi

--- a/.github/workflows/sf-plugin-release.yml
+++ b/.github/workflows/sf-plugin-release.yml
@@ -8,7 +8,7 @@ on:
     inputs:
       tag_name:
         description: 'Existing sf-plugin-vX.Y.Z tag to publish'
-        required: false
+        required: true
         type: string
 
 concurrency:
@@ -26,13 +26,14 @@ jobs:
     outputs:
       version: ${{ steps.release_meta.outputs.version }}
       tag_name: ${{ steps.release_meta.outputs.tag_name }}
+      commit_sha: ${{ steps.release_meta.outputs.commit_sha }}
       pre_release: ${{ steps.release_meta.outputs.pre_release }}
       npm_dist_tag: ${{ steps.release_meta.outputs.npm_dist_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ inputs.tag_name || github.ref }}
+          ref: ${{ inputs.tag_name && format('refs/tags/{0}', inputs.tag_name) || github.ref }}
 
       - name: Validate sf plugin release tag
         id: release_meta
@@ -53,6 +54,7 @@ jobs:
             echo "Tag ${TAG_NAME} != packages/sf-plugin/package.json version ${PKG_VERSION}" >&2
             exit 1
           fi
+          COMMIT_SHA=$(git rev-parse HEAD)
 
           PRE_RELEASE=false
           NPM_DIST_TAG=latest
@@ -64,6 +66,7 @@ jobs:
           {
             echo "version=${PKG_VERSION}"
             echo "tag_name=${TAG_NAME}"
+            echo "commit_sha=${COMMIT_SHA}"
             echo "pre_release=${PRE_RELEASE}"
             echo "npm_dist_tag=${NPM_DIST_TAG}"
           } >> "${GITHUB_OUTPUT}"
@@ -77,7 +80,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ needs.validate_tag.outputs.tag_name }}
+          ref: ${{ needs.validate_tag.outputs.commit_sha }}
 
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -128,7 +131,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ needs.validate_tag.outputs.tag_name }}
+          ref: ${{ needs.validate_tag.outputs.commit_sha }}
 
       - name: Setup Node.js from .nvmrc
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -162,7 +165,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
-          ref: ${{ needs.validate_tag.outputs.tag_name }}
+          ref: ${{ needs.validate_tag.outputs.commit_sha }}
 
       - name: Create or update GitHub release
         shell: bash

--- a/docs/PUBLISHING.md
+++ b/docs/PUBLISHING.md
@@ -6,7 +6,7 @@ Maintainer quick start
 2. Create an Open VSX namespace + PAT, add secret `OVSX_PAT` in GitHub.
 3. For standard extension releases, update `CHANGELOG.md` manually, bump `package.json`, and push a tag `vX.Y.Z`.
 4. The Release workflow on the tag builds, attaches the `.vsix`, and, if `VSCE_PAT`/`OVSX_PAT` exist, publishes automatically.
-5. For plugin-only npm releases, build and stage the plugin with `npm run publish:sf-plugin:npm -- --tag <tag>` or publish the staged `dist/sf-plugin-npm` directory from a maintainer machine.
+5. For plugin-only npm releases, bump `packages/sf-plugin/package.json`, merge the release PR, and push a tag `sf-plugin-vX.Y.Z`; the SF Plugin Release workflow validates, stages, publishes to npm, and creates the GitHub release.
 6. Alternatively, publish the extension locally with `npm run vsce:publish` (or `:pre`) and `npx --yes ovsx publish`.
 
 This repository includes automated publish flows for the Visual Studio Code Marketplace and Open VSX with first-class support for pre-releases. It uses GitHub Actions, `vsce`, `ovsx`, and npm tooling and follows a simple semver convention:
@@ -45,8 +45,9 @@ Quick recipes
 
 - Prepare a plugin npm release:
   - Bump `packages/sf-plugin/package.json` when the plugin package is published independently.
-  - Run `npm run test:sf-plugin`, `npm run build:sf-plugin`, and `npm run stage:sf-plugin-npm`.
-  - Publish `dist/sf-plugin-npm` with `node scripts/publish-npm-package-if-needed.mjs dist/sf-plugin-npm --tag <tag>` or by running `npm publish dist/sf-plugin-npm --access public`.
+  - Open and merge a release PR, then push a matching tag such as `sf-plugin-v0.1.18`.
+  - The `.github/workflows/sf-plugin-release.yml` workflow validates that the tag version matches the package manifest, runs `npm run test:sf-plugin`, `npm run build:sf-plugin`, and `npm run stage:sf-plugin-npm`, then publishes the staged package to npm through Trusted Publishing/OIDC.
+  - For an existing tag that predates the workflow, rerun the SF Plugin Release workflow manually with the `tag_name` input.
   - The staging step removes the workspace-only `private` marker and copies the built `bin`, `lib`, `messages`, `skills`, and `oclif.manifest.json` files; there are no native runtime companion packages.
   - After the cutover release is published, deprecate any old standalone binary package with:
 

--- a/scripts/docs-release.test.js
+++ b/scripts/docs-release.test.js
@@ -16,6 +16,9 @@ test('release docs mention the embedded sf plugin packaging model', () => {
   assert.match(ci, /test:sf-plugin/);
   assert.doesNotMatch(ci, /NPM_TOKEN/);
   assert.match(publishing, /plugin npm release/i);
+  assert.match(publishing, /sf-plugin-vX\.Y\.Z/);
+  assert.match(publishing, /sf-plugin-release\.yml/);
+  assert.match(publishing, /Trusted Publishing\/OIDC/);
   assert.doesNotMatch(publishing, /rust-release\.yml/);
   assert.match(architecture, /electivus-runner\.cjs/);
   assert.match(changelog, /embedded sf electivus plugin/i);

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -82,6 +82,28 @@ test('prerelease workflow computes the next publish version via the dedicated he
   );
 });
 
+test('sf plugin release workflow publishes matching sf-plugin-v tags through npm', () => {
+  const workflowSource = readFile('.github/workflows/sf-plugin-release.yml');
+  const validateJob = readWorkflowJob('.github/workflows/sf-plugin-release.yml', 'validate_tag');
+  const packageJob = readWorkflowJob('.github/workflows/sf-plugin-release.yml', 'package_plugin');
+  const publishJob = readWorkflowJob('.github/workflows/sf-plugin-release.yml', 'publish_npm');
+
+  assert.match(workflowSource, /tags:\s*\n\s+- 'sf-plugin-v\*'/);
+  assert.match(
+    validateJob,
+    /TAG_VERSION="\$\{TAG_NAME#sf-plugin-v\}"[\s\S]*?packages\/sf-plugin\/package\.json version \$\{PKG_VERSION\}/,
+    'expected the workflow to reject tags that do not match the sf plugin package version'
+  );
+  assert.match(packageJob, /\bnpm run test:sf-plugin\b/);
+  assert.match(packageJob, /\bnpm run build:sf-plugin\b/);
+  assert.match(packageJob, /\bnpm run stage:sf-plugin-npm\b/);
+  assert.match(
+    publishJob,
+    /id-token:\s+write[\s\S]*?node scripts\/publish-npm-package-if-needed\.mjs dist\/sf-plugin-npm --tag "\$\{NPM_DIST_TAG\}" --access public/,
+    'expected npm publish to use the skip-if-present script from the staged plugin package'
+  );
+});
+
 test('prerelease Open VSX publish skips already published target artifacts', () => {
   const publishJob = readWorkflowJob('.github/workflows/prerelease.yml', 'publish_open_vsx');
 

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -94,6 +94,21 @@ test('sf plugin release workflow publishes matching sf-plugin-v tags through npm
     /TAG_VERSION="\$\{TAG_NAME#sf-plugin-v\}"[\s\S]*?packages\/sf-plugin\/package\.json version \$\{PKG_VERSION\}/,
     'expected the workflow to reject tags that do not match the sf plugin package version'
   );
+  assert.match(
+    validateJob,
+    /ref:\s+\$\{\{\s*inputs\.tag_name && format\('refs\/tags\/\{0\}', inputs\.tag_name\) \|\| github\.ref\s*\}\}/,
+    'expected manual dispatch to checkout the fully qualified tag ref before validation'
+  );
+  assert.match(
+    validateJob,
+    /COMMIT_SHA=\$\(git rev-parse HEAD\)[\s\S]*?echo "commit_sha=\$\{COMMIT_SHA\}"/,
+    'expected the workflow to persist the validated commit SHA'
+  );
+  assert.match(
+    packageJob,
+    /ref:\s+\$\{\{\s*needs\.validate_tag\.outputs\.commit_sha\s*\}\}/,
+    'expected package jobs to use the validated commit SHA instead of an unqualified tag name'
+  );
   assert.match(packageJob, /\bnpm run test:sf-plugin\b/);
   assert.match(packageJob, /\bnpm run build:sf-plugin\b/);
   assert.match(packageJob, /\bnpm run stage:sf-plugin-npm\b/);

--- a/scripts/repo-security.test.js
+++ b/scripts/repo-security.test.js
@@ -923,6 +923,16 @@ test('release workflows default to read-only token permissions', () => {
   assert.deepEqual(prerelease.jobs.rollback_prerelease.permissions, { contents: 'write' });
   assert.equal(prerelease.jobs.publish_marketplace.permissions, undefined);
   assert.equal(prerelease.jobs.publish_open_vsx.permissions, undefined);
+
+  const sfPluginRelease = yaml.parse(read('.github/workflows/sf-plugin-release.yml'));
+  assert.deepEqual(sfPluginRelease.permissions, { contents: 'read' });
+  assert.equal(sfPluginRelease.jobs.validate_tag.permissions, undefined);
+  assert.equal(sfPluginRelease.jobs.package_plugin.permissions, undefined);
+  assert.deepEqual(sfPluginRelease.jobs.publish_npm.permissions, {
+    contents: 'read',
+    'id-token': 'write'
+  });
+  assert.deepEqual(sfPluginRelease.jobs.github_release.permissions, { contents: 'write' });
 });
 
 test('OpenSSF Scorecard workflow uploads SARIF with pinned actions', () => {


### PR DESCRIPTION
## Summary

- Add `SF Plugin Release`, triggered by `sf-plugin-v*` tags and manual `workflow_dispatch` with `tag_name`.
- Validate that the tag version matches `packages/sf-plugin/package.json`, then test/build/stage `@electivus/plugin-electivus` before publish.
- Publish the staged plugin package through npm Trusted Publishing/OIDC using the existing skip-if-present publish helper, then create/update the GitHub release.
- Document the repository-backed plugin release flow and add workflow/security regression coverage.

## Validation

- `node --test scripts/packaging-ci.test.js scripts/docs-release.test.js scripts/repo-security.test.js`
- `npm run test:scripts`
- `git diff --check`

## Notes

After this lands, the existing `sf-plugin-v0.1.18` tag can be published from the repository by running the `SF Plugin Release` workflow manually with `tag_name=sf-plugin-v0.1.18`.
