### PR TITLE
chore(extension): require VS Code 1.105

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Chores
 
-- Extension: require VS Code 1.101+ so the extension host runs on Node.js 22, and update packaged requirements text.
+- Extension: require VS Code 1.105+ so the extension host provides Node.js 22.19+, and update packaged requirements text.
 
 ## [0.50.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.1...v0.50.0) (2026-07-07)
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Search in the logs panel is optimized for locally saved log bodies, so the most 
 ## Requirements
 
 - Salesforce CLI installed and authenticated. `sf` is recommended, but legacy `sfdx` also works.
-- VS Code 1.101+.
+- VS Code 1.105+.
 - Recommended for Replay Debugger: Salesforce Extension Pack (`salesforce.salesforcedx-vscode`).
 
 Login example:

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -11,7 +11,7 @@
     "url": "https://github.com/Electivus/Apex-Log-Viewer"
   },
   "engines": {
-    "vscode": "^1.101.0"
+    "vscode": "^1.105.0"
   },
   "icon": "media/icon.png",
   "galleryBanner": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
         "@types/proxyquire": "^1.3.4",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
-        "@types/vscode": "1.101.0",
+        "@types/vscode": "1.105.0",
         "@typescript-eslint/eslint-plugin": "^8.62.1",
         "@typescript-eslint/parser": "^8.56.1",
         "@vscode/test-electron": "^3.0.0",
@@ -88,7 +88,7 @@
       "version": "0.50.0",
       "license": "MIT",
       "engines": {
-        "vscode": "^1.101.0"
+        "vscode": "^1.105.0"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -10089,9 +10089,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.101.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.101.0.tgz",
-      "integrity": "sha512-ZWf0IWa+NGegdW3iU42AcDTFHWW7fApLdkdnBqwYEtHVIBGbTu0ZNQKP/kX3Ds/uMJXIMQNAojHR4vexCEEz5Q==",
+      "version": "1.105.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.105.0.tgz",
+      "integrity": "sha512-Lotk3CTFlGZN8ray4VxJE7axIyLZZETQJVWi/lYoUVQuqfRxlQhVOfoejsD2V3dVXPSbS15ov5ZyowMAzgUqcw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/proxyquire": "^1.3.4",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
-    "@types/vscode": "1.101.0",
+    "@types/vscode": "1.105.0",
     "@typescript-eslint/eslint-plugin": "^8.62.1",
     "@typescript-eslint/parser": "^8.56.1",
     "@vscode/test-electron": "^3.0.0",


### PR DESCRIPTION
## Summary

- Raise the VS Code extension engine floor from `^1.101.0` to `^1.105.0`.
- Align `@types/vscode` with the new minimum supported VS Code API surface.
- Update README and changelog requirement text.

## Why

VS Code 1.101 moved the extension host to Node.js 22, but it ships Node.js 22.15.1. Some current dependency updates, including `undici@8.7.0`, require Node.js `>=22.19.0`. VS Code 1.105 is the first stable VS Code line that ships Electron 37.6.0 with Node.js 22.19.0, so this makes the published compatibility contract match that dependency floor.

## Validation

- `npm install --package-lock-only --ignore-scripts`
- `npm audit --audit-level=moderate`
- `npm ci`
- `npm run check-types`
- `git diff --check`