### PR TITLE
fix(log-viewer): preserve multiline debug JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bug Fixes
+
+- Logs/Viewer: keep multiline `System.debug` payloads, including `JSON.serializePretty` output, together and preserve their formatting in the structured log view.
+
 ## [0.52.1](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.52.0...v0.52.1) (2026-07-17)
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "@types/vscode": "1.105.0",
     "@typescript-eslint/eslint-plugin": "^8.63.0",
     "@typescript-eslint/parser": "^8.56.1",
-    "@vscode/test-electron": "^3.0.0",
+    "@vscode/test-electron": "^3.1.0",
     "@vscode/l10n-dev": "^0.0.35",
     "@vscode/ripgrep": "^1.18.0",
     "@vscode/vsce": "^3.9.2",

--- a/packages/webview/src/__tests__/logViewerApp.test.tsx
+++ b/packages/webview/src/__tests__/logViewerApp.test.tsx
@@ -211,6 +211,34 @@ describe('Log Viewer App', () => {
     });
   });
 
+  it('keeps multiline JSON from USER_DEBUG visible as one formatted debug entry', async () => {
+    const { vscode } = createVsCodeMock();
+    const bus = new EventTarget();
+
+    render(<LogViewerApp vscode={vscode} messageBus={bus} />);
+    send(bus, {
+      type: 'logViewerInit',
+      logId: 'serialize-pretty-log',
+      locale: 'en-US',
+      fileName: 'serialize-pretty.log',
+      lines: [
+        '12:00:00.000 (1)|USER_DEBUG|[7]|DEBUG|{',
+        '  "account" : {',
+        '    "name" : "Acme"',
+        '  }',
+        '}',
+        '12:00:01.000 (2)|METHOD_EXIT|[7]|Example.run()'
+      ]
+    });
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Debug Only' }));
+
+    const jsonEntry = await screen.findByText(content => content.includes('"account"') && content.includes('"name"'));
+    expect(jsonEntry).toHaveTextContent('DEBUG | { "account" : { "name" : "Acme" } }');
+    expect(jsonEntry.className).toContain('whitespace-pre-wrap');
+    expect(screen.queryByText('Example.run()')).toBeNull();
+  });
+
   it('opens logs immediately, hydrates async triage, and scrolls only when a diagnostic is clicked', async () => {
     const { vscode, posted } = createVsCodeMock();
     const bus = new EventTarget();

--- a/packages/webview/src/__tests__/logViewerParser.test.ts
+++ b/packages/webview/src/__tests__/logViewerParser.test.ts
@@ -1,0 +1,26 @@
+import { parseLogLines } from '../utils/logViewerParser';
+
+describe('logViewerParser', () => {
+  it('keeps serializePretty continuation lines in their USER_DEBUG entry', () => {
+    const parsed = parseLogLines([
+      '12:00:00.000 (1)|USER_DEBUG|[7]|DEBUG|{',
+      '  "account" : {',
+      '    "name" : "Acme | Main"',
+      '  }',
+      '}',
+      '12:00:01.000 (2)|METHOD_EXIT|[7]|Example.run()'
+    ]);
+
+    expect(parsed).toHaveLength(2);
+    expect(parsed[0]).toMatchObject({
+      id: 0,
+      category: 'debug',
+      message: ['DEBUG | {', '  "account" : {', '    "name" : "Acme | Main"', '  }', '}'].join('\n')
+    });
+    expect(parsed[1]).toMatchObject({
+      id: 5,
+      category: 'system',
+      message: 'Example.run()'
+    });
+  });
+});

--- a/packages/webview/src/components/log-viewer/LogEntryRow.tsx
+++ b/packages/webview/src/components/log-viewer/LogEntryRow.tsx
@@ -76,9 +76,11 @@ export function LogEntryRow({
         {entry.lineNumber ? `[${entry.lineNumber}]` : ''}
       </div>
       <div className="flex-1 space-y-1 text-[12px] leading-relaxed text-foreground">
-        <div className="break-words text-sm">{highlightText(entry.message || entry.raw, normalizedTerm)}</div>
+        <div className="whitespace-pre-wrap break-words text-sm">
+          {highlightText(entry.message || entry.raw, normalizedTerm)}
+        </div>
         {entry.details && (
-          <div className="rounded-md bg-muted/15 px-3 py-1 font-mono text-[11px] text-muted-foreground shadow-inner">
+          <div className="whitespace-pre-wrap rounded-md bg-muted/15 px-3 py-1 font-mono text-[11px] text-muted-foreground shadow-inner">
             {highlightText(entry.details, normalizedTerm)}
           </div>
         )}

--- a/packages/webview/src/utils/logViewerParser.ts
+++ b/packages/webview/src/utils/logViewerParser.ts
@@ -14,10 +14,19 @@ export interface ParsedLogEntry {
   category: LogCategory;
 }
 
+const APEX_EVENT_LINE = /^\d{1,2}:\d{2}:\d{2}\.\d+(?:\s+\(\d+\))?\s*\|/;
+
 export function parseLogLines(lines: string[]): ParsedLogEntry[] {
   const entries: ParsedLogEntry[] = [];
   for (let i = 0; i < lines.length; i++) {
     const raw = lines[i] ?? '';
+    const previousEntry = entries[entries.length - 1];
+    if (previousEntry?.category === 'debug' && !APEX_EVENT_LINE.test(raw.trimEnd())) {
+      const continuation = raw.trimEnd();
+      previousEntry.message = `${previousEntry.message}\n${continuation}`;
+      previousEntry.raw = `${previousEntry.raw}\n${raw}`;
+      continue;
+    }
     const entry = parseLogLine(raw, i);
     if (entry) {
       entries.push(entry);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,10 +66,10 @@ importers:
         version: 1.105.0
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.63.0
-        version: 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)
+        version: 8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/parser':
         specifier: ^8.56.1
-        version: 8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)
+        version: 8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@vscode/l10n-dev':
         specifier: ^0.0.35
         version: 0.0.35(supports-color@8.1.1)
@@ -77,8 +77,8 @@ importers:
         specifier: ^1.18.0
         version: 1.18.0
       '@vscode/test-electron':
-        specifier: ^3.0.0
-        version: 3.0.0(supports-color@8.1.1)
+        specifier: ^3.1.0
+        version: 3.1.0
       '@vscode/vsce':
         specifier: ^3.9.2
         version: 3.9.2(supports-color@8.1.1)
@@ -96,10 +96,10 @@ importers:
         version: 0.28.1
       eslint:
         specifier: ^10.8.0
-        version: 10.8.0(jiti@2.7.0)
+        version: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@10.8.0(jiti@2.7.0))
+        version: 10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       istanbul-lib-coverage:
         specifier: ^3.2.2
         version: 3.2.2
@@ -2501,8 +2501,8 @@ packages:
   '@vscode/ripgrep@1.18.0':
     resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
-  '@vscode/test-electron@3.0.0':
-    resolution: {integrity: sha512-TY5mC7aAjxSLDXsyjhrG8cJHgc/HLdiE5lvtW7hABYQrY24Qwozzr5UoO3HiuAM4Hzz4b7K/eZlwrCILj94CcA==}
+  '@vscode/test-electron@3.1.0':
+    resolution: {integrity: sha512-CRqv5u+YYoseuNVJ6Tyo4k0sF0mx4qnKMihRB0PjsUF8Dc0WKtCXo6CNL6nWWm5esfFQsQA/pejMj4ZbpJVLTw==}
     engines: {node: '>=22'}
 
   '@vscode/vsce-sign-alpine-arm64@2.0.5':
@@ -6607,14 +6607,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0))':
+  '@eslint-community/eslint-utils@4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -8150,15 +8150,15 @@ snapshots:
     dependencies:
       '@types/yargs-parser': 21.0.3
 
-  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.63.0(@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3))(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.63.0
-      '@typescript-eslint/type-utils': 8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/type-utils': 8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.63.0
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -8166,14 +8166,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.63.0
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -8196,13 +8196,13 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.63.0(eslint@10.8.0(jiti@2.7.0))(supports-color@8.1.1)(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -8225,13 +8225,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.63.0(eslint@10.8.0(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.63.0(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       '@typescript-eslint/scope-manager': 8.63.0
       '@typescript-eslint/types': 8.63.0
       '@typescript-eslint/typescript-estree': 8.63.0(supports-color@8.1.1)(typescript@6.0.3)
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -8243,8 +8243,8 @@ snapshots:
 
   '@typespec/ts-http-runtime@0.3.6':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
@@ -8397,10 +8397,10 @@ snapshots:
       '@vscode/ripgrep-win32-ia32': 1.18.0
       '@vscode/ripgrep-win32-x64': 1.18.0
 
-  '@vscode/test-electron@3.0.0(supports-color@8.1.1)':
+  '@vscode/test-electron@3.1.0':
     dependencies:
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       jszip: 3.10.1
       ora: 8.2.0
       semver: 7.8.5
@@ -9307,9 +9307,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1)):
     dependencies:
-      eslint: 10.8.0(jiti@2.7.0)
+      eslint: 10.8.0(jiti@2.7.0)(supports-color@8.1.1)
 
   eslint-scope@9.1.2:
     dependencies:
@@ -9322,11 +9322,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.8.0(jiti@2.7.0):
+  eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.10.1(eslint@10.8.0(jiti@2.7.0)(supports-color@8.1.1))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
       '@eslint/config-helpers': 0.7.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -9746,7 +9746,7 @@ snapshots:
 
   http-parser-js@0.5.10: {}
 
-  http-proxy-agent@7.0.2(supports-color@8.1.1):
+  http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -9758,7 +9758,7 @@ snapshots:
       quick-lru: 5.1.1
       resolve-alpn: 1.2.1
 
-  https-proxy-agent@7.0.6(supports-color@8.1.1):
+  https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
       debug: 4.4.3(supports-color@8.1.1)
@@ -10393,8 +10393,8 @@ snapshots:
       data-urls: 5.0.0
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
-      http-proxy-agent: 7.0.2(supports-color@8.1.1)
-      https-proxy-agent: 7.0.6(supports-color@8.1.1)
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.22
       parse5: 7.3.0

--- a/scripts/run-tests.test.js
+++ b/scripts/run-tests.test.js
@@ -1,7 +1,9 @@
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
+const os = require("node:os");
 const path = require("node:path");
+const { downloadDirToExecutablePath } = require("@vscode/test-electron/out/util");
 const { ensureDevHub, pretestSetup, resolveMissingExtensionIds, resolveRequiredDevHubConfig } = require("./run-tests");
 
 const originalEnv = { ...process.env };
@@ -26,6 +28,33 @@ test("VS Code host runner targets the extension app output paths", () => {
   assert.match(
     script,
     /mkdirSync\(dirname\(outfile\),\s*\{\s*recursive:\s*true\s*\}\)/,
+  );
+});
+
+test("VS Code host runner resolves the executable declared by modern macOS bundles", t => {
+  const installDir = fs.mkdtempSync(path.join(os.tmpdir(), "alv-vscode-darwin-"));
+  t.after(() => fs.rmSync(installDir, { recursive: true, force: true }));
+
+  const contentsDir = path.join(installDir, "Visual Studio Code.app", "Contents");
+  const macosDir = path.join(contentsDir, "MacOS");
+  fs.mkdirSync(macosDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(contentsDir, "Info.plist"),
+    [
+      '<?xml version="1.0" encoding="UTF-8"?>',
+      '<plist version="1.0">',
+      "<dict>",
+      "  <key>CFBundleExecutable</key>",
+      "  <string>CodeUX</string>",
+      "</dict>",
+      "</plist>"
+    ].join("\n")
+  );
+  fs.writeFileSync(path.join(macosDir, "CodeUX"), "");
+
+  assert.equal(
+    downloadDirToExecutablePath(installDir, "darwin-arm64"),
+    path.join(macosDir, "CodeUX")
   );
 });
 


### PR DESCRIPTION
## Summary
- keep physical continuation lines attached to the preceding `USER_DEBUG` entry until the next timestamped Apex event
- preserve multiline whitespace when rendering log messages and details
- cover `JSON.serializePretty` output, including JSON values containing `|`, at parser and webview seams
- upgrade `@vscode/test-electron` to 3.1.0 so macOS CI resolves the bundle executable from `CFBundleExecutable` instead of the removed `Electron` compatibility name
- add a runner regression using a modern macOS bundle layout and document the user-facing log-viewer fix in `CHANGELOG.md`

## Linked Issues
- None.

## Screenshots / GIFs (UI)
- Not included; the UI change preserves multiline text and is covered by a focused webview regression test.

## Verification Steps
- `pnpm exec jest --config jest.config.webview.cjs --runInBand` (19 suites, 105 tests)
- `pnpm run test:scripts` (including the modern macOS bundle resolver regression)
- `pnpm run security:pnpm-signatures` (1,291 packages verified)
- `pnpm run compile`
- `pnpm run check-types`
- `pnpm run build:webview`

## Risk / Rollback
- Low parser/UI risk: only non-timestamped physical lines following `USER_DEBUG` are folded into that entry, and existing timestamped events retain their original IDs.
- Low tooling risk: `@vscode/test-electron@3.1.0` is the upstream patch that resolves modern macOS bundle executables while retaining the legacy `Electron` fallback.
- Roll back by reverting commits `0ea5f69` and `8deeb3b`.

## Checklist
- [x] Focused and full webview tests pass
- [x] Script, provenance, signature, lint, and type validations pass
- [x] User-facing changelog updated
- [x] No secrets or org-sensitive data added