### PR TITLE
chore(release): prepare 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,31 @@
 
 ## Unreleased
 
+## [0.52.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.50.0...v0.52.0) (2026-07-11)
+
 ### Features
 
-- Architecture: introduce private `@alv/core` and `@alv/protocol` workspace packages so the VS Code extension and Salesforce CLI plugin share runtime behavior and contracts without coupling their delivery artifacts.
-- Extension: execute the shared TypeScript core in-process, remove the embedded Salesforce plugin runner from the VSIX, and move commands, views, and settings to the `electivus.apexLogViewer.*` namespace.
-- CLI/Plugin: expose each `sf electivus` operation as an independent `SfCommand` with singular topic names, declarative flags, and camel-case JSON results.
+- Architecture: introduce private `@alv/core` and `@alv/protocol` workspace packages so the VS Code extension and Salesforce CLI plugin share runtime behavior and contracts without coupling their delivery artifacts. ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
+- Extension: execute the shared TypeScript core in-process, remove the embedded Salesforce plugin runner from the VSIX, and move commands, views, and settings to the `electivus.apexLogViewer.*` namespace. ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
+- CLI/Plugin: expose each `sf electivus` operation as an independent `SfCommand` with singular topic names, declarative flags, and camel-case JSON results. ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
 
 ### Bug Fixes
 
-- Logs/Triage: replace the external parser fork with the shared TypeScript analyzer used by the CLI and extension, preserving structured validation, DML, assertion, rollback, fatal exception, and serialized-payload diagnostics without a native tree-sitter install.
+- Logs/Triage: replace the external parser fork with the shared TypeScript analyzer used by the CLI and extension, preserving structured validation, DML, assertion, rollback, fatal exception, and serialized-payload diagnostics without a native tree-sitter install. ([#962](https://github.com/Electivus/Apex-Log-Viewer/pull/962))
 
 ### Chores
 
-- Build: migrate the JavaScript repository to a pnpm workspace with a single `pnpm-lock.yaml` and package-scoped manifests.
-- Extension: require VS Code 1.105+ so the extension host provides Node.js 22.19+, and update packaged requirements text.
-- CLI/Plugin: require Node.js 22.19+ for the standalone Salesforce CLI plugin to match the dependency runtime baseline.
-- Release/SF Plugin: bump `@electivus/plugin-electivus` to `0.2.0` for the next independent Salesforce CLI plugin npm release.
+- Build: migrate the JavaScript repository to a pnpm workspace with a single `pnpm-lock.yaml` and package-scoped manifests. ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
+- Build/Tooling: remove unused Nx and stale Rust-era configuration, resolve npm deprecation warnings, and refresh the supported TypeScript, Salesforce, UI, and HTTP dependency set. ([#930](https://github.com/Electivus/Apex-Log-Viewer/pull/930)) ([#932](https://github.com/Electivus/Apex-Log-Viewer/pull/932)) ([#933](https://github.com/Electivus/Apex-Log-Viewer/pull/933)) ([#943](https://github.com/Electivus/Apex-Log-Viewer/pull/943)) ([#944](https://github.com/Electivus/Apex-Log-Viewer/pull/944)) ([#952](https://github.com/Electivus/Apex-Log-Viewer/pull/952)) ([#954](https://github.com/Electivus/Apex-Log-Viewer/pull/954)) ([#957](https://github.com/Electivus/Apex-Log-Viewer/pull/957))
+- Localization: migrate extension strings and generated language bundles to the VS Code localization APIs. ([#951](https://github.com/Electivus/Apex-Log-Viewer/pull/951))
+- CI: remove redundant commit-policy workflows and require the real-org Playwright aggregate gate on pull requests. ([#953](https://github.com/Electivus/Apex-Log-Viewer/pull/953)) ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
+- Extension: require VS Code 1.105+ so the extension host provides Node.js 22.19+, and update packaged requirements text. ([#946](https://github.com/Electivus/Apex-Log-Viewer/pull/946)) ([#947](https://github.com/Electivus/Apex-Log-Viewer/pull/947))
+- CLI/Plugin: require Node.js 22.19+ for the standalone Salesforce CLI plugin to match the dependency runtime baseline. ([#948](https://github.com/Electivus/Apex-Log-Viewer/pull/948))
+- Release/SF Plugin: publish `@electivus/plugin-electivus` `0.2.0` as the first independently delivered plugin backed by the shared TypeScript core. ([#950](https://github.com/Electivus/Apex-Log-Viewer/pull/950)) ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
+
+### Tests
+
+- E2E/CI: isolate pooled scratch orgs per test, cache reusable setup, validate telemetry, and let atomic pool leases bound parallel real-org workflows without GitHub-level serialization. ([#955](https://github.com/Electivus/Apex-Log-Viewer/pull/955)) ([#958](https://github.com/Electivus/Apex-Log-Viewer/pull/958)) ([#959](https://github.com/Electivus/Apex-Log-Viewer/pull/959)) ([#960](https://github.com/Electivus/Apex-Log-Viewer/pull/960)) ([#961](https://github.com/Electivus/Apex-Log-Viewer/pull/961)) ([#963](https://github.com/Electivus/Apex-Log-Viewer/pull/963)) ([#964](https://github.com/Electivus/Apex-Log-Viewer/pull/964))
 
 ## [0.50.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.48.1...v0.50.0) (2026-07-07)
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "Electivus Apex Log Viewer",
   "description": "Fast, searchable Salesforce Apex logs in VS Code — browse, filter, tail, and debug with Apex Replay.",
-  "version": "0.51.0",
+  "version": "0.52.0",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- Prepare the stable VS Code extension release `0.52.0`.
- Promote all release notes accumulated since `v0.50.0`, including the shared-core architecture, localization/tooling updates, and real-org E2E hardening.
- Record the independently published `@electivus/plugin-electivus@0.2.0` release.
- Bump `apps/vscode-extension/package.json` from the `0.51.x` pre-release line to stable `0.52.0`.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm run build`
- `pnpm run test:ci`
- `pnpm run vsce:package`
- `pnpm run test:smoke:vsix`
- Packaged `apex-log-viewer-0.52.0.vsix` and verified its manifest, VS Code engine, and absence of an embedded Salesforce CLI plugin payload.
- Confirmed `0.52.0` is not already published on the VS Code Marketplace or Open VSX.

## Release follow-up

After this PR is merged, create and push tag `v0.52.0` from `main` to trigger the stable extension release workflow.