### PR TITLE
fix(ci): install workspace deps for extension releases

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -80,7 +80,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Build (type-check + lint + bundle)
         run: npm run package
@@ -115,7 +115,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Compute nightly version
         id: meta
@@ -188,7 +188,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Set nightly version in apps/vscode-extension/package.json
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Build (type-check + lint + bundle)
         run: npm run build
@@ -92,7 +92,7 @@ jobs:
         run: node scripts/check-dependency-sources.mjs
 
       - name: Install dependencies
-        run: npm ci --workspaces=false
+        run: npm ci
 
       - name: Verify tag matches extension package version
         shell: bash

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -55,6 +55,17 @@ for (const workflowPath of ['.github/workflows/release.yml', '.github/workflows/
     );
     assert.doesNotMatch(workflow, /fetch-runtime-release\.mjs|verify-runtime-compatibility\.mjs/);
   });
+
+  test(`${workflowPath} installs workspace dependencies before building extension release artifacts`, () => {
+    const workflow = readFile(workflowPath);
+
+    assert.doesNotMatch(
+      workflow,
+      /npm ci --workspaces=false/,
+      'expected extension release workflows to install package workspace dependencies for the sf plugin build'
+    );
+    assert.match(workflow, /\brun:\s+npm ci\b/);
+  });
 }
 
 test('test:scripts covers the prerelease version computation regression suite', () => {


### PR DESCRIPTION
## Summary
- install full workspace dependencies in extension release and prerelease workflows
- keep release packaging compatible with the embedded sf plugin build
- add a workflow regression test that rejects workspace-excluding installs in release workflows

## Root cause
The prerelease workflow ran `npm ci --workspaces=false`, then `npm run package`. After the CLI migration, `npm run package` builds `packages/sf-plugin`, but workspace dependencies such as `@salesforce/sf-plugins-core` and `@salesforce/core` were not installed.

## Verification
- `npm ci`
- `node --test scripts/packaging-ci.test.js`
- `npm run build:sf-plugin`
- `npm run package`
- `npm run test:scripts`