### PR TITLE
ci(e2e): remove Playwright shards

### DIFF
--- a/.github/workflows/e2e-playwright.yml
+++ b/.github/workflows/e2e-playwright.yml
@@ -36,21 +36,9 @@ permissions:
 
 jobs:
   playwright_e2e:
-    name: Playwright E2E (scratch org, ${{ matrix.shard.artifact_suffix }})
+    name: Playwright E2E (scratch org)
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        shard:
-          - playwright_shard: 1/4
-            artifact_suffix: shard-1
-          - playwright_shard: 2/4
-            artifact_suffix: shard-2
-          - playwright_shard: 3/4
-            artifact_suffix: shard-3
-          - playwright_shard: 4/4
-            artifact_suffix: shard-4
     env:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
@@ -61,7 +49,7 @@ jobs:
       ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
       ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
       HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
-      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu-shards
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu
       SCRATCH_POOL_NAME: ${{ vars.SF_SCRATCH_POOL_NAME }}
       HAS_POOL_DEVHUB_AUTH: ${{ secrets.SF_DEVHUB_AUTH_URL != '' && '1' || '' }}
       SCRATCH_STRATEGY: pool
@@ -69,7 +57,6 @@ jobs:
       SALESFORCE_CLI_PACKAGE: ${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}
       PLAYWRIGHT_WORKERS: ${{ github.event.inputs.playwright_workers || vars.PLAYWRIGHT_WORKERS || '1' }}
       PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS: ${{ github.event.inputs.playwright_extension_proxy_lab_workers || vars.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS || '1' }}
-      PLAYWRIGHT_SHARD: ${{ matrix.shard.playwright_shard }}
       PLAYWRIGHT_RETRIES: ${{ vars.PLAYWRIGHT_RETRIES || '0' }}
       PLAYWRIGHT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_TIMEOUT_MS || '360000' }}
       PLAYWRIGHT_EXPECT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_EXPECT_TIMEOUT_MS || '60000' }}
@@ -111,14 +98,12 @@ jobs:
         run: |
           echo "Scratch strategy: ${SCRATCH_STRATEGY}"
           echo "Playwright workers: ${PLAYWRIGHT_WORKERS}"
-          echo "Playwright shard: ${PLAYWRIGHT_SHARD}"
           npm run test:e2e:proxy-lab -- npm run test:e2e:cli
         env:
           PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_WORKERS }}
-          PLAYWRIGHT_SHARD: ${{ env.PLAYWRIGHT_SHARD }}
           SF_SCRATCH_STRATEGY: ${{ env.SCRATCH_STRATEGY }}
           SF_SCRATCH_POOL_NAME: ${{ env.SCRATCH_POOL_NAME }}
-          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.shard.artifact_suffix }}
+          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}
           SF_SCRATCH_POOL_LEASE_TTL_SECONDS: ${{ vars.SF_SCRATCH_POOL_LEASE_TTL_SECONDS }}
           SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS: ${{ vars.SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS }}
           SF_SCRATCH_POOL_HEARTBEAT_SECONDS: ${{ vars.SF_SCRATCH_POOL_HEARTBEAT_SECONDS }}
@@ -135,11 +120,11 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: playwright-cli-e2e-${{ matrix.shard.artifact_suffix }}
+          name: playwright-cli-e2e
           path: output/playwright-cli/
           if-no-files-found: ignore
 
-      - name: Azure login for sharded App Insights telemetry
+      - name: Azure login for App Insights telemetry
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
         uses: azure/login@93381592711f247e165c389ebb30b596c84cdc48
         with:
@@ -147,7 +132,7 @@ jobs:
           tenant-id: ${{ env.AZURE_TENANT_ID }}
           subscription-id: ${{ env.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Prepare sharded App Insights telemetry
+      - name: Prepare App Insights telemetry
         if: ${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}
         run: node scripts/run-playwright-e2e-telemetry.js --export-env
 
@@ -156,17 +141,15 @@ jobs:
         run: |
           echo "Scratch strategy: ${SCRATCH_STRATEGY}"
           echo "Playwright workers: ${PLAYWRIGHT_WORKERS}"
-          echo "Playwright shard: ${PLAYWRIGHT_SHARD}"
-          echo "Running Playwright E2E shard ${PLAYWRIGHT_SHARD} through the MITM proxy lab."
+          echo "Running Playwright E2E through the MITM proxy lab."
           npm run test:e2e:proxy-lab -- npm run test:e2e
         env:
           VSCODE_TEST_VERSION: ${{ env.VSCODE_TEST_VERSION }}
           ALV_E2E_PROXY_LAB_SKIP_NPM_CI: ${{ vars.ALV_E2E_PROXY_LAB_SKIP_NPM_CI || '1' }}
           PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS }}
-          PLAYWRIGHT_SHARD: ${{ env.PLAYWRIGHT_SHARD }}
           SF_SCRATCH_STRATEGY: ${{ env.SCRATCH_STRATEGY }}
           SF_SCRATCH_POOL_NAME: ${{ env.SCRATCH_POOL_NAME }}
-          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.shard.artifact_suffix }}
+          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}
           SF_SCRATCH_POOL_LEASE_TTL_SECONDS: ${{ vars.SF_SCRATCH_POOL_LEASE_TTL_SECONDS }}
           SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS: ${{ vars.SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS }}
           SF_SCRATCH_POOL_HEARTBEAT_SECONDS: ${{ vars.SF_SCRATCH_POOL_HEARTBEAT_SECONDS }}
@@ -183,101 +166,12 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: playwright-e2e-${{ matrix.shard.artifact_suffix }}
+          name: playwright-e2e
           path: output/playwright/
           if-no-files-found: ignore
 
-  playwright_e2e_os_prepare:
-    name: Prepare Direct E2E (${{ matrix.os.artifact_suffix }})
-    runs-on: ${{ matrix.os.runner }}
-    timeout-minutes: 45
-    strategy:
-      fail-fast: false
-      matrix:
-        os:
-          - runner: windows-latest
-            vscode_platform: win32-x64-archive
-            artifact_suffix: windows
-          - runner: macos-latest
-            vscode_platform: darwin-arm64
-            artifact_suffix: macos
-    env:
-      VSCODE_TEST_VERSION: ${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}
-    steps:
-      - name: Disable Windows autocrlf
-        if: runner.os == 'Windows'
-        run: git config --global core.autocrlf false
-
-      - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-
-      - name: Setup Node.js from .nvmrc
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
-        with:
-          node-version-file: .nvmrc
-          cache: npm
-          cache-dependency-path: package-lock.json
-
-      - name: Resolve VS Code cache metadata
-        id: vscode-cache
-        env:
-          VSCODE_TARGET: ${{ env.VSCODE_TEST_VERSION }}
-          VSCODE_PLATFORM: ${{ matrix.os.vscode_platform }}
-        run: node scripts/resolve-vscode-cache-metadata.js
-
-      - name: Restore VS Code test cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: .vscode-test/vscode-*
-          key: vscode-test-${{ runner.os }}-${{ steps.vscode-cache.outputs.version }}-${{ steps.vscode-cache.outputs.build }}
-
-      - name: Restore direct E2E dependency cache
-        id: direct-e2e-deps
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9
-        with:
-          path: |
-            node_modules
-            apps/vscode-extension/node_modules
-            packages/sf-plugin/node_modules
-          key: direct-e2e-node-modules-${{ runner.os }}-${{ hashFiles('.nvmrc', 'package-lock.json') }}
-
-      - name: Enforce dependency source policy
-        run: node scripts/check-dependency-sources.mjs
-
-      - name: Install extension dependencies
-        if: steps.direct-e2e-deps.outputs.cache-hit != 'true'
-        run: npm ci
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-
-      - name: Build direct E2E artifacts
-        run: npm run build
-
-      - name: Upload direct E2E build artifacts
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-        with:
-          name: direct-e2e-build-${{ matrix.os.artifact_suffix }}
-          path: |
-            apps/vscode-extension/CHANGELOG.md
-            apps/vscode-extension/LICENSE
-            apps/vscode-extension/README.md
-            apps/vscode-extension/THIRD_PARTY_NOTICES.md
-            apps/vscode-extension/dist/
-            apps/vscode-extension/media/*.js
-            apps/vscode-extension/media/*.js.map
-            apps/vscode-extension/media/webview.css
-            apps/vscode-extension/node_modules/@vscode/
-            apps/vscode-extension/sf-plugin/
-            apps/vscode-extension/telemetry.json
-            packages/sf-plugin/lib/
-            packages/sf-plugin/oclif.lock
-            packages/sf-plugin/oclif.manifest.json
-            packages/sf-plugin/skills/
-          if-no-files-found: error
-
   playwright_e2e_os_matrix:
-    name: Playwright E2E Direct (${{ matrix.os.artifact_suffix }}, ${{ matrix.shard.artifact_suffix }})
-    needs: playwright_e2e_os_prepare
+    name: Playwright E2E Direct (${{ matrix.os.artifact_suffix }})
     runs-on: ${{ matrix.os.runner }}
     timeout-minutes: 60
     strategy:
@@ -290,15 +184,6 @@ jobs:
           - runner: macos-latest
             vscode_platform: darwin-arm64
             artifact_suffix: macos
-        shard:
-          - playwright_shard: 1/4
-            artifact_suffix: shard-1
-          - playwright_shard: 2/4
-            artifact_suffix: shard-2
-          - playwright_shard: 3/4
-            artifact_suffix: shard-3
-          - playwright_shard: 4/4
-            artifact_suffix: shard-4
     env:
       SCRATCH_POOL_NAME: ${{ vars.SF_SCRATCH_POOL_NAME }}
       HAS_POOL_DEVHUB_AUTH: ${{ secrets.SF_DEVHUB_AUTH_URL != '' && '1' || '' }}
@@ -307,7 +192,6 @@ jobs:
       SALESFORCE_CLI_PACKAGE: ${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}
       SALESFORCE_CLI_NODE_VERSION: ${{ vars.SALESFORCE_CLI_NODE_VERSION || '20' }}
       PLAYWRIGHT_WORKERS: ${{ github.event.inputs.playwright_workers || vars.PLAYWRIGHT_WORKERS || '1' }}
-      PLAYWRIGHT_SHARD: ${{ matrix.shard.playwright_shard }}
       PLAYWRIGHT_RETRIES: ${{ vars.PLAYWRIGHT_RETRIES || '0' }}
       PLAYWRIGHT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_TIMEOUT_MS || '360000' }}
       PLAYWRIGHT_EXPECT_TIMEOUT_MS: ${{ vars.PLAYWRIGHT_EXPECT_TIMEOUT_MS || '60000' }}
@@ -399,20 +283,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
 
-      - name: Download direct E2E build artifacts
-        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: direct-e2e-build-${{ matrix.os.artifact_suffix }}
-          path: .
-
-      - name: Restore direct E2E runtime executable bits
-        if: runner.os != 'Windows'
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -d apps/vscode-extension/node_modules/@vscode ]]; then
-            find apps/vscode-extension/node_modules/@vscode -type f -path '*/bin/*' -exec chmod 755 {} +
-          fi
+      - name: Build direct E2E artifacts
+        run: npm run build
 
       - name: Require scratch-org pool configuration
         shell: bash
@@ -436,15 +308,13 @@ jobs:
         run: |
           echo "Scratch strategy: ${SCRATCH_STRATEGY}"
           echo "Playwright workers: ${PLAYWRIGHT_WORKERS}"
-          echo "Playwright shard: ${PLAYWRIGHT_SHARD}"
           echo "Direct E2E OS: ${{ matrix.os.artifact_suffix }}"
           node scripts/run-playwright-cli-e2e.js
         env:
           PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_WORKERS }}
-          PLAYWRIGHT_SHARD: ${{ env.PLAYWRIGHT_SHARD }}
           SF_SCRATCH_STRATEGY: ${{ env.SCRATCH_STRATEGY }}
           SF_SCRATCH_POOL_NAME: ${{ env.SCRATCH_POOL_NAME }}
-          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}/${{ matrix.shard.artifact_suffix }}
+          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}
           SF_SCRATCH_POOL_LEASE_TTL_SECONDS: ${{ vars.SF_SCRATCH_POOL_LEASE_TTL_SECONDS }}
           SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS: ${{ vars.SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS }}
           SF_SCRATCH_POOL_HEARTBEAT_SECONDS: ${{ vars.SF_SCRATCH_POOL_HEARTBEAT_SECONDS }}
@@ -460,7 +330,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: playwright-cli-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}
+          name: playwright-cli-e2e-${{ matrix.os.artifact_suffix }}
           path: output/playwright-cli/
           if-no-files-found: ignore
 
@@ -469,16 +339,14 @@ jobs:
         run: |
           echo "Scratch strategy: ${SCRATCH_STRATEGY}"
           echo "Playwright workers: ${PLAYWRIGHT_WORKERS}"
-          echo "Playwright shard: ${PLAYWRIGHT_SHARD}"
           echo "Direct E2E OS: ${{ matrix.os.artifact_suffix }}"
           node scripts/run-playwright-e2e.js
         env:
           VSCODE_TEST_VERSION: ${{ env.VSCODE_TEST_VERSION }}
           PLAYWRIGHT_WORKERS: ${{ env.PLAYWRIGHT_WORKERS }}
-          PLAYWRIGHT_SHARD: ${{ env.PLAYWRIGHT_SHARD }}
           SF_SCRATCH_STRATEGY: ${{ env.SCRATCH_STRATEGY }}
           SF_SCRATCH_POOL_NAME: ${{ env.SCRATCH_POOL_NAME }}
-          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}/${{ matrix.shard.artifact_suffix }}
+          SF_SCRATCH_POOL_OWNER: github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}
           SF_SCRATCH_POOL_LEASE_TTL_SECONDS: ${{ vars.SF_SCRATCH_POOL_LEASE_TTL_SECONDS }}
           SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS: ${{ vars.SF_SCRATCH_POOL_WAIT_TIMEOUT_SECONDS }}
           SF_SCRATCH_POOL_HEARTBEAT_SECONDS: ${{ vars.SF_SCRATCH_POOL_HEARTBEAT_SECONDS }}
@@ -494,7 +362,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
-          name: playwright-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}
+          name: playwright-e2e-${{ matrix.os.artifact_suffix }}
           path: output/playwright/
           if-no-files-found: ignore
 
@@ -516,7 +384,7 @@ jobs:
       ALV_E2E_TELEMETRY_BASE_APP: ${{ vars.ALV_E2E_TELEMETRY_BASE_APP }}
       ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID: ${{ vars.ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID }}
       HAS_AZURE_E2E_TELEMETRY_CONFIG: ${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}
-      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu-shards
+      ALV_E2E_TELEMETRY_RUN_ID_SEED: github:${{ github.run_id }}/ubuntu
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
@@ -538,8 +406,8 @@ jobs:
         shell: bash
         run: |
           if [[ -z "${AZURE_CLIENT_ID}" || -z "${AZURE_TENANT_ID}" || -z "${AZURE_SUBSCRIPTION_ID}" || "${HAS_AZURE_E2E_TELEMETRY_CONFIG}" != "1" ]]; then
-            echo "Azure OIDC secrets or E2E telemetry target variables are not fully configured; skipping dedicated telemetry validation after the sharded E2E jobs."
+            echo "Azure OIDC secrets or E2E telemetry target variables are not fully configured; skipping dedicated telemetry validation after the E2E jobs."
             exit 0
           fi
-          echo "Validating telemetry emitted by the sharded Ubuntu Playwright E2E jobs."
+          echo "Validating telemetry emitted by the Ubuntu Playwright E2E job."
           node scripts/run-playwright-e2e-telemetry.js --validate-only

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -4,7 +4,7 @@ This repository uses GitHub Actions to build, test, package, and publish the ext
 
 - Workflow CI (`.github/workflows/ci.yml`): build/test on `push` and `pull_request` across `ubuntu-latest`, `windows-latest`, and `macos-latest`. Manual `workflow_dispatch` allows choosing the test scope (`unit`, `integration`, or `all`). This workflow enforces dependency provenance with `node scripts/check-dependency-sources.mjs` before every `npm ci`, then runs npm registry signature verification (`npm run security:npm-signatures`) before compile/test. The VSIX smoke test remains Ubuntu-only after the OS matrix succeeds.
 - Workflow Dependency Review (`.github/workflows/dependency-review.yml`): blocks pull requests that introduce new moderate-or-higher dependency risk in runtime or development scopes.
-- Workflow E2E (`.github/workflows/e2e-playwright.yml`): real scratch-org Playwright validation on `pull_request` and manual dispatch. This workflow is pool-only in CI: it requires `SF_SCRATCH_POOL_NAME` plus `SF_DEVHUB_AUTH_URL`, leases one pooled scratch org per Playwright test through each slot's stored `sfdxAuthUrl`, and defaults to `1` Playwright worker unless `PLAYWRIGHT_WORKERS` is set as a repository variable or `playwright_workers` is set for a manual dispatch. Ubuntu keeps the full MITM proxy-lab path and runs both real-org surfaces in order across four Playwright shards: `npm run test:e2e:cli` for the `sf electivus` plugin, then `npm run test:e2e` for the VS Code extension flow. The Ubuntu extension proxy-lab lane has a dedicated `PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS` override because that path exercises VS Code/Electron inside Docker. Windows and macOS run the same CLI and VS Code E2E suites directly against the scratch-org pool, without Docker/proxy-lab, also across four shards. After those sharded jobs pass, a final non-sharded Ubuntu telemetry job runs `npm run test:e2e:telemetry` through the proxy lab when Azure OIDC secrets and the E2E telemetry target variables are configured. CLI artifacts upload from `output/playwright-cli/`; extension artifacts upload from `output/playwright/`, with OS and shard suffixes for direct Windows/macOS runs.
+- Workflow E2E (`.github/workflows/e2e-playwright.yml`): real scratch-org Playwright validation on `pull_request` and manual dispatch. This workflow is pool-only in CI: it requires `SF_SCRATCH_POOL_NAME` plus `SF_DEVHUB_AUTH_URL`, leases one pooled scratch org per Playwright test through each slot's stored `sfdxAuthUrl`, and defaults to `1` Playwright worker unless `PLAYWRIGHT_WORKERS` is set as a repository variable or `playwright_workers` is set for a manual dispatch. Ubuntu runs one full CLI and extension pass through the MITM proxy lab, while Windows and macOS each run one full direct pass. The direct jobs reuse the dependency, VS Code, and Salesforce CLI caches and build their artifacts in the same job. The Ubuntu extension proxy-lab lane has a dedicated `PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS` override. When Azure telemetry configuration is present, the Ubuntu extension run emits telemetry and a final lightweight job validates it. CLI artifacts upload from `output/playwright-cli/`; extension artifacts upload from `output/playwright/`, with OS suffixes for direct Windows/macOS runs.
 - Workflow Release (`.github/workflows/release.yml`): runs on tag push `v*`. Packages the VSIX and publishes to Marketplace (if `VSCE_PAT` is configured) and Open VSX (if `OVSX_PAT` is configured). Channel is auto‑detected: odd minor → pre‑release; even minor → stable.
 - Workflow Pre‑release (`.github/workflows/prerelease.yml`): runs nightly (03:00 UTC) and on manual dispatch. Builds and packages a pre‑release VSIX, creates/updates a GitHub pre‑release and attaches the asset, and publishes automatically to the Marketplace and Open VSX pre‑release channels (when `VSCE_PAT`/`OVSX_PAT` are set).
 
@@ -35,11 +35,11 @@ Concurrency: Workflows use concurrency groups to avoid duplicate runs per ref, e
 The Playwright workflow in `.github/workflows/e2e-playwright.yml` is pool-only in CI:
 
 - It uses the Dev Hub scratch-org pool.
-- It leases a dedicated org per Playwright test within each sharded Playwright job.
-- It defaults to four shards with `1` worker per shard on PR runs unless `PLAYWRIGHT_WORKERS` or `playwright_workers` raises per-shard workers.
+- It leases a dedicated org per Playwright test within each Playwright job.
+- It runs one full test pass per operating system and defaults to `1` worker unless `PLAYWRIGHT_WORKERS` or `playwright_workers` raises it.
 - It runs the `sf electivus` real-org suite before the VS Code extension suite on every E2E lane.
 - Ubuntu runs those suites through the MITM proxy lab; Windows and macOS run them directly on the hosted runner.
-- A final non-sharded Ubuntu telemetry job runs after the sharded jobs and performs the dedicated App Insights validation when telemetry config is present.
+- A final Ubuntu telemetry job runs after the E2E jobs and validates the App Insights events emitted by the Ubuntu extension run when telemetry config is present.
 - It fails fast when the pool configuration is incomplete instead of falling back to the legacy single-scratch CI path.
 
 ### Pool mode
@@ -72,12 +72,11 @@ Key behavior in pool mode:
 - `SF_SCRATCH_STRATEGY=pool` and `PLAYWRIGHT_WORKERS` are injected automatically.
 - The workflow defaults to `PLAYWRIGHT_WORKERS=1` in pool mode; repository variables can override it for pull requests, and manual dispatch can override it with the `playwright_workers` input.
 - The Ubuntu extension proxy-lab step defaults to `PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS=1` and can be raised independently of the CLI and direct Windows/macOS lanes.
-- `PLAYWRIGHT_SHARD` is injected from the GitHub Actions matrix as `1/4`, `2/4`, `3/4`, or `4/4`; the local runner scripts translate it to Playwright's `--shard` flag.
 - `PLAYWRIGHT_TIMEOUT_MS` and `PLAYWRIGHT_EXPECT_TIMEOUT_MS` default to `360000` and `60000` in GitHub Actions so stuck tests fail faster than the historical local 15-minute test timeout.
-- The Ubuntu CLI real-org step runs `npm run test:e2e:cli` through the proxy lab with the same scratch-org env contract as the extension step, then uploads `output/playwright-cli/` as a dedicated shard artifact.
-- The Ubuntu extension step then runs `npm run test:e2e` through the proxy lab and uploads `output/playwright/` as a dedicated shard artifact.
-- The final Ubuntu telemetry job waits for both sharded E2E jobs, runs without `PLAYWRIGHT_SHARD`, and uses `npm run test:e2e:telemetry` to generate and validate a dedicated `testRunId` after the faster shard coverage has completed.
-- The Windows/macOS direct matrix runs `npm run test:e2e:cli` and `npm run test:e2e` without proxy-lab, then uploads artifacts with OS and shard suffixes such as `playwright-cli-e2e-windows-shard-1` and `playwright-e2e-macos-shard-4`.
+- The Ubuntu CLI real-org step runs `npm run test:e2e:cli` through the proxy lab with the same scratch-org env contract as the extension step, then uploads `output/playwright-cli/` as a dedicated artifact.
+- The Ubuntu extension step then runs `npm run test:e2e` through the proxy lab and uploads `output/playwright/` as a dedicated artifact.
+- The final Ubuntu telemetry job waits for both E2E jobs and validates the shared `testRunId` emitted by the Ubuntu extension run without rerunning Playwright.
+- The Windows/macOS direct matrix runs one full `npm run test:e2e:cli` and `npm run test:e2e` pass per OS without proxy-lab, reusing the configured caches and uploading artifacts with OS suffixes such as `playwright-cli-e2e-windows` and `playwright-e2e-macos`.
 - The workflow-level concurrency lock uses the configured `SF_SCRATCH_POOL_NAME` when pool mode is active, with `cancel-in-progress: false`, so active runs sharing the same Dev Hub pool are not canceled or allowed to over-lease the pool during dependency bursts.
 - The Playwright configs enable `fullyParallel` in pool mode because each test acquires its own scratch org slot; legacy single-scratch mode stays serial.
 - Manual `workflow_dispatch` runs use the same pool-only path as `pull_request`, so dispatch validation exercises the same concurrency and lease behavior as CI.
@@ -106,7 +105,7 @@ Configure these repository variables:
 - `ALV_E2E_TELEMETRY_BASE_APP`
 - `ALV_E2E_TELEMETRY_WORKSPACE_RESOURCE_ID` (optional)
 
-When the three Azure OIDC secrets and the required telemetry target variables are present, the workflow authenticates to Azure in the final telemetry job, runs `npm run test:e2e:telemetry` without a shard, and validates that the current E2E run reached the shared Log Analytics workspace rows for the configured E2E Application Insights component. If any required setting is missing, the workflow still runs the sharded Playwright suites and only skips the telemetry-validation layer.
+When the three Azure OIDC secrets and the required telemetry target variables are present, the Ubuntu extension job exports a dedicated `testRunId`, runs the full Playwright suite, and emits test telemetry. The final telemetry job authenticates to Azure and validates that the current E2E run reached the shared Log Analytics workspace rows for the configured E2E Application Insights component. If any required setting is missing, the workflow still runs all Playwright suites and only skips the telemetry-validation layer.
 
 ## Release Flow
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -99,7 +99,7 @@ Useful env vars:
 - `SF_SCRATCH_STRATEGY`: `single` or `pool`. If unset, the helper auto-enables pool mode when `SF_SCRATCH_POOL_NAME` is present. Local runs can use either mode; CI forces `pool`.
 - `PLAYWRIGHT_WORKERS`: Number of Playwright workers. In pool mode this controls how many isolated tests can run at once, with one scratch-org lease per test. Default `1` locally; the GitHub Actions pool workflow also defaults to `1` unless overridden by the `PLAYWRIGHT_WORKERS` repository variable or the `playwright_workers` dispatch input. In single-scratch mode, the Playwright configs force serial execution.
 - `PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS`: GitHub Actions-only worker override for the Ubuntu VS Code extension proxy-lab lane. This is mapped into `PLAYWRIGHT_WORKERS` for that step.
-- `PLAYWRIGHT_SHARD`: Optional Playwright shard in `current/total` form, for example `1/4`. The GitHub Actions E2E workflow sets this from its shard matrix for each OS lane.
+- `PLAYWRIGHT_SHARD`: Optional local Playwright shard in `current/total` form, for example `1/4`. The GitHub Actions E2E workflow does not set it and runs each OS lane as one full pass.
 - `PLAYWRIGHT_RETRIES`: Number of Playwright retries passed by the E2E wrapper.
 - `PLAYWRIGHT_TIMEOUT_MS`: Per-test Playwright timeout. Defaults to 15 minutes locally and 6 minutes in the GitHub Actions E2E workflow.
 - `PLAYWRIGHT_EXPECT_TIMEOUT_MS`: Playwright expect assertion timeout. Defaults to 60 seconds.
@@ -163,7 +163,7 @@ To validate against a Salesforce CLI package override, such as the nightly build
 npm run test:e2e:proxy-lab:sf-nightly -- npm run test:e2e -- test/e2e/specs/openLogViewer.e2e.spec.ts
 ```
 
-The standard GitHub Playwright E2E workflow keeps the Ubuntu lane on this MITM proxy lab and fans each OS lane out across four Playwright shards. Each shard keeps `PLAYWRIGHT_WORKERS=1` by default unless the workflow tunables raise it, and the runner scripts translate `PLAYWRIGHT_SHARD` into Playwright's `--shard` flag. The Ubuntu CLI step populates the proxy-lab dependency volume, and the Ubuntu extension step reuses that volume with `ALV_E2E_PROXY_LAB_SKIP_NPM_CI=1`. Windows and macOS lanes run the same real-org CLI and VS Code E2E commands directly on their hosted runners against the scratch-org pool. When telemetry validation is configured, Azure resource resolution and Log Analytics queries stay on the GitHub runner host while a final non-sharded Ubuntu telemetry job executes its Playwright child run inside the MITM proxy lab after the sharded jobs pass.
+The standard GitHub Playwright E2E workflow runs one full pass per operating system. Ubuntu stays on this MITM proxy lab: its CLI step populates the proxy-lab dependency volume, and its extension step reuses that volume with `ALV_E2E_PROXY_LAB_SKIP_NPM_CI=1`. Windows and macOS run the same real-org CLI and VS Code E2E commands directly on their hosted runners against the scratch-org pool, reusing the dependency, VS Code, and Salesforce CLI caches. When telemetry validation is configured, the Ubuntu extension run emits telemetry under a shared `testRunId`, and a final lightweight Ubuntu job queries Log Analytics after the E2E jobs pass.
 
 Pool-specific env vars:
 
@@ -202,7 +202,7 @@ Troubleshooting:
 4. Runs the full Playwright suite
 5. Queries `AppEvents` in the linked Log Analytics workspace and fails if the current run's telemetry does not arrive
 
-The final telemetry job in `.github/workflows/e2e-playwright.yml` prefers this path automatically after the sharded E2E jobs pass when Azure OIDC secrets and the E2E telemetry target variables are configured. It intentionally runs without `PLAYWRIGHT_SHARD` so the telemetry wrapper can generate and validate one complete `testRunId`. If that Azure configuration is incomplete, the workflow still runs the sharded Playwright suites, but skips the telemetry-validation layer. The Ubuntu shard jobs and the Windows and macOS E2E lanes run non-telemetry Playwright validation.
+The workflow uses this telemetry path automatically when Azure OIDC secrets and the E2E telemetry target variables are configured. Before the Ubuntu extension pass, it exports a dedicated `testRunId`; after all E2E jobs pass, the final telemetry job validates the emitted events without rerunning Playwright. If that Azure configuration is incomplete, the workflow still runs every Playwright suite but skips the telemetry-validation layer. Windows and macOS continue to run non-telemetry Playwright validation.
 
 Required Azure targets for the telemetry path:
 

--- a/scripts/cli-e2e-workflow.test.js
+++ b/scripts/cli-e2e-workflow.test.js
@@ -4,7 +4,6 @@ const fs = require('node:fs');
 const YAML = require('yaml');
 
 const SHARED_SCRATCH_ENV_KEYS = [
-  'PLAYWRIGHT_SHARD',
   'SF_SCRATCH_STRATEGY',
   'SF_SCRATCH_POOL_NAME',
   'SF_SCRATCH_POOL_OWNER',
@@ -18,13 +17,6 @@ const SHARED_SCRATCH_ENV_KEYS = [
   'SF_DEVHUB_ALIAS',
   'SF_SCRATCH_DURATION',
   'SF_TEST_KEEP_ORG'
-];
-
-const EXPECTED_SHARD_MATRIX = [
-  { playwright_shard: '1/4', artifact_suffix: 'shard-1' },
-  { playwright_shard: '2/4', artifact_suffix: 'shard-2' },
-  { playwright_shard: '3/4', artifact_suffix: 'shard-3' },
-  { playwright_shard: '4/4', artifact_suffix: 'shard-4' }
 ];
 
 function read(relativePath) {
@@ -56,10 +48,6 @@ function getWorkflowStep(workflow, stepName, jobName = 'playwright_e2e') {
 
 function getDirectWorkflowStep(workflow, stepName) {
   return getWorkflowStep(workflow, stepName, 'playwright_e2e_os_matrix');
-}
-
-function getDirectPrepareWorkflowStep(workflow, stepName) {
-  return getWorkflowStep(workflow, stepName, 'playwright_e2e_os_prepare');
 }
 
 function getTelemetryWorkflowStep(workflow, stepName) {
@@ -138,12 +126,12 @@ test('real-org Playwright workflow runs the extension suite through the MITM pro
   assert.doesNotMatch(
     runBlock,
     /\btest:e2e:telemetry\b/,
-    'expected sharded Ubuntu extension E2E to leave telemetry validation to the final telemetry job'
+    'expected Ubuntu extension E2E to leave telemetry validation to the final telemetry job'
   );
   assert.match(
     runBlock,
     /^\s*npm run test:e2e:proxy-lab -- npm run test:e2e\s*$/m,
-    'expected each sharded extension suite to run through the MITM proxy lab'
+    'expected the extension suite to run through the MITM proxy lab'
   );
   assert.equal(
     cliStep.env?.PLAYWRIGHT_WORKERS,
@@ -181,7 +169,10 @@ test('real-org Playwright workflow keeps E2E tunables configurable with safe def
   assert.ok(!Object.prototype.hasOwnProperty.call(inputs.playwright_workers || {}, 'default'));
   assert.ok(!Object.prototype.hasOwnProperty.call(inputs.playwright_extension_proxy_lab_workers || {}, 'default'));
 
-  assert.equal(job?.env?.VSCODE_TEST_VERSION, "${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}");
+  assert.equal(
+    job?.env?.VSCODE_TEST_VERSION,
+    "${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}"
+  );
   assert.equal(job?.env?.SALESFORCE_CLI_PACKAGE, "${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}");
   assert.equal(
     job?.env?.PLAYWRIGHT_WORKERS,
@@ -192,11 +183,14 @@ test('real-org Playwright workflow keeps E2E tunables configurable with safe def
     "${{ github.event.inputs.playwright_extension_proxy_lab_workers || vars.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS || '1' }}"
   );
   assert.equal(job?.env?.PLAYWRIGHT_RETRIES, "${{ vars.PLAYWRIGHT_RETRIES || '0' }}");
-  assert.equal(job?.env?.PLAYWRIGHT_SHARD, '${{ matrix.shard.playwright_shard }}');
+  assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'PLAYWRIGHT_SHARD'));
   assert.equal(job?.env?.PLAYWRIGHT_TIMEOUT_MS, "${{ vars.PLAYWRIGHT_TIMEOUT_MS || '360000' }}");
   assert.equal(job?.env?.PLAYWRIGHT_EXPECT_TIMEOUT_MS, "${{ vars.PLAYWRIGHT_EXPECT_TIMEOUT_MS || '60000' }}");
   assert.equal(job?.env?.SF_DEVHUB_ALIAS, "${{ vars.SF_DEVHUB_ALIAS || 'DevHubElectivus' }}");
-  assert.equal(job?.env?.SF_SCRATCH_DURATION, "${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}");
+  assert.equal(
+    job?.env?.SF_SCRATCH_DURATION,
+    "${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}"
+  );
   assert.equal(job?.env?.SF_TEST_KEEP_ORG, "${{ vars.SF_TEST_KEEP_ORG || '1' }}");
   assert.equal(job?.env?.INSTALL_LINUX_DEPS, "${{ vars.INSTALL_LINUX_DEPS || 'true' }}");
   assert.equal(job?.env?.AZURE_CLIENT_ID, '${{ secrets.AZURE_CLIENT_ID }}');
@@ -206,37 +200,35 @@ test('real-org Playwright workflow keeps E2E tunables configurable with safe def
     job?.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
     "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
   );
-  assert.equal(job?.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu-shards');
+  assert.equal(job?.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu');
   assert.ok(!Object.prototype.hasOwnProperty.call(job?.env || {}, 'ALV_E2E_PROXY_LAB_SKIP_NPM_CI'));
 });
 
-test('real-org Playwright workflow shards the Ubuntu proxy-lab run while keeping worker tunables', () => {
+test('real-org Playwright workflow runs once on Ubuntu without shard configuration', () => {
   const workflow = readWorkflow();
   const job = getWorkflowJob(workflow, 'playwright_e2e');
   const { step: cliStep } = getWorkflowStep(workflow, 'Run CLI real-org E2E');
   const { step: extensionStep } = getWorkflowStep(workflow, 'Run Playwright E2E');
 
-  assert.equal(job.strategy?.['fail-fast'], false);
-  assert.deepEqual(job.strategy?.matrix?.shard, EXPECTED_SHARD_MATRIX);
-  assert.equal(job.env?.PLAYWRIGHT_SHARD, '${{ matrix.shard.playwright_shard }}');
-  assert.match(String(cliStep.run || ''), /Playwright shard: \$\{PLAYWRIGHT_SHARD\}/);
-  assert.match(String(extensionStep.run || ''), /Playwright shard: \$\{PLAYWRIGHT_SHARD\}/);
+  assert.ok(!Object.prototype.hasOwnProperty.call(job, 'strategy'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'PLAYWRIGHT_SHARD'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(cliStep.env || {}, 'PLAYWRIGHT_SHARD'));
+  assert.ok(!Object.prototype.hasOwnProperty.call(extensionStep.env || {}, 'PLAYWRIGHT_SHARD'));
+  assert.doesNotMatch(read('.github/workflows/e2e-playwright.yml'), /PLAYWRIGHT_SHARD|playwright_shard|matrix\.shard/);
   assert.equal(cliStep.env?.PLAYWRIGHT_WORKERS, '${{ env.PLAYWRIGHT_WORKERS }}');
   assert.equal(extensionStep.env?.PLAYWRIGHT_WORKERS, '${{ env.PLAYWRIGHT_EXTENSION_PROXY_LAB_WORKERS }}');
-  assert.equal(cliStep.env?.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
-  assert.equal(extensionStep.env?.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
 });
 
-test('real-org Playwright workflow enables test telemetry on the existing Ubuntu shards', () => {
+test('real-org Playwright workflow enables test telemetry on the Ubuntu run', () => {
   const workflow = readWorkflow();
-  const azureLoginStep = getWorkflowStep(workflow, 'Azure login for sharded App Insights telemetry');
-  const prepareTelemetryStep = getWorkflowStep(workflow, 'Prepare sharded App Insights telemetry');
+  const azureLoginStep = getWorkflowStep(workflow, 'Azure login for App Insights telemetry');
+  const prepareTelemetryStep = getWorkflowStep(workflow, 'Prepare App Insights telemetry');
   const uploadCliStep = getWorkflowStep(workflow, 'Upload CLI E2E artifacts');
   const extensionStep = getWorkflowStep(workflow, 'Run Playwright E2E');
 
-  assert.ok(uploadCliStep.index < azureLoginStep.index, 'expected sharded telemetry login after CLI artifacts');
+  assert.ok(uploadCliStep.index < azureLoginStep.index, 'expected telemetry login after CLI artifacts');
   assert.ok(azureLoginStep.index < prepareTelemetryStep.index, 'expected Azure login before exporting telemetry env');
-  assert.ok(prepareTelemetryStep.index < extensionStep.index, 'expected test telemetry env before sharded extension E2E');
+  assert.ok(prepareTelemetryStep.index < extensionStep.index, 'expected test telemetry env before extension E2E');
   assert.equal(
     azureLoginStep.step.if,
     "${{ env.AZURE_CLIENT_ID != '' && env.AZURE_TENANT_ID != '' && env.AZURE_SUBSCRIPTION_ID != '' && env.HAS_AZURE_E2E_TELEMETRY_CONFIG == '1' }}"
@@ -312,7 +304,7 @@ test('direct real-org Playwright OS matrix runs Windows and macOS without the pr
       }
     ]
   );
-  assert.deepEqual(matrix?.shard, EXPECTED_SHARD_MATRIX);
+  assert.ok(!Object.prototype.hasOwnProperty.call(matrix || {}, 'shard'));
 
   assert.match(String(cliStep.step.run || ''), /^\s*node scripts\/run-playwright-cli-e2e\.js\s*$/m);
   assert.doesNotMatch(String(cliStep.step.run || ''), /proxy-lab/);
@@ -344,12 +336,10 @@ test('direct real-org Playwright workflow keeps the CLI scratch-env contract ali
 
   assert.equal(cliStep.env.PLAYWRIGHT_WORKERS, '${{ env.PLAYWRIGHT_WORKERS }}');
   assert.equal(extensionStep.env.PLAYWRIGHT_WORKERS, '${{ env.PLAYWRIGHT_WORKERS }}');
-  assert.equal(cliStep.env.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
-  assert.equal(extensionStep.env.PLAYWRIGHT_SHARD, '${{ env.PLAYWRIGHT_SHARD }}');
   assert.equal(
     cliStep.env.SF_SCRATCH_POOL_OWNER,
-    'github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}/${{ matrix.shard.artifact_suffix }}',
-    'expected direct E2E pool owners to include the OS and shard artifact suffixes'
+    'github:${{ github.run_id }}/${{ github.run_attempt }}/${{ matrix.os.artifact_suffix }}',
+    'expected direct E2E pool owners to include the OS artifact suffix'
   );
 });
 
@@ -359,89 +349,55 @@ test('direct real-org Playwright workflow uploads OS-specific artifacts and keep
   const uploadCliStep = getDirectWorkflowStep(workflow, 'Upload CLI E2E artifacts');
   const uploadExtensionStep = getDirectWorkflowStep(workflow, 'Upload Playwright artifacts');
 
-  assert.equal(job.needs, 'playwright_e2e_os_prepare');
-  assert.equal(job.env?.VSCODE_TEST_VERSION, "${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}");
+  assert.ok(!Object.prototype.hasOwnProperty.call(job, 'needs'));
+  assert.equal(
+    job.env?.VSCODE_TEST_VERSION,
+    "${{ vars.VSCODE_TEST_VERSION || github.event.inputs.vscode_version || 'stable' }}"
+  );
   assert.equal(job.env?.SALESFORCE_CLI_PACKAGE, "${{ vars.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8' }}");
   assert.equal(job.env?.SALESFORCE_CLI_NODE_VERSION, "${{ vars.SALESFORCE_CLI_NODE_VERSION || '20' }}");
   assert.equal(
     job.env?.PLAYWRIGHT_WORKERS,
     "${{ github.event.inputs.playwright_workers || vars.PLAYWRIGHT_WORKERS || '1' }}"
   );
-  assert.equal(job.env?.PLAYWRIGHT_SHARD, '${{ matrix.shard.playwright_shard }}');
+  assert.ok(!Object.prototype.hasOwnProperty.call(job.env || {}, 'PLAYWRIGHT_SHARD'));
   assert.equal(job.env?.PLAYWRIGHT_RETRIES, "${{ vars.PLAYWRIGHT_RETRIES || '0' }}");
   assert.equal(job.env?.PLAYWRIGHT_TIMEOUT_MS, "${{ vars.PLAYWRIGHT_TIMEOUT_MS || '360000' }}");
   assert.equal(job.env?.PLAYWRIGHT_EXPECT_TIMEOUT_MS, "${{ vars.PLAYWRIGHT_EXPECT_TIMEOUT_MS || '60000' }}");
   assert.equal(job.env?.SF_DEVHUB_ALIAS, "${{ vars.SF_DEVHUB_ALIAS || 'DevHubElectivus' }}");
-  assert.equal(job.env?.SF_SCRATCH_DURATION, "${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}");
+  assert.equal(
+    job.env?.SF_SCRATCH_DURATION,
+    "${{ github.event.inputs.scratch_duration_days || vars.SF_SCRATCH_DURATION || '1' }}"
+  );
   assert.equal(job.env?.SF_TEST_KEEP_ORG, "${{ vars.SF_TEST_KEEP_ORG || '1' }}");
-  assert.equal(uploadCliStep.step.with?.name, 'playwright-cli-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}');
+  assert.equal(uploadCliStep.step.with?.name, 'playwright-cli-e2e-${{ matrix.os.artifact_suffix }}');
   assert.equal(uploadCliStep.step.with?.path, 'output/playwright-cli/');
-  assert.equal(uploadExtensionStep.step.with?.name, 'playwright-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}');
+  assert.equal(uploadExtensionStep.step.with?.name, 'playwright-e2e-${{ matrix.os.artifact_suffix }}');
   assert.equal(uploadExtensionStep.step.with?.path, 'output/playwright/');
 });
 
-test('direct E2E prepare job warms dependencies and uploads OS-specific build artifacts once', () => {
+test('direct E2E jobs restore cached dependencies and build in the same job', () => {
   const workflow = readWorkflow();
-  const job = getWorkflowJob(workflow, 'playwright_e2e_os_prepare');
-  const cacheStep = getDirectPrepareWorkflowStep(workflow, 'Restore direct E2E dependency cache');
-  const installDepsStep = getDirectPrepareWorkflowStep(workflow, 'Install extension dependencies');
-  const buildStep = getDirectPrepareWorkflowStep(workflow, 'Build direct E2E artifacts');
-  const uploadStep = getDirectPrepareWorkflowStep(workflow, 'Upload direct E2E build artifacts');
+  const job = getWorkflowJob(workflow, 'playwright_e2e_os_matrix');
+  const cacheStep = getDirectWorkflowStep(workflow, 'Restore direct E2E dependency cache');
+  const installDepsStep = getDirectWorkflowStep(workflow, 'Install extension dependencies');
+  const buildStep = getDirectWorkflowStep(workflow, 'Build direct E2E artifacts');
+  const requireConfigStep = getDirectWorkflowStep(workflow, 'Require scratch-org pool configuration');
 
-  assert.deepEqual(
-    job.strategy?.matrix?.os?.map(entry => ({
-      artifact_suffix: entry.artifact_suffix,
-      runner: entry.runner,
-      vscode_platform: entry.vscode_platform
-    })),
-    [
-      {
-        runner: 'windows-latest',
-        vscode_platform: 'win32-x64-archive',
-        artifact_suffix: 'windows'
-      },
-      {
-        runner: 'macos-latest',
-        vscode_platform: 'darwin-arm64',
-        artifact_suffix: 'macos'
-      }
-    ]
+  assert.ok(
+    cacheStep.index < installDepsStep.index &&
+      installDepsStep.index < buildStep.index &&
+      buildStep.index < requireConfigStep.index,
+    'expected dependency fallback and build to run before the E2E commands'
   );
+  assert.ok(!Object.prototype.hasOwnProperty.call(workflow.jobs, 'playwright_e2e_os_prepare'));
   assert.equal(cacheStep.step.uses, 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9');
   assert.match(String(cacheStep.step.with?.key || ''), /^direct-e2e-node-modules-/);
   assert.match(String(cacheStep.step.with?.path || ''), /node_modules/);
   assert.equal(installDepsStep.step.if, "steps.direct-e2e-deps.outputs.cache-hit != 'true'");
   assert.equal(buildStep.step.run, 'npm run build');
-  assert.equal(uploadStep.step.uses, 'actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a');
-  assert.equal(uploadStep.step.with?.name, 'direct-e2e-build-${{ matrix.os.artifact_suffix }}');
-  assert.match(String(uploadStep.step.with?.path || ''), /apps\/vscode-extension\/sf-plugin\//);
-  assert.match(String(uploadStep.step.with?.path || ''), /packages\/sf-plugin\/lib\//);
-});
-
-test('direct E2E shards restore cached dependencies and downloaded build artifacts', () => {
-  const workflow = readWorkflow();
-  const cacheStep = getDirectWorkflowStep(workflow, 'Restore direct E2E dependency cache');
-  const installDepsStep = getDirectWorkflowStep(workflow, 'Install extension dependencies');
-  const downloadStep = getDirectWorkflowStep(workflow, 'Download direct E2E build artifacts');
-  const restoreExecutableBitsStep = getDirectWorkflowStep(workflow, 'Restore direct E2E runtime executable bits');
-  const requireConfigStep = getDirectWorkflowStep(workflow, 'Require scratch-org pool configuration');
-
-  assert.ok(
-    cacheStep.index < installDepsStep.index && installDepsStep.index < downloadStep.index,
-    'expected dependency fallback to run before build artifacts are downloaded'
-  );
-  assert.ok(
-    downloadStep.index < restoreExecutableBitsStep.index && restoreExecutableBitsStep.index < requireConfigStep.index,
-    'expected build artifacts to have runtime executable bits before E2E commands can run'
-  );
-  assert.equal(cacheStep.step.uses, 'actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9');
-  assert.equal(installDepsStep.step.if, "steps.direct-e2e-deps.outputs.cache-hit != 'true'");
-  assert.equal(downloadStep.step.uses, 'actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c');
-  assert.equal(downloadStep.step.with?.name, 'direct-e2e-build-${{ matrix.os.artifact_suffix }}');
-  assert.equal(downloadStep.step.with?.path, '.');
-  assert.equal(restoreExecutableBitsStep.step.if, "runner.os != 'Windows'");
-  assert.match(String(restoreExecutableBitsStep.step.run || ''), /apps\/vscode-extension\/node_modules\/@vscode/);
-  assert.match(String(restoreExecutableBitsStep.step.run || ''), /chmod 755/);
+  assert.ok(!job.steps.some(step => step.name === 'Download direct E2E build artifacts'));
+  assert.ok(!job.steps.some(step => step.name === 'Restore direct E2E runtime executable bits'));
 });
 
 test('direct macOS Playwright workflow runs Salesforce CLI through the cached setup helper with an LTS Node runtime', () => {
@@ -479,7 +435,7 @@ test('direct macOS Playwright workflow runs Salesforce CLI through the cached se
   );
 });
 
-test('real-org Playwright workflow runs telemetry validation after sharded E2E jobs', () => {
+test('real-org Playwright workflow runs telemetry validation after the E2E jobs', () => {
   const workflow = readWorkflow();
   const job = getWorkflowJob(workflow, 'playwright_e2e_telemetry');
   const telemetryStep = getTelemetryWorkflowStep(workflow, 'Run Playwright E2E telemetry validation');
@@ -488,7 +444,7 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
   assert.deepEqual(
     job.needs,
     ['playwright_e2e', 'playwright_e2e_os_matrix'],
-    'expected telemetry validation to wait for both sharded E2E jobs'
+    'expected telemetry validation to wait for both E2E jobs'
   );
   assert.equal(
     job.if,
@@ -505,10 +461,10 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
     job.env?.HAS_AZURE_E2E_TELEMETRY_CONFIG,
     "${{ vars.ALV_E2E_TELEMETRY_RESOURCE_GROUP != '' && vars.ALV_E2E_TELEMETRY_APP != '' && vars.ALV_E2E_TELEMETRY_BASE_APP != '' && '1' || '' }}"
   );
-  assert.equal(job.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu-shards');
+  assert.equal(job.env?.ALV_E2E_TELEMETRY_RUN_ID_SEED, 'github:${{ github.run_id }}/ubuntu');
   assert.match(
     runBlock,
-    /skipping dedicated telemetry validation after the sharded E2E jobs/,
+    /skipping dedicated telemetry validation after the E2E jobs/,
     'expected the final telemetry job to pass cleanly when telemetry config is incomplete'
   );
   assert.match(
@@ -517,11 +473,7 @@ test('real-org Playwright workflow runs telemetry validation after sharded E2E j
     'expected the final telemetry job to query telemetry without running Playwright'
   );
   assert.doesNotMatch(runBlock, /\btest:e2e\b/, 'expected final telemetry validation not to run E2E tests');
-  assert.doesNotMatch(
-    runBlock,
-    /PLAYWRIGHT_SHARD/,
-    'expected final telemetry validation to run unsharded'
-  );
+  assert.doesNotMatch(runBlock, /PLAYWRIGHT_SHARD/, 'expected final telemetry validation not to configure a shard');
   assert.equal(
     job.steps.some(step => step?.name === 'Upload Playwright telemetry artifacts'),
     false,
@@ -551,10 +503,7 @@ test('real-org Playwright workflow logs into Azure immediately before final tele
     setupNodeStep.index < azureLoginStep.index,
     'expected Azure login to run after checkout/setup so the OIDC assertion is fresher for telemetry validation'
   );
-  assert.ok(
-    azureLoginStep.index < telemetryStep.index,
-    'expected Azure login to run before telemetry validation'
-  );
+  assert.ok(azureLoginStep.index < telemetryStep.index, 'expected Azure login to run before telemetry validation');
   assert.equal(
     azureLoginStep.index + 1,
     telemetryStep.index,

--- a/scripts/pr-matrix-workflow.test.js
+++ b/scripts/pr-matrix-workflow.test.js
@@ -35,13 +35,6 @@ function matrixByOs(job) {
   return new Map(entries.map(entry => [entry.os || entry.runner, entry]));
 }
 
-const EXPECTED_SHARD_MATRIX = [
-  { playwright_shard: '1/4', artifact_suffix: 'shard-1' },
-  { playwright_shard: '2/4', artifact_suffix: 'shard-2' },
-  { playwright_shard: '3/4', artifact_suffix: 'shard-3' },
-  { playwright_shard: '4/4', artifact_suffix: 'shard-4' }
-];
-
 test('package.json test:scripts includes the PR matrix workflow guard', () => {
   const packageJson = JSON.parse(read('package.json'));
 
@@ -108,12 +101,12 @@ test('real-org E2E keeps Ubuntu on the proxy lab and adds direct Windows/macOS l
   const proxyExtensionStep = getStep(proxyJob, 'Run Playwright E2E').step;
 
   assert.equal(proxyJob['runs-on'], 'ubuntu-latest');
-  assert.deepEqual(proxyJob.strategy?.matrix?.shard, EXPECTED_SHARD_MATRIX);
+  assert.ok(!Object.prototype.hasOwnProperty.call(proxyJob, 'strategy'));
   assert.match(String(proxyCliStep.run || ''), /\bnpm run test:e2e:proxy-lab -- npm run test:e2e:cli\b/);
   assert.match(String(proxyExtensionStep.run || ''), /\bnpm run test:e2e:proxy-lab -- npm run test:e2e\b/);
 
   assert.equal(directJob.strategy?.['fail-fast'], false);
-  assert.deepEqual(directJob.strategy?.matrix?.shard, EXPECTED_SHARD_MATRIX);
+  assert.ok(!Object.prototype.hasOwnProperty.call(directJob.strategy?.matrix || {}, 'shard'));
   assert.deepEqual(Array.from(matrix.keys()).sort(), ['macos-latest', 'windows-latest']);
   assert.equal(matrix.get('windows-latest')?.vscode_platform, 'win32-x64-archive');
   assert.equal(matrix.get('windows-latest')?.artifact_suffix, 'windows');
@@ -135,8 +128,8 @@ test('direct E2E lanes run without proxy-lab and publish OS-specific artifacts',
   assert.match(String(extensionStep.run || ''), /^\s*node scripts\/run-playwright-e2e\.js\s*$/m);
   assert.doesNotMatch(String(extensionStep.run || ''), /proxy-lab/);
   assert.doesNotMatch(String(extensionStep.run || ''), /npm run test:e2e/);
-  assert.equal(uploadCliStep.with?.name, 'playwright-cli-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}');
+  assert.equal(uploadCliStep.with?.name, 'playwright-cli-e2e-${{ matrix.os.artifact_suffix }}');
   assert.equal(uploadCliStep.with?.path, 'output/playwright-cli/');
-  assert.equal(uploadExtensionStep.with?.name, 'playwright-e2e-${{ matrix.os.artifact_suffix }}-${{ matrix.shard.artifact_suffix }}');
+  assert.equal(uploadExtensionStep.with?.name, 'playwright-e2e-${{ matrix.os.artifact_suffix }}');
   assert.equal(uploadExtensionStep.with?.path, 'output/playwright/');
 });


### PR DESCRIPTION
## Summary

- run the real-org Playwright workflow once per operating system instead of across four shards
- fold the Windows/macOS preparation job into each direct E2E job while retaining the dependency, VS Code, and Salesforce CLI caches
- update artifact names, scratch-pool ownership, telemetry identifiers, workflow guards, and CI documentation for the unsharded layout

## Why

The recently added caches remove much of the repeated setup cost that motivated splitting the suites. A single full run per operating system avoids extra runner startup, artifact handoff, and scratch-pool contention while keeping the same CLI and extension coverage.

## Impact

The main E2E workload drops from 12 Playwright job instances to 3: one Ubuntu proxy-lab run plus one direct run on Windows and macOS. Local runner support for optional `PLAYWRIGHT_SHARD` values remains available, but GitHub Actions no longer configures it. Telemetry is still emitted by the Ubuntu extension run and validated by the final lightweight job.

## Validation

- `npm run test:scripts`
- `npx --no-install prettier --check .github/workflows/e2e-playwright.yml scripts/cli-e2e-workflow.test.js scripts/pr-matrix-workflow.test.js docs/CI.md docs/TESTING.md`
- `git diff --check`

The real-org E2E workflow itself is left to the pull request checks.
