### PR TITLE
fix(e2e): isolate pooled scratch orgs per test

### DIFF
--- a/docs/CI.md
+++ b/docs/CI.md
@@ -4,7 +4,7 @@ This repository uses GitHub Actions to build, test, package, and publish the ext
 
 - Workflow CI (`.github/workflows/ci.yml`): build/test on `push` and `pull_request` across `ubuntu-latest`, `windows-latest`, and `macos-latest`. Manual `workflow_dispatch` allows choosing the test scope (`unit`, `integration`, or `all`). This workflow enforces dependency provenance with `node scripts/check-dependency-sources.mjs` before every `npm ci`, then runs npm registry signature verification (`npm run security:npm-signatures`) before compile/test. The VSIX smoke test remains Ubuntu-only after the OS matrix succeeds.
 - Workflow Dependency Review (`.github/workflows/dependency-review.yml`): blocks pull requests that introduce new moderate-or-higher dependency risk in runtime or development scopes.
-- Workflow E2E (`.github/workflows/e2e-playwright.yml`): real scratch-org Playwright validation on `pull_request` and manual dispatch. This workflow is pool-only in CI: it requires `SF_SCRATCH_POOL_NAME` plus `SF_DEVHUB_AUTH_URL`, reuses pooled scratch orgs through each slot's stored `sfdxAuthUrl`, and defaults to `1` Playwright worker on PR runs unless `playwright_workers` is set for a manual dispatch. Ubuntu keeps the full MITM proxy-lab path and runs both real-org surfaces in order: `npm run test:e2e:cli` for the `sf electivus` plugin, then `npm run test:e2e:telemetry` when Azure OIDC secrets and the E2E telemetry target variables are configured, otherwise `npm run test:e2e`, for the VS Code extension flow. Windows and macOS run the same CLI and VS Code E2E suites directly against the scratch-org pool, without Docker/proxy-lab. CLI artifacts upload from `output/playwright-cli/`; extension artifacts upload from `output/playwright/`, with OS-specific artifact names for direct Windows/macOS runs.
+- Workflow E2E (`.github/workflows/e2e-playwright.yml`): real scratch-org Playwright validation on `pull_request` and manual dispatch. This workflow is pool-only in CI: it requires `SF_SCRATCH_POOL_NAME` plus `SF_DEVHUB_AUTH_URL`, leases one pooled scratch org per Playwright test through each slot's stored `sfdxAuthUrl`, and defaults to `1` Playwright worker on PR runs unless `playwright_workers` is set for a manual dispatch. Ubuntu keeps the full MITM proxy-lab path and runs both real-org surfaces in order: `npm run test:e2e:cli` for the `sf electivus` plugin, then `npm run test:e2e:telemetry` when Azure OIDC secrets and the E2E telemetry target variables are configured, otherwise `npm run test:e2e`, for the VS Code extension flow. Windows and macOS run the same CLI and VS Code E2E suites directly against the scratch-org pool, without Docker/proxy-lab. CLI artifacts upload from `output/playwright-cli/`; extension artifacts upload from `output/playwright/`, with OS-specific artifact names for direct Windows/macOS runs.
 - Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 
@@ -35,7 +35,7 @@ Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref, e
 The Playwright workflow in `.github/workflows/e2e-playwright.yml` is pool-only in CI:
 
 - It uses the Dev Hub scratch-org pool.
-- It leases a dedicated org per Playwright worker.
+- It leases a dedicated org per Playwright test.
 - It defaults to `1` worker on PR runs unless `playwright_workers` is provided for a manual dispatch.
 - It runs the `sf electivus` real-org suite before the VS Code extension suite on every E2E lane.
 - Ubuntu runs those suites through the MITM proxy lab; Windows and macOS run them directly on the hosted runner.
@@ -63,19 +63,19 @@ Optional repository variables:
 Key behavior in pool mode:
 
 - `SF_SCRATCH_STRATEGY=pool` and `PLAYWRIGHT_WORKERS` are injected automatically.
-- The workflow defaults to `PLAYWRIGHT_WORKERS=1` in pool mode on `pull_request`; manual dispatch can override that value with the `playwright_workers` input.
+- The workflow defaults to `PLAYWRIGHT_WORKERS=1` in pool mode on `pull_request`; manual dispatch can override that value with the `playwright_workers` input to run multiple isolated tests concurrently.
 - The Ubuntu CLI real-org step runs `npm run test:e2e:cli` through the proxy lab with the same scratch-org env contract as the extension step, then uploads `output/playwright-cli/` as a dedicated artifact.
 - The Ubuntu extension step then runs `npm run test:e2e:telemetry` or `npm run test:e2e` through the proxy lab and uploads `output/playwright/`.
 - The Windows/macOS direct matrix runs `npm run test:e2e:cli` and `npm run test:e2e` without proxy-lab, then uploads artifacts with OS suffixes such as `playwright-cli-e2e-windows` and `playwright-e2e-macos`.
 - The workflow-level concurrency lock uses the configured `SF_SCRATCH_POOL_NAME` when pool mode is active, with `cancel-in-progress: false`, so active runs sharing the same Dev Hub pool are not canceled or allowed to over-lease the pool during dependency bursts.
-- The helper still keeps `fullyParallel: false`, but multiple Playwright workers can now run in parallel because each worker acquires its own scratch org slot.
+- The Playwright configs enable `fullyParallel` in pool mode because each test acquires its own scratch org slot; legacy single-scratch mode stays serial.
 - Manual `workflow_dispatch` runs use the same pool-only path as `pull_request`, so dispatch validation exercises the same concurrency and lease behavior as CI.
 
 In pool mode, the Dev Hub uses `SF_DEVHUB_AUTH_URL` for create/delete/recreate operations, and each slot reuses its own stored `sfdxAuthUrl` to log back into the scratch org. No custom Connected App or External Client App is required for the pool.
 
 Operational note:
 
-- The scratch org is expected to be cleaned and reseeded by the E2E suite itself before each run. Pooling reduces daily org creation and unlocks worker-level parallelism, but it does not replace test-level cleanup.
+- Each scratch org is expected to be cleaned and reseeded by the E2E test that uses it. Pooling reduces daily org creation and unlocks test-level parallelism, but it does not replace test-level cleanup.
 
 See also: `docs/SCRATCH_ORG_POOL.md`.
 

--- a/docs/SCRATCH_ORG_POOL.md
+++ b/docs/SCRATCH_ORG_POOL.md
@@ -97,6 +97,8 @@ SF_SCRATCH_STRATEGY=pool SF_SCRATCH_POOL_NAME=alv-e2e PLAYWRIGHT_WORKERS=7 npm r
 
 If `SF_SCRATCH_STRATEGY` is unset, the helper automatically switches to pool mode when `SF_SCRATCH_POOL_NAME` is present. The legacy single-scratch flow still works and remains the fallback when the pool is not configured.
 
+In pool mode, each Playwright test acquires its own scratch-org pool slot. `PLAYWRIGHT_WORKERS` controls how many isolated tests may run at the same time. In legacy single-scratch mode, the Playwright configs force serial execution so parallel tests do not share the same scratch alias.
+
 ## GitHub Actions
 
 The Playwright workflow is pool-only in CI. It requires `SF_SCRATCH_POOL_NAME` and `SF_DEVHUB_AUTH_URL`, and it fails fast when either value is missing instead of falling back to the legacy single-scratch path.
@@ -115,7 +117,7 @@ Repository variables for pool mode:
 - `SF_SCRATCH_POOL_SEED_VERSION` (optional)
 - `SF_SCRATCH_POOL_SNAPSHOT_NAME` (optional)
 
-When pool mode is active, the workflow lets each Playwright worker acquire its own scratch org slot and reuse the stored `sfdxAuthUrl` for future runs. The repository workflow defaults to `1` Playwright worker for CI PR runs; manual `workflow_dispatch` runs can override that with the `playwright_workers` input.
+When pool mode is active, each Playwright test acquires its own scratch org slot and reuses the stored `sfdxAuthUrl` for that slot. The repository workflow defaults to `1` Playwright worker for CI PR runs; manual `workflow_dispatch` runs can override that with the `playwright_workers` input to run multiple isolated tests concurrently.
 
 The workflow-level concurrency group is keyed by `SF_SCRATCH_POOL_NAME` with `cancel-in-progress: false`. Active runs that share the same Dev Hub pool are not canceled or allowed to run every PR ref at once. This prevents Dependabot bursts from producing spurious lease-exhaustion failures.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -97,7 +97,7 @@ Useful env vars:
 - `SF_DEVHUB_AUTH_URL`: Explicit Dev Hub auth for the run. Required for real-org `test:e2e:proxy-lab` runs because the clean runner container cannot use a host `SF_DEVHUB_ALIAS`.
 - `SF_DEVHUB_ALIAS`: Explicit Dev Hub alias to use for non-proxy-lab runs. Set this or `SF_DEVHUB_AUTH_URL`.
 - `SF_SCRATCH_STRATEGY`: `single` or `pool`. If unset, the helper auto-enables pool mode when `SF_SCRATCH_POOL_NAME` is present. Local runs can use either mode; CI forces `pool`.
-- `PLAYWRIGHT_WORKERS`: Number of Playwright workers. Default `1` locally; the GitHub Actions pool workflow also defaults to `1` unless overridden by workflow-dispatch input.
+- `PLAYWRIGHT_WORKERS`: Number of Playwright workers. In pool mode this controls how many isolated tests can run at once, with one scratch-org lease per test. Default `1` locally; the GitHub Actions pool workflow also defaults to `1` unless overridden by workflow-dispatch input. In single-scratch mode, the Playwright configs force serial execution.
 - `SF_SCRATCH_ALIAS`: Scratch alias (default `ALV_E2E_Scratch`).
 - `SF_SCRATCH_DURATION`: Scratch duration in days (default `1`).
 - `SF_TEST_KEEP_ORG=1`: Keep the scratch org after the run (recommended while iterating).

--- a/playwright.cli.config.ts
+++ b/playwright.cli.config.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { defineConfig } from '@playwright/test';
+import { resolvePlaywrightParallelism } from './test/e2e/utils/playwrightParallelism';
 import { applyE2eNetworkEnvironment } from './test/e2e/utils/proxy';
 
 applyE2eNetworkEnvironment();
@@ -7,21 +8,18 @@ applyE2eNetworkEnvironment();
 const repoRoot = __dirname;
 const artifactsRoot = path.join(repoRoot, 'output', 'playwright-cli');
 const resultsRoot = path.join(artifactsRoot, 'test-results');
-const configuredWorkers = Math.max(1, Number(process.env.PLAYWRIGHT_WORKERS || 1) || 1);
+const parallelism = resolvePlaywrightParallelism();
 
 export default defineConfig({
   testDir: path.join(__dirname, 'test', 'e2e', 'cli'),
-  fullyParallel: false,
-  workers: configuredWorkers,
+  fullyParallel: parallelism.fullyParallel,
+  workers: parallelism.workers,
   timeout: 15 * 60 * 1000,
   expect: { timeout: 60 * 1000 },
   retries: process.env.CI ? 1 : 0,
   outputDir: resultsRoot,
   reporter: process.env.CI
-    ? [
-        ['list'],
-        ['html', { open: 'never', outputFolder: path.join(artifactsRoot, 'report') }]
-      ]
+    ? [['list'], ['html', { open: 'never', outputFolder: path.join(artifactsRoot, 'report') }]]
     : [['list']],
   use: {
     trace: 'retain-on-failure',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,6 @@
 import path from 'path';
 import { defineConfig } from '@playwright/test';
+import { resolvePlaywrightParallelism } from './test/e2e/utils/playwrightParallelism';
 import { applyE2eNetworkEnvironment } from './test/e2e/utils/proxy';
 
 applyE2eNetworkEnvironment();
@@ -7,21 +8,18 @@ applyE2eNetworkEnvironment();
 const repoRoot = __dirname;
 const artifactsRoot = path.join(repoRoot, 'output', 'playwright');
 const resultsRoot = path.join(artifactsRoot, 'test-results');
-const configuredWorkers = Math.max(1, Number(process.env.PLAYWRIGHT_WORKERS || 1) || 1);
+const parallelism = resolvePlaywrightParallelism();
 
 export default defineConfig({
   testDir: path.join(__dirname, 'test', 'e2e', 'specs'),
-  fullyParallel: false,
-  workers: configuredWorkers,
+  fullyParallel: parallelism.fullyParallel,
+  workers: parallelism.workers,
   timeout: 15 * 60 * 1000,
   expect: { timeout: 60 * 1000 },
   retries: process.env.CI ? 1 : 0,
   outputDir: resultsRoot,
   reporter: process.env.CI
-    ? [
-        ['list'],
-        ['html', { open: 'never', outputFolder: path.join(artifactsRoot, 'report') }]
-      ]
+    ? [['list'], ['html', { open: 'never', outputFolder: path.join(artifactsRoot, 'report') }]]
     : [['list']],
   use: {
     trace: 'retain-on-failure',

--- a/test/e2e/cli/fixtures/alvCliE2E.ts
+++ b/test/e2e/cli/fixtures/alvCliE2E.ts
@@ -29,10 +29,17 @@ type Fixtures = {
   scratchLeaseState: ScratchLeaseState;
 };
 
-async function attachTextArtifact(name: string, body: string, attach: (name: string, options: {
-  body: Buffer;
-  contentType: string;
-}) => Promise<void>): Promise<void> {
+async function attachTextArtifact(
+  name: string,
+  body: string,
+  attach: (
+    name: string,
+    options: {
+      body: Buffer;
+      contentType: string;
+    }
+  ) => Promise<void>
+): Promise<void> {
   await attach(name, {
     body: Buffer.from(body, 'utf8'),
     contentType: 'text/plain'
@@ -44,26 +51,23 @@ export function sfJsonResult(result: CliRunResult): any {
 }
 
 export const test = base.extend<Fixtures>({
-  scratchLeaseState: [
-    async ({}, use) => {
-      const scratch = await ensureScratchOrg();
-      const state: ScratchLeaseState = {
-        scratch,
-        hadFailure: false
-      };
-      try {
-        await use(state);
-      } finally {
-        await scratch.cleanup({
-          success: !state.hadFailure,
-          needsRecreate: state.hadFailure,
-          errorMessage: state.failureMessage,
-          lastRunResult: state.hadFailure ? 'failed' : 'completed'
-        });
-      }
-    },
-    { scope: 'worker' }
-  ],
+  scratchLeaseState: async ({}, use) => {
+    const scratch = await ensureScratchOrg();
+    const state: ScratchLeaseState = {
+      scratch,
+      hadFailure: false
+    };
+    try {
+      await use(state);
+    } finally {
+      await scratch.cleanup({
+        success: !state.hadFailure,
+        needsRecreate: state.hadFailure,
+        errorMessage: state.failureMessage,
+        lastRunResult: state.hadFailure ? 'failed' : 'completed'
+      });
+    }
+  },
 
   _scratchLeaseGuard: [
     async ({ scratchLeaseState }, use, testInfo) => {
@@ -71,8 +75,7 @@ export const test = base.extend<Fixtures>({
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
 
@@ -80,28 +83,23 @@ export const test = base.extend<Fixtures>({
 
       if (testInfo.status !== testInfo.expectedStatus) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
+        scratchLeaseState.failureMessage ??= `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
       }
 
       try {
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
     },
     { auto: true }
   ],
 
-  scratchAlias: [
-    async ({ scratchLeaseState }, use) => {
-      await use(scratchLeaseState.scratch.scratchAlias);
-    },
-    { scope: 'worker' }
-  ],
+  scratchAlias: async ({ scratchLeaseState }, use) => {
+    await use(scratchLeaseState.scratch.scratchAlias);
+  },
 
   seededLog: async ({ scratchAlias }, use) => {
     await clearOrgApexLogs(scratchAlias, 'all');

--- a/test/e2e/fixtures/alvE2E.ts
+++ b/test/e2e/fixtures/alvE2E.ts
@@ -34,26 +34,23 @@ type Options = {
 export const test = base.extend<Fixtures & Options>({
   supportExtensionIds: [[], { option: true }],
 
-  scratchLeaseState: [
-    async ({}, use) => {
-      const scratch = await ensureScratchOrg();
-      const state: ScratchLeaseState = {
-        scratch,
-        hadFailure: false
-      };
-      try {
-        await use(state);
-      } finally {
-        await scratch.cleanup({
-          success: !state.hadFailure,
-          needsRecreate: state.hadFailure,
-          errorMessage: state.failureMessage,
-          lastRunResult: state.hadFailure ? 'failed' : 'completed'
-        });
-      }
-    },
-    { scope: 'worker' }
-  ],
+  scratchLeaseState: async ({}, use) => {
+    const scratch = await ensureScratchOrg();
+    const state: ScratchLeaseState = {
+      scratch,
+      hadFailure: false
+    };
+    try {
+      await use(state);
+    } finally {
+      await scratch.cleanup({
+        success: !state.hadFailure,
+        needsRecreate: state.hadFailure,
+        errorMessage: state.failureMessage,
+        lastRunResult: state.hadFailure ? 'failed' : 'completed'
+      });
+    }
+  },
 
   _scratchLeaseGuard: [
     async ({ scratchLeaseState }, use, testInfo) => {
@@ -61,36 +58,30 @@ export const test = base.extend<Fixtures & Options>({
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
       await use();
 
       if (testInfo.status !== testInfo.expectedStatus) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
+        scratchLeaseState.failureMessage ??= `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
       }
 
       try {
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
     },
     { auto: true }
   ],
 
-  scratchAlias: [
-    async ({ scratchLeaseState }, use) => {
-      await use(scratchLeaseState.scratch.scratchAlias);
-    },
-    { scope: 'worker' }
-  ],
+  scratchAlias: async ({ scratchLeaseState }, use) => {
+    await use(scratchLeaseState.scratch.scratchAlias);
+  },
 
   seededLog: async ({ scratchAlias }, use) => {
     const seeded = await seedApexLog(scratchAlias);

--- a/test/e2e/fixtures/alvNoSeed.ts
+++ b/test/e2e/fixtures/alvNoSeed.ts
@@ -25,26 +25,23 @@ type Options = {
 export const test = base.extend<Fixtures & Options>({
   supportExtensionIds: [[], { option: true }],
 
-  scratchLeaseState: [
-    async ({}, use) => {
-      const scratch = await ensureScratchOrg();
-      const state = {
-        scratch,
-        hadFailure: false
-      };
-      try {
-        await use(state);
-      } finally {
-        await scratch.cleanup({
-          success: !state.hadFailure,
-          needsRecreate: state.hadFailure,
-          errorMessage: state.failureMessage,
-          lastRunResult: state.hadFailure ? 'failed' : 'completed'
-        });
-      }
-    },
-    { scope: 'worker' }
-  ],
+  scratchLeaseState: async ({}, use) => {
+    const scratch = await ensureScratchOrg();
+    const state = {
+      scratch,
+      hadFailure: false
+    };
+    try {
+      await use(state);
+    } finally {
+      await scratch.cleanup({
+        success: !state.hadFailure,
+        needsRecreate: state.hadFailure,
+        errorMessage: state.failureMessage,
+        lastRunResult: state.hadFailure ? 'failed' : 'completed'
+      });
+    }
+  },
 
   _scratchLeaseGuard: [
     async ({ scratchLeaseState }, use, testInfo) => {
@@ -52,36 +49,30 @@ export const test = base.extend<Fixtures & Options>({
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
       await use();
 
       if (testInfo.status !== testInfo.expectedStatus) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
+        scratchLeaseState.failureMessage ??= `Test '${testInfo.title}' ended with status '${testInfo.status}' (expected '${testInfo.expectedStatus}').`;
       }
 
       try {
         scratchLeaseState.scratch.assertLeaseHealthy?.();
       } catch (error) {
         scratchLeaseState.hadFailure = true;
-        scratchLeaseState.failureMessage ??=
-          error instanceof Error ? error.message : String(error);
+        scratchLeaseState.failureMessage ??= error instanceof Error ? error.message : String(error);
         throw error;
       }
     },
     { auto: true }
   ],
 
-  scratchAlias: [
-    async ({ scratchLeaseState }, use) => {
-      await use(scratchLeaseState.scratch.scratchAlias);
-    },
-    { scope: 'worker' }
-  ],
+  scratchAlias: async ({ scratchLeaseState }, use) => {
+    await use(scratchLeaseState.scratch.scratchAlias);
+  },
 
   workspacePath: async ({ scratchAlias }, use, testInfo) => {
     const sfCli = await resolveSfCliInvocation();

--- a/test/e2e/utils/__tests__/playwrightParallelism.test.ts
+++ b/test/e2e/utils/__tests__/playwrightParallelism.test.ts
@@ -1,0 +1,60 @@
+import { resolvePlaywrightParallelism } from '../playwrightParallelism';
+
+describe('resolvePlaywrightParallelism', () => {
+  test('enables full parallelism and respects workers for explicit pool mode', () => {
+    expect(
+      resolvePlaywrightParallelism({
+        SF_SCRATCH_STRATEGY: 'pool',
+        PLAYWRIGHT_WORKERS: '4'
+      })
+    ).toEqual({
+      fullyParallel: true,
+      workers: 4
+    });
+  });
+
+  test('auto-detects pool mode from SF_SCRATCH_POOL_NAME', () => {
+    expect(
+      resolvePlaywrightParallelism({
+        SF_SCRATCH_POOL_NAME: 'alv-e2e',
+        PLAYWRIGHT_WORKERS: '3'
+      })
+    ).toEqual({
+      fullyParallel: true,
+      workers: 3
+    });
+  });
+
+  test('forces serial execution for explicit single mode', () => {
+    expect(
+      resolvePlaywrightParallelism({
+        SF_SCRATCH_STRATEGY: 'single',
+        SF_SCRATCH_POOL_NAME: 'alv-e2e',
+        PLAYWRIGHT_WORKERS: '5'
+      })
+    ).toEqual({
+      fullyParallel: false,
+      workers: 1
+    });
+  });
+
+  test.each(['', '0', '-1', 'abc', '2.5'])('falls back to one worker for invalid PLAYWRIGHT_WORKERS=%p', workers => {
+    expect(
+      resolvePlaywrightParallelism({
+        SF_SCRATCH_STRATEGY: 'pool',
+        PLAYWRIGHT_WORKERS: workers
+      })
+    ).toEqual({
+      fullyParallel: true,
+      workers: 1
+    });
+  });
+
+  test('rejects invalid scratch strategies', () => {
+    expect(() =>
+      resolvePlaywrightParallelism({
+        SF_SCRATCH_STRATEGY: 'parallel'
+      })
+    ).toThrow("Invalid SF_SCRATCH_STRATEGY value 'parallel'. Expected 'single' or 'pool'.");
+  });
+});

--- a/test/e2e/utils/playwrightParallelism.ts
+++ b/test/e2e/utils/playwrightParallelism.ts
@@ -1,0 +1,43 @@
+export type PlaywrightParallelism = {
+  fullyParallel: boolean;
+  workers: number;
+};
+
+function readEnvValue(env: NodeJS.ProcessEnv, name: string): string | undefined {
+  const value = String(env[name] || '').trim();
+  return value || undefined;
+}
+
+function resolveConfiguredWorkers(env: NodeJS.ProcessEnv): number {
+  const rawWorkers = readEnvValue(env, 'PLAYWRIGHT_WORKERS');
+  if (!rawWorkers || !/^\d+$/.test(rawWorkers)) {
+    return 1;
+  }
+
+  const workers = Number(rawWorkers);
+  return Number.isFinite(workers) && workers > 0 ? workers : 1;
+}
+
+function resolvePoolMode(env: NodeJS.ProcessEnv): boolean {
+  const strategy = String(env.SF_SCRATCH_STRATEGY || '')
+    .trim()
+    .toLowerCase();
+  if (strategy === 'pool') {
+    return true;
+  }
+  if (strategy === 'single') {
+    return false;
+  }
+  if (strategy) {
+    throw new Error(`Invalid SF_SCRATCH_STRATEGY value '${strategy}'. Expected 'single' or 'pool'.`);
+  }
+  return Boolean(readEnvValue(env, 'SF_SCRATCH_POOL_NAME'));
+}
+
+export function resolvePlaywrightParallelism(env: NodeJS.ProcessEnv = process.env): PlaywrightParallelism {
+  const poolMode = resolvePoolMode(env);
+  return {
+    fullyParallel: poolMode,
+    workers: poolMode ? resolveConfiguredWorkers(env) : 1
+  };
+}


### PR DESCRIPTION
## Summary
- isolate pooled scratch-org leases at Playwright test scope for extension and CLI E2E fixtures
- enable `fullyParallel` only in pool mode while forcing single-scratch runs to stay serial
- document that `PLAYWRIGHT_WORKERS` controls concurrent isolated tests, not scratch sharing

## Validation
- `npm run test:e2e:utils`
- `npm run check-types`
- `npx prettier --check playwright.config.ts playwright.cli.config.ts test/e2e/utils/playwrightParallelism.ts test/e2e/utils/__tests__/playwrightParallelism.test.ts test/e2e/fixtures/alvE2E.ts test/e2e/fixtures/alvNoSeed.ts test/e2e/cli/fixtures/alvCliE2E.ts docs/SCRATCH_ORG_POOL.md docs/CI.md docs/TESTING.md`
- `SF_SCRATCH_STRATEGY=pool SF_SCRATCH_POOL_NAME=alv-e2e PLAYWRIGHT_WORKERS=2 npm run test:e2e:cli -- test/e2e/cli/specs/logs.e2e.spec.ts`

The focused CLI E2E run reported `Running 2 tests using 2 workers` and used separate pool slots.
