### PR TITLE
ci(e2e): validate telemetry from sharded jobs

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -61,7 +61,7 @@ jobs:
       ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
       ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
       HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
-      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu-shards
       SCRATCH_POOL_NAME: ${{ vars.SF_SCRATCH_POOL_NAME }}
       HAS_POOL_DEVHUB_AUTH: ${{ secrets.SF_DEVHUB_AUTH_URL != '' && '1' || '' }}
       SCRATCH_STRATEGY: pool
@@ -439,7 +439,7 @@ jobs:
       ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
       ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
       HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
-      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu-shards
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0

--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -52,6 +52,16 @@ jobs:
           - playwright_shard: 4/4
             artifact_suffix: shard-4
     env:
+      AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+      AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      ALV_E2E_TELEMETRY_RESOURCE_GROUP: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP }}
+      ALV_E2E_TELEMETRY_LOCATION: ${{ vars.ALV_E2E_TELEMETRY_LOCATION }}
+      ALV_E2E_TELEMETRY_APP: ${{ vars.ALV_E2E_TELEMETRY_APP }}
+      ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
+      ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
+      HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards
       SCRATCH_POOL_NAME: ${{ vars.SF_SCRATCH_POOL_NAME }}
       HAS_POOL_DEVHUB_AUTH: ${{ secrets.SF_DEVHUB_AUTH_URL != '' && '1' || '' }}
       SCRATCH_STRATEGY: pool
@@ -154,6 +164,18 @@ jobs:
           name: playwright-cli-e2e-${{ matrix.shard.artifact_suffix }}
           path: output/playwright-cli/
           if-no-files-found: ignore
+
+      - name: Azure login for sharded App Insights telemetry
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
+        uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48
+        with:
+          client-id: ${{ env.AZURE_CLIENT_ID }}
+          tenant-id: ${{ env.AZURE_TENANT_ID }}
+          subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Prepare sharded App Insights telemetry
+        if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
+        run: node scripts/run-playwright-e2e-telemetry.js --export-env
 
       - name: Run Playwright E2E
         shell: bash
@@ -406,7 +428,7 @@ jobs:
       - playwright_e2e_os_matrix
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 20
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -417,19 +439,7 @@ jobs:
       ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
       ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
       HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
-      SCRATCH_POOL_NAME: ${{ vars.SF_SCRATCH_POOL_NAME }}
-      HAS_POOL_DEVHUB_AUTH: ${{ secrets.SF_DEVHUB_AUTH_URL != '' && '1' || '' }}
-      SCRATCH_STRATEGY: pool
-      VSCODE_TEST_VERSION: ${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}
-      SALESFORCE_CLI_PACKAGE: ${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}
-      PLAYWRIGHT_WORKERS: ${{ github.event.inputs.playwright_extension_proxy_lab_workers || vars.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS || '1' }}
-      PLAYWRIGHT_RETRIES: ${{ vars.PLAYWRIGHT_RETRIES || '0' }}
-      PLAYWRIGHT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_TIMEOUT_MS || '360000' }}
-      PLAYWRIGHT_EXPECT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_EXPECT_TIMEOUT_MS || '60000' }}
-      SF_DEVHUB_ALIAS: ${{ vars.SF_DEVHUB_ALIAS || 'DevHubElectivus' }}
-      SF_SCRATCH_DURATION: ${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}
-      SF_TEST_KEEP_ORG: ${{ vars.SF_TEST_KEEP_ORG || '1' }}
-      INSTALL_LINUX_DEPS: ${{ vars.INSTALL_LINUX_DEPS || 'true' }}
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -440,50 +450,6 @@ jobs:
           node-version-file: .nvmrc
           cache: npm
           cache-dependency-path: package-lock.json
-
-      - name: Resolve VS Code cache metadata
-        id: vscode-cache
-        env:
-          VSCODE_TARGET: ${{ env.VSCODE_TEST_VERSION }}
-          VSCODE_PLATFORM: linux-x64
-        run: node scripts/resolve-vscode-cache-metadata.js
-
-      - name: Restore VS Code test cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: .vscode-test/vscode-*
-          key: vscode-test-${{ runner.os }}-${{ steps.vscode-cache.outputs.version }}-${{ steps.vscode-cache.outputs.build }}
-
-      - name: Install Salesforce CLI
-        run: npm install -g "${{ env.SALESFORCE_CLI_PACKAGE }}" --no-audit --no-fund
-
-      - name: Require scratch-org pool configuration
-        shell: bash
-        run: |
-          set -euo pipefail
-          missing=0
-          if [[ -z "${SCRATCH_POOL_NAME}" ]]; then
-            echo "::error::SF_SCRATCH_POOL_NAME must be configured for the Playwright E2E workflow."
-            missing=1
-          fi
-          if [[ "${HAS_POOL_DEVHUB_AUTH}" != "1" ]]; then
-            echo "::error::SF_DEVHUB_AUTH_URL must be configured for the Playwright E2E workflow."
-            missing=1
-          fi
-          if [[ "${missing}" != "0" ]]; then
-            exit 1
-          fi
-
-      - name: Enforce dependency source policy
-        run: node scripts/check-dependency-sources.mjs
-
-      - name: Install extension dependencies
-        run: npm ci
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Install Linux deps for Electron (best-effort)
-        run: bash scripts/install-linux-deps.sh
 
       - name: Azure login for dedicated App Insights validation
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
@@ -496,37 +462,9 @@ jobs:
       - name: Run Playwright E2E telemetry validation
         shell: bash
         run: |
-          echo "Scratch strategy: ${SCRATCH_STRATEGY}"
-          echo "Playwright workers: ${PLAYWRIGHT_WORKERS}"
           if [[ -z "${AZURE_CLIENT_ID}" || -z "${AZURE_TENANT_ID}" || -z "${AZURE_SUBSCRIPTION_ID}" || "${HAS_AZURE_E2E_TELEMETRY_CONFIG}" != "1" ]]; then
             echo "Azure OIDC secrets or E2E telemetry target variables are not fully configured; skipping dedicated telemetry validation after the sharded E2E jobs."
             exit 0
           fi
-          echo "Running final Playwright E2E telemetry validation through the MITM proxy lab."
-          npm run test:e2e:telemetry
-        env:
-          VSCODE_TEST_VERSION: ${{ env.VSCODE_TEST_VERSION }}
-          ALV_E2E_TELEMETRY_PROXY_LAB: '1'
-          PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_WORKERS }}
-          SF_SCRATCH_STRATEGY: ${{ env.SCRATCH_STRATEGY }}
-          SF_SCRATCH_POOL_NAME: ${{ env.SCRATCH_POOL_NAME }}
-          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/telemetry
-          SF_SCRATCH_POOL_LEASE_TTL_SECONDS: ${{ vars.SF_SCRATCH_POOL_LEASE_TTL_SECONDS }}
-          SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS: ${{ vars.SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS }}
-          SF_SCRATCH_POOL_HEARTBEAT_SECONDS: ${{ vars.SF_SCRATCH_POOL_HEARTBEAT_SECONDS }}
-          SF_SCRATCH_POOL_MIN_REMAINING_MINUTES: ${{ vars.SF_SCRATCH_POOL_MIN_REMAINING_MINUTES }}
-          SF_SCRATCH_POOL_SEED_VERSION: ${{ vars.SF_SCRATCH_POOL_SEED_VERSION }}
-          SF_SCRATCH_POOL_SNAPSHOT_NAME: ${{ vars.SF_SCRATCH_POOL_SNAPSHOT_NAME }}
-          SF_DEVHUB_AUTH_URL: ${{ secrets.SF_DEVHUB_AUTH_URL }}
-          SF_DEVHUB_ALIAS: ${{ env.SF_DEVHUB_ALIAS }}
-          SF_SCRATCH_DURATION: ${{ env.SF_SCRATCH_DURATION }}
-          SF_TEST_KEEP_ORG: ${{ env.SF_TEST_KEEP_ORG }}
-          ALV_E2E_PROXY_LAB_DEVHUB_ALIAS: ${{ env.SF_DEVHUB_ALIAS }}
-
-      - name: Upload Playwright telemetry artifacts
-        if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: playwright-e2e-telemetry
-          path: output/playwright/
-          if-no-files-found: ignore
+          echo "Validating telemetry emitted by the sharded Ubuntu Playwright E2E jobs."
+          node scripts/run-playwright-e2e-telemetry.js --validate-only

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -202,7 +202,7 @@ test('real-org Playwright workflow keeps E2E tunables configurable with safe def
     job?.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
     "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
   );
-  assert.equal(job?.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards');
+  assert.equal(job?.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu-shards');
   assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'ALV_E2E_PROXY_LAB_SKIP_NPM_CI'));
 });
 
@@ -443,7 +443,7 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
     job.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
     "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
   );
-  assert.equal(job.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards');
+  assert.equal(job.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu-shards');
   assert.match(
     runBlock,
     /skipping dedicated telemetry validation after the sharded E2E jobs/,

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -195,8 +195,14 @@ test('real-org Playwright workflow keeps E2E tunables configurable with safe def
   assert.equal(job?.env?.SF_SCRATCH_DURATION, "${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}");
   assert.equal(job?.env?.SF_TEST_KEEP_ORG, "${{ vars.SF_TEST_KEEP_ORG || '1' }}");
   assert.equal(job?.env?.INSTALL_LINUX_DEPS, "${{ vars.INSTALL_LINUX_DEPS || 'true' }}");
-  assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'AZURE_CLIENT_ID'));
-  assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'HAS_AZURE_E2E_TELEMETRY_CONFIG'));
+  assert.equal(job?.env?.AZURE_CLIENT_ID, '${{ secrets.AZURE_CLIENT_ID }}');
+  assert.equal(job?.env?.AZURE_TENANT_ID, '${{ secrets.AZURE_TENANT_ID }}');
+  assert.equal(job?.env?.AZURE_SUBSCRIPTION_ID, '${{ secrets.AZURE_SUBSCRIPTION_ID }}');
+  assert.equal(
+    job?.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
+    "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
+  );
+  assert.equal(job?.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards');
   assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'ALV_E2E_PROXY_LAB_SKIP_NPM_CI'));
 });
 
@@ -215,6 +221,27 @@ test('real-org Playwright workflow shards the Ubuntu proxy-lab run while keeping
   assert.equal(extensionStep.env?.PLAYWRIGHT_WORKERS, '${{ env.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS }}');
   assert.equal(cliStep.env?.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
   assert.equal(extensionStep.env?.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
+});
+
+test('real-org Playwright workflow enables test telemetry on the existing Ubuntu shards', () => {
+  const workflow = readWorkflow();
+  const azureLoginStep = getWorkflowStep(workflow, 'Azure login for sharded App Insights telemetry');
+  const prepareTelemetryStep = getWorkflowStep(workflow, 'Prepare sharded App Insights telemetry');
+  const uploadCliStep = getWorkflowStep(workflow, 'Upload CLI E2E artifacts');
+  const extensionStep = getWorkflowStep(workflow, 'Run Playwright E2E');
+
+  assert.ok(uploadCliStep.index < azureLoginStep.index, 'expected sharded telemetry login after CLI artifacts');
+  assert.ok(azureLoginStep.index < prepareTelemetryStep.index, 'expected Azure login before exporting telemetry env');
+  assert.ok(prepareTelemetryStep.index < extensionStep.index, 'expected test telemetry env before sharded extension E2E');
+  assert.equal(
+    azureLoginStep.step.if,
+    "${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}"
+  );
+  assert.equal(
+    prepareTelemetryStep.step.if,
+    "${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}"
+  );
+  assert.equal(prepareTelemetryStep.step.run, 'node scripts/run-playwright-e2e-telemetry.js --export-env');
 });
 
 test('real-org Playwright workflow serializes CI runs by scratch-org pool', () => {
@@ -394,7 +421,6 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
   const workflow = readWorkflow();
   const job = getWorkflowJob(workflow, 'playwright_e2e_telemetry');
   const telemetryStep = getTelemetryWorkflowStep(workflow, 'Run Playwright E2E telemetry validation');
-  const uploadStep = getTelemetryWorkflowStep(workflow, 'Upload Playwright telemetry artifacts');
   const runBlock = String(telemetryStep.step.run || '');
 
   assert.deepEqual(
@@ -409,16 +435,15 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
   );
   assert.ok(!Object.prototype.hasOwnProperty.call(job, 'strategy'));
   assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'PLAYWRIGHT_SHARD'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'PLAYWRIGHT_WORKERS'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'SCRATCH_POOL_NAME'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'SALESFORCE_CLI_PACKAGE'));
   assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'ALV_E2E_PROXY_LAB_SKIP_NPM_CI'));
-  assert.equal(
-    job.env?.PLAYWRIGHT_WORKERS,
-    "${{ github.event.inputs.playwright_extension_proxy_lab_workers || vars.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS || '1' }}",
-    'expected final telemetry validation to use the Ubuntu extension proxy-lab worker setting'
-  );
   assert.equal(
     job.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
     "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
   );
+  assert.equal(job.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/${{ github.run_attempt }}/ubuntu-shards');
   assert.match(
     runBlock,
     /skipping dedicated telemetry validation after the sharded E2E jobs/,
@@ -426,41 +451,26 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
   );
   assert.match(
     runBlock,
-    /^\s*npm run test:e2e:telemetry\s*$/m,
-    'expected the final telemetry job to run the host-side telemetry wrapper'
+    /^\s*node scripts\/run-playwright-e2e-telemetry\.js --validate-only\s*$/m,
+    'expected the final telemetry job to query telemetry without running Playwright'
   );
+  assert.doesNotMatch(runBlock, /\btest:e2e\b/, 'expected final telemetry validation not to run E2E tests');
   assert.doesNotMatch(
     runBlock,
     /PLAYWRIGHT_SHARD/,
     'expected final telemetry validation to run unsharded'
   );
   assert.equal(
-    telemetryStep.step.env?.ALV_E2E_TELEMETRY_PROXY_LAB,
-    '1',
-    'expected telemetry wrapper to launch its Playwright child through the MITM proxy lab'
+    job.steps.some(step => step?.name === 'Upload Playwright telemetry artifacts'),
+    false,
+    'expected final telemetry validation not to upload Playwright artifacts'
   );
-  assert.ok(
-    !Object.prototype.hasOwnProperty.call(telemetryStep.step.env || {}, 'PLAYWRIGHT_SHARD'),
-    'expected final telemetry validation not to pass a shard to Playwright'
-  );
-  assert.ok(
-    !Object.prototype.hasOwnProperty.call(telemetryStep.step.env || {}, 'ALV_E2E_PROXY_LAB_SKIP_NPM_CI'),
-    'expected final telemetry validation to prepare its own proxy-lab dependency volume'
-  );
-  assert.equal(
-    telemetryStep.step.env?.SF_SCRATCH_POOL_OWNER,
-    'github:${{ github.run_id }}/${{ github.run_attempt }}/telemetry',
-    'expected telemetry validation to use a dedicated scratch-pool owner suffix'
-  );
-  assert.equal(uploadStep.step.with?.name, 'playwright-e2e-telemetry');
-  assert.equal(uploadStep.step.with?.path, 'output/playwright/');
 });
 
 test('real-org Playwright workflow logs into Azure immediately before final telemetry validation', () => {
   const workflow = readWorkflow();
   const azureLoginStep = getTelemetryWorkflowStep(workflow, 'Azure login for dedicated App Insights validation');
-  const installDepsStep = getTelemetryWorkflowStep(workflow, 'Install extension dependencies');
-  const installLinuxDepsStep = getTelemetryWorkflowStep(workflow, 'Install Linux deps for Electron (best-effort)');
+  const setupNodeStep = getTelemetryWorkflowStep(workflow, 'Setup Node.js from .nvmrc');
   const telemetryStep = getTelemetryWorkflowStep(workflow, 'Run Playwright E2E telemetry validation');
 
   assert.equal(
@@ -469,12 +479,8 @@ test('real-org Playwright workflow logs into Azure immediately before final tele
     'expected azure/login to stay pinned to the SHA currently allowed by the Electivus org action policy'
   );
   assert.ok(
-    installDepsStep.index < azureLoginStep.index,
-    'expected Azure login to run after dependency install so the OIDC assertion is fresher for telemetry validation'
-  );
-  assert.ok(
-    installLinuxDepsStep.index < azureLoginStep.index,
-    'expected Azure login to run after Linux dependency setup and immediately before telemetry validation'
+    setupNodeStep.index < azureLoginStep.index,
+    'expected Azure login to run after checkout/setup so the OIDC assertion is fresher for telemetry validation'
   );
   assert.ok(
     azureLoginStep.index < telemetryStep.index,

--- a/scripts/repo-security.test.js
+++ b/scripts/repo-security.test.js
@@ -989,7 +989,7 @@ test('Playwright E2E workflow uses a configurable Salesforce CLI package with a 
   const parsed = yaml.parse(workflow);
   const installs = workflow.match(/npm install -g "\$\{\{ env\.SALESFORCE_CLI_PACKAGE \}\}" --no-audit --no-fund/g) || [];
 
-  assert.equal(installs.length, 3);
+  assert.equal(installs.length, 2);
   assert.equal(
     parsed.jobs.playwright_e2e.env.SALESFORCE_CLI_PACKAGE,
     "${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}"
@@ -998,10 +998,7 @@ test('Playwright E2E workflow uses a configurable Salesforce CLI package with a 
     parsed.jobs.playwright_e2e_os_matrix.env.SALESFORCE_CLI_PACKAGE,
     "${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}"
   );
-  assert.equal(
-    parsed.jobs.playwright_e2e_telemetry.env.SALESFORCE_CLI_PACKAGE,
-    "${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}"
-  );
+  assert.ok(!Object.hasOwn(parsed.jobs.playwright_e2e_telemetry.env, 'SALESFORCE_CLI_PACKAGE'));
   assert.doesNotMatch(workflow, /npm install -g @salesforce\/cli(?:\s|$)/);
 });
 

--- a/scripts/run-playwright-e2e-telemetry.js
+++ b/scripts/run-playwright-e2e-telemetry.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 'use strict';
 
-const { randomUUID } = require('crypto');
+const { createHash, randomUUID } = require('crypto');
 const { spawn } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 
 const {
@@ -20,6 +21,7 @@ function sleep(ms) {
 }
 
 const REPO_ROOT = path.join(__dirname, '..');
+const TEST_RUN_ID_PATTERN = /^[a-f0-9-]{36}$/i;
 
 function spawnAsync(command, args, options = {}, spawnImpl = spawn) {
   return new Promise((resolve, reject) => {
@@ -32,6 +34,11 @@ function spawnAsync(command, args, options = {}, spawnImpl = spawn) {
 function isResourceNotFound(error) {
   const text = [error && error.message, error && error.stderr, error && error.stdout].filter(Boolean).join('\n');
   return /ResourceNotFound|was not found|ARMResourceNotFoundFix/i.test(text);
+}
+
+function isResourceConflict(error) {
+  const text = [error && error.message, error && error.stderr, error && error.stdout].filter(Boolean).join('\n');
+  return /Conflict|ResourceAlreadyExists|already exists/i.test(text);
 }
 
 async function showComponentForConfig(config, appName) {
@@ -57,33 +64,41 @@ async function ensureTelemetryComponent(config) {
   }
 
   const workspaceResourceId = await resolveWorkspaceId(config);
-  const created = await azJson([
-    'monitor',
-    'app-insights',
-    'component',
-    'create',
-    '-a',
-    config.appName,
-    '-g',
-    config.resourceGroup,
-    '-l',
-    config.location,
-    '--kind',
-    'web',
-    '--application-type',
-    'web',
-    '--workspace',
-    workspaceResourceId,
-    '--subscription',
-    config.subscription,
-    '--tags',
-    'app=apex-log-viewer',
-    'component=telemetry',
-    'env=e2e',
-    'managed-by=az-cli',
-    'repo=Apex-Log-Viewer'
-  ]);
-  return { component: created, created: true };
+  try {
+    const created = await azJson([
+      'monitor',
+      'app-insights',
+      'component',
+      'create',
+      '-a',
+      config.appName,
+      '-g',
+      config.resourceGroup,
+      '-l',
+      config.location,
+      '--kind',
+      'web',
+      '--application-type',
+      'web',
+      '--workspace',
+      workspaceResourceId,
+      '--subscription',
+      config.subscription,
+      '--tags',
+      'app=apex-log-viewer',
+      'component=telemetry',
+      'env=e2e',
+      'managed-by=az-cli',
+      'repo=Apex-Log-Viewer'
+    ]);
+    return { component: created, created: true };
+  } catch (error) {
+    if (!isResourceConflict(error)) {
+      throw error;
+    }
+    const existing = await showComponentForConfig(config, config.appName);
+    return { component: existing, created: false };
+  }
 }
 
 function buildRunValidationQuery({ componentResourceId, lookback, runId }) {
@@ -144,6 +159,43 @@ function readEnv(env, name) {
 function envFlag(env, name) {
   const normalized = String(env[name] || '').trim().toLowerCase();
   return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'on';
+}
+
+function formatUuidFromBytes(bytes) {
+  const copy = Buffer.from(bytes.subarray(0, 16));
+  copy[6] = (copy[6] & 0x0f) | 0x40;
+  copy[8] = (copy[8] & 0x3f) | 0x80;
+  const hex = copy.toString('hex');
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
+
+function runIdFromSeed(seed) {
+  return formatUuidFromBytes(createHash('sha256').update(String(seed)).digest());
+}
+
+function validateTelemetryRunId(runId) {
+  if (!TEST_RUN_ID_PATTERN.test(runId)) {
+    throw new Error(`Telemetry test run id must be a UUID, got '${runId}'.`);
+  }
+  return runId.toLowerCase();
+}
+
+function resolveTelemetryRunId(env = process.env, randomUUIDImpl = randomUUID, options = {}) {
+  const explicitRunId = readEnv(env, 'ALV_TEST_TELEMETRY_RUN_ID');
+  if (explicitRunId) {
+    return validateTelemetryRunId(explicitRunId);
+  }
+
+  const seed = readEnv(env, 'ALV_E2E_TELEMETRY_RUN_ID_SEED');
+  if (seed) {
+    return runIdFromSeed(seed);
+  }
+
+  if (options.requireConfigured) {
+    throw new Error('Missing ALV_TEST_TELEMETRY_RUN_ID or ALV_E2E_TELEMETRY_RUN_ID_SEED for telemetry validation.');
+  }
+
+  return validateTelemetryRunId(randomUUIDImpl());
 }
 
 function resolvePlaywrightChildInvocation(extraArgs, env = process.env, repoRoot = REPO_ROOT) {
@@ -254,7 +306,7 @@ async function runTelemetryE2e(options = {}) {
   const config = resolveConfig(env);
 
   const { component, created } = await ensureTelemetryComponentImpl(config);
-  const runId = randomUUIDImpl();
+  const runId = resolveTelemetryRunId(env, randomUUIDImpl);
 
   logger.log(
     `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
@@ -297,8 +349,110 @@ async function runTelemetryE2e(options = {}) {
   return { exitCode: 0, validation };
 }
 
+async function exportTelemetryEnv(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const randomUUIDImpl = options.randomUUIDImpl || randomUUID;
+  const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
+  const writeEnvImpl = options.writeEnvImpl || appendGitHubEnv;
+  const maskSecretImpl = options.maskSecretImpl || maskSecret;
+
+  const config = resolveConfig(env);
+  const { component, created } = await ensureTelemetryComponentImpl(config);
+  const runId = resolveTelemetryRunId(env, randomUUIDImpl);
+
+  logger.log(
+    `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
+  );
+  logger.log(`[e2e] Exporting test telemetry run id: ${runId}`);
+
+  maskSecretImpl(component.connectionString);
+  writeEnvImpl({
+    ALV_ENABLE_TEST_TELEMETRY: '1',
+    ALV_TEST_TELEMETRY_CONNECTION_STRING: component.connectionString,
+    ALV_TEST_TELEMETRY_RUN_ID: runId
+  });
+
+  return { exitCode: 0, runId };
+}
+
+async function validateTelemetryOnly(options = {}) {
+  const env = options.env || process.env;
+  const logger = options.logger || console;
+  const randomUUIDImpl = options.randomUUIDImpl || randomUUID;
+  const ensureTelemetryComponentImpl = options.ensureTelemetryComponentImpl || ensureTelemetryComponent;
+  const prepareTelemetryValidationContextImpl =
+    options.prepareTelemetryValidationContextImpl || prepareTelemetryValidationContext;
+  const waitForTelemetryImpl = options.waitForTelemetryImpl || waitForTelemetry;
+
+  const config = resolveConfig(env);
+  const { component, created } = await ensureTelemetryComponentImpl(config);
+  const runId = resolveTelemetryRunId(env, randomUUIDImpl, { requireConfigured: true });
+
+  logger.log(
+    `[e2e] ${created ? 'Created' : 'Using'} dedicated Application Insights resource: ${component.name} (${component.resourceGroup})`
+  );
+  logger.log(`[e2e] Validating telemetry run id: ${runId}`);
+
+  const validationContext = await prepareTelemetryValidationContextImpl(config, component);
+  const validation = await waitForTelemetryImpl(config, component, runId, { validationContext });
+  logger.log(
+    `[e2e] Telemetry validated after ${validation.attempt} query attempt(s): ${validation.summary.totalEvents} events across ${validation.summary.distinctNames} event names.`
+  );
+  for (const row of validation.rows) {
+    logger.log(`[e2e] ${row.name}: ${row.events}`);
+  }
+
+  return { exitCode: 0, validation };
+}
+
+function maskSecret(value) {
+  const text = String(value || '');
+  if (text) {
+    console.log(`::add-mask::${text}`);
+  }
+}
+
+function appendGitHubEnv(values, env = process.env) {
+  const githubEnv = readEnv(env, 'GITHUB_ENV');
+  if (!githubEnv) {
+    throw new Error('GITHUB_ENV is not set; cannot export telemetry environment for later workflow steps.');
+  }
+  const lines = [];
+  for (const [key, value] of Object.entries(values)) {
+    const text = String(value || '');
+    if (text.includes('\n') || text.includes('\r')) {
+      throw new Error(`Refusing to write multiline value for ${key} to GITHUB_ENV.`);
+    }
+    lines.push(`${key}=${text}`);
+  }
+  fs.appendFileSync(githubEnv, `${lines.join('\n')}\n`, 'utf8');
+}
+
+function parseCliArgs(argv = []) {
+  const modes = new Set(argv.filter(arg => arg === '--export-env' || arg === '--validate-only'));
+  if (modes.size > 1) {
+    throw new Error('Use only one telemetry mode flag: --export-env or --validate-only.');
+  }
+  if (modes.has('--export-env')) {
+    return { mode: 'export-env', extraArgs: argv.filter(arg => arg !== '--export-env') };
+  }
+  if (modes.has('--validate-only')) {
+    return { mode: 'validate-only', extraArgs: argv.filter(arg => arg !== '--validate-only') };
+  }
+  return { mode: 'run-tests', extraArgs: argv };
+}
+
 async function main() {
-  const result = await runTelemetryE2e();
+  const cli = parseCliArgs(process.argv.slice(2));
+  let result;
+  if (cli.mode === 'export-env') {
+    result = await exportTelemetryEnv();
+  } else if (cli.mode === 'validate-only') {
+    result = await validateTelemetryOnly();
+  } else {
+    result = await runTelemetryE2e({ extraArgs: cli.extraArgs });
+  }
   if (typeof result.exitCode === 'number' && result.exitCode !== 0) {
     process.exit(result.exitCode);
   }
@@ -312,12 +466,17 @@ if (require.main === module) {
 }
 
 module.exports = {
+  appendGitHubEnv,
   buildRunValidationQuery,
+  exportTelemetryEnv,
   prepareTelemetryValidationContext,
   prewarmTelemetryQueryToken,
+  parseCliArgs,
   resolveConfig,
   resolvePlaywrightChildInvocation,
+  resolveTelemetryRunId,
   runTelemetryE2e,
   spawnAsync,
-  summarizeTelemetry
+  summarizeTelemetry,
+  validateTelemetryOnly
 };

--- a/scripts/run-playwright-e2e-telemetry.test.js
+++ b/scripts/run-playwright-e2e-telemetry.test.js
@@ -3,12 +3,15 @@ const assert = require('node:assert/strict');
 const path = require('node:path');
 
 const {
+  exportTelemetryEnv,
   buildRunValidationQuery,
   resolveConfig,
   resolvePlaywrightChildInvocation,
+  resolveTelemetryRunId,
   runTelemetryE2e,
   spawnAsync,
-  summarizeTelemetry
+  summarizeTelemetry,
+  validateTelemetryOnly
 } = require('./run-playwright-e2e-telemetry');
 
 test('buildRunValidationQuery targets AppEvents in the workspace and filters by resource id plus testRunId', () => {
@@ -68,6 +71,23 @@ test('resolveConfig fails fast when explicit telemetry target names are missing'
   );
 });
 
+test('resolveTelemetryRunId derives stable UUIDs from workflow seeds', () => {
+  const first = resolveTelemetryRunId({ ALV_E2E_TELEMETRY_RUN_ID_SEED: 'github:123/1/ubuntu-shards' });
+  const second = resolveTelemetryRunId({ ALV_E2E_TELEMETRY_RUN_ID_SEED: 'github:123/1/ubuntu-shards' });
+  const different = resolveTelemetryRunId({ ALV_E2E_TELEMETRY_RUN_ID_SEED: 'github:123/2/ubuntu-shards' });
+
+  assert.match(first, /^[a-f0-9-]{36}$/);
+  assert.equal(first, second);
+  assert.notEqual(first, different);
+});
+
+test('resolveTelemetryRunId requires a configured id for validate-only mode', () => {
+  assert.throws(
+    () => resolveTelemetryRunId({}, () => '123e4567-e89b-12d3-a456-426614174000', { requireConfigured: true }),
+    /Missing ALV_TEST_TELEMETRY_RUN_ID or ALV_E2E_TELEMETRY_RUN_ID_SEED/
+  );
+});
+
 test('spawnAsync rejects when the child process cannot be started', async () => {
   await assert.rejects(
     () =>
@@ -99,7 +119,7 @@ test('runTelemetryE2e preflights a Log Analytics query before spawning Playwrigh
     extraArgs: ['--grep', 'logs'],
     repoRoot: path.join('/repo', 'apex-log-viewer'),
     logger: { log() {} },
-    randomUUIDImpl: () => 'run-123',
+    randomUUIDImpl: () => '123e4567-e89b-12d3-a456-426614174000',
     ensureTelemetryComponentImpl: async config => {
       calls.push(['ensure', config.appName]);
       return {
@@ -149,12 +169,99 @@ test('runTelemetryE2e preflights a Log Analytics query before spawning Playwrigh
       'query-preflight',
       validationContext.workspaceCustomerId,
       validationContext.componentResourceId,
-      'run-123',
+      '123e4567-e89b-12d3-a456-426614174000',
       '5m'
     ],
     ['resolve-child', '--grep logs'],
     ['spawn', 'node', 'child.js'],
-    ['wait', 'run-123', 'workspace-customer-id']
+    ['wait', '123e4567-e89b-12d3-a456-426614174000', 'workspace-customer-id']
+  ]);
+});
+
+test('exportTelemetryEnv writes the connection string and deterministic run id for later workflow steps', async () => {
+  const written = [];
+  const masked = [];
+  const result = await exportTelemetryEnv({
+    env: {
+      ALV_E2E_TELEMETRY_APP: 'appi-e2e',
+      ALV_E2E_TELEMETRY_BASE_APP: 'appi-base',
+      ALV_E2E_TELEMETRY_RESOURCE_GROUP: 'rg-telemetry',
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: 'github:123/1/ubuntu-shards',
+      AZURE_SUBSCRIPTION_ID: 'sub-123'
+    },
+    logger: { log() {} },
+    ensureTelemetryComponentImpl: async () => ({
+      component: {
+        connectionString: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+        name: 'appi-e2e',
+        resourceGroup: 'rg-telemetry'
+      },
+      created: false
+    }),
+    maskSecretImpl: value => masked.push(value),
+    writeEnvImpl: values => written.push(values)
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.match(result.runId, /^[a-f0-9-]{36}$/);
+  assert.deepEqual(masked, ['InstrumentationKey=00000000-0000-0000-0000-000000000000']);
+  assert.deepEqual(written, [
+    {
+      ALV_ENABLE_TEST_TELEMETRY: '1',
+      ALV_TEST_TELEMETRY_CONNECTION_STRING: 'InstrumentationKey=00000000-0000-0000-0000-000000000000',
+      ALV_TEST_TELEMETRY_RUN_ID: result.runId
+    }
+  ]);
+});
+
+test('validateTelemetryOnly queries a configured telemetry run without spawning Playwright', async () => {
+  const calls = [];
+  const validationContext = {
+    componentResourceId: '/subscriptions/sub/resourceGroups/rg/providers/microsoft.insights/components/appi-e2e',
+    workspaceCustomerId: 'workspace-customer-id'
+  };
+
+  const result = await validateTelemetryOnly({
+    env: {
+      ALV_E2E_TELEMETRY_APP: 'appi-e2e',
+      ALV_E2E_TELEMETRY_BASE_APP: 'appi-base',
+      ALV_E2E_TELEMETRY_RESOURCE_GROUP: 'rg-telemetry',
+      ALV_TEST_TELEMETRY_RUN_ID: '123e4567-e89b-12d3-a456-426614174000',
+      AZURE_SUBSCRIPTION_ID: 'sub-123'
+    },
+    logger: { log() {} },
+    ensureTelemetryComponentImpl: async config => {
+      calls.push(['ensure', config.appName]);
+      return {
+        component: {
+          id: validationContext.componentResourceId,
+          name: 'appi-e2e',
+          resourceGroup: 'rg-telemetry',
+          workspaceResourceId:
+            '/subscriptions/sub/resourceGroups/rg/providers/microsoft.operationalinsights/workspaces/law-e2e'
+        },
+        created: false
+      };
+    },
+    prepareTelemetryValidationContextImpl: async (_config, component) => {
+      calls.push(['prepare', component.id]);
+      return validationContext;
+    },
+    waitForTelemetryImpl: async (_config, _component, runId, options) => {
+      calls.push(['wait', runId, options.validationContext.workspaceCustomerId]);
+      return {
+        attempt: 1,
+        rows: [{ name: 'electivus.apex-log-viewer/extension.activate', events: 5 }],
+        summary: { distinctNames: 3, hasActivation: true, totalEvents: 5 }
+      };
+    }
+  });
+
+  assert.equal(result.exitCode, 0);
+  assert.deepEqual(calls, [
+    ['ensure', 'appi-e2e'],
+    ['prepare', validationContext.componentResourceId],
+    ['wait', '123e4567-e89b-12d3-a456-426614174000', 'workspace-customer-id']
   ]);
 });
 


### PR DESCRIPTION
## Summary

- stop running the full Playwright suite again in the final telemetry validation job
- have the existing Ubuntu sharded Playwright jobs emit test telemetry with a deterministic run id
- make the final telemetry job validate Log Analytics only, without scratch-org setup, Salesforce CLI install, proxy-lab, or Playwright execution

## Validation

- npm run test:scripts
