### PR TITLE
fix(extension): resolve packaged sf runner from installed dist

### DIFF
--- a/apps/vscode-extension/src/node-test/runtime/sfPluginClient.test.ts
+++ b/apps/vscode-extension/src/node-test/runtime/sfPluginClient.test.ts
@@ -1,5 +1,6 @@
 import assert from 'assert/strict';
 import os from 'node:os';
+import path from 'node:path';
 import proxyquire from 'proxyquire';
 
 const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
@@ -273,5 +274,16 @@ suite('sf plugin client', () => {
     const { runEmbeddedSfPlugin } = loadRuntimeClient({ existsSync: () => false });
 
     await assert.rejects(runEmbeddedSfPlugin(['doctor']), /Unable to locate embedded sf electivus runner/);
+  });
+
+  test('resolves packaged runner from installed extension dist directory', async () => {
+    const extensionRoot = path.join(os.tmpdir(), 'extensions', 'electivus.apex-log-viewer-0.49.12');
+    const runtimeDir = path.join(extensionRoot, 'dist');
+    const expectedRunner = path.join(extensionRoot, 'sf-plugin', 'electivus-runner.cjs');
+    const { resolveEmbeddedRunnerFromRuntimeDir } = loadRuntimeClient({
+      existsSync: filePath => filePath === expectedRunner
+    });
+
+    assert.equal(resolveEmbeddedRunnerFromRuntimeDir(runtimeDir), expectedRunner);
   });
 });

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -107,32 +107,39 @@ const METHOD_TELEMETRY_NAMES: Record<string, string> = {
   'tooling/request/get': 'tooling_request_get'
 };
 
-function repoRootFromRuntimeDir(): string {
-  const extensionRoot = extensionRootFromRuntimeDir();
+function repoRootFromRuntimeDir(runtimeDir = __dirname): string {
+  const extensionRoot = extensionRootFromRuntimeDir(runtimeDir);
   return path.basename(extensionRoot) === 'vscode-extension'
     ? path.resolve(extensionRoot, '..', '..')
-    : path.resolve(__dirname, '..', '..', '..', '..');
+    : path.resolve(runtimeDir, '..', '..', '..', '..');
 }
 
-function extensionRootFromRuntimeDir(): string {
-  const distRoot = path.resolve(__dirname, '..');
-  if (path.basename(distRoot) === 'vscode-extension') {
-    return distRoot;
+export function extensionRootFromRuntimeDir(runtimeDir = __dirname): string {
+  const currentDir = path.resolve(runtimeDir);
+  if (path.basename(currentDir) === 'dist') {
+    return path.resolve(currentDir, '..');
   }
-  return path.resolve(__dirname, '..', '..');
+  return path.resolve(currentDir, '..', '..');
 }
 
-function resolveEmbeddedRunner(): string | undefined {
-  const packaged = path.join(extensionRootFromRuntimeDir(), 'sf-plugin', 'electivus-runner.cjs');
-  if (existsSync(packaged)) {
+export function resolveEmbeddedRunnerFromRuntimeDir(
+  runtimeDir = __dirname,
+  fileExists: (filePath: string) => boolean = existsSync
+): string | undefined {
+  const packaged = path.join(extensionRootFromRuntimeDir(runtimeDir), 'sf-plugin', 'electivus-runner.cjs');
+  if (fileExists(packaged)) {
     return packaged;
   }
-  const repoRoot = repoRootFromRuntimeDir();
+  const repoRoot = repoRootFromRuntimeDir(runtimeDir);
   const built = path.join(repoRoot, 'packages', 'sf-plugin', 'lib', 'embedded.js');
-  if (existsSync(built)) {
+  if (fileExists(built)) {
     return built;
   }
   return undefined;
+}
+
+function resolveEmbeddedRunner(): string | undefined {
+  return resolveEmbeddedRunnerFromRuntimeDir();
 }
 
 function stripAnsi(value: string): string {


### PR DESCRIPTION
## Summary
- resolve the embedded sf runner from an installed extension `dist` directory
- keep local source/runtime fallback behavior for development
- add a regression test matching VS Code/Insiders install paths like `electivus.apex-log-viewer-0.49.12/dist`

## Root cause
The pre-release VSIX includes `extension/sf-plugin/electivus-runner.cjs`, but the runtime path resolver assumed any extension root not named `vscode-extension` should climb another directory. In an installed extension folder, that made the extension look for `sf-plugin/electivus-runner.cjs` outside the extension install directory.

## Verification
- `npm run test:extension:node`
- `npm run compile`
- `npm run package`
- `node scripts/run-vsce.js package --skip-prepublish --no-yarn --target linux-x64 --out /tmp/alv-fixed.vsix --pre-release`
- `unzip -l /tmp/alv-fixed.vsix | rg "extension/(sf-plugin/electivus-runner.cjs|dist/extension.js|package.json)"`