### PR TITLE
fix(sf-plugin): publish staged package by local path

### DIFF
--- a/.github/workflows/sf-plugin-release.yml
+++ b/.github/workflows/sf-plugin-release.yml
@@ -147,7 +147,7 @@ jobs:
           path: dist/sf-plugin-npm
 
       - name: Publish sf plugin package
-        run: node scripts/publish-npm-package-if-needed.mjs dist/sf-plugin-npm --tag "${NPM_DIST_TAG}" --access public
+        run: node scripts/publish-npm-package-if-needed.mjs ./dist/sf-plugin-npm --tag "${NPM_DIST_TAG}" --access public
 
   github_release:
     name: Create GitHub release

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -114,7 +114,7 @@ test('sf plugin release workflow publishes matching sf-plugin-v tags through npm
   assert.match(packageJob, /\bnpm run stage:sf-plugin-npm\b/);
   assert.match(
     publishJob,
-    /id-token:\s+write[\s\S]*?node scripts\/publish-npm-package-if-needed\.mjs dist\/sf-plugin-npm --tag "\$\{NPM_DIST_TAG\}" --access public/,
+    /id-token:\s+write[\s\S]*?node scripts\/publish-npm-package-if-needed\.mjs \.\/dist\/sf-plugin-npm --tag "\$\{NPM_DIST_TAG\}" --access public/,
     'expected npm publish to use the skip-if-present script from the staged plugin package'
   );
 });

--- a/scripts/publish-npm-package-if-needed.mjs
+++ b/scripts/publish-npm-package-if-needed.mjs
@@ -64,7 +64,8 @@ export function publishPackageIfNeeded(packageDir, {
   runCommand = defaultRunCommand,
   logger = console
 } = {}) {
-  const { name, version } = readPackageManifest(packageDir);
+  const resolvedPackageDir = path.resolve(packageDir);
+  const { name, version } = readPackageManifest(resolvedPackageDir);
 
   if (packageVersionExists(name, version, { runCommand })) {
     logger.log(`Skipping npm publish for ${name}@${version}; version already exists.`);
@@ -72,7 +73,7 @@ export function publishPackageIfNeeded(packageDir, {
   }
 
   const result = runCommand(
-    ['publish', packageDir, '--tag', tag, '--access', access],
+    ['publish', resolvedPackageDir, '--tag', tag, '--access', access],
     { stdio: 'inherit' }
   );
 

--- a/scripts/publish-npm-package-if-needed.test.js
+++ b/scripts/publish-npm-package-if-needed.test.js
@@ -85,7 +85,7 @@ test('publishPackageIfNeeded publishes when npm view reports the version is miss
 
     assert.deepEqual(calls, [
       ['view', '@electivus/apex-log-viewer-linux-x64@0.1.1', 'version', '--json'],
-      ['publish', packageDir, '--tag', 'next', '--access', 'public']
+      ['publish', path.resolve(packageDir), '--tag', 'next', '--access', 'public']
     ]);
     assert.equal(result.published, true);
     assert.equal(result.name, '@electivus/apex-log-viewer-linux-x64');


### PR DESCRIPTION
## Summary

- Pass `./dist/sf-plugin-npm` to the sf plugin release publish helper so npm treats it as a local package directory.
- Resolve local package paths to absolute paths inside `publish-npm-package-if-needed.mjs` before invoking `npm publish`.
- Update workflow and helper tests for the local-path publish contract.

## Validation

- `node --test scripts/publish-npm-package-if-needed.test.js scripts/packaging-ci.test.js scripts/repo-security.test.js`
- `git diff --check`

## Context

The first `SF Plugin Release` run for `sf-plugin-v0.1.18` validated and staged the package, then failed because npm interpreted `dist/sf-plugin-npm` as a GitHub shorthand instead of a local path.
