### PR TITLE
chore(extension): require VS Code 1.101

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Chores
+
+- Extension: require VS Code 1.101+ so the extension host runs on Node.js 22, and update packaged requirements text.
+
 ## [0.50.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.1...v0.50.0) (2026-07-07)
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Search in the logs panel is optimized for locally saved log bodies, so the most 
 ## Requirements
 
 - Salesforce CLI installed and authenticated. `sf` is recommended, but legacy `sfdx` also works.
-- VS Code 1.90+.
+- VS Code 1.101+.
 - Recommended for Replay Debugger: Salesforce Extension Pack (`salesforce.salesforcedx-vscode`).
 
 Login example:

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/Electivus/Apex-Log-Viewer"
   },
   "engines": {
-    "vscode": "^1.90.0"
+    "vscode": "^1.101.0"
   },
   "icon": "media/icon.png",
   "galleryBanner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/proxyquire": "^1.3.4",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@types/vscode": "1.90.0",
+        "@types/vscode": "1.101.0",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vscode/test-electron": "^3.0.0",
@@ -88,7 +88,7 @@
       "version": "0.50.0",
       "license": "MIT",
       "engines": {
-        "vscode": "^1.90.0"
+        "vscode": "^1.101.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10089,9 +10089,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.90.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.90.0.tgz",
-      "integrity": "sha512-oT+ZJL7qHS9Z8bs0+WKf/kQ27qWYR3trsXpq46YDjFqBsMLG4ygGGjPaJ2tyrH0wJzjOEmDyg9PDJBBhWg9pkQ==",
+      "version": "1.101.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
+      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/proxyquire": "^1.3.4",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@types/vscode": "1.90.0",
+    "@types/vscode": "1.101.0",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@vscode/test-electron": "^3.0.0",


### PR DESCRIPTION
## Summary

- Raise the VS Code extension engine requirement from `^1.90.0` to `^1.101.0`, the stable release line that moves the Node.js extension host to Node 22.
- Align the development VS Code typings to `@types/vscode@1.101.0` and refresh the lockfile.

## Validation

- `npm ci`
- `npm run check-types`
- `npm run compile`
- `git diff --check`
