### PR TITLE
fix(logs): search gitignored log bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Logs/Search: search downloaded Apex log bodies even when the managed `apexlogs/` cache is excluded by the workspace's ignore files.
+
 ## [0.52.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.50.0...v0.52.0) (2026-07-11)
 
 ### Features

--- a/apps/vscode-extension/src/host/utils/ripgrep.ts
+++ b/apps/vscode-extension/src/host/utils/ripgrep.ts
@@ -4,13 +4,17 @@ import { constants as fsConstants, promises as fs } from 'fs';
 
 let cachedBinary: string | null | undefined;
 
-const RG_ARGS_BASE = ['--no-messages', '--ignore-case', '--fixed-strings', '--glob', '*.log'];
+const RG_ARGS_BASE = ['--no-messages', '--no-ignore', '--ignore-case', '--fixed-strings', '--glob', '*.log'];
 
 export type RipgrepMatch = {
   filePath: string;
   lineText: string;
   submatches: Array<{ start: number; end: number }>;
 };
+
+export function buildRipgrepSearchArgs(pattern: string): string[] {
+  return [...RG_ARGS_BASE, '--json', '--max-count', '1', '--', pattern, '.'];
+}
 
 async function resolveRipgrepBinary(): Promise<string> {
   if (cachedBinary) {
@@ -72,7 +76,7 @@ export async function ripgrepSearch(pattern: string, cwd: string, signal?: Abort
     return [];
   }
 
-  const args = [...RG_ARGS_BASE, '--json', '--max-count', '1', '--', pattern, '.'];
+  const args = buildRipgrepSearchArgs(pattern);
   return new Promise((resolve, reject) => {
     if (signal?.aborted) {
       resolve([]);

--- a/apps/vscode-extension/src/node-test/host/utils/ripgrep.test.ts
+++ b/apps/vscode-extension/src/node-test/host/utils/ripgrep.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict';
+
+import { buildRipgrepSearchArgs } from '../../../host/utils/ripgrep';
+
+suite('ripgrep log search', () => {
+  test('searches the managed apexlogs cache even when gitignored', () => {
+    const args = buildRipgrepSearchArgs('STATEMENT_EXECUT');
+
+    assert.ok(args.includes('--no-ignore'));
+    assert.deepEqual(args.slice(-3), ['--', 'STATEMENT_EXECUT', '.']);
+  });
+});

--- a/packages/webview/src/__tests__/LogRow.test.tsx
+++ b/packages/webview/src/__tests__/LogRow.test.tsx
@@ -47,6 +47,7 @@ describe('LogRow', () => {
     opened = undefined;
     replayed = undefined;
     const rowEl = getByRole('row');
+    expect(rowEl).toHaveAttribute('data-log-id', row.Id);
     fireEvent.keyDown(rowEl, { key: 'Enter' });
     expect(opened).toBe('1');
     opened = undefined;

--- a/packages/webview/src/components/table/LogRow.tsx
+++ b/packages/webview/src/components/table/LogRow.tsx
@@ -143,6 +143,7 @@ export function LogRow({
   return (
     <div
       role="row"
+      data-log-id={r.Id}
       tabIndex={0}
       onKeyDown={handleKeyDown}
       style={style}

--- a/test/e2e/specs/openLogViewer.e2e.spec.ts
+++ b/test/e2e/specs/openLogViewer.e2e.spec.ts
@@ -3,7 +3,7 @@ import { runCommandWhenAvailable } from '../utils/commandPalette';
 import { closeQuickInputIfOpen, dismissAllNotifications } from '../utils/notifications';
 import { waitForWebviewFrame } from '../utils/webviews';
 
-test('opens the seeded Apex log in the Log Viewer panel', async ({ vscodePage, seededLog }) => {
+test('searches a gitignored Apex log body and opens it in the Log Viewer panel', async ({ vscodePage, seededLog }) => {
   // Activate the extension by running a contributed command.
   // (The command will be updated to ensure the Logs view is visible.)
   await runCommandWhenAvailable(vscodePage, 'Electivus Apex Logs: Refresh Logs', { timeoutMs: 90_000 });
@@ -15,16 +15,22 @@ test('opens the seeded Apex log in the Log Viewer panel', async ({ vscodePage, s
     { timeoutMs: 180_000 }
   );
 
-  await expect
-    .poll(() => logsFrame.locator('[role="row"][tabindex="0"]').count(), { timeout: 180_000 })
-    .toBeGreaterThan(0);
+  const searchInput = logsFrame.locator('input[type="search"]').first();
+  const rows = logsFrame.locator('[role="row"][tabindex="0"]');
+  await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
+  await searchInput.fill(seededLog.marker);
+  await expect.poll(() => rows.count(), { timeout: 180_000 }).toBeGreaterThan(0);
+  const matchingRow = logsFrame.locator(`[data-log-id="${seededLog.logId}"]`);
+  await expect(matchingRow).toBeVisible({ timeout: 180_000 });
+  await expect(matchingRow.locator('mark.match-highlight').filter({ hasText: seededLog.marker }).first()).toBeVisible({
+    timeout: 180_000
+  });
 
-  // Select the first row and press Enter to open (LogRow binds Enter/Space to open).
-  const firstRow = logsFrame.locator('[role="row"][tabindex="0"]').first();
+  // Select the matching row and press Enter to open (LogRow binds Enter/Space to open).
   await dismissAllNotifications(vscodePage);
   await closeQuickInputIfOpen(vscodePage);
-  await firstRow.click();
-  await firstRow.press('Enter');
+  await matchingRow.click();
+  await matchingRow.press('Enter');
 
   // Find the Log Viewer panel webview by its stable header text.
   const viewerFrame = await waitForWebviewFrame(
@@ -39,8 +45,8 @@ test('opens the seeded Apex log in the Log Viewer panel', async ({ vscodePage, s
   await expect(viewerFrame.locator(`text=${seededLog.logId}`).first()).toBeVisible({ timeout: 60_000 });
 
   // Use the built-in search to ensure the marker is present in the parsed entries.
-  const searchInput = viewerFrame.locator('input[placeholder=\"Search entries…\"]');
-  await searchInput.waitFor({ state: 'visible', timeout: 60_000 });
-  await searchInput.fill(seededLog.marker);
+  const viewerSearchInput = viewerFrame.locator('input[placeholder=\"Search entries…\"]');
+  await viewerSearchInput.waitFor({ state: 'visible', timeout: 60_000 });
+  await viewerSearchInput.fill(seededLog.marker);
   await expect(viewerFrame.locator(`text=${seededLog.marker}`).first()).toBeVisible({ timeout: 60_000 });
 });

--- a/test/e2e/utils/__tests__/tempWorkspace.test.ts
+++ b/test/e2e/utils/__tests__/tempWorkspace.test.ts
@@ -9,9 +9,11 @@ describe('createTempWorkspace', () => {
       sfCli: { sfBinPath: '/unused/sf', nodeBinPath: '/unused/node' }
     });
     try {
+      const gitignore = await readFile(path.join(workspace.workspacePath, '.gitignore'), 'utf8');
       const settings = JSON.parse(
         await readFile(path.join(workspace.workspacePath, '.vscode', 'settings.json'), 'utf8')
       );
+      expect(gitignore.split(/\r?\n/)).toContain('apexlogs/');
       expect(settings['electivus.apexLogViewer.logging.trace']).toBe(true);
       expect(Object.keys(settings).some(key => /cliPath/i.test(key))).toBe(false);
     } finally {

--- a/test/e2e/utils/tempWorkspace.ts
+++ b/test/e2e/utils/tempWorkspace.ts
@@ -41,6 +41,7 @@ export async function createTempWorkspace(options: {
       sourceApiVersion: String(process.env.SF_TEST_API_VERSION || '60.0')
     };
     await writeFile(path.join(workspacePath, 'sfdx-project.json'), JSON.stringify(proj, null, 2), 'utf8');
+    await writeFile(path.join(workspacePath, '.gitignore'), 'apexlogs/\n', 'utf8');
     await mkdir(path.join(workspacePath, 'force-app'), { recursive: true });
 
     const sfDir = path.join(workspacePath, '.sf');


### PR DESCRIPTION
## Summary

- make full-body Apex log search bypass workspace ignore rules while retaining the `*.log` scope
- create E2E workspaces with `apexlogs/` gitignored so tests reproduce production behavior
- filter the logs table by a body-only marker and select the matching `logId` deterministically before opening it

## Root cause

The extension intentionally adds `apexlogs/` to `.gitignore`, but the packaged ripgrep search used its default ignore handling. As a result, a real workspace could contain and open a downloaded log while full-body search scanned zero bytes. Existing provider and webview tests mocked the search result, while Playwright workspaces did not include a `.gitignore`, so the environment mismatch stayed uncovered.

## User impact

Downloaded log bodies remain excluded from source control and are now searchable from the Electivus Apex Logs panel.

## Validation

- `pnpm run compile`
- `pnpm run build`
- `pnpm run build:webview`
- `pnpm run test:webview --runInBand` (103 passed)
- `pnpm run test:extension:node` (8 passed)
- `pnpm run test:e2e:utils` (107 passed)
- `PLAYWRIGHT_RETRIES=0 node scripts/run-playwright-e2e.js test/e2e/specs/openLogViewer.e2e.spec.ts` (1 passed)
