### PR TITLE
fix(ci): install after setting nightly version

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -196,12 +196,12 @@ jobs:
       - name: Enforce dependency source policy
         run: node scripts/check-dependency-sources.mjs
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
       - name: Set nightly version in apps/vscode-extension/package.json
         run: |
           node -e "const fs=require('fs');const pkgPath='apps/vscode-extension/package.json';const pkg=JSON.parse(fs.readFileSync(pkgPath,'utf8'));pkg.version=process.env.VERSION;fs.writeFileSync(pkgPath,JSON.stringify(pkg,null,2)+'\n')"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build extension packaging assets
         shell: bash

--- a/scripts/packaging-ci.test.js
+++ b/scripts/packaging-ci.test.js
@@ -106,6 +106,31 @@ test('prerelease workflow computes the next publish version via the dedicated he
   );
 });
 
+test('prerelease workflow sets the nightly manifest version before installing package dependencies', () => {
+  const packageJob = readWorkflowJob('.github/workflows/prerelease.yml', 'package_vsix');
+
+  assert.match(
+    packageJob,
+    /- name:\s+Set nightly version in apps\/vscode-extension\/package\.json[\s\S]*?- name:\s+Install dependencies[\s\S]*?- name:\s+Build extension packaging assets/,
+    'expected pnpm to install against the rewritten nightly manifest before verifyDepsBeforeRun checks it'
+  );
+});
+
+test('tag release workflow keeps the checked-in manifest unchanged after installing dependencies', () => {
+  const packageJob = readWorkflowJob('.github/workflows/release.yml', 'package');
+
+  assert.match(
+    packageJob,
+    /- name:\s+Install dependencies[\s\S]*?- name:\s+Verify tag matches extension package version[\s\S]*?- name:\s+Build extension packaging assets/,
+    'expected tag releases to verify, but not rewrite, the manifest installed by pnpm'
+  );
+  assert.doesNotMatch(
+    packageJob,
+    /writeFileSync\(/,
+    'expected tag releases not to invalidate pnpm dependency verification by rewriting the manifest'
+  );
+});
+
 test('sf plugin release workflow publishes matching sf-plugin-v tags through npm', () => {
   const workflowSource = readFile('.github/workflows/sf-plugin-release.yml');
   const validateJob = readWorkflowJob('.github/workflows/sf-plugin-release.yml', 'validate_tag');


### PR DESCRIPTION
## Summary

- set the nightly extension manifest version before installing workspace dependencies
- preserve `verifyDepsBeforeRun: error` while ensuring pnpm records the rewritten manifest
- add regression coverage for the nightly ordering and the tag-release no-rewrite contract

## Root cause

The pre-release packaging matrix ran `pnpm install --frozen-lockfile`, rewrote `apps/vscode-extension/package.json`, and then invoked `pnpm run clean`. pnpm correctly rejected the post-install manifest change with `ERR_PNPM_VERIFY_DEPS_BEFORE_RUN`.

The tag release workflow does not have the same issue: it verifies the checked-in package version against the tag without rewriting the manifest after installation.

## Validation

- `node --test scripts/packaging-ci.test.js` (20 passed)
- `pnpm run test:scripts` (249 passed in the script lane, plus core/protocol/plugin suites)
- `pnpm exec prettier --check .github/workflows/prerelease.yml scripts/packaging-ci.test.js`
- `git diff --check`