### PR TITLE
fix(security): resolve dependency and shell alerts

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5753,8 +5753,8 @@ packages:
     resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
     engines: {node: '>=20'}
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -9427,7 +9427,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   faye@1.4.1:
     dependencies:
@@ -12100,7 +12100,7 @@ snapshots:
 
   webidl-conversions@8.0.1: {}
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1

--- a/scripts/setup-salesforce-cli.mjs
+++ b/scripts/setup-salesforce-cli.mjs
@@ -4,8 +4,7 @@ import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-export const SALESFORCE_CLI_PACKAGE_PATTERN =
-  /^@salesforce\/cli@(?:\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?|nightly)$/;
+export const SALESFORCE_CLI_PACKAGE_PATTERN = /^@salesforce\/cli@(?:\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?|nightly)$/;
 
 const WRAPPER_ENV_UNSET_NAMES = [
   'ELECTRON_RUN_AS_NODE',
@@ -65,9 +64,7 @@ export function resolveSalesforceCliCacheConfig({
 } = {}) {
   const normalizedPackageName = normalizeSalesforceCliPackage(packageName);
   const cacheRoot = path.resolve(
-    env.SALESFORCE_CLI_CACHE_ROOT ||
-      env.RUNNER_TOOL_CACHE ||
-      path.join(os.tmpdir(), 'alv-salesforce-cli-cache')
+    env.SALESFORCE_CLI_CACHE_ROOT || env.RUNNER_TOOL_CACHE || path.join(os.tmpdir(), 'alv-salesforce-cli-cache')
   );
   const key = [
     'alv-sf-cli',
@@ -104,18 +101,7 @@ function assertPathInside(parent, child) {
   }
 }
 
-function resolveManagedCommand(commandKey) {
-  if (commandKey === 'npm') {
-    return 'npm';
-  }
-  if (commandKey === 'cmd') {
-    return 'cmd.exe';
-  }
-  throw new Error(`Unsupported managed command: ${commandKey}`);
-}
-
-function runCommand(commandKey, args, options = {}, spawnSyncFn = spawnSync) {
-  const command = resolveManagedCommand(commandKey);
+function runCommand(command, args, options = {}, spawnSyncFn = spawnSync) {
   const result = spawnSyncFn(command, args, {
     stdio: options.stdio || 'inherit',
     env: options.env,
@@ -132,15 +118,29 @@ function runCommand(commandKey, args, options = {}, spawnSyncFn = spawnSync) {
   return result;
 }
 
-function npmInstallInvocation({ prefix, packageName, platform = process.platform }) {
+function resolveWindowsNpmCliPath(nodePath, fsImpl = fs) {
+  const npmCliPath = path.join(path.dirname(nodePath), 'node_modules', 'npm', 'bin', 'npm-cli.js');
+  if (!fsImpl.existsSync(npmCliPath)) {
+    throw new Error(`Unable to find the npm CLI distributed with Node at ${npmCliPath}.`);
+  }
+  return npmCliPath;
+}
+
+function npmInstallInvocation({
+  prefix,
+  packageName,
+  platform = process.platform,
+  nodePath = process.execPath,
+  fsImpl = fs
+}) {
   const args = ['install', '-g', '--prefix', prefix, packageName, '--no-audit', '--no-fund'];
   if (platform === 'win32') {
     return {
-      commandKey: 'cmd',
-      args: ['/d', '/s', '/c', 'npm.cmd', ...args]
+      command: nodePath,
+      args: [resolveWindowsNpmCliPath(nodePath, fsImpl), ...args]
     };
   }
-  return { commandKey: 'npm', args };
+  return { command: 'npm', args };
 }
 
 function sfVersionInvocation(prefix, platform = process.platform) {
@@ -222,17 +222,8 @@ function formatOutputValue(name, value) {
   return `${name}=${String(value).replace(/\r?\n/g, ' ')}`;
 }
 
-export function writeGitHubExports({
-  env = process.env,
-  sfBinPath,
-  pathEntry,
-  nodePath,
-  fsImpl = fs
-}) {
-  const envLines = [
-    formatOutputValue('SF_CLI_BIN_PATH', sfBinPath),
-    formatOutputValue('ALV_SF_BIN_PATH', sfBinPath)
-  ];
+export function writeGitHubExports({ env = process.env, sfBinPath, pathEntry, nodePath, fsImpl = fs }) {
+  const envLines = [formatOutputValue('SF_CLI_BIN_PATH', sfBinPath), formatOutputValue('ALV_SF_BIN_PATH', sfBinPath)];
   if (nodePath) {
     envLines.push(formatOutputValue('SF_CLI_NODE_PATH', nodePath));
   }
@@ -242,10 +233,7 @@ export function writeGitHubExports({
 }
 
 export function writeGitHubCacheOutputs({ env = process.env, cacheKey, cacheDir, fsImpl = fs }) {
-  const output = [
-    formatOutputValue('cache-key', cacheKey),
-    formatOutputValue('cache-dir', cacheDir)
-  ].join('\n');
+  const output = [formatOutputValue('cache-key', cacheKey), formatOutputValue('cache-dir', cacheDir)].join('\n');
   appendOutput(env.GITHUB_OUTPUT, output, fsImpl);
   return output;
 }
@@ -275,10 +263,12 @@ export function setupSalesforceCli({
     const invocation = npmInstallInvocation({
       prefix: config.cacheDir,
       packageName: config.packageName,
-      platform
+      platform,
+      nodePath,
+      fsImpl
     });
     stdout.write(`[sf-cli] Installing ${config.packageName} into ${config.cacheDir}\n`);
-    runCommand(invocation.commandKey, invocation.args, { env }, spawnSyncFn);
+    runCommand(invocation.command, invocation.args, { env }, spawnSyncFn);
   } else {
     stdout.write(`[sf-cli] Reusing cached ${config.packageName} from ${config.cacheDir}\n`);
   }
@@ -325,7 +315,8 @@ export function setupSalesforceCli({
 
 function main() {
   const args = process.argv.slice(2);
-  const packageName = readArgValue(args, '--package') || process.env.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8';
+  const packageName =
+    readArgValue(args, '--package') || process.env.SALESFORCE_CLI_PACKAGE || '@salesforce/cli@2.136.8';
   const env = { ...process.env, SALESFORCE_CLI_PACKAGE: packageName };
   const config = resolveSalesforceCliCacheConfig({ env });
 

--- a/scripts/setup-salesforce-cli.test.js
+++ b/scripts/setup-salesforce-cli.test.js
@@ -82,11 +82,61 @@ test('setupSalesforceCli installs into the managed prefix and exports bin paths 
     });
 
     assert.equal(calls[0].command, 'npm');
-    assert.deepEqual(calls[0].args.slice(0, 5), ['install', '-g', '--prefix', result.cacheDir, '@salesforce/cli@2.136.8']);
+    assert.deepEqual(calls[0].args.slice(0, 5), [
+      'install',
+      '-g',
+      '--prefix',
+      result.cacheDir,
+      '@salesforce/cli@2.136.8'
+    ]);
     assert.equal(result.sfBinPath, path.join(result.cacheDir, 'bin', 'sf'));
     assert.match(fs.readFileSync(githubEnv, 'utf8'), /SF_CLI_BIN_PATH=.*[\\/]bin[\\/]sf/);
     assert.match(fs.readFileSync(githubEnv, 'utf8'), /ALV_SF_BIN_PATH=.*[\\/]bin[\\/]sf/);
     assert.equal(fs.readFileSync(githubPath, 'utf8').trim(), path.join(result.cacheDir, 'bin'));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('setupSalesforceCli invokes npm without a shell for an environment-derived Windows cache path', async () => {
+  const mod = await loadModule();
+  const root = tempDir();
+  const nodePath = path.join(root, 'node.exe');
+  const npmCliPath = path.join(root, 'node_modules', 'npm', 'bin', 'npm-cli.js');
+  const runnerToolCache = path.join(root, 'cache & echo compromised');
+  const calls = [];
+
+  try {
+    fs.mkdirSync(path.dirname(npmCliPath), { recursive: true });
+    fs.writeFileSync(npmCliPath, '#!/usr/bin/env node\n');
+
+    const result = mod.setupSalesforceCli({
+      env: {
+        RUNNER_TOOL_CACHE: runnerToolCache,
+        SALESFORCE_CLI_PACKAGE: '@salesforce/cli@2.136.8'
+      },
+      platform: 'win32',
+      nodePath,
+      spawnSyncFn(command, args, options) {
+        calls.push({ command, args, options });
+        return { status: 0 };
+      },
+      execFileSyncFn() {
+        return '@salesforce/cli/2.136.8 win32-x64 node-v24.15.0\n';
+      },
+      stdout: silentStdout()
+    });
+
+    assert.equal(calls[0].command, nodePath);
+    assert.equal(calls[0].args[0], npmCliPath);
+    assert.deepEqual(calls[0].args.slice(1, 6), [
+      'install',
+      '-g',
+      '--prefix',
+      result.cacheDir,
+      '@salesforce/cli@2.136.8'
+    ]);
+    assert.equal(calls[0].options.shell, undefined);
   } finally {
     fs.rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary

- upgrade the transitive `websocket-driver` resolution from 0.7.4 to 0.7.5, addressing GHSA-xv26-6w52-cph6 and GHSA-mp7j-qc5w-4988
- execute the npm CLI through the known Node executable on Windows instead of `cmd.exe /c npm.cmd`
- cover environment-derived cache paths containing spaces and shell metacharacters through the public setup helper

## Security reports

- Dependabot alert: https://github.com/Electivus/Apex-Log-Viewer/security/dependabot/144
- CodeQL alert: https://github.com/Electivus/Apex-Log-Viewer/security/code-scanning/58
- Scorecard vulnerability alert expected to clear after the dependency update: https://github.com/Electivus/Apex-Log-Viewer/security/code-scanning/50

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm audit --json` — 0 advisories
- `node --test scripts/setup-salesforce-cli.test.js` — 8 passed
- `pnpm run check-types`
- `pnpm run lint`
- `pnpm run security:dependency-sources`
- `pnpm run security:pnpm-signatures` — 1,287 verified signatures
- `pnpm test`

## Review

- Standards review: no findings
- Spec review: no findings