### PR TITLE
fix(extension): run embedded sf runner under electron node

### DIFF
--- a/apps/vscode-extension/src/node-test/runtime/sfPluginClient.test.ts
+++ b/apps/vscode-extension/src/node-test/runtime/sfPluginClient.test.ts
@@ -286,4 +286,19 @@ suite('sf plugin client', () => {
 
     assert.equal(resolveEmbeddedRunnerFromRuntimeDir(runtimeDir), expectedRunner);
   });
+
+  test('forces embedded runner subprocesses to run Electron as Node without Salesforce log files', () => {
+    const { embeddedRunnerEnv } = loadRuntimeClient({});
+    const env = embeddedRunnerEnv({ ELECTRON_RUN_AS_NODE: '', SF_DISABLE_LOG_FILE: '' });
+
+    assert.deepEqual({
+      ELECTRON_RUN_AS_NODE: env.ELECTRON_RUN_AS_NODE,
+      SF_DISABLE_LOG_FILE: env.SF_DISABLE_LOG_FILE,
+      SFDX_DISABLE_LOG_FILE: env.SFDX_DISABLE_LOG_FILE
+    }, {
+      ELECTRON_RUN_AS_NODE: '1',
+      SF_DISABLE_LOG_FILE: 'true',
+      SFDX_DISABLE_LOG_FILE: 'true'
+    });
+  });
 });

--- a/apps/vscode-extension/src/runtime/runtimeClient.ts
+++ b/apps/vscode-extension/src/runtime/runtimeClient.ts
@@ -142,6 +142,15 @@ function resolveEmbeddedRunner(): string | undefined {
   return resolveEmbeddedRunnerFromRuntimeDir();
 }
 
+export function embeddedRunnerEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  return {
+    ...baseEnv,
+    ELECTRON_RUN_AS_NODE: '1',
+    SF_DISABLE_LOG_FILE: 'true',
+    SFDX_DISABLE_LOG_FILE: 'true'
+  };
+}
+
 function stripAnsi(value: string): string {
   return value.replace(/\u001b\[[0-9;]*m/g, '');
 }
@@ -457,7 +466,7 @@ export function runEmbeddedSfPlugin(
     );
   }
   const childArgs = [runnerPath, ...args, '--json'];
-  const env = options.env ?? process.env;
+  const env = embeddedRunnerEnv(options.env ?? process.env);
   const cwd = options.cwd ?? process.cwd();
   return new Promise((resolve, reject) => {
     const child = spawn(process.execPath, childArgs, { cwd, env, windowsHide: true });

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -846,8 +846,32 @@ async function run() {
     writeFileSync(join(dev, 'package.json'), JSON.stringify(pkg, null, 2));
     writeFileSync(join(dev, 'index.js'), 'exports.activate=()=>{};exports.deactivate=()=>{};\n');
     extensionDevelopmentPath = dev;
-    // Write runner that activates installed extension
-    const runner = `"use strict";const assert=require('assert/strict');const vscode=require('vscode');exports.run=async function(){const ext=vscode.extensions.getExtension('electivus.apex-log-viewer');assert.ok(ext,'extension not found');await ext.activate();const cmds=await vscode.commands.getCommands(true);for(const c of ['sfLogs.refresh','sfLogs.selectOrg','sfLogs.tail','sfLogs.showOutput']){assert.ok(cmds.includes(c),'missing command: '+c);} };\n`;
+    // Write runner that activates the installed extension and exercises the packaged embedded sf runner.
+    const runner = [
+      '"use strict";',
+      "const assert=require('assert/strict');",
+      "const fs=require('fs');",
+      "const path=require('path');",
+      "const {spawn}=require('child_process');",
+      "const vscode=require('vscode');",
+      'function run(command,args,options){return new Promise((resolve,reject)=>{const child=spawn(command,args,options);let stdout="";let stderr="";child.stdout.setEncoding("utf8");child.stderr.setEncoding("utf8");child.stdout.on("data",chunk=>{stdout+=String(chunk);});child.stderr.on("data",chunk=>{stderr+=String(chunk);});child.on("error",reject);child.on("close",(code,signal)=>resolve({code,signal,stdout,stderr}));});}',
+      'function parseJson(stdout){const text=String(stdout||"").trim();assert.ok(text,"embedded runner did not produce JSON output");try{return JSON.parse(text);}catch{}const firstArray=text.indexOf("[");const firstObject=text.indexOf("{");const start=firstArray===-1?firstObject:firstObject===-1?firstArray:Math.min(firstArray,firstObject);const end=Math.max(text.lastIndexOf("]"),text.lastIndexOf("}"));assert.ok(start>=0&&end>start,"embedded runner produced invalid JSON: "+text.slice(0,300));return JSON.parse(text.slice(start,end+1));}',
+      "exports.run=async function(){",
+      "const ext=vscode.extensions.getExtension('electivus.apex-log-viewer');",
+      "assert.ok(ext,'extension not found');",
+      "await ext.activate();",
+      "const cmds=await vscode.commands.getCommands(true);",
+      "for(const c of ['sfLogs.refresh','sfLogs.selectOrg','sfLogs.tail','sfLogs.showOutput']){assert.ok(cmds.includes(c),'missing command: '+c);}",
+      "const runnerPath=path.join(ext.extensionPath,'sf-plugin','electivus-runner.cjs');",
+      "assert.ok(fs.existsSync(runnerPath),'embedded runner missing: '+runnerPath);",
+      "const workspace=vscode.workspace.workspaceFolders&&vscode.workspace.workspaceFolders[0]&&vscode.workspace.workspaceFolders[0].uri.fsPath;",
+      "const result=await run(process.execPath,[runnerPath,'orgs','list','--json'],{cwd:workspace||ext.extensionPath,env:{...process.env,ELECTRON_RUN_AS_NODE:'1',SF_DISABLE_LOG_FILE:'true',SFDX_DISABLE_LOG_FILE:'true'},windowsHide:true});",
+      "assert.equal(result.code,0,'embedded runner failed with code '+result.code+' signal '+result.signal+' stdout: '+result.stdout.slice(0,500)+' stderr: '+result.stderr.slice(0,500));",
+      "const parsed=parseJson(result.stdout);",
+      "assert.ok(Array.isArray(parsed),'embedded runner orgs list should return an array');",
+      "};",
+      ''
+    ].join('\n');
     const testsDir = mkdtempSync(join(tmpdir(), 'alv-smoke-tests-'));
     extensionTestsPath = join(testsDir, 'smoke-runner.js');
     writeFileSync(extensionTestsPath, runner, 'utf8');

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -43,6 +43,15 @@ test("VSIX smoke validation keeps existsSync available for the packaged VSIX che
   assert.match(script, /if \(!existsSync\(smokeVsixPath\)\) throw new Error\('\[smoke\] VSIX not found'\);/);
 });
 
+test("VSIX smoke validation exercises the packaged embedded sf runner", () => {
+  const script = fs.readFileSync(path.join(__dirname, "run-tests.js"), "utf8");
+
+  assert.match(script, /'sf-plugin','electivus-runner\.cjs'/);
+  assert.match(script, /ELECTRON_RUN_AS_NODE:'1'/);
+  assert.match(script, /\[runnerPath,'orgs','list','--json'\]/);
+  assert.match(script, /embedded runner did not produce JSON output/);
+});
+
 test("resolveMissingExtensionIds reports missing dependencies instead of relying on local user extensions", () => {
   const output = [
     "salesforce.salesforcedx-vscode@58.5.0",


### PR DESCRIPTION
## Summary

- Force the embedded sf plugin subprocess to run Electron/VS Code as Node with `ELECTRON_RUN_AS_NODE=1`.
- Disable Salesforce SDK log-file transports for the embedded runner subprocess.
- Extend the VSIX smoke test so it installs the packaged VSIX and executes `sf-plugin/electivus-runner.cjs orgs list --json` from the installed extension path.

## Root Cause

The extension used `process.execPath` to launch `electivus-runner.cjs`. In an installed VS Code/Insiders extension host, `process.execPath` is the Electron/Code executable, not a plain Node binary. Without `ELECTRON_RUN_AS_NODE=1`, the child process can exit successfully without running the script, leaving stdout empty and causing `sf electivus did not produce JSON output`.

The existing E2E path did not catch this because it exercised the development extension layout. The old VSIX smoke test only verified activation and command registration; it did not execute the embedded sf runner inside the installed VSIX.

## Validation

- `npm run test:extension:node`
- `npm run test:scripts`
- `npm run compile`
- `npm run test:smoke:vsix`
