### PR TITLE
fix(package): run npm install through cmd on windows

### DIFF
--- a/apps/vscode-extension/scripts/copy-ripgrep-runtime.mjs
+++ b/apps/vscode-extension/scripts/copy-ripgrep-runtime.mjs
@@ -18,8 +18,18 @@ const RIPGREP_PACKAGE_BY_TARGET = {
   'win32-x64': 'ripgrep-win32-x64'
 };
 
-function npmCommand() {
-  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+function npmInstallInvocation({ platform, args }) {
+  if (platform === 'win32') {
+    return {
+      command: 'cmd.exe',
+      args: ['/d', '/s', '/c', 'npm.cmd', ...args]
+    };
+  }
+
+  return {
+    command: 'npm',
+    args
+  };
 }
 
 function targetPackageName(target) {
@@ -42,32 +52,31 @@ function readRipgrepMetaPackage(sourceNamespaceRoot) {
   return JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 }
 
-function ensureRipgrepPackage({ repoRoot, sourceNamespaceRoot, packageName, version, execFileSyncFn }) {
+function ensureRipgrepPackage({ repoRoot, sourceNamespaceRoot, packageName, version, execFileSyncFn, platform }) {
   const packageRoot = path.join(sourceNamespaceRoot, packageName);
   if (fs.existsSync(packageRoot)) {
     return;
   }
 
-  execFileSyncFn(
-    npmCommand(),
-    [
-      'install',
-      '--no-save',
-      '--package-lock=false',
-      '--ignore-scripts',
-      '--force',
-      '--workspaces=false',
-      `@vscode/${packageName}@${version}`
-    ],
-    { cwd: repoRoot, stdio: 'inherit' }
-  );
+  const installArgs = [
+    'install',
+    '--no-save',
+    '--package-lock=false',
+    '--ignore-scripts',
+    '--force',
+    '--workspaces=false',
+    `@vscode/${packageName}@${version}`
+  ];
+  const invocation = npmInstallInvocation({ platform, args: installArgs });
+
+  execFileSyncFn(invocation.command, invocation.args, { cwd: repoRoot, stdio: 'inherit' });
 
   if (!fs.existsSync(packageRoot)) {
     throw new Error(`failed to install @vscode/${packageName}@${version}`);
   }
 }
 
-export function copyRipgrepRuntime({ repoRoot, target, execFileSyncFn = execFileSync }) {
+export function copyRipgrepRuntime({ repoRoot, target, execFileSyncFn = execFileSync, platform = process.platform }) {
   const sourceNamespaceRoot = path.join(repoRoot, 'node_modules', '@vscode');
   const destinationNamespaceRoot = path.join(repoRoot, 'apps', 'vscode-extension', 'node_modules', '@vscode');
 
@@ -91,7 +100,14 @@ export function copyRipgrepRuntime({ repoRoot, target, execFileSyncFn = execFile
 
   if (requestedPackage) {
     const version = metaPackage.optionalDependencies?.[`@vscode/${requestedPackage}`] ?? metaPackage.version;
-    ensureRipgrepPackage({ repoRoot, sourceNamespaceRoot, packageName: requestedPackage, version, execFileSyncFn });
+    ensureRipgrepPackage({
+      repoRoot,
+      sourceNamespaceRoot,
+      packageName: requestedPackage,
+      version,
+      execFileSyncFn,
+      platform
+    });
   }
 
   fs.mkdirSync(destinationNamespaceRoot, { recursive: true });

--- a/scripts/copy-ripgrep-runtime.test.js
+++ b/scripts/copy-ripgrep-runtime.test.js
@@ -119,3 +119,48 @@ test('copyRipgrepRuntime installs the requested VSIX target package when npm omi
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }
 });
+
+test('copyRipgrepRuntime installs missing target packages through cmd.exe on Windows', async () => {
+  const mod = await import(pathToFileURL(modulePath).href);
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'alv-copy-ripgrep-install-win-'));
+  const vscodeRoot = path.join(repoRoot, 'node_modules', '@vscode');
+  const sourceRoot = path.join(vscodeRoot, 'ripgrep');
+  const armRoot = path.join(vscodeRoot, 'ripgrep-win32-arm64');
+  const installCalls = [];
+
+  try {
+    fs.mkdirSync(sourceRoot, { recursive: true });
+    fs.writeFileSync(
+      path.join(sourceRoot, 'package.json'),
+      JSON.stringify({
+        version: '1.18.0',
+        optionalDependencies: {
+          '@vscode/ripgrep-win32-arm64': '1.18.0'
+        }
+      })
+    );
+
+    const execFileSyncFn = (cmd, args, options) => {
+      installCalls.push({ cmd, args, options });
+      fs.mkdirSync(path.join(armRoot, 'bin'), { recursive: true });
+      fs.writeFileSync(path.join(armRoot, 'package.json'), '{}\n');
+      fs.writeFileSync(path.join(armRoot, 'bin', 'rg.exe'), 'arm');
+    };
+
+    const result = mod.copyRipgrepRuntime({
+      repoRoot,
+      target: 'win32-arm64',
+      execFileSyncFn,
+      platform: 'win32'
+    });
+
+    assert.equal(installCalls.length, 1);
+    assert.equal(installCalls[0].cmd, 'cmd.exe');
+    assert.deepEqual(installCalls[0].args.slice(0, 4), ['/d', '/s', '/c', 'npm.cmd']);
+    assert.ok(installCalls[0].args.includes('@vscode/ripgrep-win32-arm64@1.18.0'));
+    assert.equal(installCalls[0].options.cwd, repoRoot);
+    assert.deepEqual(result.packages, ['ripgrep', 'ripgrep-win32-arm64']);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- invoke missing ripgrep target installs through `cmd.exe /d /s /c npm.cmd` on Windows
- keep the normal `npm` invocation for non-Windows platforms
- add a regression test for the Windows `win32-arm64` packaging path

## Root cause
The prerelease workflow reached VSIX packaging, but `win32-arm64` failed in `copy-ripgrep-runtime.mjs` with `spawnSync npm.cmd EINVAL` while installing the omitted optional package `@vscode/ripgrep-win32-arm64` from a Git Bash shell on the Windows runner.

## Verification
- `node --test scripts/copy-ripgrep-runtime.test.js`
- `node --test scripts/packaging-ci.test.js`
- `npm run test:scripts`