### PR TITLE
chore(sf-plugin): prepare 0.2.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Logs/Viewer: keep multiline `System.debug` payloads, including `JSON.serializePretty` output, together and preserve their formatting in the structured log view.
 
+### Chores
+
+- Release/SF Plugin: bump `@electivus/plugin-electivus` to `0.2.1` so the standalone CLI publishes the shared log lifecycle and refreshed Salesforce/runtime dependencies. ([#983](https://github.com/Electivus/Apex-Log-Viewer/pull/983)) ([#987](https://github.com/Electivus/Apex-Log-Viewer/pull/987)) ([#988](https://github.com/Electivus/Apex-Log-Viewer/pull/988))
+
 ## [0.52.1](https://github.com/Electivus/Apex-Log-Viewer/compare/v0.52.0...v0.52.1) (2026-07-17)
 
 ### Bug Fixes

--- a/packages/sf-plugin/package.json
+++ b/packages/sf-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@electivus/plugin-electivus",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "private": true,
   "description": "Salesforce CLI plugin for Electivus Apex Log Viewer workflows.",
   "type": "module",


### PR DESCRIPTION
## Summary

- bump `@electivus/plugin-electivus` from `0.2.0` to `0.2.1`
- publish the shared `ApexLogLifecycle` implementation and refreshed Salesforce/runtime dependencies in the standalone CLI package
- record the plugin release in `CHANGELOG.md`

## Impact

This is a patch release. Existing `sf electivus ...` command names and contracts remain unchanged; the packaged private `@alv/core` now contains the shared log lifecycle used by both product adapters.

## Release sequence

After this PR merges, create and push `sf-plugin-v0.2.1` on the merge commit to trigger `.github/workflows/sf-plugin-release.yml`. Prepare the extension `0.54.0` stable release after the plugin release completes.

## Validation

- Node `v24.15.0` and pnpm `11.11.0`
- `pnpm install --frozen-lockfile`
- `pnpm run security:dependency-sources`
- `pnpm run test:sf-plugin` (4 passed)
- `pnpm run build:sf-plugin`
- `pnpm run stage:sf-plugin-npm`
- staged manifest verification (`0.2.1`, publishable, bundled `@alv/core` present)
- `npm pack --dry-run --json ./dist/sf-plugin-npm` (152 files; bundled `@alv/core` confirmed)
- `pnpm exec prettier --check CHANGELOG.md packages/sf-plugin/package.json`
- `git diff --check`