### PR TITLE
chore(sf-plugin): prepare 0.1.19 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Extension: require VS Code 1.105+ so the extension host provides Node.js 22.19+, and update packaged requirements text.
 - CLI/Plugin: require Node.js 22.19+ for the standalone Salesforce CLI plugin to match the dependency runtime baseline.
+- Release/SF Plugin: bump `@electivus/plugin-electivus` to `0.1.19` for the next independent Salesforce CLI plugin npm release.
 
 ## [0.50.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.1...v0.50.0) (2026-07-07)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25477,7 +25477,7 @@
     },
     "packages/sf-plugin": {
       "name": "@electivus/plugin-electivus",
-      "version": "0.1.18",
+      "version": "0.1.19",
       "license": "MIT",
       "dependencies": {
         "@jsforce/jsforce-node": "3.10.19",

--- a/packages/sf-plugin/package.json
+++ b/packages/sf-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electivus/plugin-electivus",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "private": true,
   "description": "Salesforce CLI plugin for Electivus Apex Log Viewer workflows.",
   "type": "module",


### PR DESCRIPTION
## Summary

Prepare the next independent Salesforce CLI plugin npm release by bumping `@electivus/plugin-electivus` from `0.1.18` to `0.1.19`.

After this PR merges, create the release tag as `sf-plugin-v0.1.19` on the merge commit to trigger `.github/workflows/sf-plugin-release.yml`.

## Validation

- `node scripts/check-dependency-sources.mjs`
- `npm run test:sf-plugin`
- `npm run build:sf-plugin`
- `npm run stage:sf-plugin-npm`
- `node -e "const p=require('./dist/sf-plugin-npm/package.json'); if (p.version !== '0.1.19') { throw new Error('staged package version ' + p.version + ' != 0.1.19'); } if (p.private !== undefined) { throw new Error('staged package must not be private'); }"`
- `git diff --check`