### PR TITLE
chore(sf-plugin): require Node 22.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Chores
 
 - Extension: require VS Code 1.105+ so the extension host provides Node.js 22.19+, and update packaged requirements text.
+- CLI/Plugin: require Node.js 22.19+ for the standalone Salesforce CLI plugin to match the dependency runtime baseline.
 
 ## [0.50.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.1...v0.50.0) (2026-07-07)
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Search in the logs panel is optimized for locally saved log bodies, so the most 
 
 - Salesforce CLI installed and authenticated. `sf` is recommended, but legacy `sfdx` also works.
 - VS Code 1.105+.
+- Standalone Salesforce CLI plugin: Node.js 22.19+.
 - Recommended for Replay Debugger: Salesforce Extension Pack (`salesforce.salesforcedx-vscode`).
 
 Login example:
@@ -71,6 +72,7 @@ sf electivus logs status --target-org my-org
 `logs sync` resolves org auth through Salesforce CLI/Core, lists `ApexLog` rows, and downloads raw log bodies over the Salesforce Tooling REST API. It materializes those bodies under `apexlogs/`, keeps incremental state in `apexlogs/.alv/sync-state.json`, writes the canonical org-first layout at `apexlogs/orgs/<safe-target-org>/logs/YYYY-MM-DD/<logId>.log`, and removes the legacy SQLite search index files from older runtime versions. Use `--concurrency` when you want to tune how many log bodies are downloaded in parallel; the default is `6` and `1` keeps the serial-style troubleshooting mode.
 
 The VS Code extension bundles this plugin and invokes its embedded runner directly, so extension users do not need to install the plugin globally. The published plugin remains useful for terminal and agent workflows that want the same JSON command surface outside VS Code.
+The standalone plugin runs on Node.js 22.19+; extension users get the compatible runtime through VS Code 1.105+.
 
 Install the companion Codex skill for agent workflows with:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -611,7 +611,7 @@
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/@azu/format-text": {
@@ -25361,7 +25361,7 @@
         "tsx": "^4.22.4"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=22.19.0"
       }
     },
     "packages/webview": {

--- a/packages/sf-plugin/package.json
+++ b/packages/sf-plugin/package.json
@@ -31,7 +31,7 @@
     "tsx": "^4.22.4"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=22.19.0"
   },
   "keywords": [
     "salesforce",


### PR DESCRIPTION
## Summary
- raise the standalone Salesforce CLI plugin engine floor to Node.js 22.19
- document the standalone plugin runtime requirement alongside the VS Code 1.105+ requirement
- record the runtime contract change in the changelog

## Validation
- npm install --package-lock-only --ignore-scripts
- npm run check-types
- git diff --check

## Dependency triage context
- prepares the plugin contract for Dependabot runtime updates that pull `undici@8.x`, whose package engine requires Node.js >=22.19.0
