### PR TITLE
chore(release): prepare 0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Unreleased
 
+## [0.52.1](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.52.0...v0.52.1) (2026-07-17)
+
 ### Bug Fixes
 
-- Logs/Search: search downloaded Apex log bodies even when the managed `apexlogs/` cache is excluded by the workspace's ignore files.
+- Logs/Search: search downloaded Apex log bodies even when the managed `apexlogs/` cache is excluded by the workspace's ignore files. ([#974](https://github.com/Electivus/Apex-Log-Viewer/pull/974))
 
 ## [0.52.0](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.50.0...v0.52.0) (2026-07-11)
 

--- a/apps/vscode-extension/package.json
+++ b/apps/vscode-extension/package.json
@@ -2,7 +2,7 @@
   "name": "apex-log-viewer",
   "displayName": "Electivus Apex Log Viewer",
   "description": "Fast, searchable Salesforce Apex logs in VS Code — browse, filter, tail, and debug with Apex Replay.",
-  "version": "0.52.0",
+  "version": "0.52.1",
   "publisher": "electivus",
   "telemetryConnectionString": "InstrumentationKey=a8895b37-e877-4b0c-bed4-0d421e313bf5;IngestionEndpoint=https://eastus-8.in.applicationinsights.azure.com/;LiveEndpoint=https://eastus.livediagnostics.monitor.azure.com/;ApplicationId=91194049-f752-4b25-934c-0cdef9251e6f",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- prepare the stable VS Code extension release `0.52.1`
- move the log-search fix from `Unreleased` into the dated `0.52.1` changelog section
- link the release note to #974

## Release contents

- fix full-body Apex log search when the managed `apexlogs/` cache is excluded by workspace ignore files

## Validation

- `pnpm run build`
- `pnpm run test:ci`
- release documentation and packaging tests: 21 passed

## After merge

Create and push the annotated tag `v0.52.1` to trigger `.github/workflows/release.yml`.
