### PR TITLE
refactor(webview): centralize session mechanics

### DIFF
--- a/apps/vscode-extension/src/extension.ts
+++ b/apps/vscode-extension/src/extension.ts
@@ -1,10 +1,7 @@
 import * as vscode from 'vscode';
-import {
-  SfLogsViewProvider,
-  WEBVIEW_READY_TIMEOUT_MS,
-  WEBVIEW_STABLE_VISIBILITY_DELAY_MS
-} from './provider/SfLogsViewProvider';
+import { SfLogsViewProvider } from './provider/SfLogsViewProvider';
 import { SfLogTailViewProvider } from './provider/SfLogTailViewProvider';
+import { WEBVIEW_SESSION_MOUNT_DELAY_MS, WEBVIEW_SESSION_READY_TIMEOUT_MS } from './provider/webviewSession';
 import type { OrgItem } from './shared/types';
 import * as path from 'path';
 import { setApiVersion, getApiVersion, clearListCache } from './host/salesforce/http';
@@ -94,8 +91,8 @@ function buildDiagnosticsPackage(
     },
     webview: {
       retainContextWhenHidden: true,
-      stableVisibilityDelayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS,
-      readyTimeoutMs: WEBVIEW_READY_TIMEOUT_MS,
+      stableVisibilityDelayMs: WEBVIEW_SESSION_MOUNT_DELAY_MS,
+      readyTimeoutMs: WEBVIEW_SESSION_READY_TIMEOUT_MS,
       providers: providerStates,
       events: getWebviewDiagnosticEvents()
     },
@@ -364,7 +361,6 @@ export async function activate(context: vscode.ExtensionContext) {
       }
     })
   );
-
 
   // Return exports for tests and programmatic use
   try {

--- a/apps/vscode-extension/src/node-test/webviewSession.test.ts
+++ b/apps/vscode-extension/src/node-test/webviewSession.test.ts
@@ -1,0 +1,884 @@
+import assert from 'assert/strict';
+import * as webviewSessionModule from '../provider/webviewSession';
+import {
+  WEBVIEW_SESSION_MAX_RETRIES,
+  WEBVIEW_SESSION_MOUNT_DELAY_MS,
+  WEBVIEW_SESSION_READY_TIMEOUT_MS,
+  WEBVIEW_SESSION_RETRY_DELAY_MS,
+  type WebviewSessionDiagnostic,
+  type WebviewSessionHost,
+  type WebviewSessionInbound,
+  type WebviewSessionOptions
+} from '../provider/webviewSession';
+import { createWebviewSessionForTest, type WebviewSessionClock } from './webviewSessionTestSupport';
+
+interface TestOutboundMessage {
+  readonly value: string;
+}
+
+interface TestInboundMessage {
+  readonly action: string;
+}
+
+interface TestTimer {
+  readonly id: number;
+  readonly runAt: number;
+  readonly callback: () => void;
+}
+
+function deferred<T>(): { readonly promise: Promise<T>; resolve(value: T): void } {
+  let resolvePromise: ((value: T) => void) | undefined;
+  const promise = new Promise<T>(resolve => {
+    resolvePromise = resolve;
+  });
+  return {
+    promise,
+    resolve(value) {
+      resolvePromise?.(value);
+    }
+  };
+}
+
+class FakeClock implements WebviewSessionClock {
+  private readonly timers = new Map<number, TestTimer>();
+  private now = 0;
+  private nextId = 1;
+
+  setTimeout(callback: () => void, delayMs: number): { dispose(): void } {
+    const timer: TestTimer = {
+      id: this.nextId++,
+      runAt: this.now + delayMs,
+      callback
+    };
+    this.timers.set(timer.id, timer);
+    return {
+      dispose: () => {
+        this.timers.delete(timer.id);
+      }
+    };
+  }
+
+  async advanceBy(delayMs: number): Promise<void> {
+    const target = this.now + delayMs;
+    while (true) {
+      const next = [...this.timers.values()]
+        .filter(timer => timer.runAt <= target)
+        .sort((left, right) => left.runAt - right.runAt || left.id - right.id)[0];
+      if (!next) {
+        break;
+      }
+      this.timers.delete(next.id);
+      this.now = next.runAt;
+      next.callback();
+      await this.flushMicrotasks();
+    }
+    this.now = target;
+    await this.flushMicrotasks();
+  }
+
+  async flushMicrotasks(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+}
+
+class FakeHost implements WebviewSessionHost<TestOutboundMessage> {
+  visible = true;
+  readonly posted: TestOutboundMessage[] = [];
+  readonly mountedGenerations: number[] = [];
+  readonly postOutcomes: Array<boolean | Error | Promise<boolean>> = [];
+  recoveryRequests = 0;
+  recoverFromReadyTimeout: (remount: () => void) => void | Promise<void> = () => undefined;
+  private readonly disposeListeners = new Set<() => void>();
+  private readonly messageListeners = new Set<(message: unknown) => void | Promise<void>>();
+  private readonly visibilityListeners = new Set<(visible: boolean) => void>();
+
+  readonly webview = {
+    postMessage: async (message: TestOutboundMessage): Promise<boolean> => {
+      this.posted.push(message);
+      const outcome = this.postOutcomes.shift() ?? true;
+      if (outcome instanceof Error) {
+        throw outcome;
+      }
+      return outcome;
+    },
+    onDidReceiveMessage: (listener: (message: unknown) => void | Promise<void>) => {
+      this.messageListeners.add(listener);
+      return {
+        dispose: () => {
+          this.messageListeners.delete(listener);
+        }
+      };
+    }
+  };
+
+  recoverAfterReadyTimeout(remount: () => void): void | Promise<void> {
+    this.recoveryRequests += 1;
+    return this.recoverFromReadyTimeout(remount);
+  }
+
+  onDidDispose(listener: () => void): { dispose(): void } {
+    this.disposeListeners.add(listener);
+    return {
+      dispose: () => {
+        this.disposeListeners.delete(listener);
+      }
+    };
+  }
+
+  onDidChangeVisibility(listener: (visible: boolean) => void): { dispose(): void } {
+    this.visibilityListeners.add(listener);
+    return {
+      dispose: () => {
+        this.visibilityListeners.delete(listener);
+      }
+    };
+  }
+
+  emitMessage(message: unknown): void {
+    for (const listener of [...this.messageListeners]) {
+      void listener(message);
+    }
+  }
+
+  disposeHost(): void {
+    for (const listener of [...this.disposeListeners]) {
+      listener();
+    }
+  }
+
+  setVisible(visible: boolean): void {
+    this.visible = visible;
+    for (const listener of [...this.visibilityListeners]) {
+      listener(visible);
+    }
+  }
+}
+
+interface SessionHarness {
+  readonly clock: FakeClock;
+  readonly diagnostics: WebviewSessionDiagnostic[];
+  readonly host: FakeHost;
+  readonly receivedActions: string[];
+  readonly options: WebviewSessionOptions<TestOutboundMessage, TestInboundMessage, FakeHost>;
+}
+
+function createHarness(): SessionHarness {
+  const clock = new FakeClock();
+  const diagnostics: WebviewSessionDiagnostic[] = [];
+  const host = new FakeHost();
+  const receivedActions: string[] = [];
+  const options: WebviewSessionOptions<TestOutboundMessage, TestInboundMessage, FakeHost> = {
+    mount: (boundHost, generation) => {
+      boundHost.mountedGenerations.push(generation);
+    },
+    getReplaySnapshot: () => [],
+    validateInbound: (raw): WebviewSessionInbound<TestInboundMessage> | undefined => {
+      if (!raw || typeof raw !== 'object') {
+        return undefined;
+      }
+      const candidate = raw as { type?: unknown; generation?: unknown; action?: unknown };
+      if (candidate.type === 'ready') {
+        return {
+          kind: 'ready',
+          ...(typeof candidate.generation === 'number' ? { generation: candidate.generation } : {})
+        };
+      }
+      if (candidate.type === 'action' && typeof candidate.action === 'string') {
+        return { kind: 'message', message: { action: candidate.action } };
+      }
+      return undefined;
+    },
+    onMessage: message => {
+      receivedActions.push(message.action);
+    },
+    onDiagnostic: diagnostic => {
+      diagnostics.push(diagnostic);
+    }
+  };
+  return { clock, diagnostics, host, receivedActions, options };
+}
+
+suite('Webview Session', () => {
+  test('keeps clock construction out of the surface-facing module', () => {
+    assert.ok(!('createWebviewSessionWithClock' in webviewSessionModule));
+  });
+
+  test('mounts a visible host after the default delay', async () => {
+    const harness = createHarness();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+
+    assert.deepEqual(harness.host.mountedGenerations, []);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS - 1);
+    assert.deepEqual(harness.host.mountedGenerations, []);
+
+    await harness.clock.advanceBy(1);
+    assert.deepEqual(harness.host.mountedGenerations, [1]);
+  });
+
+  test('ignores readiness until the current mount has completed', async () => {
+    const harness = createHarness();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    harness.host.emitMessage({ type: 'ready', generation: 0 });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, false);
+    assert.deepEqual(harness.host.posted, []);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+  });
+
+  test('consumes current readiness and replays the latest snapshot once', async () => {
+    const harness = createHarness();
+    let snapshotVersion = 1;
+    let replaySuccesses = 0;
+    harness.options.getReplaySnapshot = () => [{ value: `snapshot-${snapshotVersion}` }];
+    harness.options.onReplaySucceeded = () => {
+      replaySuccesses += 1;
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    snapshotVersion = 2;
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, true);
+    assert.deepEqual(harness.host.posted, [{ value: 'snapshot-2' }]);
+    assert.equal(replaySuccesses, 1);
+  });
+
+  test('runs the surface ready workflow once after the initial snapshot is accepted', async () => {
+    const harness = createHarness();
+    const events: string[] = [];
+    harness.options.getReplaySnapshot = () => {
+      events.push('snapshot');
+      return [{ value: 'snapshot' }];
+    };
+    harness.host.webview.postMessage = async message => {
+      events.push(`posted:${message.value}`);
+      return true;
+    };
+    harness.options.onReady = () => {
+      events.push('ready-workflow');
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    assert.deepEqual(events, ['snapshot', 'posted:snapshot', 'ready-workflow']);
+  });
+
+  test('treats duplicate readiness for the current mount as a no-op', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [{ value: 'snapshot' }];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, true);
+    assert.deepEqual(harness.host.posted, [{ value: 'snapshot' }]);
+    assert.equal(harness.diagnostics.filter(diagnostic => diagnostic.event === 'readyDuplicate').length, 1);
+  });
+
+  test('forwards validated surface messages once and rejects invalid input', async () => {
+    const harness = createHarness();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    harness.host.emitMessage({ type: 'action', action: 'refresh' });
+    harness.host.emitMessage({ type: 'action', action: 42 });
+    await harness.clock.flushMicrotasks();
+
+    assert.deepEqual(harness.receivedActions, ['refresh']);
+  });
+
+  test('diagnoses surface callback failure without changing readiness', async () => {
+    const harness = createHarness();
+    harness.options.onMessage = async () => {
+      throw new Error('surface workflow failed');
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.emitMessage({ type: 'action', action: 'refresh' });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, true);
+    assert.ok(
+      harness.diagnostics.some(diagnostic => diagnostic.event === 'callbackFailed' && diagnostic.callback === 'message')
+    );
+  });
+
+  test('keeps a ready hidden host mounted and replays the latest snapshot when visible', async () => {
+    const harness = createHarness();
+    let snapshotValue = 'initial';
+    harness.options.getReplaySnapshot = () => [{ value: snapshotValue }];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.posted.length = 0;
+
+    harness.host.setVisible(false);
+    snapshotValue = 'latest';
+    const accepted = await session.deliver({ value: 'hidden-update' }, 'replayable');
+    harness.host.setVisible(true);
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(accepted, true);
+    assert.equal(session.ready, true);
+    assert.deepEqual(harness.host.mountedGenerations, [1]);
+    assert.deepEqual(harness.host.posted, [{ value: 'hidden-update' }, { value: 'latest' }]);
+  });
+
+  test('preserves hidden replay intent created during an older in-flight snapshot', async () => {
+    const harness = createHarness();
+    const startupSnapshot = deferred<readonly TestOutboundMessage[]>();
+    let snapshotCalls = 0;
+    harness.options.getReplaySnapshot = () => {
+      snapshotCalls += 1;
+      return snapshotCalls === 1 ? startupSnapshot.promise : [{ value: 'latest' }];
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.setVisible(false);
+    await session.deliver({ value: 'hidden-update' }, 'replayable');
+
+    startupSnapshot.resolve([{ value: 'startup-snapshot' }]);
+    await harness.clock.flushMicrotasks();
+    harness.host.setVisible(true);
+    await harness.clock.flushMicrotasks();
+
+    assert.deepEqual(harness.host.posted, [{ value: 'hidden-update' }, { value: 'latest' }]);
+  });
+
+  test('reconverges when an older replay completes after a newer replay', async () => {
+    const harness = createHarness();
+    const olderSnapshot = deferred<readonly TestOutboundMessage[]>();
+    let snapshotCalls = 0;
+    harness.options.getReplaySnapshot = () => {
+      snapshotCalls += 1;
+      return snapshotCalls === 1 ? olderSnapshot.promise : [{ value: 'latest' }];
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.setVisible(false);
+    await session.deliver({ value: 'hidden-update' }, 'replayable');
+    harness.host.setVisible(true);
+    await harness.clock.flushMicrotasks();
+
+    olderSnapshot.resolve([{ value: 'older-snapshot' }]);
+    await harness.clock.flushMicrotasks();
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+
+    assert.deepEqual(harness.host.posted, [{ value: 'hidden-update' }, { value: 'latest' }, { value: 'latest' }]);
+  });
+
+  test('retries a rejected replayable delivery with the latest all-accepted snapshot', async () => {
+    const harness = createHarness();
+    let snapshotVersion = 1;
+    harness.options.getReplaySnapshot = () => [
+      { value: `snapshot-${snapshotVersion}-a` },
+      { value: `snapshot-${snapshotVersion}-b` }
+    ];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.options.getReplaySnapshot = () => [];
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.options.getReplaySnapshot = () => [
+      { value: `snapshot-${snapshotVersion}-a` },
+      { value: `snapshot-${snapshotVersion}-b` }
+    ];
+    harness.host.posted.length = 0;
+    harness.host.postOutcomes.push(false, true, false, true, true);
+
+    const accepted = await session.deliver({ value: 'update' }, 'replayable');
+    snapshotVersion = 2;
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+    snapshotVersion = 3;
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS * 2);
+
+    assert.equal(accepted, false);
+    assert.deepEqual(harness.host.posted, [
+      { value: 'update' },
+      { value: 'snapshot-2-a' },
+      { value: 'snapshot-2-b' },
+      { value: 'snapshot-3-a' },
+      { value: 'snapshot-3-b' }
+    ]);
+  });
+
+  test('bounds immediate retries but remains eligible on a future visibility transition', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.options.getReplaySnapshot = () => [{ value: 'latest' }];
+    harness.host.posted.length = 0;
+    harness.host.postOutcomes.push(false, false, false, false, false, false, false, true);
+
+    await session.deliver({ value: 'update' }, 'replayable');
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS * 4);
+
+    assert.deepEqual(harness.host.posted, [
+      { value: 'update' },
+      { value: 'latest' },
+      { value: 'latest' },
+      { value: 'latest' }
+    ]);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'retryExhausted'));
+
+    harness.host.setVisible(false);
+    harness.host.setVisible(true);
+    await harness.clock.flushMicrotasks();
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS * 4);
+
+    assert.equal(
+      harness.diagnostics.filter(diagnostic => diagnostic.event === 'retryAttempted').length,
+      WEBVIEW_SESSION_MAX_RETRIES * 2
+    );
+    assert.equal(harness.host.posted.length, 8);
+    assert.deepEqual(harness.host.posted.at(-1), { value: 'latest' });
+  });
+
+  test('retains replay intent when snapshot production fails', async () => {
+    const harness = createHarness();
+    let snapshotAttempts = 0;
+    harness.options.getReplaySnapshot = () => {
+      snapshotAttempts += 1;
+      if (snapshotAttempts === 1) {
+        throw new Error('snapshot unavailable');
+      }
+      return [{ value: 'recovered-latest' }];
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, true);
+    assert.ok(
+      harness.diagnostics.some(
+        diagnostic => diagnostic.event === 'callbackFailed' && diagnostic.callback === 'snapshot'
+      )
+    );
+
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+    assert.deepEqual(harness.host.posted, [{ value: 'recovered-latest' }]);
+  });
+
+  test('requests capability-based recovery after the default ready timeout', async () => {
+    const harness = createHarness();
+    harness.host.recoverFromReadyTimeout = remount => {
+      remount();
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_READY_TIMEOUT_MS - 1);
+    assert.equal(harness.host.recoveryRequests, 0);
+
+    await harness.clock.advanceBy(1);
+    assert.equal(harness.host.recoveryRequests, 1);
+    assert.deepEqual(harness.host.mountedGenerations, [1]);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'recoveryRequested'));
+    assert.ok(!harness.diagnostics.some(diagnostic => diagnostic.event === ('readyTimeout' as never)));
+
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    assert.deepEqual(harness.host.mountedGenerations, [1, 2]);
+  });
+
+  test('ignores stale timeout recovery that completes after rebinding', async () => {
+    const harness = createHarness();
+    const recovery = deferred<void>();
+    harness.host.recoverFromReadyTimeout = async remount => {
+      await recovery.promise;
+      remount();
+    };
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_READY_TIMEOUT_MS);
+    assert.equal(harness.host.recoveryRequests, 1);
+
+    session.bind(replacement);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    assert.deepEqual(replacement.mountedGenerations, [2]);
+
+    recovery.resolve();
+    await harness.clock.flushMicrotasks();
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS * 2);
+
+    assert.deepEqual(harness.host.mountedGenerations, [1]);
+    assert.deepEqual(replacement.mountedGenerations, [2]);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+  });
+
+  test('temporarily detaches on host disposal and rebinds with retained replay intent', async () => {
+    const harness = createHarness();
+    let detachNotifications = 0;
+    harness.options.getReplaySnapshot = () => [{ value: 'latest' }];
+    harness.options.onDetach = () => {
+      detachNotifications += 1;
+    };
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.disposeHost();
+
+    assert.equal(session.ready, false);
+    assert.equal(detachNotifications, 1);
+    assert.equal(await session.deliver({ value: 'while-detached' }, 'replayable'), false);
+
+    session.bind(replacement);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    replacement.emitMessage({ type: 'ready', generation: 2 });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, true);
+    assert.deepEqual(replacement.mountedGenerations, [2]);
+    assert.deepEqual(replacement.posted, [{ value: 'latest' }]);
+  });
+
+  test('reports why a host detached without exposing host-specific policy', () => {
+    const harness = createHarness();
+    const reasons: string[] = [];
+    harness.options.onDetach = reason => {
+      reasons.push(reason);
+    };
+    const replacement = new FakeHost();
+    const explicit = new FakeHost();
+    const final = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    session.bind(replacement);
+    replacement.disposeHost();
+    session.bind(explicit);
+    session.detach();
+    session.bind(final);
+    session.dispose();
+
+    assert.deepEqual(reasons, ['rebind', 'hostDisposed', 'explicit', 'finalDispose']);
+  });
+
+  test('ignores a stale delivery result after rebinding to a replacement host', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [{ value: 'latest' }];
+    const replacement = new FakeHost();
+    const staleResult = deferred<boolean>();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.postOutcomes.push(staleResult.promise);
+    const pendingDelivery = session.deliver({ value: 'old-update' }, 'replayable');
+
+    session.bind(replacement);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    replacement.emitMessage({ type: 'ready', generation: 2 });
+    await harness.clock.flushMicrotasks();
+    replacement.posted.length = 0;
+
+    staleResult.resolve(true);
+    const accepted = await pendingDelivery;
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+
+    assert.equal(accepted, false);
+    assert.deepEqual(replacement.posted, []);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+  });
+
+  test('coalesces an asynchronous replay to a newer authoritative delivery', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    const staleSnapshot = deferred<readonly TestOutboundMessage[]>();
+    let snapshotCalls = 0;
+    harness.options.getReplaySnapshot = () => {
+      snapshotCalls += 1;
+      return snapshotCalls === 1 ? staleSnapshot.promise : [{ value: 'latest-authoritative' }];
+    };
+    harness.host.posted.length = 0;
+    harness.host.postOutcomes.push(false, true, true);
+
+    assert.equal(await session.deliver({ value: 'trigger-replay' }, 'replayable'), false);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+    assert.equal(await session.deliver({ value: 'newer-direct' }, 'replayable'), true);
+
+    staleSnapshot.resolve([{ value: 'stale-snapshot' }]);
+    await harness.clock.flushMicrotasks();
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+
+    assert.deepEqual(harness.host.posted, [
+      { value: 'trigger-replay' },
+      { value: 'newer-direct' },
+      { value: 'latest-authoritative' }
+    ]);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'replaySuperseded'));
+  });
+
+  test('does not deliver a stale snapshot callback after rebinding', async () => {
+    const harness = createHarness();
+    const staleSnapshot = deferred<readonly TestOutboundMessage[]>();
+    let snapshotCalls = 0;
+    harness.options.getReplaySnapshot = () => {
+      snapshotCalls += 1;
+      return snapshotCalls === 1 ? staleSnapshot.promise : [{ value: 'replacement-latest' }];
+    };
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+
+    session.bind(replacement);
+    staleSnapshot.resolve([{ value: 'stale-snapshot' }]);
+    await harness.clock.flushMicrotasks();
+    assert.deepEqual(harness.host.posted, []);
+
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    replacement.emitMessage({ type: 'ready', generation: 2 });
+    await harness.clock.flushMicrotasks();
+    assert.deepEqual(replacement.posted, [{ value: 'replacement-latest' }]);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+  });
+
+  test('ignores completion of a stale surface message callback after rebinding', async () => {
+    const harness = createHarness();
+    const callback = deferred<void>();
+    harness.options.onMessage = () => callback.promise;
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'action', action: 'refresh' });
+    await harness.clock.flushMicrotasks();
+    session.bind(replacement);
+
+    callback.resolve();
+    await harness.clock.flushMicrotasks();
+
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+    assert.ok(!harness.diagnostics.some(diagnostic => diagnostic.event === 'messageForwarded'));
+  });
+
+  test('rejects stale and ambiguous readiness after a replacement mount', async () => {
+    const harness = createHarness();
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    session.detach();
+    session.bind(replacement);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+
+    replacement.emitMessage({ type: 'ready', generation: 1 });
+    replacement.emitMessage({ type: 'ready' });
+    await harness.clock.flushMicrotasks();
+    assert.equal(session.ready, false);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'staleWorkIgnored'));
+
+    replacement.emitMessage({ type: 'ready', generation: 2 });
+    await harness.clock.flushMicrotasks();
+    assert.equal(session.ready, true);
+  });
+
+  test('waits for an initially hidden host to become visible before mounting', async () => {
+    const harness = createHarness();
+    harness.host.visible = false;
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS * 2);
+    assert.deepEqual(harness.host.mountedGenerations, []);
+
+    harness.host.setVisible(true);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    assert.deepEqual(harness.host.mountedGenerations, [1]);
+  });
+
+  test('pauses readiness timing when a mount completes while hidden', async () => {
+    const harness = createHarness();
+    const mountCompletion = deferred<void>();
+    harness.options.mount = async (host, generation) => {
+      host.mountedGenerations.push(generation);
+      await mountCompletion.promise;
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.setVisible(false);
+    mountCompletion.resolve();
+    await harness.clock.flushMicrotasks();
+    await harness.clock.advanceBy(WEBVIEW_SESSION_READY_TIMEOUT_MS);
+    assert.equal(harness.host.recoveryRequests, 0);
+
+    harness.host.setVisible(true);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_READY_TIMEOUT_MS);
+    assert.equal(harness.host.recoveryRequests, 1);
+  });
+
+  test('final disposal cancels pending work and makes rebinding terminal', async () => {
+    const harness = createHarness();
+    const replacement = new FakeHost();
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    session.dispose();
+    session.bind(replacement);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS * 2);
+
+    assert.equal(session.ready, false);
+    assert.deepEqual(harness.host.mountedGenerations, []);
+    assert.deepEqual(replacement.mountedGenerations, []);
+    assert.ok(harness.diagnostics.some(diagnostic => diagnostic.event === 'disposed'));
+  });
+
+  test('diagnoses inbound validation failure without routing the raw message', async () => {
+    const harness = createHarness();
+    harness.options.validateInbound = () => {
+      throw new Error('validator failed');
+    };
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+
+    session.bind(harness.host);
+    harness.host.emitMessage({ token: 'do-not-record' });
+    await harness.clock.flushMicrotasks();
+
+    assert.equal(session.ready, false);
+    assert.deepEqual(harness.receivedActions, []);
+    assert.ok(
+      harness.diagnostics.some(
+        diagnostic => diagnostic.event === 'callbackFailed' && diagnostic.callback === 'validateInbound'
+      )
+    );
+    assert.ok(!JSON.stringify(harness.diagnostics).includes('do-not-record'));
+  });
+
+  test('does not retain or retry a rejected transient delivery', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.postOutcomes.push(false);
+
+    assert.equal(await session.deliver({ value: 'transient' }, 'transient'), false);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS * 4);
+
+    assert.deepEqual(harness.host.posted, [{ value: 'transient' }]);
+    assert.ok(
+      harness.diagnostics.some(
+        diagnostic => diagnostic.event === 'deliveryRejected' && diagnostic.classification === 'transient'
+      )
+    );
+  });
+
+  test('reports metadata-only lifecycle, delivery, retry, and replay diagnostics', async () => {
+    const harness = createHarness();
+    harness.options.getReplaySnapshot = () => [];
+    const session = createWebviewSessionForTest(harness.options, harness.clock);
+    session.bind(harness.host);
+    await harness.clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    harness.host.emitMessage({ type: 'ready', generation: 1 });
+    await harness.clock.flushMicrotasks();
+    harness.host.setVisible(false);
+    harness.host.setVisible(true);
+    harness.host.postOutcomes.push(false);
+    await session.deliver({ value: 'secret-log-body' }, 'replayable');
+    await harness.clock.advanceBy(WEBVIEW_SESSION_RETRY_DELAY_MS);
+    session.detach();
+    session.dispose();
+
+    const events = new Set(harness.diagnostics.map(diagnostic => diagnostic.event));
+    for (const event of [
+      'attached',
+      'mountScheduled',
+      'mounted',
+      'ready',
+      'hidden',
+      'visible',
+      'deliveryAttempted',
+      'deliveryRejected',
+      'retryScheduled',
+      'retryAttempted',
+      'replaySucceeded',
+      'detached',
+      'disposed'
+    ] as const) {
+      assert.ok(events.has(event), `expected diagnostic event ${event}`);
+    }
+    const mountScheduled = harness.diagnostics.find(diagnostic => diagnostic.event === 'mountScheduled');
+    const mounted = harness.diagnostics.find(diagnostic => diagnostic.event === 'mounted');
+    const ready = harness.diagnostics.find(diagnostic => diagnostic.event === 'ready');
+    assert.equal(mountScheduled?.mountTimerActive, true);
+    assert.equal(mountScheduled?.contentMounted, false);
+    assert.equal(mounted?.mountTimerActive, false);
+    assert.equal(mounted?.readyTimerActive, true);
+    assert.equal(mounted?.contentMounted, true);
+    assert.equal(ready?.readyTimerActive, false);
+    assert.equal(ready?.contentMounted, true);
+    assert.ok(!JSON.stringify(harness.diagnostics).includes('secret-log-body'));
+  });
+});

--- a/apps/vscode-extension/src/node-test/webviewSessionTestSupport.ts
+++ b/apps/vscode-extension/src/node-test/webviewSessionTestSupport.ts
@@ -1,0 +1,12 @@
+import { type WebviewSession, type WebviewSessionHost, type WebviewSessionOptions } from '../provider/webviewSession';
+import { createWebviewSessionInternal } from '../provider/webviewSessionInternal';
+import type { WebviewSessionClock } from '../provider/webviewSessionClock';
+
+export type { WebviewSessionClock } from '../provider/webviewSessionClock';
+
+export function createWebviewSessionForTest<TOutbound, TInbound, THost extends WebviewSessionHost<TOutbound>>(
+  options: WebviewSessionOptions<TOutbound, TInbound, THost>,
+  clock: WebviewSessionClock
+): WebviewSession<TOutbound, THost> {
+  return createWebviewSessionInternal(options, clock);
+}

--- a/apps/vscode-extension/src/panel/LogsEditorPanel.ts
+++ b/apps/vscode-extension/src/panel/LogsEditorPanel.ts
@@ -38,7 +38,6 @@ export class LogsEditorPanel {
 
   private readonly controller: SfLogsViewProvider;
   private readonly context: vscode.ExtensionContext;
-  private readonly instanceDisposables: vscode.Disposable[] = [];
   private panel: vscode.WebviewPanel;
   private panelDisposables: vscode.Disposable[] = [];
   private recreating = false;
@@ -50,11 +49,6 @@ export class LogsEditorPanel {
     if (typeof options?.selectedOrg === 'string' && options.selectedOrg.trim()) {
       this.controller.setSelectedOrg(options.selectedOrg);
     }
-    this.instanceDisposables.push(
-      this.controller.onDidReadyTimeout(() => {
-        void this.handleReadyTimeout();
-      })
-    );
 
     this.panel = this.createPanel();
     this.bindPanel(this.panel);
@@ -86,7 +80,7 @@ export class LogsEditorPanel {
   private bindPanel(panel: vscode.WebviewPanel): void {
     disposeAll(this.panelDisposables);
     this.panel = panel;
-    this.controller.resolveWebviewPanel(panel);
+    this.controller.resolveWebviewPanel(panel, () => this.handleReadyTimeout(panel));
     this.panelDisposables.push(
       panel.onDidDispose(() => {
         this.handlePanelDisposed();
@@ -94,8 +88,8 @@ export class LogsEditorPanel {
     );
   }
 
-  private async handleReadyTimeout(): Promise<void> {
-    if (this.retryAttempted || this.recreating || !this.panel.visible) {
+  private async handleReadyTimeout(panel: vscode.WebviewPanel): Promise<void> {
+    if (panel !== this.panel || this.retryAttempted || this.recreating || !panel.visible) {
       return;
     }
     this.retryAttempted = true;
@@ -122,7 +116,6 @@ export class LogsEditorPanel {
       LogsEditorPanel.instance = undefined;
     }
     disposeAll(this.panelDisposables);
-    disposeAll(this.instanceDisposables);
     this.controller.dispose();
   }
 }

--- a/apps/vscode-extension/src/panel/TailEditorPanel.ts
+++ b/apps/vscode-extension/src/panel/TailEditorPanel.ts
@@ -38,7 +38,6 @@ export class TailEditorPanel {
 
   private readonly controller: SfLogTailViewProvider;
   private readonly context: vscode.ExtensionContext;
-  private readonly instanceDisposables: vscode.Disposable[] = [];
   private panel: vscode.WebviewPanel;
   private panelDisposables: vscode.Disposable[] = [];
   private recreating = false;
@@ -50,11 +49,6 @@ export class TailEditorPanel {
     if (typeof options?.selectedOrg === 'string' && options.selectedOrg.trim()) {
       this.controller.setSelectedOrg(options.selectedOrg);
     }
-    this.instanceDisposables.push(
-      this.controller.onDidReadyTimeout(() => {
-        void this.handleReadyTimeout();
-      })
-    );
 
     this.panel = this.createPanel();
     this.bindPanel(this.panel);
@@ -86,7 +80,7 @@ export class TailEditorPanel {
   private bindPanel(panel: vscode.WebviewPanel): void {
     disposeAll(this.panelDisposables);
     this.panel = panel;
-    this.controller.resolveWebviewPanel(panel);
+    this.controller.resolveWebviewPanel(panel, () => this.handleReadyTimeout(panel));
     this.panelDisposables.push(
       panel.onDidDispose(() => {
         this.handlePanelDisposed();
@@ -94,8 +88,8 @@ export class TailEditorPanel {
     );
   }
 
-  private async handleReadyTimeout(): Promise<void> {
-    if (this.retryAttempted || this.recreating || !this.panel.visible) {
+  private async handleReadyTimeout(panel: vscode.WebviewPanel): Promise<void> {
+    if (panel !== this.panel || this.retryAttempted || this.recreating || !panel.visible) {
       return;
     }
     this.retryAttempted = true;
@@ -122,7 +116,6 @@ export class TailEditorPanel {
       TailEditorPanel.instance = undefined;
     }
     disposeAll(this.panelDisposables);
-    disposeAll(this.instanceDisposables);
     this.controller.dispose();
   }
 }

--- a/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogTailViewProvider.ts
@@ -1,12 +1,12 @@
 import * as vscode from 'vscode';
 import { localize } from '../host/utils/localize';
-import {
-  listDebugLevels,
-  getActiveUserDebugLevel,
-  ensureDefaultTailDebugLevel
-} from '../host/salesforce/traceflags';
+import { listDebugLevels, getActiveUserDebugLevel, ensureDefaultTailDebugLevel } from '../host/salesforce/traceflags';
 import type { OrgAuth } from '../host/salesforce/types';
-import { parseWebviewToExtensionMessage, type ExtensionToWebviewMessage } from '../shared/messages';
+import {
+  parseWebviewToExtensionMessage,
+  type ExtensionToWebviewMessage,
+  type WebviewToExtensionMessage
+} from '../shared/messages';
 import { logInfo, logWarn } from '../host/utils/logger';
 import { safeSendEvent } from '../shared/telemetry';
 import { getTelemetryErrorCode } from '../shared/telemetryErrorCodes';
@@ -27,56 +27,24 @@ import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
 import { runtimeClient } from '../runtime/runtimeClient';
 import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
 import { recordWebviewEvent, type WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
-
-// Corporate-managed notebooks can take several seconds to initialize VS Code
-// webviews and their internal service worker. Keep these windows generous so a
-// slow-but-healthy startup is not torn down into a remount loop.
-export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 1000;
-export const WEBVIEW_READY_TIMEOUT_MS = 30000;
-const WEBVIEW_REPLAY_RETRY_DELAY_MS = 250;
-const WEBVIEW_REPLAY_MAX_RETRIES = 3;
-const TAIL_REPLAYABLE_VISIBLE_UPDATE_TYPES = new Set<ExtensionToWebviewMessage['type']>([
-  'loading',
-  'error',
-  'orgs',
-  'debugLevels',
-  'tailStatus',
-  'tailData',
-  'tailReset',
-  'tailConfig'
-]);
-
-interface ReplayDeliveryBatch {
-  pending: number;
-  dropped: boolean;
-  resetRetryBudgetOnSuccess: boolean;
-}
-
-interface WebviewPostOptions {
-  replay?: boolean;
-  requeueReplayOnDrop?: boolean;
-  onDelivered?: () => void;
-  replayBatch?: ReplayDeliveryBatch;
-}
+import {
+  createWebviewSession,
+  type WebviewDeliveryClassification,
+  type WebviewSession,
+  type WebviewSessionDiagnostic,
+  type WebviewSessionDetachReason,
+  type WebviewSessionInbound
+} from './webviewSession';
 
 export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = 'electivus.apexLogViewer.tailView';
   private view?: { webview: vscode.Webview };
-  private host?: BoundWebviewHost;
   private readonly disposables: vscode.Disposable[] = [];
-  private hostDisposables: vscode.Disposable[] = [];
-  private readonly readyTimeoutListeners = new Set<() => void>();
+  private readonly session: WebviewSession<ExtensionToWebviewMessage, BoundWebviewHost>;
+  private sessionDiagnostic: WebviewSessionDiagnostic | undefined;
   private disposed = false;
-  private ready = false;
-  private contentMounted = false;
-  private needsReplayOnVisible = false;
-  private mountTimer: ReturnType<typeof setTimeout> | undefined;
-  private readyTimer: ReturnType<typeof setTimeout> | undefined;
-  private visibleReplayRetryTimer: ReturnType<typeof setTimeout> | undefined;
-  private visibleReplayRetryAttempts = 0;
-  private mountSequence = 0;
   private selectedOrg: string | undefined;
-  private tailService = new TailService(m => this.post(m));
+  private tailService = new TailService(m => this.post(m, 'replayable'));
   private loadingState = false;
   private orgsSnapshot: OrgItem[] = [];
   private hasOrgsSnapshot = false;
@@ -95,6 +63,24 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     this.tailService.setOrg(this.selectedOrg);
     this.tailBufferSizeSnapshot = this.getTailBufferSize();
     this.tailService.setBufferLimit(this.tailBufferSizeSnapshot);
+    this.session = createWebviewSession({
+      mount: (host, generation) => {
+        host.webview.html = this.getHtmlForWebview(host.webview, generation);
+        logInfo('Tail webview mounted.');
+      },
+      getReplaySnapshot: () => this.getReplaySnapshot(),
+      validateInbound: message => this.validateInbound(message),
+      onDetach: reason => this.handleSessionDetach(reason),
+      onMessage: message => this.handleMessage(message),
+      onReady: () => this.bootstrapWebview(),
+      onReplaySucceeded: () => {
+        this.tailResetNeedsReplay = false;
+        if (this.errorMessage === undefined) {
+          this.errorClearNeedsReplay = false;
+        }
+      },
+      onDiagnostic: diagnostic => this.handleSessionDiagnostic(diagnostic)
+    });
 
     // React to tail buffer size changes live
     this.disposables.push(
@@ -103,7 +89,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
           try {
             const size = this.getTailBufferSize();
             this.tailService.setBufferLimit(size);
-            this.post({ type: 'tailConfig', tailBufferSize: size });
+            this.post({ type: 'tailConfig', tailBufferSize: size }, 'replayable');
           } catch {
             // ignore
           }
@@ -128,27 +114,17 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
-    this.bindHost(createWebviewViewHost(webviewView));
+    let host: BoundWebviewHost;
+    host = createWebviewViewHost(webviewView, () => this.showPlaceholder(host));
+    this.bindHost(host);
   }
 
-  public resolveWebviewPanel(panel: vscode.WebviewPanel): void {
-    this.bindHost(createWebviewPanelHost(panel));
+  public resolveWebviewPanel(panel: vscode.WebviewPanel, replaceAfterReadyTimeout?: () => void | Promise<void>): void {
+    this.bindHost(createWebviewPanelHost(panel, replaceAfterReadyTimeout));
   }
 
-  private async onMessage(rawMessage: unknown): Promise<void> {
-    const message = parseWebviewToExtensionMessage(rawMessage);
-    const t = message?.type;
-    if (t) {
-      logInfo('Tail: received message from webview:', t);
-    }
-    if (!message) {
-      logWarn('Tail: ignored invalid webview message');
-      return;
-    }
-    if (message.type === 'ready') {
-      await this.handleReadyMessage(message.mountSequence);
-      return;
-    }
+  private async handleMessage(message: WebviewToExtensionMessage): Promise<void> {
+    logInfo('Tail: received message from webview:', message.type);
     if (message.type === 'selectOrg') {
       const target = typeof message.target === 'string' ? message.target.trim() : undefined;
       const next = target || undefined;
@@ -160,12 +136,12 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         this.clearTailReplayState();
       }
       logInfo('Tail: selected org set to', next || '(none)');
-      this.post({ type: 'loading', value: true });
+      this.post({ type: 'loading', value: true }, 'replayable');
       try {
         await this.sendOrgs();
         await this.sendDebugLevels();
       } finally {
-        this.post({ type: 'loading', value: false });
+        this.post({ type: 'loading', value: false }, 'replayable');
       }
       return;
     }
@@ -191,11 +167,11 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     }
     if (message.type === 'tailStart') {
       // Surface loading while ensuring TraceFlag and priming tail
-      this.post({ type: 'loading', value: true });
+      this.post({ type: 'loading', value: true }, 'replayable');
       try {
         await this.tailService.start(typeof message.debugLevel === 'string' ? message.debugLevel.trim() : undefined);
       } finally {
-        this.post({ type: 'loading', value: false });
+        this.post({ type: 'loading', value: false }, 'replayable');
       }
       return;
     }
@@ -206,7 +182,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     if (message.type === 'tailClear') {
       this.tailService.clearLogPaths();
       this.tailService.clearBufferedLines();
-      this.post({ type: 'tailReset' });
+      this.post({ type: 'tailReset' }, 'replayable');
       return;
     }
   }
@@ -216,22 +192,22 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   }
 
   public isReady(): boolean {
-    return this.ready && !this.disposed;
+    return this.session.ready && !this.disposed;
   }
 
   public getWebviewDiagnosticState(): WebviewProviderDiagnosticState {
+    const diagnostic = this.sessionDiagnostic;
     return {
       surface: 'tail',
-      hasHost: !!this.host,
-      hostKind: this.host?.kind,
-      visible: this.host?.visible,
-      ready: this.ready,
+      hasHost: !!this.view,
+      visible: diagnostic?.visible,
+      ready: this.session.ready,
       disposed: this.disposed,
-      contentMounted: this.contentMounted,
-      mountSequence: this.mountSequence,
-      mountTimerActive: this.mountTimer !== undefined,
-      readyTimerActive: this.readyTimer !== undefined,
-      needsReplayOnVisible: this.needsReplayOnVisible,
+      contentMounted: diagnostic?.contentMounted ?? false,
+      mountSequence: diagnostic?.generation ?? 0,
+      mountTimerActive: diagnostic?.mountTimerActive ?? false,
+      readyTimerActive: diagnostic?.readyTimerActive ?? false,
+      needsReplayOnVisible: diagnostic?.needsReplay ?? true,
       snapshots: {
         loading: this.loadingState,
         hasOrgsSnapshot: this.hasOrgsSnapshot,
@@ -243,35 +219,23 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         bufferedLineCount: this.tailService.getBufferedLines().length,
         tailResetNeedsReplay: this.tailResetNeedsReplay,
         hasError: this.errorMessage !== undefined,
-        visibleReplayRetryTimerActive: this.visibleReplayRetryTimer !== undefined,
-        visibleReplayRetryAttempts: this.visibleReplayRetryAttempts
-      }
-    };
-  }
-
-  public onDidReadyTimeout(listener: () => void): vscode.Disposable {
-    this.readyTimeoutListeners.add(listener);
-    return {
-      dispose: () => {
-        this.readyTimeoutListeners.delete(listener);
+        errorClearNeedsReplay: this.errorClearNeedsReplay,
+        sessionEvent: diagnostic?.event,
+        sessionGeneration: diagnostic?.generation,
+        sessionRetryAttempt: diagnostic?.attempt,
+        sessionDeliveryClassification: diagnostic?.classification
       }
     };
   }
 
   public dispose(): void {
+    if (this.disposed) {
+      return;
+    }
     this.disposed = true;
-    this.ready = false;
-    this.contentMounted = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
-    this.tailResetNeedsReplay = false;
     this.view = undefined;
-    this.host = undefined;
-    this.clearBootstrapTimers();
+    this.session.dispose();
     this.tailService.stop();
-    this.readyTimeoutListeners.clear();
-    vscode.Disposable.from(...this.hostDisposables).dispose();
-    this.hostDisposables = [];
     vscode.Disposable.from(...this.disposables).dispose();
     this.disposables.length = 0;
   }
@@ -307,222 +271,18 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       .replace(/'/g, '&#39;');
   }
 
-  private clearMountTimer(): void {
-    if (this.mountTimer) {
-      clearTimeout(this.mountTimer);
-      this.mountTimer = undefined;
-    }
-  }
-
-  private clearReadyTimer(): void {
-    if (this.readyTimer) {
-      clearTimeout(this.readyTimer);
-      this.readyTimer = undefined;
-    }
-  }
-
-  private clearVisibleReplayRetryTimer(): void {
-    if (this.visibleReplayRetryTimer) {
-      clearTimeout(this.visibleReplayRetryTimer);
-      this.visibleReplayRetryTimer = undefined;
-    }
-  }
-
-  private clearBootstrapTimers(): void {
-    this.clearMountTimer();
-    this.clearReadyTimer();
-    this.clearVisibleReplayRetryTimer();
-  }
-
   private showPlaceholder(host: BoundWebviewHost): void {
-    this.contentMounted = false;
     host.webview.html = this.getPlaceholderHtml();
     recordWebviewEvent({
       surface: 'tail',
       event: 'placeholder',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
       visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
+      ready: this.session.ready,
+      contentMounted: false
     });
   }
 
-  private scheduleMount(host = this.host): void {
-    if (!host || this.disposed || !host.visible) {
-      return;
-    }
-    this.clearMountTimer();
-    recordWebviewEvent({
-      surface: 'tail',
-      event: 'mountScheduled',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { delayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS }
-    });
-    this.mountTimer = setTimeout(() => {
-      this.mountTimer = undefined;
-      if (this.host !== host || this.disposed || !host.visible) {
-        return;
-      }
-      this.mountWebview(host);
-    }, WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-  }
-
-  private mountWebview(host: BoundWebviewHost): void {
-    this.ready = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
-    const mountId = ++this.mountSequence;
-    this.contentMounted = true;
-    host.webview.html = this.getHtmlForWebview(host.webview, mountId);
-    this.startReadyTimer(host, mountId);
-    recordWebviewEvent({
-      surface: 'tail',
-      event: 'mounted',
-      hostKind: host.kind,
-      mountSequence: mountId,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-    logInfo(`Tail webview mounted (${host.kind}).`);
-  }
-
-  private startReadyTimer(host: BoundWebviewHost, mountId: number): void {
-    this.clearReadyTimer();
-    this.readyTimer = setTimeout(() => {
-      this.readyTimer = undefined;
-      if (this.host !== host || this.disposed || this.ready || mountId !== this.mountSequence) {
-        return;
-      }
-      logWarn(`Tail webview did not report ready within ${WEBVIEW_READY_TIMEOUT_MS}ms (${host.kind}).`);
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'readyTimeout',
-        hostKind: host.kind,
-        mountSequence: mountId,
-        visible: host.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted,
-        details: { timeoutMs: WEBVIEW_READY_TIMEOUT_MS }
-      });
-      this.ready = false;
-      this.showPlaceholder(host);
-      if (host.kind === 'editor') {
-        this.fireReadyTimeout();
-      } else if (host.visible) {
-        // Sidebar views need an internal remount because they do not recreate themselves.
-        this.scheduleMount(host);
-      }
-    }, WEBVIEW_READY_TIMEOUT_MS);
-  }
-
-  private fireReadyTimeout(): void {
-    for (const listener of [...this.readyTimeoutListeners]) {
-      try {
-        listener();
-      } catch {}
-    }
-  }
-
-  private handleVisibilityChange(host: BoundWebviewHost, visible: boolean): void {
-    if (this.host !== host || this.disposed) {
-      return;
-    }
-    if (!visible) {
-      this.clearBootstrapTimers();
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'hidden',
-        hostKind: host.kind,
-        mountSequence: this.mountSequence,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-      return;
-    }
-    recordWebviewEvent({
-      surface: 'tail',
-      event: 'visible',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { needsReplayOnVisible: this.needsReplayOnVisible }
-    });
-    if (this.ready) {
-      if (this.needsReplayOnVisible) {
-        this.replayRetainedState(host, visible, 'replayedOnVisible', true);
-      }
-      return;
-    }
-    if (this.contentMounted && this.mountSequence > 0) {
-      this.startReadyTimer(host, this.mountSequence);
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'resumedPendingReady',
-        hostKind: host.kind,
-        mountSequence: this.mountSequence,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-      return;
-    }
-    this.scheduleMount(host);
-  }
-
-  private async handleReadyMessage(mountSequence?: number): Promise<void> {
-    if (!this.host || this.disposed || this.ready) {
-      return;
-    }
-    if (mountSequence === undefined) {
-      if (this.mountSequence > 1) {
-        logInfo(`Tail webview ignored unsequenced stale ready (${this.host.kind}).`);
-        recordWebviewEvent({
-          surface: 'tail',
-          event: 'ignoredUnsequencedReady',
-          hostKind: this.host.kind,
-          mountSequence: this.mountSequence,
-          visible: this.host.visible,
-          ready: this.ready,
-          contentMounted: this.contentMounted
-        });
-        return;
-      }
-    } else if (mountSequence !== this.mountSequence) {
-      logInfo(`Tail webview ignored stale ready (${this.host.kind}).`);
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'ignoredStaleReady',
-        hostKind: this.host.kind,
-        mountSequence: this.mountSequence,
-        visible: this.host.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted,
-        details: { receivedMountSequence: mountSequence }
-      });
-      return;
-    }
-    this.ready = true;
-    this.clearReadyTimer();
-    recordWebviewEvent({
-      surface: 'tail',
-      event: 'ready',
-      hostKind: this.host.kind,
-      mountSequence: this.mountSequence,
-      visible: this.host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-    this.post({ type: 'init', locale: vscode.env.language });
-    this.replaySnapshot();
+  private async bootstrapWebview(): Promise<void> {
     const needsBootstrap =
       !this.hasOrgsSnapshot ||
       !this.hasDebugLevelsSnapshot ||
@@ -532,110 +292,50 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       await this.refreshViewState();
       return;
     }
-    if (this.mountSequence > 1) {
+    if ((this.sessionDiagnostic?.generation ?? 0) > 1) {
       void this.refreshViewState({ showLoading: false });
     }
   }
 
-  private replayRetainedState(
-    host: BoundWebviewHost,
-    visible: boolean,
-    event: string,
-    resetRetryBudget: boolean
-  ): void {
-    if (resetRetryBudget) {
-      this.visibleReplayRetryAttempts = 0;
-    }
-    const replayBatch: ReplayDeliveryBatch = {
-      pending: 0,
-      dropped: false,
-      resetRetryBudgetOnSuccess: !resetRetryBudget
-    };
-    this.needsReplayOnVisible = false;
-    this.post({ type: 'init', locale: vscode.env.language }, { requeueReplayOnDrop: true, replayBatch });
-    this.replaySnapshot({ requeueReplayOnDrop: true, replayBatch });
-    recordWebviewEvent({
-      surface: 'tail',
-      event,
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { retryAttempts: this.visibleReplayRetryAttempts }
-    });
-  }
-
-  private replaySnapshot(options?: WebviewPostOptions): void {
-    const replayOptions: WebviewPostOptions = {
-      replay: true,
-      requeueReplayOnDrop: options?.requeueReplayOnDrop,
-      replayBatch: options?.replayBatch
-    };
-    this.post({ type: 'loading', value: this.loadingState }, replayOptions);
+  private getReplaySnapshot(): readonly ExtensionToWebviewMessage[] {
+    const snapshot: ExtensionToWebviewMessage[] = [
+      { type: 'init', locale: vscode.env.language },
+      { type: 'loading', value: this.loadingState }
+    ];
     if (this.hasOrgsSnapshot) {
-      this.post({ type: 'orgs', data: this.orgsSnapshot, selected: this.selectedOrg }, replayOptions);
+      snapshot.push({ type: 'orgs', data: this.orgsSnapshot, selected: this.selectedOrg });
     }
     if (this.hasDebugLevelsSnapshot) {
-      this.post(
-        { type: 'debugLevels', data: this.debugLevelsSnapshot, active: this.activeDebugLevelSnapshot },
-        replayOptions
-      );
+      snapshot.push({
+        type: 'debugLevels',
+        data: this.debugLevelsSnapshot,
+        active: this.activeDebugLevelSnapshot
+      });
     }
-    this.post({ type: 'tailConfig', tailBufferSize: this.tailBufferSizeSnapshot }, replayOptions);
-    this.post({ type: 'tailStatus', running: this.tailRunningSnapshot }, replayOptions);
+    snapshot.push(
+      { type: 'tailConfig', tailBufferSize: this.tailBufferSizeSnapshot },
+      { type: 'tailStatus', running: this.tailRunningSnapshot }
+    );
     const bufferedLines = this.tailService.getBufferedLines();
     if (bufferedLines.length > 0) {
-      this.post({ type: 'tailReset' }, replayOptions);
-      this.post({ type: 'tailData', lines: bufferedLines }, replayOptions);
+      snapshot.push({ type: 'tailReset' }, { type: 'tailData', lines: bufferedLines });
     } else if (this.tailResetNeedsReplay) {
-      this.post({ type: 'tailReset' }, replayOptions);
+      snapshot.push({ type: 'tailReset' });
     }
     if (this.errorMessage !== undefined) {
-      this.post({ type: 'error', message: this.errorMessage }, replayOptions);
+      snapshot.push({ type: 'error', message: this.errorMessage });
     } else if (this.errorClearNeedsReplay) {
-      this.post(
-        { type: 'error', message: undefined },
-        {
-          ...replayOptions,
-          onDelivered: () => {
-            if (this.errorMessage === undefined) {
-              this.errorClearNeedsReplay = false;
-            }
-          }
-        }
-      );
+      snapshot.push({ type: 'error', message: undefined });
     }
+    return snapshot;
   }
 
   private clearTailReplayState(): void {
     this.tailService.clearBufferedLines();
-    this.post({ type: 'tailReset' });
+    this.post({ type: 'tailReset' }, 'replayable');
   }
 
-  private settleReplayDeliveryBatch(batch: ReplayDeliveryBatch | undefined): void {
-    if (!batch) {
-      return;
-    }
-    batch.pending = Math.max(0, batch.pending - 1);
-    if (batch.pending > 0) {
-      return;
-    }
-    if (!batch.dropped && batch.resetRetryBudgetOnSuccess && !this.needsReplayOnVisible) {
-      this.visibleReplayRetryAttempts = 0;
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'replayRetryBudgetResetAfterDelivery',
-        hostKind: this.host?.kind,
-        mountSequence: this.mountSequence,
-        visible: this.host?.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-    }
-  }
-
-  private post(msg: ExtensionToWebviewMessage, options?: WebviewPostOptions): void {
+  private post(msg: ExtensionToWebviewMessage, classification: WebviewDeliveryClassification): void {
     let shouldClearWebviewError = false;
     switch (msg.type) {
       case 'loading':
@@ -659,184 +359,42 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
         break;
       case 'tailStatus':
         this.tailRunningSnapshot = !!msg.running;
-        if (msg.running && !options?.replay && this.errorMessage !== undefined) {
+        if (msg.running && this.errorMessage !== undefined) {
           this.errorMessage = undefined;
           shouldClearWebviewError = true;
         }
         break;
       case 'tailData':
-        if (Array.isArray(msg.lines) && msg.lines.length > 0 && !options?.replay && this.errorMessage !== undefined) {
+        if (Array.isArray(msg.lines) && msg.lines.length > 0 && this.errorMessage !== undefined) {
           this.errorMessage = undefined;
           shouldClearWebviewError = true;
         }
         break;
       case 'tailReset':
-        if (!options?.replay) {
-          this.tailResetNeedsReplay = true;
-        }
+        this.tailResetNeedsReplay = true;
         break;
       case 'tailConfig':
         this.tailBufferSizeSnapshot = msg.tailBufferSize;
         break;
     }
-    const visible = this.host?.visible ?? false;
-    if (this.host && !visible && !options?.replay) {
-      this.needsReplayOnVisible = true;
-      this.visibleReplayRetryAttempts = 0;
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'messagePostedWhileHidden',
-        hostKind: this.host.kind,
-        mountSequence: this.mountSequence,
-        messageType: msg.type,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-    }
-    const postContext = {
-      hostKind: this.host?.kind,
-      mountSequence: this.mountSequence,
-      visible: this.host?.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    };
-    const scheduleVisibleReplayRetry = () => {
-      if (
-        !postContext.visible ||
-        !this.host ||
-        !this.host.visible ||
-        !this.ready ||
-        this.visibleReplayRetryTimer ||
-        this.visibleReplayRetryAttempts >= WEBVIEW_REPLAY_MAX_RETRIES
-      ) {
-        return;
-      }
-
-      const host = this.host;
-      const mountSequence = this.mountSequence;
-      const attempt = ++this.visibleReplayRetryAttempts;
-      this.visibleReplayRetryTimer = setTimeout(() => {
-        this.visibleReplayRetryTimer = undefined;
-        if (
-          this.disposed ||
-          this.host !== host ||
-          !host.visible ||
-          !this.ready ||
-          mountSequence !== this.mountSequence ||
-          !this.needsReplayOnVisible
-        ) {
-          return;
+    const visibleAtDelivery = this.session.visible === true;
+    const delivery = this.session.deliver(msg, classification);
+    if (msg.type === 'tailReset') {
+      void delivery.then(accepted => {
+        if (accepted && visibleAtDelivery) {
+          this.tailResetNeedsReplay = false;
         }
-        this.replayRetainedState(host, true, 'retriedReplayAfterDroppedPost', false);
-      }, WEBVIEW_REPLAY_RETRY_DELAY_MS);
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'scheduledReplayRetryAfterDroppedPost',
-        hostKind: postContext.hostKind,
-        mountSequence: postContext.mountSequence,
-        messageType: msg.type,
-        visible: postContext.visible,
-        ready: postContext.ready,
-        contentMounted: postContext.contentMounted,
-        details: { attempt, delayMs: WEBVIEW_REPLAY_RETRY_DELAY_MS }
       });
-    };
-    const requeueReplay = () => {
-      const requeueReason = options?.requeueReplayOnDrop
-        ? 'explicit'
-        : !options?.replay &&
-            postContext.visible === true &&
-            postContext.ready === true &&
-            TAIL_REPLAYABLE_VISIBLE_UPDATE_TYPES.has(msg.type)
-          ? 'visibleUpdate'
-          : undefined;
-      if (!requeueReason || this.disposed || postContext.mountSequence !== this.mountSequence) {
-        return;
-      }
-      this.needsReplayOnVisible = true;
-      scheduleVisibleReplayRetry();
-      recordWebviewEvent({
-        surface: 'tail',
-        event: 'replayRequeuedAfterDroppedPost',
-        hostKind: postContext.hostKind,
-        mountSequence: postContext.mountSequence,
-        messageType: msg.type,
-        visible: postContext.visible,
-        ready: postContext.ready,
-        contentMounted: postContext.contentMounted,
-        details: { reason: requeueReason }
-      });
-    };
-    const replayBatch = options?.replayBatch;
-    if (replayBatch) {
-      replayBatch.pending += 1;
-    }
-    const postResult = this.view?.webview.postMessage(msg);
-    if (postResult) {
-      postResult.then(
-        delivered => {
-          if (!delivered) {
-            if (replayBatch) {
-              replayBatch.dropped = true;
-            }
-            recordWebviewEvent({
-              surface: 'tail',
-              event: 'messageDropped',
-              hostKind: postContext.hostKind,
-              mountSequence: postContext.mountSequence,
-              messageType: msg.type,
-              visible: postContext.visible,
-              ready: postContext.ready,
-              contentMounted: postContext.contentMounted
-            });
-            logInfo('Tail webview postMessage dropped', msg.type);
-            requeueReplay();
-          } else {
-            if (msg.type === 'tailReset') {
-              this.tailResetNeedsReplay = false;
-            }
-            options?.onDelivered?.();
-          }
-          this.settleReplayDeliveryBatch(replayBatch);
-        },
-        error => {
-          if (replayBatch) {
-            replayBatch.dropped = true;
-          }
-          recordWebviewEvent({
-            surface: 'tail',
-            event: 'messagePostRejected',
-            hostKind: postContext.hostKind,
-            mountSequence: postContext.mountSequence,
-            messageType: msg.type,
-            visible: postContext.visible,
-            ready: postContext.ready,
-            contentMounted: postContext.contentMounted,
-            details: { error: getErrorMessage(error) }
-          });
-          logWarn('Tail webview postMessage failed ->', getErrorMessage(error));
-          requeueReplay();
-          this.settleReplayDeliveryBatch(replayBatch);
+    } else if (msg.type === 'error' && msg.message === undefined) {
+      void delivery.then(accepted => {
+        if (accepted && visibleAtDelivery && this.errorMessage === undefined) {
+          this.errorClearNeedsReplay = false;
         }
-      );
-    } else if (replayBatch) {
-      replayBatch.dropped = true;
-      this.settleReplayDeliveryBatch(replayBatch);
+      });
     }
     if (shouldClearWebviewError) {
       this.errorClearNeedsReplay = true;
-      this.post(
-        { type: 'error', message: undefined },
-        {
-          requeueReplayOnDrop: true,
-          onDelivered: () => {
-            if (this.errorMessage === undefined) {
-              this.errorClearNeedsReplay = false;
-            }
-          }
-        }
-      );
+      this.post({ type: 'error', message: undefined }, 'replayable');
     }
   }
 
@@ -858,7 +416,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       this.setSelectedOrg(selected);
       this.tailService.setOrg(selected);
       this.orgsBootstrapNeedsRefresh = false;
-      this.post({ type: 'orgs', data: orgs, selected });
+      this.post({ type: 'orgs', data: orgs, selected }, 'replayable');
       try {
         const durationMs = Date.now() - t0;
         safeSendEvent('orgs.list', { outcome: 'ok', view: 'tail' }, { durationMs, count: orgs.length });
@@ -866,7 +424,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     } catch (e) {
       logWarn('Tail: sendOrgs failed ->', getErrorMessage(e));
       this.orgsBootstrapNeedsRefresh = true;
-      this.post({ type: 'orgs', data: [], selected: this.selectedOrg });
+      this.post({ type: 'orgs', data: [], selected: this.selectedOrg }, 'replayable');
       try {
         const durationMs = Date.now() - t0;
         safeSendEvent('orgs.list', { outcome: 'error', view: 'tail', code: getTelemetryErrorCode(e) }, { durationMs });
@@ -881,16 +439,16 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
 
     const showLoading = options?.showLoading !== false;
     if (showLoading) {
-      this.post({ type: 'loading', value: true });
+      this.post({ type: 'loading', value: true }, 'replayable');
     }
     try {
       await this.sendOrgs();
       await this.sendDebugLevels();
-      this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() });
-      this.post({ type: 'tailStatus', running: this.tailService.isRunning() });
+      this.post({ type: 'tailConfig', tailBufferSize: this.getTailBufferSize() }, 'replayable');
+      this.post({ type: 'tailStatus', running: this.tailService.isRunning() }, 'replayable');
     } finally {
       if (showLoading) {
-        this.post({ type: 'loading', value: false });
+        this.post({ type: 'loading', value: false }, 'replayable');
       }
     }
   }
@@ -929,7 +487,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     } catch (e) {
       logWarn('Tail: could not load auth for debug levels ->', getErrorMessage(e));
       this.debugLevelsBootstrapNeedsRefresh = true;
-      this.post({ type: 'debugLevels', data: [] });
+      this.post({ type: 'debugLevels', data: [] }, 'replayable');
       try {
         const durationMs = Date.now() - t0;
         safeSendEvent('debugLevels.load', { outcome: 'error', code: getTelemetryErrorCode(e) }, { durationMs });
@@ -971,7 +529,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       active = out[0];
     }
     this.debugLevelsBootstrapNeedsRefresh = out.length === 0;
-    this.post({ type: 'debugLevels', data: out, active });
+    this.post({ type: 'debugLevels', data: out, active }, 'replayable');
     try {
       const durationMs = Date.now() - t0;
       safeSendEvent('debugLevels.load', { outcome: 'ok' }, { durationMs, count: out.length });
@@ -980,7 +538,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
   // Tail webview actions
   private async openLog(logId: string): Promise<void> {
     const t0 = Date.now();
-    this.post({ type: 'loading', value: true });
+    this.post({ type: 'loading', value: true }, 'replayable');
     try {
       const filePath = await this.tailService.ensureLogSaved(logId);
       await LogViewerPanel.show({ logId, filePath });
@@ -992,13 +550,13 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     } catch (e) {
       const msg = getErrorMessage(e);
       logWarn('Tail: openLog failed ->', msg);
-      this.post({ type: 'error', message: msg });
+      this.post({ type: 'error', message: msg }, 'replayable');
       try {
         const durationMs = Date.now() - t0;
         safeSendEvent('log.open', { view: 'tail', outcome: 'error' }, { durationMs });
       } catch {}
     } finally {
-      this.post({ type: 'loading', value: false });
+      this.post({ type: 'loading', value: false }, 'replayable');
     }
   }
 
@@ -1044,7 +602,7 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
       } else {
         const msg = getErrorMessage(e);
         logWarn('Tail: replay failed ->', msg);
-        this.post({ type: 'error', message: msg });
+        this.post({ type: 'error', message: msg }, 'replayable');
         try {
           const durationMs = Date.now() - t0;
           safeSendEvent('logs.replay', { view: 'tail', outcome: 'error' }, { durationMs });
@@ -1062,68 +620,61 @@ export class SfLogTailViewProvider implements vscode.WebviewViewProvider, vscode
     return normalized.includes('abort') || normalized.includes('canceled') || normalized.includes('cancelled');
   }
 
+  private validateInbound(message: unknown): WebviewSessionInbound<WebviewToExtensionMessage> | undefined {
+    const parsed = parseWebviewToExtensionMessage(message);
+    if (!parsed) {
+      logWarn('Tail: ignored invalid webview message');
+      return undefined;
+    }
+    return parsed.type === 'ready'
+      ? {
+          kind: 'ready',
+          ...(parsed.mountSequence !== undefined ? { generation: parsed.mountSequence } : {})
+        }
+      : { kind: 'message', message: parsed };
+  }
+
+  private handleSessionDiagnostic(diagnostic: WebviewSessionDiagnostic): void {
+    this.sessionDiagnostic = diagnostic;
+    if (diagnostic.event === 'ready') {
+      logInfo('Tail webview ready.');
+    }
+    recordWebviewEvent({
+      surface: 'tail',
+      event: diagnostic.event,
+      mountSequence: diagnostic.generation,
+      visible: diagnostic.visible,
+      ready: diagnostic.ready,
+      contentMounted: diagnostic.contentMounted,
+      details: {
+        ...(diagnostic.classification ? { classification: diagnostic.classification } : {}),
+        ...(diagnostic.attempt !== undefined ? { attempt: diagnostic.attempt } : {}),
+        ...(diagnostic.callback ? { callback: diagnostic.callback } : {})
+      }
+    });
+  }
+
+  private handleSessionDetach(reason: WebviewSessionDetachReason): void {
+    this.view = undefined;
+    if (reason === 'hostDisposed' || reason === 'explicit') {
+      this.tailService.stop();
+    }
+    logInfo(
+      `Tail webview detached${reason === 'hostDisposed' || reason === 'explicit' ? '; stopped tail' : ''} (${reason}).`
+    );
+  }
+
   private bindHost(host: BoundWebviewHost): void {
-    vscode.Disposable.from(...this.hostDisposables).dispose();
-    this.hostDisposables = [];
-    this.host = host;
-    this.view = host;
-    this.disposed = false;
-    this.ready = false;
-    this.contentMounted = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
-    this.tailResetNeedsReplay = false;
-    this.clearBootstrapTimers();
+    if (this.disposed) {
+      return;
+    }
     host.webview.options = {
       enableScripts: true,
       localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
     };
     this.showPlaceholder(host);
-    logInfo(`Tail webview resolved (${host.kind}).`);
-    recordWebviewEvent({
-      surface: 'tail',
-      event: 'resolved',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-
-    this.hostDisposables.push(
-      host.onDidDispose(() => {
-        if (this.host !== host) {
-          return;
-        }
-        this.disposed = true;
-        this.ready = false;
-        this.contentMounted = false;
-        this.needsReplayOnVisible = false;
-        this.visibleReplayRetryAttempts = 0;
-        this.view = undefined;
-        this.host = undefined;
-        this.clearBootstrapTimers();
-        // Stop timers and clear caches, but keep controller disposal separate.
-        this.tailService.stop();
-        logInfo(`Tail webview disposed; stopped tail (${host.kind}).`);
-        recordWebviewEvent({
-          surface: 'tail',
-          event: 'disposed',
-          hostKind: host.kind,
-          mountSequence: this.mountSequence,
-          visible: host.visible,
-          ready: this.ready,
-          contentMounted: this.contentMounted
-        });
-      }),
-      host.onDidChangeVisibility(visible => {
-        this.handleVisibilityChange(host, visible);
-      }),
-      host.webview.onDidReceiveMessage(message => {
-        void this.onMessage(message);
-      })
-    );
-
-    this.handleVisibilityChange(host, host.visible);
+    this.session.bind(host);
+    this.view = host;
+    logInfo('Tail webview resolved.');
   }
 }

--- a/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
+++ b/apps/vscode-extension/src/provider/SfLogsViewProvider.ts
@@ -34,29 +34,17 @@ import { normalizeLogTriageSummary, type LogDiagnostic, type LogTriageSummary } 
 import { bucketQueryLength } from '../shared/telemetryBuckets';
 import { createWebviewPanelHost, createWebviewViewHost, type BoundWebviewHost } from './webviewHost';
 import { recordWebviewEvent, type WebviewProviderDiagnosticState } from '../shared/webviewDiagnostics';
+import {
+  createWebviewSession,
+  type WebviewDeliveryClassification,
+  type WebviewSession,
+  type WebviewSessionDiagnostic,
+  type WebviewSessionDetachReason,
+  type WebviewSessionInbound
+} from './webviewSession';
 
 const SALESFORCE_ID_REGEX = /^[a-zA-Z0-9]{15,18}$/;
-// Corporate-managed notebooks can take several seconds to initialize VS Code
-// webviews and their internal service worker. Keep these windows generous so a
-// slow-but-healthy startup is not torn down into a remount loop.
-export const WEBVIEW_STABLE_VISIBILITY_DELAY_MS = 1000;
-export const WEBVIEW_READY_TIMEOUT_MS = 30000;
-const WEBVIEW_REPLAY_RETRY_DELAY_MS = 250;
-const WEBVIEW_REPLAY_MAX_RETRIES = 3;
 const BACKGROUND_SYNC_COOLDOWN_MS = 5 * 60 * 1000;
-const LOGS_REPLAYABLE_VISIBLE_UPDATE_TYPES = new Set<ExtensionToWebviewMessage['type']>([
-  'loading',
-  'error',
-  'warning',
-  'orgs',
-  'logsColumns',
-  'logs',
-  'appendLogs',
-  'logHead',
-  'errorScanStatus',
-  'searchMatches',
-  'searchStatus'
-]);
 
 interface LogHeadSnapshot {
   hasErrors?: boolean;
@@ -64,37 +52,15 @@ interface LogHeadSnapshot {
   reasons?: LogDiagnostic[];
 }
 
-interface ReplayDeliveryBatch {
-  pending: number;
-  dropped: boolean;
-  resetRetryBudgetOnSuccess: boolean;
-}
-
-interface WebviewPostOptions {
-  replay?: boolean;
-  requeueReplayOnDrop?: boolean;
-  onDelivered?: () => void;
-  replayBatch?: ReplayDeliveryBatch;
-}
-
 export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Disposable {
   public static readonly viewType = 'electivus.apexLogViewer.logsView';
   private view?: { webview: vscode.Webview };
-  private host?: BoundWebviewHost;
   private readonly disposables: vscode.Disposable[] = [];
-  private hostDisposables: vscode.Disposable[] = [];
-  private readonly readyTimeoutListeners = new Set<() => void>();
+  private readonly session: WebviewSession<ExtensionToWebviewMessage, BoundWebviewHost>;
+  private sessionDiagnostic: WebviewSessionDiagnostic | undefined;
   private pageLimit = 100;
   private currentOffset = 0;
   private disposed = false;
-  private ready = false;
-  private contentMounted = false;
-  private needsReplayOnVisible = false;
-  private mountTimer: ReturnType<typeof setTimeout> | undefined;
-  private readyTimer: ReturnType<typeof setTimeout> | undefined;
-  private visibleReplayRetryTimer: ReturnType<typeof setTimeout> | undefined;
-  private visibleReplayRetryAttempts = 0;
-  private mountSequence = 0;
   private refreshToken = 0;
   private activeRefreshToken: number | undefined;
   private messageHandler: LogsMessageHandler;
@@ -172,6 +138,23 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       value => this.setSearchQuery(value),
       value => this.saveLogsColumns(value)
     );
+    this.session = createWebviewSession({
+      mount: (host, generation) => {
+        host.webview.html = this.getHtmlForWebview(host.webview, generation);
+        logInfo('Logs webview mounted.');
+      },
+      getReplaySnapshot: () => this.getReplaySnapshot(),
+      validateInbound: message => this.validateInbound(message),
+      onDetach: reason => this.handleSessionDetach(reason),
+      onMessage: message => this.messageHandler.handleMessage(message),
+      onReady: () => this.bootstrapWebview(),
+      onReplaySucceeded: () => {
+        if (this.errorMessage === undefined) {
+          this.errorClearNeedsReplay = false;
+        }
+      },
+      onDiagnostic: diagnostic => this.handleSessionDiagnostic(diagnostic)
+    });
     this.disposables.push(
       vscode.workspace.onDidChangeConfiguration(e => {
         const prevFullBodies = this.configManager.shouldLoadFullLogBodies();
@@ -179,7 +162,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.logService.setHeadConcurrency(this.configManager.getHeadConcurrency());
         if (affectsConfiguration(e, 'electivus.apexLogViewer.logs.columns')) {
           this.logsColumns = this.readLogsColumns();
-          this.post({ type: 'logsColumns', value: this.logsColumns });
+          this.post({ type: 'logsColumns', value: this.logsColumns }, 'replayable');
         }
         if (prevFullBodies !== this.configManager.shouldLoadFullLogBodies()) {
           void this.refresh();
@@ -189,11 +172,13 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   }
 
   resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
-    this.bindHost(createWebviewViewHost(webviewView));
+    let host: BoundWebviewHost;
+    host = createWebviewViewHost(webviewView, () => this.showPlaceholder(host));
+    this.bindHost(host);
   }
 
-  public resolveWebviewPanel(panel: vscode.WebviewPanel): void {
-    this.bindHost(createWebviewPanelHost(panel));
+  public resolveWebviewPanel(panel: vscode.WebviewPanel, replaceAfterReadyTimeout?: () => void | Promise<void>): void {
+    this.bindHost(createWebviewPanelHost(panel, replaceAfterReadyTimeout));
   }
 
   public hasResolvedView(): boolean {
@@ -205,22 +190,22 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   }
 
   public isReady(): boolean {
-    return this.ready && !this.disposed;
+    return this.session.ready && !this.disposed;
   }
 
   public getWebviewDiagnosticState(): WebviewProviderDiagnosticState {
+    const diagnostic = this.sessionDiagnostic;
     return {
       surface: 'logs',
-      hasHost: !!this.host,
-      hostKind: this.host?.kind,
-      visible: this.host?.visible,
-      ready: this.ready,
+      hasHost: !!this.view,
+      visible: diagnostic?.visible,
+      ready: this.session.ready,
       disposed: this.disposed,
-      contentMounted: this.contentMounted,
-      mountSequence: this.mountSequence,
-      mountTimerActive: this.mountTimer !== undefined,
-      readyTimerActive: this.readyTimer !== undefined,
-      needsReplayOnVisible: this.needsReplayOnVisible,
+      contentMounted: diagnostic?.contentMounted ?? false,
+      mountSequence: diagnostic?.generation ?? 0,
+      mountTimerActive: diagnostic?.mountTimerActive ?? false,
+      readyTimerActive: diagnostic?.readyTimerActive ?? false,
+      needsReplayOnVisible: diagnostic?.needsReplay ?? true,
       snapshots: {
         hasOrgsSnapshot: this.hasOrgsSnapshot,
         orgCount: this.orgsSnapshot.length,
@@ -232,30 +217,21 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         errorClearNeedsReplay: this.errorClearNeedsReplay,
         searchStatus: this.searchStatusSnapshot,
         errorScanStatus: this.errorScanStatusSnapshot.state,
-        visibleReplayRetryTimerActive: this.visibleReplayRetryTimer !== undefined,
-        visibleReplayRetryAttempts: this.visibleReplayRetryAttempts
-      }
-    };
-  }
-
-  public onDidReadyTimeout(listener: () => void): vscode.Disposable {
-    this.readyTimeoutListeners.add(listener);
-    return {
-      dispose: () => {
-        this.readyTimeoutListeners.delete(listener);
+        sessionEvent: diagnostic?.event,
+        sessionGeneration: diagnostic?.generation,
+        sessionRetryAttempt: diagnostic?.attempt,
+        sessionDeliveryClassification: diagnostic?.classification
       }
     };
   }
 
   public dispose(): void {
+    if (this.disposed) {
+      return;
+    }
     this.disposed = true;
-    this.ready = false;
-    this.contentMounted = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
     this.view = undefined;
-    this.host = undefined;
-    this.clearBootstrapTimers();
+    this.session.dispose();
     this.refreshToken++;
     this.activeRefreshToken = undefined;
     this.cancelErrorScan();
@@ -267,9 +243,6 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       this.backgroundSyncAbortController.abort();
       this.backgroundSyncAbortController = undefined;
     }
-    this.readyTimeoutListeners.clear();
-    vscode.Disposable.from(...this.hostDisposables).dispose();
-    this.hostDisposables = [];
     vscode.Disposable.from(...this.disposables).dispose();
     this.disposables.length = 0;
   }
@@ -304,8 +277,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           },
           { force: true }
         );
-        this.post({ type: 'loading', value: true });
-        this.post({ type: 'warning', message: undefined });
+        this.post({ type: 'loading', value: true }, 'replayable');
+        this.post({ type: 'warning', message: undefined }, 'replayable');
         try {
           clearListCache();
           this.pageLimit = this.configManager.getPageLimit();
@@ -338,14 +311,17 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           if (!isCurrentRefresh()) {
             return;
           }
-          this.post({
-            type: 'init',
-            locale: vscode.env.language,
-            fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
-            logsColumns: this.logsColumns
-          });
+          this.post(
+            {
+              type: 'init',
+              locale: vscode.env.language,
+              fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
+              logsColumns: this.logsColumns
+            },
+            'replayable'
+          );
           const hasMore = logs.length === this.pageLimit;
-          this.post({ type: 'logs', data: logs, hasMore });
+          this.post({ type: 'logs', data: logs, hasMore }, 'replayable');
           this.setCurrentLogs(logs);
           this.postKnownErrorStateForLogs(logs);
           this.purgeLogCache(controller.signal);
@@ -357,7 +333,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           if (this.lastSearchQuery.trim()) {
             this.rerunActiveSearch();
           } else {
-            this.post({ type: 'searchMatches', query: '', logIds: [] });
+            this.post({ type: 'searchMatches', query: '', logIds: [] }, 'replayable');
           }
           try {
             const durationMs = Date.now() - t0;
@@ -367,7 +343,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           if (!controller.signal.aborted) {
             const msg = getErrorMessage(e);
             logWarn('Logs: refresh failed ->', msg);
-            this.post({ type: 'error', message: msg });
+            this.post({ type: 'error', message: msg }, 'replayable');
             try {
               const durationMs = Date.now() - t0;
               safeSendEvent(
@@ -381,7 +357,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           if (this.activeRefreshToken === token) {
             this.activeRefreshToken = undefined;
           }
-          this.post({ type: 'loading', value: false });
+          this.post({ type: 'loading', value: false }, 'replayable');
         }
       }
     );
@@ -394,8 +370,8 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     const token = this.refreshToken;
     const isCurrentRefresh = () => token === this.refreshToken && !this.disposed;
     const t0 = Date.now();
-    this.post({ type: 'loading', value: true });
-    this.post({ type: 'warning', message: undefined });
+    this.post({ type: 'loading', value: true }, 'replayable');
+    this.post({ type: 'warning', message: undefined }, 'replayable');
     try {
       const selectedOrg = this.orgManager.getSelectedOrg();
       const authHandle = this.observeDeferredAuth({ username: selectedOrg });
@@ -421,7 +397,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         return;
       }
       const hasMore = logs.length === this.pageLimit;
-      this.post({ type: 'appendLogs', data: logs, hasMore });
+      this.post({ type: 'appendLogs', data: logs, hasMore }, 'replayable');
       this.setCurrentLogs([...this.currentLogs, ...logs]);
       this.postKnownErrorStateForLogs(logs);
       this.purgeLogCache();
@@ -438,13 +414,13 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     } catch (e) {
       const msg = getErrorMessage(e);
       logWarn('Logs: loadMore failed ->', msg);
-      this.post({ type: 'error', message: msg });
+      this.post({ type: 'error', message: msg }, 'replayable');
       try {
         const durationMs = Date.now() - t0;
         safeSendEvent('logs.loadMore', { outcome: 'error' }, { durationMs });
       } catch {}
     } finally {
-      this.post({ type: 'loading', value: false });
+      this.post({ type: 'loading', value: false }, 'replayable');
     }
   }
 
@@ -456,7 +432,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         }
         const warning = getApiVersionFallbackWarning(auth);
         if (warning) {
-          this.post({ type: 'warning', message: warning });
+          this.post({ type: 'warning', message: warning }, 'replayable');
         }
       })
       .catch(e => {
@@ -692,7 +668,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       }
       this.errorScanLastPostedAt = now;
     }
-    this.post({ type: 'errorScanStatus', ...status });
+    this.post({ type: 'errorScanStatus', ...status }, 'replayable');
   }
 
   private postKnownErrorStateForLogs(logs: ApexLogRow[]): void {
@@ -702,13 +678,16 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       }
       const summary = this.errorByLogId.get(log.Id);
       if (summary) {
-        this.post({
-          type: 'logHead',
-          logId: log.Id,
-          hasErrors: summary.hasErrors,
-          primaryReason: summary.primaryReason,
-          reasons: summary.reasons
-        });
+        this.post(
+          {
+            type: 'logHead',
+            logId: log.Id,
+            hasErrors: summary.hasErrors,
+            primaryReason: summary.primaryReason,
+            reasons: summary.reasons
+          },
+          'replayable'
+        );
       }
     }
   }
@@ -810,13 +789,16 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             errorsFound += 1;
           }
           if (this.currentLogIds.has(entry.logId)) {
-            this.post({
-              type: 'logHead',
-              logId: entry.logId,
-              hasErrors: summary.hasErrors,
-              primaryReason: summary.primaryReason,
-              reasons: summary.reasons
-            });
+            this.post(
+              {
+                type: 'logHead',
+                logId: entry.logId,
+                hasErrors: summary.hasErrors,
+                primaryReason: summary.primaryReason,
+                reasons: summary.reasons
+              },
+              'replayable'
+            );
           }
           this.postErrorScanStatus({
             state: 'running',
@@ -880,7 +862,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
   }
 
   private postSearchStatus(state: 'idle' | 'loading'): void {
-    this.post({ type: 'searchStatus', state });
+    this.post({ type: 'searchStatus', state }, 'replayable');
   }
 
   private purgeLogCache(signal?: AbortSignal): void {
@@ -949,7 +931,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     const isActive = () => token === this.searchToken && !this.disposed;
     if (!trimmed) {
       if (isActive()) {
-        this.post({ type: 'searchMatches', query: '', logIds: [] });
+        this.post({ type: 'searchMatches', query: '', logIds: [] }, 'replayable');
         this.postSearchStatus('idle');
       }
       return;
@@ -961,7 +943,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     }
     if (!this.configManager.shouldLoadFullLogBodies()) {
       if (isActive()) {
-        this.post({ type: 'searchMatches', query: trimmed, logIds: [] });
+        this.post({ type: 'searchMatches', query: trimmed, logIds: [] }, 'replayable');
         this.postSearchStatus('idle');
       }
       this.sendSearchTelemetry('searched', queryLength, { durationMs: 0, matchCount: 0, pendingCount: 0 });
@@ -975,7 +957,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     });
     if (logsSnapshot.length === 0) {
       if (isActive()) {
-        this.post({ type: 'searchMatches', query: trimmed, logIds: [] });
+        this.post({ type: 'searchMatches', query: trimmed, logIds: [] }, 'replayable');
         this.postSearchStatus('idle');
       }
       this.sendSearchTelemetry('searched', queryLength, { durationMs: 0, matchCount: 0, pendingCount: 0 });
@@ -1035,13 +1017,16 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
 
       const logIds = Array.from(matches);
       const pendingLogIds = Array.from(missingLogIds);
-      this.post({
-        type: 'searchMatches',
-        query: trimmed,
-        logIds,
-        snippets,
-        pendingLogIds
-      });
+      this.post(
+        {
+          type: 'searchMatches',
+          query: trimmed,
+          logIds,
+          snippets,
+          pendingLogIds
+        },
+        'replayable'
+      );
       this.sendSearchTelemetry('searched', queryLength, {
         durationMs: Date.now() - t0,
         matchCount: logIds.length,
@@ -1056,7 +1041,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     } catch (e) {
       logWarn('Logs: search failed ->', getErrorMessage(e));
       if (token === this.searchToken && !this.disposed && !signal?.aborted) {
-        this.post({ type: 'searchMatches', query: trimmed, logIds: [] });
+        this.post({ type: 'searchMatches', query: trimmed, logIds: [] }, 'replayable');
         this.sendSearchTelemetry('error', queryLength, {
           durationMs: Date.now() - t0,
           matchCount: 0,
@@ -1567,7 +1552,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
           if (ct.isCancellationRequested) {
             return;
           }
-          this.post({ type: 'orgs', data: orgs, selected });
+          this.post({ type: 'orgs', data: orgs, selected }, 'replayable');
           try {
             const durationMs = Date.now() - t0;
             safeSendEvent('orgs.list', { outcome: 'ok', view: 'logs' }, { durationMs, count: orgs.length });
@@ -1578,7 +1563,7 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
             logError('Logs: list orgs failed ->', msg);
             this.orgsBootstrapNeedsRefresh = true;
             void vscode.window.showErrorMessage(localize('sendOrgsFailed', 'Failed to list Salesforce orgs: {0}', msg));
-            this.post({ type: 'orgs', data: [], selected: this.orgManager.getSelectedOrg() });
+            this.post({ type: 'orgs', data: [], selected: this.orgManager.getSelectedOrg() }, 'replayable');
             try {
               const durationMs = Date.now() - t0;
               safeSendEvent(
@@ -1640,6 +1625,118 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
     });
   }
 
+  private async bootstrapWebview(): Promise<void> {
+    const shouldRefreshOrgs = !this.hasOrgsSnapshot || this.orgsBootstrapNeedsRefresh;
+    const selectedOrgBeforeBootstrap = this.selectedOrgSnapshot;
+    if (shouldRefreshOrgs) {
+      await this.sendOrgs();
+    }
+    const shouldRefreshLogs =
+      (!this.hasLogsSnapshot ||
+        this.logsBootstrapNeedsRefresh ||
+        selectedOrgBeforeBootstrap !== this.selectedOrgSnapshot) &&
+      this.activeRefreshToken === undefined;
+    if (shouldRefreshLogs) {
+      await this.refresh();
+      return;
+    }
+    if (this.hasLogsSnapshot && this.lastSearchQuery.trim()) {
+      this.rerunActiveSearch();
+    }
+  }
+
+  private getReplaySnapshot(): readonly ExtensionToWebviewMessage[] {
+    const snapshot: ExtensionToWebviewMessage[] = [
+      {
+        type: 'init',
+        locale: vscode.env.language,
+        fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
+        logsColumns: this.logsColumns
+      }
+    ];
+    if (this.hasOrgsSnapshot) {
+      snapshot.push({
+        type: 'orgs',
+        data: this.orgsSnapshot,
+        selected: this.selectedOrgSnapshot
+      });
+    }
+    snapshot.push(
+      { type: 'warning', message: this.warningMessage },
+      { type: 'loading', value: this.loadingState },
+      { type: 'errorScanStatus', ...this.errorScanStatusSnapshot }
+    );
+    if (this.hasLogsSnapshot && !this.logsBootstrapNeedsRefresh) {
+      snapshot.push({ type: 'logs', data: this.currentLogs, hasMore: this.currentHasMore });
+      for (const [logId, retainedHead] of this.logHeadByLogId.entries()) {
+        snapshot.push({
+          type: 'logHead',
+          logId,
+          ...(retainedHead.hasErrors !== undefined ? { hasErrors: retainedHead.hasErrors } : {}),
+          ...(retainedHead.primaryReason !== undefined ? { primaryReason: retainedHead.primaryReason } : {}),
+          ...(retainedHead.reasons !== undefined ? { reasons: retainedHead.reasons } : {})
+        });
+      }
+      snapshot.push(
+        {
+          type: 'searchMatches',
+          query: this.searchMatchesSnapshot.query,
+          logIds: this.searchMatchesSnapshot.logIds,
+          ...(this.searchMatchesSnapshot.snippets ? { snippets: this.searchMatchesSnapshot.snippets } : {}),
+          ...(this.searchMatchesSnapshot.pendingLogIds
+            ? { pendingLogIds: this.searchMatchesSnapshot.pendingLogIds }
+            : {})
+        },
+        { type: 'searchStatus', state: this.searchStatusSnapshot }
+      );
+    }
+    if (this.errorMessage !== undefined) {
+      snapshot.push({ type: 'error', message: this.errorMessage });
+    } else if (this.errorClearNeedsReplay) {
+      snapshot.push({ type: 'error', message: undefined });
+    }
+    return snapshot;
+  }
+
+  private bindHost(host: BoundWebviewHost): void {
+    if (this.disposed) {
+      return;
+    }
+    host.webview.options = {
+      enableScripts: true,
+      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
+    };
+    this.showPlaceholder(host);
+    this.session.bind(host);
+    this.view = host;
+    logInfo('Logs webview resolved.');
+  }
+
+  private validateInbound(message: unknown): WebviewSessionInbound<WebviewToExtensionMessage> | undefined {
+    const parsed = parseWebviewToExtensionMessage(message);
+    if (!parsed) {
+      logWarn('Logs: ignored invalid webview message');
+      return undefined;
+    }
+    return parsed.type === 'ready'
+      ? {
+          kind: 'ready',
+          ...(parsed.mountSequence !== undefined ? { generation: parsed.mountSequence } : {})
+        }
+      : { kind: 'message', message: parsed };
+  }
+
+  private showPlaceholder(host: BoundWebviewHost): void {
+    host.webview.html = this.getPlaceholderHtml();
+    recordWebviewEvent({
+      surface: 'logs',
+      event: 'placeholder',
+      visible: host.visible,
+      ready: this.session.ready,
+      contentMounted: false
+    });
+  }
+
   private getPlaceholderHtml(): string {
     const title = this.escapeHtml(localize('salesforce.logs.view.name', 'Electivus Apex Logs'));
     return `<!DOCTYPE html>
@@ -1661,454 +1758,39 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       .replace(/'/g, '&#39;');
   }
 
-  private clearMountTimer(): void {
-    if (this.mountTimer) {
-      clearTimeout(this.mountTimer);
-      this.mountTimer = undefined;
+  private handleSessionDiagnostic(diagnostic: WebviewSessionDiagnostic): void {
+    this.sessionDiagnostic = diagnostic;
+    if (diagnostic.event === 'ready') {
+      logInfo('Logs webview ready.');
     }
-  }
-
-  private clearReadyTimer(): void {
-    if (this.readyTimer) {
-      clearTimeout(this.readyTimer);
-      this.readyTimer = undefined;
-    }
-  }
-
-  private clearVisibleReplayRetryTimer(): void {
-    if (this.visibleReplayRetryTimer) {
-      clearTimeout(this.visibleReplayRetryTimer);
-      this.visibleReplayRetryTimer = undefined;
-    }
-  }
-
-  private clearBootstrapTimers(): void {
-    this.clearMountTimer();
-    this.clearReadyTimer();
-    this.clearVisibleReplayRetryTimer();
-  }
-
-  private showPlaceholder(host: BoundWebviewHost): void {
-    this.contentMounted = false;
-    host.webview.html = this.getPlaceholderHtml();
     recordWebviewEvent({
       surface: 'logs',
-      event: 'placeholder',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-  }
-
-  private scheduleMount(host = this.host): void {
-    if (!host || this.disposed || !host.visible) {
-      return;
-    }
-    this.clearMountTimer();
-    recordWebviewEvent({
-      surface: 'logs',
-      event: 'mountScheduled',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { delayMs: WEBVIEW_STABLE_VISIBILITY_DELAY_MS }
-    });
-    this.mountTimer = setTimeout(() => {
-      this.mountTimer = undefined;
-      if (this.host !== host || this.disposed || !host.visible) {
-        return;
+      event: diagnostic.event,
+      mountSequence: diagnostic.generation,
+      visible: diagnostic.visible,
+      ready: diagnostic.ready,
+      contentMounted: diagnostic.contentMounted,
+      details: {
+        ...(diagnostic.classification ? { classification: diagnostic.classification } : {}),
+        ...(diagnostic.attempt !== undefined ? { attempt: diagnostic.attempt } : {}),
+        ...(diagnostic.callback ? { callback: diagnostic.callback } : {})
       }
-      this.mountWebview(host);
-    }, WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-  }
-
-  private mountWebview(host: BoundWebviewHost): void {
-    this.ready = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
-    const mountId = ++this.mountSequence;
-    this.contentMounted = true;
-    host.webview.html = this.getHtmlForWebview(host.webview, mountId);
-    this.startReadyTimer(host, mountId);
-    recordWebviewEvent({
-      surface: 'logs',
-      event: 'mounted',
-      hostKind: host.kind,
-      mountSequence: mountId,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-    logInfo(`Logs webview mounted (${host.kind}).`);
-  }
-
-  private startReadyTimer(host: BoundWebviewHost, mountId: number): void {
-    this.clearReadyTimer();
-    this.readyTimer = setTimeout(() => {
-      this.readyTimer = undefined;
-      if (this.host !== host || this.disposed || this.ready || mountId !== this.mountSequence) {
-        return;
-      }
-      logWarn(`Logs webview did not report ready within ${WEBVIEW_READY_TIMEOUT_MS}ms (${host.kind}).`);
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'readyTimeout',
-        hostKind: host.kind,
-        mountSequence: mountId,
-        visible: host.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted,
-        details: { timeoutMs: WEBVIEW_READY_TIMEOUT_MS }
-      });
-      this.ready = false;
-      this.showPlaceholder(host);
-      if (host.kind === 'editor') {
-        this.fireReadyTimeout();
-      } else if (host.visible) {
-        // Sidebar views need an internal remount because they do not recreate themselves.
-        this.scheduleMount(host);
-      }
-    }, WEBVIEW_READY_TIMEOUT_MS);
-  }
-
-  private fireReadyTimeout(): void {
-    for (const listener of [...this.readyTimeoutListeners]) {
-      try {
-        listener();
-      } catch {}
-    }
-  }
-
-  private handleVisibilityChange(host: BoundWebviewHost, visible: boolean): void {
-    if (this.host !== host || this.disposed) {
-      return;
-    }
-    if (!visible) {
-      this.clearBootstrapTimers();
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'hidden',
-        hostKind: host.kind,
-        mountSequence: this.mountSequence,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-      return;
-    }
-    recordWebviewEvent({
-      surface: 'logs',
-      event: 'visible',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { needsReplayOnVisible: this.needsReplayOnVisible }
-    });
-    if (this.ready) {
-      if (this.needsReplayOnVisible) {
-        this.replayRetainedState(host, visible, 'replayedOnVisible', true);
-      }
-      return;
-    }
-    if (this.contentMounted && this.mountSequence > 0) {
-      this.startReadyTimer(host, this.mountSequence);
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'resumedPendingReady',
-        hostKind: host.kind,
-        mountSequence: this.mountSequence,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-      return;
-    }
-    this.scheduleMount(host);
-  }
-
-  private async handleReadyMessage(mountSequence?: number): Promise<void> {
-    if (!this.host || this.disposed || this.ready) {
-      return;
-    }
-    if (mountSequence === undefined) {
-      if (this.mountSequence > 1) {
-        logInfo(`Logs webview ignored unsequenced stale ready (${this.host.kind}).`);
-        recordWebviewEvent({
-          surface: 'logs',
-          event: 'ignoredUnsequencedReady',
-          hostKind: this.host.kind,
-          mountSequence: this.mountSequence,
-          visible: this.host.visible,
-          ready: this.ready,
-          contentMounted: this.contentMounted
-        });
-        return;
-      }
-    } else if (mountSequence !== this.mountSequence) {
-      logInfo(`Logs webview ignored stale ready (${this.host.kind}).`);
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'ignoredStaleReady',
-        hostKind: this.host.kind,
-        mountSequence: this.mountSequence,
-        visible: this.host.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted,
-        details: { receivedMountSequence: mountSequence }
-      });
-      return;
-    }
-    this.ready = true;
-    this.clearReadyTimer();
-    logInfo(`Logs webview ready (${this.host.kind}).`);
-    recordWebviewEvent({
-      surface: 'logs',
-      event: 'ready',
-      hostKind: this.host.kind,
-      mountSequence: this.mountSequence,
-      visible: this.host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-    await this.bootstrapWebview();
-  }
-
-  private async bootstrapWebview(): Promise<void> {
-    this.post({
-      type: 'init',
-      locale: vscode.env.language,
-      fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
-      logsColumns: this.logsColumns
-    });
-    this.replaySnapshot();
-
-    const shouldRefreshOrgs = !this.hasOrgsSnapshot || this.orgsBootstrapNeedsRefresh;
-    const selectedOrgBeforeBootstrap = this.selectedOrgSnapshot;
-    if (shouldRefreshOrgs) {
-      await this.sendOrgs();
-    }
-    const shouldRefreshLogs =
-      (!this.hasLogsSnapshot ||
-        this.logsBootstrapNeedsRefresh ||
-        selectedOrgBeforeBootstrap !== this.selectedOrgSnapshot) &&
-      this.activeRefreshToken === undefined;
-    if (shouldRefreshLogs) {
-      await this.refresh();
-      return;
-    }
-    if (this.hasLogsSnapshot && this.lastSearchQuery.trim()) {
-      this.rerunActiveSearch();
-    }
-  }
-
-  private replayRetainedState(
-    host: BoundWebviewHost,
-    visible: boolean,
-    event: string,
-    resetRetryBudget: boolean
-  ): void {
-    if (resetRetryBudget) {
-      this.visibleReplayRetryAttempts = 0;
-    }
-    const replayBatch: ReplayDeliveryBatch = {
-      pending: 0,
-      dropped: false,
-      resetRetryBudgetOnSuccess: !resetRetryBudget
-    };
-    this.needsReplayOnVisible = false;
-    this.post(
-      {
-        type: 'init',
-        locale: vscode.env.language,
-        fullLogSearchEnabled: this.configManager.shouldLoadFullLogBodies(),
-        logsColumns: this.logsColumns
-      },
-      { requeueReplayOnDrop: true, replayBatch }
-    );
-    this.replaySnapshot({ requeueReplayOnDrop: true, replayBatch });
-    recordWebviewEvent({
-      surface: 'logs',
-      event,
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted,
-      details: { retryAttempts: this.visibleReplayRetryAttempts }
     });
   }
 
-  private replaySnapshot(options?: WebviewPostOptions): void {
-    const replayOptions: WebviewPostOptions = {
-      replay: true,
-      requeueReplayOnDrop: options?.requeueReplayOnDrop,
-      replayBatch: options?.replayBatch
-    };
-    if (this.hasOrgsSnapshot) {
-      this.post(
-        {
-          type: 'orgs',
-          data: this.orgsSnapshot,
-          selected: this.selectedOrgSnapshot
-        },
-        replayOptions
-      );
-    }
-    this.post({ type: 'warning', message: this.warningMessage }, replayOptions);
-    this.post({ type: 'loading', value: this.loadingState }, replayOptions);
-    this.post({ type: 'errorScanStatus', ...this.errorScanStatusSnapshot }, replayOptions);
-    if (this.hasLogsSnapshot && !this.logsBootstrapNeedsRefresh) {
-      this.post({ type: 'logs', data: this.currentLogs, hasMore: this.currentHasMore }, replayOptions);
-      for (const [logId, snapshot] of this.logHeadByLogId.entries()) {
-        this.post(
-          {
-            type: 'logHead',
-            logId,
-            ...(snapshot.hasErrors !== undefined ? { hasErrors: snapshot.hasErrors } : {}),
-            ...(snapshot.primaryReason !== undefined ? { primaryReason: snapshot.primaryReason } : {}),
-            ...(snapshot.reasons !== undefined ? { reasons: snapshot.reasons } : {})
-          },
-          replayOptions
-        );
-      }
-      this.post(
-        {
-          type: 'searchMatches',
-          query: this.searchMatchesSnapshot.query,
-          logIds: this.searchMatchesSnapshot.logIds,
-          ...(this.searchMatchesSnapshot.snippets ? { snippets: this.searchMatchesSnapshot.snippets } : {}),
-          ...(this.searchMatchesSnapshot.pendingLogIds
-            ? { pendingLogIds: this.searchMatchesSnapshot.pendingLogIds }
-            : {})
-        },
-        replayOptions
-      );
-      this.post({ type: 'searchStatus', state: this.searchStatusSnapshot }, replayOptions);
-    }
-    if (this.errorMessage !== undefined) {
-      this.post({ type: 'error', message: this.errorMessage }, replayOptions);
-    } else if (this.errorClearNeedsReplay) {
-      this.post(
-        { type: 'error', message: undefined },
-        {
-          ...replayOptions,
-          onDelivered: () => {
-            if (this.errorMessage === undefined) {
-              this.errorClearNeedsReplay = false;
-            }
-          }
-        }
-      );
-    }
-  }
-
-  private bindHost(host: BoundWebviewHost): void {
-    vscode.Disposable.from(...this.hostDisposables).dispose();
-    this.hostDisposables = [];
-    this.host = host;
-    this.view = host;
-    this.disposed = false;
-    this.ready = false;
-    this.contentMounted = false;
-    this.needsReplayOnVisible = false;
-    this.visibleReplayRetryAttempts = 0;
-    this.clearBootstrapTimers();
-    host.webview.options = {
-      enableScripts: true,
-      localResourceRoots: [vscode.Uri.joinPath(this.context.extensionUri, 'media')]
-    };
-    this.showPlaceholder(host);
-    logInfo(`Logs webview resolved (${host.kind}).`);
-    recordWebviewEvent({
-      surface: 'logs',
-      event: 'resolved',
-      hostKind: host.kind,
-      mountSequence: this.mountSequence,
-      visible: host.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    });
-
-    this.hostDisposables.push(
-      host.onDidDispose(() => {
-        if (this.host !== host) {
-          return;
-        }
-        this.disposed = true;
-        this.ready = false;
-        this.contentMounted = false;
-        this.needsReplayOnVisible = false;
-        this.visibleReplayRetryAttempts = 0;
-        this.view = undefined;
-        this.host = undefined;
-        this.clearBootstrapTimers();
-        this.refreshToken++;
-        this.activeRefreshToken = undefined;
-        this.cancelErrorScan();
-        if (this.searchAbortController) {
-          this.searchAbortController.abort();
-          this.searchAbortController = undefined;
-        }
-        logInfo(`Logs webview disposed (${host.kind}).`);
-        recordWebviewEvent({
-          surface: 'logs',
-          event: 'disposed',
-          hostKind: host.kind,
-          mountSequence: this.mountSequence,
-          visible: host.visible,
-          ready: this.ready,
-          contentMounted: this.contentMounted
-        });
-      }),
-      host.onDidChangeVisibility(visible => {
-        this.handleVisibilityChange(host, visible);
-      }),
-      host.webview.onDidReceiveMessage(message => {
-        const parsed = parseWebviewToExtensionMessage(message);
-        if (!parsed) {
-          logWarn('Logs: ignored invalid webview message');
-          return;
-        }
-        if (parsed.type === 'ready') {
-          void this.handleReadyMessage(parsed.mountSequence);
-          return;
-        }
-        void this.messageHandler.handleMessage(parsed);
-      })
-    );
-
-    this.handleVisibilityChange(host, host.visible);
-  }
-
-  private settleReplayDeliveryBatch(batch: ReplayDeliveryBatch | undefined): void {
-    if (!batch) {
+  private handleSessionDetach(reason: WebviewSessionDetachReason): void {
+    this.view = undefined;
+    if (reason === 'rebind') {
       return;
     }
-    batch.pending = Math.max(0, batch.pending - 1);
-    if (batch.pending > 0) {
-      return;
-    }
-    if (!batch.dropped && batch.resetRetryBudgetOnSuccess && !this.needsReplayOnVisible) {
-      this.visibleReplayRetryAttempts = 0;
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'replayRetryBudgetResetAfterDelivery',
-        hostKind: this.host?.kind,
-        mountSequence: this.mountSequence,
-        visible: this.host?.visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-    }
+    this.refreshToken++;
+    this.activeRefreshToken = undefined;
+    this.cancelErrorScan();
+    this.searchAbortController?.abort();
+    this.searchAbortController = undefined;
   }
 
-  private post(msg: ExtensionToWebviewMessage, options?: WebviewPostOptions): void {
+  private post(msg: ExtensionToWebviewMessage, classification: WebviewDeliveryClassification): void {
     let shouldClearWebviewError = false;
     switch (msg.type) {
       case 'loading':
@@ -2131,23 +1813,19 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
       case 'logs':
         this.hasLogsSnapshot = true;
         this.currentHasMore = !!msg.hasMore;
-        if (!options?.replay) {
-          this.logsBootstrapNeedsRefresh = false;
-          if (this.errorMessage !== undefined) {
-            this.errorMessage = undefined;
-            shouldClearWebviewError = true;
-          }
+        this.logsBootstrapNeedsRefresh = false;
+        if (this.errorMessage !== undefined) {
+          this.errorMessage = undefined;
+          shouldClearWebviewError = true;
         }
         break;
       case 'appendLogs':
         this.hasLogsSnapshot = true;
         this.currentHasMore = !!msg.hasMore;
-        if (!options?.replay) {
-          this.logsBootstrapNeedsRefresh = false;
-          if (this.errorMessage !== undefined) {
-            this.errorMessage = undefined;
-            shouldClearWebviewError = true;
-          }
+        this.logsBootstrapNeedsRefresh = false;
+        if (this.errorMessage !== undefined) {
+          this.errorMessage = undefined;
+          shouldClearWebviewError = true;
         }
         break;
       case 'logHead': {
@@ -2180,161 +1858,18 @@ export class SfLogsViewProvider implements vscode.WebviewViewProvider, vscode.Di
         this.searchStatusSnapshot = msg.state === 'loading' ? 'loading' : 'idle';
         break;
     }
-    const visible = this.host?.visible ?? false;
-    if (this.host && !visible && !options?.replay) {
-      this.needsReplayOnVisible = true;
-      this.visibleReplayRetryAttempts = 0;
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'messagePostedWhileHidden',
-        hostKind: this.host.kind,
-        mountSequence: this.mountSequence,
-        messageType: msg.type,
-        visible,
-        ready: this.ready,
-        contentMounted: this.contentMounted
-      });
-    }
-    const postContext = {
-      hostKind: this.host?.kind,
-      mountSequence: this.mountSequence,
-      visible: this.host?.visible,
-      ready: this.ready,
-      contentMounted: this.contentMounted
-    };
-    const scheduleVisibleReplayRetry = () => {
-      if (
-        !postContext.visible ||
-        !this.host ||
-        !this.host.visible ||
-        !this.ready ||
-        this.visibleReplayRetryTimer ||
-        this.visibleReplayRetryAttempts >= WEBVIEW_REPLAY_MAX_RETRIES
-      ) {
-        return;
-      }
-
-      const host = this.host;
-      const mountSequence = this.mountSequence;
-      const attempt = ++this.visibleReplayRetryAttempts;
-      this.visibleReplayRetryTimer = setTimeout(() => {
-        this.visibleReplayRetryTimer = undefined;
-        if (
-          this.disposed ||
-          this.host !== host ||
-          !host.visible ||
-          !this.ready ||
-          mountSequence !== this.mountSequence ||
-          !this.needsReplayOnVisible
-        ) {
-          return;
+    const visibleAtDelivery = this.session.visible === true;
+    const delivery = this.session.deliver(msg, classification);
+    if (msg.type === 'error' && msg.message === undefined) {
+      void delivery.then(accepted => {
+        if (accepted && visibleAtDelivery && this.errorMessage === undefined) {
+          this.errorClearNeedsReplay = false;
         }
-        this.replayRetainedState(host, true, 'retriedReplayAfterDroppedPost', false);
-      }, WEBVIEW_REPLAY_RETRY_DELAY_MS);
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'scheduledReplayRetryAfterDroppedPost',
-        hostKind: postContext.hostKind,
-        mountSequence: postContext.mountSequence,
-        messageType: msg.type,
-        visible: postContext.visible,
-        ready: postContext.ready,
-        contentMounted: postContext.contentMounted,
-        details: { attempt, delayMs: WEBVIEW_REPLAY_RETRY_DELAY_MS }
       });
-    };
-    const requeueReplay = () => {
-      const requeueReason = options?.requeueReplayOnDrop
-        ? 'explicit'
-        : !options?.replay &&
-            postContext.visible === true &&
-            postContext.ready === true &&
-            LOGS_REPLAYABLE_VISIBLE_UPDATE_TYPES.has(msg.type)
-          ? 'visibleUpdate'
-          : undefined;
-      if (!requeueReason || this.disposed || postContext.mountSequence !== this.mountSequence) {
-        return;
-      }
-      this.needsReplayOnVisible = true;
-      scheduleVisibleReplayRetry();
-      recordWebviewEvent({
-        surface: 'logs',
-        event: 'replayRequeuedAfterDroppedPost',
-        hostKind: postContext.hostKind,
-        mountSequence: postContext.mountSequence,
-        messageType: msg.type,
-        visible: postContext.visible,
-        ready: postContext.ready,
-        contentMounted: postContext.contentMounted,
-        details: { reason: requeueReason }
-      });
-    };
-    const replayBatch = options?.replayBatch;
-    if (replayBatch) {
-      replayBatch.pending += 1;
-    }
-    const postResult = this.view?.webview.postMessage(msg);
-    if (postResult) {
-      postResult.then(
-        delivered => {
-          if (!delivered) {
-            if (replayBatch) {
-              replayBatch.dropped = true;
-            }
-            recordWebviewEvent({
-              surface: 'logs',
-              event: 'messageDropped',
-              hostKind: postContext.hostKind,
-              mountSequence: postContext.mountSequence,
-              messageType: msg.type,
-              visible: postContext.visible,
-              ready: postContext.ready,
-              contentMounted: postContext.contentMounted
-            });
-            logTrace('Logs webview postMessage dropped', msg.type);
-            requeueReplay();
-          } else {
-            options?.onDelivered?.();
-          }
-          this.settleReplayDeliveryBatch(replayBatch);
-        },
-        error => {
-          if (replayBatch) {
-            replayBatch.dropped = true;
-          }
-          recordWebviewEvent({
-            surface: 'logs',
-            event: 'messagePostRejected',
-            hostKind: postContext.hostKind,
-            mountSequence: postContext.mountSequence,
-            messageType: msg.type,
-            visible: postContext.visible,
-            ready: postContext.ready,
-            contentMounted: postContext.contentMounted,
-            details: { error: getErrorMessage(error) }
-          });
-          logWarn('Logs webview postMessage failed ->', getErrorMessage(error));
-          requeueReplay();
-          this.settleReplayDeliveryBatch(replayBatch);
-        }
-      );
-    } else if (replayBatch) {
-      replayBatch.dropped = true;
-      this.settleReplayDeliveryBatch(replayBatch);
     }
     if (shouldClearWebviewError) {
       this.errorClearNeedsReplay = true;
-      this.post(
-        { type: 'error', message: undefined },
-        {
-          requeueReplayOnDrop: true,
-          onDelivered: () => {
-            if (this.errorMessage === undefined) {
-              this.errorClearNeedsReplay = false;
-            }
-          }
-        }
-      );
+      this.post({ type: 'error', message: undefined }, 'replayable');
     }
   }
 }

--- a/apps/vscode-extension/src/provider/webviewHost.ts
+++ b/apps/vscode-extension/src/provider/webviewHost.ts
@@ -1,22 +1,27 @@
 import * as vscode from 'vscode';
 
 export interface BoundWebviewHost {
-  readonly kind: 'panel' | 'editor';
   readonly webview: vscode.Webview;
   readonly visible: boolean;
+  recoverAfterReadyTimeout(remount: () => void): void | Promise<void>;
   onDidDispose(listener: () => void): vscode.Disposable;
   onDidChangeVisibility(listener: (visible: boolean) => void): vscode.Disposable;
-  onDidBecomeVisible(listener: () => void): vscode.Disposable;
 }
 
-export function createWebviewViewHost(view: vscode.WebviewView): BoundWebviewHost {
+export function createWebviewViewHost(
+  view: vscode.WebviewView,
+  prepareForRemount: () => void = () => undefined
+): BoundWebviewHost {
   return {
-    kind: 'panel',
     get webview() {
       return view.webview;
     },
     get visible() {
       return view.visible;
+    },
+    recoverAfterReadyTimeout(remount): void {
+      prepareForRemount();
+      remount();
     },
     onDidDispose(listener: () => void): vscode.Disposable {
       return view.onDidDispose(listener);
@@ -25,18 +30,14 @@ export function createWebviewViewHost(view: vscode.WebviewView): BoundWebviewHos
       return view.onDidChangeVisibility(() => {
         listener(view.visible);
       });
-    },
-    onDidBecomeVisible(listener: () => void): vscode.Disposable {
-      return view.onDidChangeVisibility(() => {
-        if (view.visible) {
-          listener();
-        }
-      });
     }
   };
 }
 
-export function createWebviewPanelHost(panel: vscode.WebviewPanel): BoundWebviewHost {
+export function createWebviewPanelHost(
+  panel: vscode.WebviewPanel,
+  replaceAfterReadyTimeout: () => void | Promise<void> = () => undefined
+): BoundWebviewHost {
   const onVisibilityTransition = (listener: (visible: boolean) => void): vscode.Disposable => {
     let lastVisible = panel.visible;
     return panel.onDidChangeViewState(event => {
@@ -50,25 +51,20 @@ export function createWebviewPanelHost(panel: vscode.WebviewPanel): BoundWebview
   };
 
   return {
-    kind: 'editor',
     get webview() {
       return panel.webview;
     },
     get visible() {
       return panel.visible;
     },
+    recoverAfterReadyTimeout(): void | Promise<void> {
+      return replaceAfterReadyTimeout();
+    },
     onDidDispose(listener: () => void): vscode.Disposable {
       return panel.onDidDispose(listener);
     },
     onDidChangeVisibility(listener: (visible: boolean) => void): vscode.Disposable {
       return onVisibilityTransition(listener);
-    },
-    onDidBecomeVisible(listener: () => void): vscode.Disposable {
-      return onVisibilityTransition(visible => {
-        if (visible) {
-          listener();
-        }
-      });
     }
   };
 }

--- a/apps/vscode-extension/src/provider/webviewSession.ts
+++ b/apps/vscode-extension/src/provider/webviewSession.ts
@@ -1,0 +1,101 @@
+import { realWebviewSessionClock } from './webviewSessionClock';
+import { createWebviewSessionInternal } from './webviewSessionInternal';
+
+export const WEBVIEW_SESSION_MOUNT_DELAY_MS = 1000;
+export const WEBVIEW_SESSION_READY_TIMEOUT_MS = 30_000;
+export const WEBVIEW_SESSION_RETRY_DELAY_MS = 250;
+export const WEBVIEW_SESSION_MAX_RETRIES = 3;
+
+export interface WebviewSessionDisposable {
+  dispose(): void;
+}
+
+export interface WebviewSessionHost<TOutbound> {
+  readonly webview: {
+    postMessage(message: TOutbound): Thenable<boolean>;
+    onDidReceiveMessage(listener: (message: unknown) => void | Promise<void>): WebviewSessionDisposable;
+  };
+  readonly visible: boolean;
+  recoverAfterReadyTimeout(remount: () => void): void | Promise<void>;
+  onDidDispose(listener: () => void): WebviewSessionDisposable;
+  onDidChangeVisibility(listener: (visible: boolean) => void): WebviewSessionDisposable;
+}
+
+export type WebviewSessionInbound<TInbound> =
+  { readonly kind: 'ready'; readonly generation?: number } | { readonly kind: 'message'; readonly message: TInbound };
+
+export type WebviewDeliveryClassification = 'replayable' | 'transient';
+export type WebviewSessionDetachReason = 'rebind' | 'hostDisposed' | 'explicit' | 'finalDispose';
+
+export type WebviewSessionDiagnosticEvent =
+  | 'attached'
+  | 'callbackFailed'
+  | 'deliveryAccepted'
+  | 'deliveryAttempted'
+  | 'deliveryFailed'
+  | 'deliveryRejected'
+  | 'deliverySkipped'
+  | 'detached'
+  | 'disposed'
+  | 'hidden'
+  | 'invalidInbound'
+  | 'messageForwarded'
+  | 'mountScheduled'
+  | 'mounted'
+  | 'ready'
+  | 'readyDuplicate'
+  | 'recoveryRequested'
+  | 'replayIncomplete'
+  | 'replayStarted'
+  | 'replaySucceeded'
+  | 'replaySuperseded'
+  | 'retryAttempted'
+  | 'retryExhausted'
+  | 'retryScheduled'
+  | 'staleWorkIgnored'
+  | 'visible';
+
+export interface WebviewSessionDiagnostic {
+  readonly event: WebviewSessionDiagnosticEvent;
+  readonly generation: number;
+  readonly ready: boolean;
+  readonly visible?: boolean;
+  readonly contentMounted: boolean;
+  readonly mountTimerActive: boolean;
+  readonly readyTimerActive: boolean;
+  readonly needsReplay: boolean;
+  readonly classification?: WebviewDeliveryClassification;
+  readonly attempt?: number;
+  readonly callback?:
+    'detach' | 'mount' | 'snapshot' | 'validateInbound' | 'message' | 'ready' | 'replay' | 'timeoutRecovery';
+}
+
+export interface WebviewSessionOptions<
+  TOutbound,
+  TInbound,
+  THost extends WebviewSessionHost<TOutbound> = WebviewSessionHost<TOutbound>
+> {
+  mount(host: THost, generation: number): void | Promise<void>;
+  getReplaySnapshot(): readonly TOutbound[] | Promise<readonly TOutbound[]>;
+  validateInbound(message: unknown): WebviewSessionInbound<TInbound> | undefined;
+  onDetach?(reason: WebviewSessionDetachReason): void;
+  onMessage(message: TInbound): void | Promise<void>;
+  onReady?(): void | Promise<void>;
+  onReplaySucceeded?(): void;
+  onDiagnostic?(diagnostic: WebviewSessionDiagnostic): void;
+}
+
+export interface WebviewSession<TOutbound, THost extends WebviewSessionHost<TOutbound>> {
+  readonly ready: boolean;
+  readonly visible: boolean | undefined;
+  bind(host: THost): void;
+  detach(): void;
+  deliver(message: TOutbound, classification: WebviewDeliveryClassification): Promise<boolean>;
+  dispose(): void;
+}
+
+export function createWebviewSession<TOutbound, TInbound, THost extends WebviewSessionHost<TOutbound>>(
+  options: WebviewSessionOptions<TOutbound, TInbound, THost>
+): WebviewSession<TOutbound, THost> {
+  return createWebviewSessionInternal(options, realWebviewSessionClock);
+}

--- a/apps/vscode-extension/src/provider/webviewSessionClock.ts
+++ b/apps/vscode-extension/src/provider/webviewSessionClock.ts
@@ -1,0 +1,14 @@
+export interface WebviewSessionClock {
+  setTimeout(callback: () => void, delayMs: number): { dispose(): void };
+}
+
+export const realWebviewSessionClock: WebviewSessionClock = {
+  setTimeout(callback, delayMs) {
+    const handle = setTimeout(callback, delayMs);
+    return {
+      dispose() {
+        clearTimeout(handle);
+      }
+    };
+  }
+};

--- a/apps/vscode-extension/src/provider/webviewSessionInternal.ts
+++ b/apps/vscode-extension/src/provider/webviewSessionInternal.ts
@@ -1,0 +1,510 @@
+import {
+  WEBVIEW_SESSION_MAX_RETRIES,
+  WEBVIEW_SESSION_MOUNT_DELAY_MS,
+  WEBVIEW_SESSION_READY_TIMEOUT_MS,
+  WEBVIEW_SESSION_RETRY_DELAY_MS,
+  type WebviewDeliveryClassification,
+  type WebviewSession,
+  type WebviewSessionDiagnostic,
+  type WebviewSessionDetachReason,
+  type WebviewSessionDisposable,
+  type WebviewSessionHost,
+  type WebviewSessionInbound,
+  type WebviewSessionOptions
+} from './webviewSession';
+import type { WebviewSessionClock } from './webviewSessionClock';
+
+class DefaultWebviewSession<TOutbound, TInbound, THost extends WebviewSessionHost<TOutbound>> implements WebviewSession<
+  TOutbound,
+  THost
+> {
+  private host: THost | undefined;
+  private mountTimer: WebviewSessionDisposable | undefined;
+  private readyTimer: WebviewSessionDisposable | undefined;
+  private retryTimer: WebviewSessionDisposable | undefined;
+  private messageListener: WebviewSessionDisposable | undefined;
+  private visibilityListener: WebviewSessionDisposable | undefined;
+  private hostDisposeListener: WebviewSessionDisposable | undefined;
+  private generation = 0;
+  private activeMountGeneration: number | undefined;
+  private disposed = false;
+  private readyState = false;
+  private needsReplay = true;
+  private replayIntentVersion = 0;
+  private retryAttempts = 0;
+  private retryExhaustionDiagnosed = false;
+
+  constructor(
+    private readonly options: WebviewSessionOptions<TOutbound, TInbound, THost>,
+    private readonly clock: WebviewSessionClock
+  ) {}
+
+  get ready(): boolean {
+    return this.readyState;
+  }
+
+  get visible(): boolean | undefined {
+    return this.host?.visible;
+  }
+
+  bind(host: THost): void {
+    if (this.disposed) {
+      return;
+    }
+    if (this.host) {
+      this.detachInternal('rebind');
+    }
+    this.host = host;
+    this.readyState = false;
+    this.activeMountGeneration = undefined;
+    this.diagnose({ event: 'attached' });
+    this.messageListener?.dispose();
+    this.messageListener = host.webview.onDidReceiveMessage(message => this.handleInbound(host, message));
+    this.visibilityListener?.dispose();
+    this.visibilityListener = host.onDidChangeVisibility(visible => {
+      if (this.host !== host || this.disposed) {
+        return;
+      }
+      if (!visible) {
+        this.mountTimer?.dispose();
+        this.mountTimer = undefined;
+        this.readyTimer?.dispose();
+        this.readyTimer = undefined;
+        this.retryTimer?.dispose();
+        this.retryTimer = undefined;
+        this.diagnose({ event: 'hidden' });
+        return;
+      }
+      this.diagnose({ event: 'visible' });
+      if (this.readyState) {
+        if (this.needsReplay) {
+          this.resetReplayRetryBudget();
+          void this.replayLatest();
+        }
+        return;
+      }
+      if (this.activeMountGeneration !== undefined) {
+        this.startReadyTimer(host, this.activeMountGeneration);
+        return;
+      }
+      this.scheduleMount(host);
+    });
+    this.hostDisposeListener = host.onDidDispose(() => {
+      if (this.host === host) {
+        this.detachInternal('hostDisposed');
+      }
+    });
+    if (!host.visible) {
+      return;
+    }
+    this.scheduleMount(host);
+  }
+
+  detach(): void {
+    this.detachInternal('explicit');
+  }
+
+  private detachInternal(reason: WebviewSessionDetachReason): void {
+    const wasAttached = this.host !== undefined;
+    this.host = undefined;
+    this.readyState = false;
+    this.activeMountGeneration = undefined;
+    this.mountTimer?.dispose();
+    this.mountTimer = undefined;
+    this.readyTimer?.dispose();
+    this.readyTimer = undefined;
+    this.retryTimer?.dispose();
+    this.retryTimer = undefined;
+    this.resetReplayRetryBudget();
+    this.messageListener?.dispose();
+    this.messageListener = undefined;
+    this.visibilityListener?.dispose();
+    this.visibilityListener = undefined;
+    this.hostDisposeListener?.dispose();
+    this.hostDisposeListener = undefined;
+    if (wasAttached) {
+      this.diagnose({ event: 'detached' });
+      try {
+        this.options.onDetach?.(reason);
+      } catch {
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'detach'
+        });
+      }
+    }
+  }
+
+  async deliver(message: TOutbound, classification: WebviewDeliveryClassification): Promise<boolean> {
+    const host = this.host;
+    if (!host || !this.readyState || this.disposed) {
+      if (classification === 'replayable') {
+        this.markReplayNeeded();
+      }
+      this.diagnose({
+        event: 'deliverySkipped',
+        classification
+      });
+      return false;
+    }
+    const generation = this.generation;
+    const deliveryIntentVersion = classification === 'replayable' ? this.advanceReplayIntentVersion() : undefined;
+    if (!host.visible && classification === 'replayable') {
+      this.needsReplay = true;
+    }
+    this.diagnose({
+      event: 'deliveryAttempted',
+      classification
+    });
+    try {
+      const accepted = await host.webview.postMessage(message);
+      if (!this.isCurrentGeneration(host, generation)) {
+        this.diagnose({ event: 'staleWorkIgnored' });
+        return false;
+      }
+      if (
+        accepted &&
+        classification === 'replayable' &&
+        deliveryIntentVersion !== undefined &&
+        this.replayIntentVersion !== deliveryIntentVersion
+      ) {
+        this.diagnose({ event: 'replaySuperseded' });
+        return false;
+      }
+      if (!accepted && classification === 'replayable') {
+        this.markReplayNeeded();
+        this.scheduleReplayRetry();
+      }
+      this.diagnose({
+        event: accepted ? 'deliveryAccepted' : 'deliveryRejected',
+        classification
+      });
+      return accepted;
+    } catch {
+      if (!this.isCurrentGeneration(host, generation)) {
+        this.diagnose({ event: 'staleWorkIgnored' });
+        return false;
+      }
+      if (classification === 'replayable') {
+        this.markReplayNeeded();
+        this.scheduleReplayRetry();
+      }
+      this.diagnose({
+        event: 'deliveryFailed',
+        classification
+      });
+      return false;
+    }
+  }
+
+  dispose(): void {
+    if (this.disposed) {
+      return;
+    }
+    this.disposed = true;
+    this.detachInternal('finalDispose');
+    this.diagnose({ event: 'disposed' });
+  }
+
+  private scheduleMount(host: THost): void {
+    this.mountTimer?.dispose();
+    this.mountTimer = this.clock.setTimeout(() => {
+      this.mountTimer = undefined;
+      if (this.disposed || this.host !== host || !host.visible) {
+        return;
+      }
+      const generation = ++this.generation;
+      void this.mount(host, generation);
+    }, WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    this.diagnose({ event: 'mountScheduled' });
+  }
+
+  private async handleInbound(host: THost, raw: unknown): Promise<void> {
+    const generation = this.generation;
+    if (this.host !== host || this.disposed) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    let inbound: WebviewSessionInbound<TInbound> | undefined;
+    try {
+      inbound = this.options.validateInbound(raw);
+    } catch {
+      this.diagnose({
+        event: 'callbackFailed',
+        callback: 'validateInbound'
+      });
+      return;
+    }
+    if (!inbound) {
+      this.diagnose({ event: 'invalidInbound' });
+      return;
+    }
+    if (inbound.kind === 'message') {
+      try {
+        await this.options.onMessage(inbound.message);
+        if (!this.isCurrentGeneration(host, generation)) {
+          this.diagnose({ event: 'staleWorkIgnored' });
+          return;
+        }
+        this.diagnose({ event: 'messageForwarded' });
+      } catch {
+        if (!this.isCurrentGeneration(host, generation)) {
+          this.diagnose({ event: 'staleWorkIgnored' });
+          return;
+        }
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'message'
+        });
+      }
+      return;
+    }
+    const activeMountGeneration = this.activeMountGeneration;
+    if (
+      activeMountGeneration === undefined ||
+      (inbound.generation === undefined && activeMountGeneration > 1) ||
+      (inbound.generation !== undefined && inbound.generation !== activeMountGeneration)
+    ) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    if (this.readyState) {
+      this.diagnose({ event: 'readyDuplicate' });
+      return;
+    }
+    this.readyState = true;
+    this.readyTimer?.dispose();
+    this.readyTimer = undefined;
+    this.resetReplayRetryBudget();
+    this.markReplayNeeded();
+    this.diagnose({ event: 'ready' });
+    await this.replayLatest();
+    if (!this.isCurrentGeneration(host, generation) || !this.readyState) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    try {
+      await this.options.onReady?.();
+    } catch {
+      if (this.isCurrentGeneration(host, generation) && this.readyState) {
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'ready'
+        });
+      }
+    }
+  }
+
+  private async mount(host: THost, generation: number): Promise<void> {
+    try {
+      await this.options.mount(host, generation);
+    } catch {
+      if (this.isCurrentGeneration(host, generation)) {
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'mount'
+        });
+      }
+      return;
+    }
+    if (!this.isCurrentGeneration(host, generation)) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    this.activeMountGeneration = generation;
+    if (host.visible) {
+      this.startReadyTimer(host, generation);
+    }
+    this.diagnose({ event: 'mounted' });
+  }
+
+  private startReadyTimer(host: THost, generation: number): void {
+    this.readyTimer?.dispose();
+    this.readyTimer = this.clock.setTimeout(() => {
+      this.readyTimer = undefined;
+      if (!this.isCurrentGeneration(host, generation) || this.readyState) {
+        return;
+      }
+      void this.requestReadyTimeoutRecovery(host, generation);
+    }, WEBVIEW_SESSION_READY_TIMEOUT_MS);
+  }
+
+  private async requestReadyTimeoutRecovery(host: THost, generation: number): Promise<void> {
+    this.diagnose({ event: 'recoveryRequested' });
+    try {
+      await host.recoverAfterReadyTimeout(() => {
+        if (!this.isCurrentGeneration(host, generation) || this.readyState) {
+          this.diagnose({ event: 'staleWorkIgnored' });
+          return;
+        }
+        this.activeMountGeneration = undefined;
+        this.scheduleMount(host);
+      });
+    } catch {
+      if (this.isCurrentGeneration(host, generation)) {
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'timeoutRecovery'
+        });
+      }
+    }
+  }
+
+  private async replayLatest(): Promise<void> {
+    const host = this.host;
+    if (!host || !this.readyState || this.disposed) {
+      return;
+    }
+    const generation = this.generation;
+    const replayIntentVersion = this.replayIntentVersion;
+    this.diagnose({ event: 'replayStarted' });
+    let snapshot: readonly TOutbound[];
+    try {
+      snapshot = await this.options.getReplaySnapshot();
+    } catch {
+      if (!this.isCurrentGeneration(host, generation)) {
+        this.diagnose({ event: 'staleWorkIgnored' });
+        return;
+      }
+      this.markReplayNeeded();
+      this.diagnose({
+        event: 'callbackFailed',
+        callback: 'snapshot'
+      });
+      this.scheduleReplayRetry();
+      return;
+    }
+    if (!this.isCurrentGeneration(host, generation)) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    if (this.replayIntentVersion !== replayIntentVersion) {
+      this.markReplayNeeded();
+      this.diagnose({ event: 'replaySuperseded' });
+      this.scheduleReplayRetry();
+      return;
+    }
+    const outcomes = await Promise.all(
+      snapshot.map(async message => {
+        try {
+          return await host.webview.postMessage(message);
+        } catch {
+          return false;
+        }
+      })
+    );
+    if (!this.isCurrentGeneration(host, generation)) {
+      this.diagnose({ event: 'staleWorkIgnored' });
+      return;
+    }
+    const allAccepted = outcomes.every(Boolean);
+    if (allAccepted) {
+      if (this.replayIntentVersion !== replayIntentVersion) {
+        this.markReplayNeeded();
+        this.diagnose({ event: 'replaySuperseded' });
+        this.scheduleReplayRetry();
+        return;
+      }
+      this.needsReplay = false;
+      this.retryAttempts = 0;
+      this.retryExhaustionDiagnosed = false;
+      this.retryTimer?.dispose();
+      this.retryTimer = undefined;
+      this.diagnose({ event: 'replaySucceeded' });
+      try {
+        this.options.onReplaySucceeded?.();
+      } catch {
+        this.diagnose({
+          event: 'callbackFailed',
+          callback: 'replay'
+        });
+      }
+      return;
+    }
+    this.markReplayNeeded();
+    this.diagnose({ event: 'replayIncomplete' });
+    this.scheduleReplayRetry();
+  }
+
+  private scheduleReplayRetry(): void {
+    if (this.retryAttempts >= WEBVIEW_SESSION_MAX_RETRIES) {
+      if (!this.retryExhaustionDiagnosed) {
+        this.retryExhaustionDiagnosed = true;
+        this.diagnose({
+          event: 'retryExhausted',
+          attempt: this.retryAttempts
+        });
+      }
+      return;
+    }
+    if (this.retryTimer || this.disposed || !this.host?.visible || !this.readyState) {
+      return;
+    }
+    this.retryTimer = this.clock.setTimeout(() => {
+      this.retryTimer = undefined;
+      if (this.disposed || !this.host?.visible || !this.readyState || !this.needsReplay) {
+        return;
+      }
+      this.retryAttempts += 1;
+      this.diagnose({
+        event: 'retryAttempted',
+        attempt: this.retryAttempts
+      });
+      void this.replayLatest();
+    }, WEBVIEW_SESSION_RETRY_DELAY_MS);
+    this.diagnose({
+      event: 'retryScheduled',
+      attempt: this.retryAttempts + 1
+    });
+  }
+
+  private diagnose(
+    diagnostic: Omit<
+      WebviewSessionDiagnostic,
+      'generation' | 'ready' | 'visible' | 'contentMounted' | 'mountTimerActive' | 'readyTimerActive' | 'needsReplay'
+    >
+  ): void {
+    try {
+      this.options.onDiagnostic?.({
+        generation: this.generation,
+        ready: this.readyState,
+        ...(this.host ? { visible: this.host.visible } : {}),
+        contentMounted: this.activeMountGeneration !== undefined,
+        mountTimerActive: this.mountTimer !== undefined,
+        readyTimerActive: this.readyTimer !== undefined,
+        needsReplay: this.needsReplay,
+        ...diagnostic
+      });
+    } catch {
+      // Diagnostics must never affect session mechanics.
+    }
+  }
+
+  private markReplayNeeded(): void {
+    this.needsReplay = true;
+    this.advanceReplayIntentVersion();
+  }
+
+  private advanceReplayIntentVersion(): number {
+    this.replayIntentVersion += 1;
+    return this.replayIntentVersion;
+  }
+
+  private resetReplayRetryBudget(): void {
+    this.retryAttempts = 0;
+    this.retryExhaustionDiagnosed = false;
+    this.retryTimer?.dispose();
+    this.retryTimer = undefined;
+  }
+
+  private isCurrentGeneration(host: THost, generation: number): boolean {
+    return this.host === host && this.generation === generation && !this.disposed;
+  }
+}
+
+export function createWebviewSessionInternal<TOutbound, TInbound, THost extends WebviewSessionHost<TOutbound>>(
+  options: WebviewSessionOptions<TOutbound, TInbound, THost>,
+  clock: WebviewSessionClock
+): WebviewSession<TOutbound, THost> {
+  return new DefaultWebviewSession(options, clock);
+}

--- a/apps/vscode-extension/src/shared/diagnosticsPackage.ts
+++ b/apps/vscode-extension/src/shared/diagnosticsPackage.ts
@@ -48,17 +48,16 @@ export interface DiagnosticsPackage {
 export function formatDiagnosticsPackageMarkdown(pkg: DiagnosticsPackage): string {
   const providers = pkg.webview.providers
     .map(provider => {
-      const host = provider.hostKind ? `${provider.hostKind}, visible=${String(provider.visible)}` : 'unresolved';
-      return `- ${provider.surface}: ready=${provider.ready}, mounted=${provider.contentMounted}, host=${host}, mountSequence=${provider.mountSequence}`;
+      const host = provider.hasHost ? 'attached' : 'unresolved';
+      return `- ${provider.surface}: ready=${provider.ready}, mounted=${provider.contentMounted}, host=${host}, visible=${String(provider.visible)}, mountSequence=${provider.mountSequence}`;
     })
     .join('\n');
 
   const recentEvents = pkg.webview.events
     .slice(-20)
     .map(event => {
-      const host = event.hostKind ? ` ${event.hostKind}` : '';
       const sequence = event.mountSequence === undefined ? '' : ` #${event.mountSequence}`;
-      return `- ${event.timestamp} ${event.surface}${host}${sequence}: ${event.event}`;
+      return `- ${event.timestamp} ${event.surface}${sequence}: ${event.event}`;
     })
     .join('\n');
 

--- a/apps/vscode-extension/src/test/extension.activation.gating.test.ts
+++ b/apps/vscode-extension/src/test/extension.activation.gating.test.ts
@@ -213,7 +213,6 @@ function createExtensionHarness(options: {
         getDiagnosticState: () => ({
           surface: 'logs',
           hasHost: true,
-          hostKind: 'editor',
           ready: true,
           disposed: false,
           contentMounted: true,
@@ -468,7 +467,11 @@ suite('extension activation gating', () => {
     assert.ok(copied.includes('# Electivus Apex Logs Diagnostics'), 'should copy a markdown diagnostics package');
     assert.ok(copied.includes('```json'), 'should include machine-readable JSON');
     assert.ok(copied.includes('"logs"'), 'should include logs provider state');
-    assert.ok(copied.includes('"hostKind": "editor"'), 'should include active editor panel provider state');
+    assert.ok(
+      copied.includes('- logs: ready=true, mounted=true, host=attached, visible=undefined, mountSequence=7'),
+      'should include active editor panel provider state without a legacy host discriminator'
+    );
+    assert.ok(!copied.includes('"hostKind"'), 'should not emit the removed host discriminator');
     assert.ok(copied.includes('sample warn'), 'should include recent extension output entries');
   });
 });

--- a/apps/vscode-extension/src/test/logsEditorPanel.test.ts
+++ b/apps/vscode-extension/src/test/logsEditorPanel.test.ts
@@ -20,6 +20,9 @@ function createPanel() {
     reveal() {
       this.revealCount += 1;
     },
+    dispose() {
+      onDispose?.();
+    },
     onDidDispose(listener: () => void) {
       onDispose = listener;
       return createDisposable();
@@ -43,6 +46,7 @@ suite('LogsEditorPanel', () => {
       selectedOrgs: Array<string | undefined> = [];
       syncedOrgs: Array<string | undefined> = [];
       resolvedPanels: any[] = [];
+      recoveryCallbacks: Array<() => void | Promise<void>> = [];
 
       constructor(_context: any) {
         createdProviders.push(this);
@@ -56,12 +60,9 @@ suite('LogsEditorPanel', () => {
         this.syncedOrgs.push(org);
       }
 
-      onDidReadyTimeout(): { dispose(): void } {
-        return createDisposable();
-      }
-
-      resolveWebviewPanel(nextPanel: any): void {
+      resolveWebviewPanel(nextPanel: any, recover: () => void | Promise<void>): void {
         this.resolvedPanels.push(nextPanel);
+        this.recoveryCallbacks.push(recover);
       }
 
       dispose(): void {}
@@ -107,6 +108,62 @@ suite('LogsEditorPanel', () => {
     assert.equal(panelOptions[0]?.retainContextWhenHidden, true, 'logs editor should retain context while hidden');
   });
 
+  test('replaces a timed-out editor through the bound host recovery capability', async () => {
+    const createdProviders: any[] = [];
+    const panels = [createPanel(), createPanel()];
+    let panelIndex = 0;
+
+    class FakeLogsProvider {
+      resolvedPanels: any[] = [];
+      recoveryCallbacks: Array<() => void | Promise<void>> = [];
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(_org?: string): void {}
+
+      resolveWebviewPanel(nextPanel: any, recover: () => void | Promise<void>): void {
+        this.resolvedPanels.push(nextPanel);
+        this.recoveryCallbacks.push(recover);
+      }
+
+      dispose(): void {}
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panels[panelIndex++]
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { LogsEditorPanel } = proxyquireStrict('../panel/LogsEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogsViewProvider': { SfLogsViewProvider: FakeLogsProvider },
+      '../host/utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    LogsEditorPanel.initialize(context as any);
+    await LogsEditorPanel.show();
+    await createdProviders[0]?.recoveryCallbacks[0]?.();
+
+    assert.deepEqual(createdProviders[0]?.resolvedPanels, panels);
+    assert.equal(panelIndex, 2, 'ready timeout should create one replacement panel');
+  });
+
   test('clears the singleton after dispose so a new editor panel can be created', async () => {
     const createdProviders: any[] = [];
     const panels = [createPanel(), createPanel()];
@@ -121,11 +178,7 @@ suite('LogsEditorPanel', () => {
 
       setSelectedOrg(_org?: string): void {}
 
-      onDidReadyTimeout(): { dispose(): void } {
-        return createDisposable();
-      }
-
-      resolveWebviewPanel(_panel: any): void {}
+      resolveWebviewPanel(_panel: any, _recover: () => void | Promise<void>): void {}
 
       dispose(): void {
         this.disposeCount += 1;

--- a/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
+++ b/apps/vscode-extension/src/test/provider.logs.behavior.test.ts
@@ -4,6 +4,7 @@ import * as path from 'path';
 import * as fs from 'fs/promises';
 import * as os from 'node:os';
 import proxyquire from 'proxyquire';
+import { TestClock } from './testClock';
 
 const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
 const makeUri = (filePath: string) => ({ fsPath: filePath, path: filePath, toString: () => filePath });
@@ -15,6 +16,55 @@ function makeContext() {
     subscriptions: [] as Array<{ dispose?: () => void }>
   } as unknown as vscode.ExtensionContext;
   return context;
+}
+
+async function connectProvider(
+  provider: {
+    resolveWebviewView(view: vscode.WebviewView): void | Thenable<void>;
+    sendOrgs(forceRefresh?: boolean): Promise<void>;
+    refresh(): Promise<void>;
+  },
+  posted: any[] = []
+): Promise<void> {
+  const clock = new TestClock();
+  let messageListener: ((message: unknown) => void) | undefined;
+  const webview = {
+    html: '',
+    options: {},
+    postMessage: (message: unknown) => {
+      posted.push(message);
+      return Promise.resolve(true);
+    },
+    onDidReceiveMessage: (listener: (message: unknown) => void) => {
+      messageListener = listener;
+      return makeDisposable();
+    }
+  };
+  const view = {
+    visible: true,
+    webview,
+    onDidDispose: () => makeDisposable(),
+    onDidChangeVisibility: () => makeDisposable()
+  } as unknown as vscode.WebviewView;
+  const originalSendOrgs = provider.sendOrgs;
+  const originalRefresh = provider.refresh;
+  provider.sendOrgs = async () => undefined;
+  provider.refresh = async () => undefined;
+  try {
+    await provider.resolveWebviewView(view);
+    await clock.advanceBy(1000);
+    const generation = Number(webview.html.match(/content="(\d+)"/)?.[1]);
+    assert.ok(Number.isInteger(generation), 'public webview mount should expose a readiness generation');
+    messageListener?.({ type: 'ready', mountSequence: generation });
+    for (let turn = 0; turn < 10; turn += 1) {
+      await Promise.resolve();
+    }
+  } finally {
+    provider.sendOrgs = originalSendOrgs;
+    provider.refresh = originalRefresh;
+    posted.length = 0;
+    clock.dispose();
+  }
 }
 
 async function waitForCondition(
@@ -187,7 +237,13 @@ function createProviderHarness() {
       '@noCallThru': true
     },
     '../host/utils/webviewHtml': {
-      buildWebviewHtml: () => '<html></html>',
+      buildWebviewHtml: (
+        _webview: unknown,
+        _extensionUri: unknown,
+        _script: unknown,
+        _title: unknown,
+        options?: { mountSequence?: number }
+      ) => `<html><meta content="${options?.mountSequence ?? ''}"></html>`,
       '@noCallThru': true
     },
     '../host/utils/ripgrep': ripgrepStub,
@@ -222,6 +278,29 @@ function createProviderHarness() {
 }
 
 suite('SfLogsViewProvider behavior', () => {
+  test('preserves active refresh and search work across host replacement', () => {
+    const { SfLogsViewProvider } = createProviderHarness();
+    const provider = new SfLogsViewProvider(makeContext()) as any;
+    const searchController = new AbortController();
+    provider.refreshToken = 7;
+    provider.activeRefreshToken = 7;
+    provider.searchAbortController = searchController;
+
+    provider.handleSessionDetach('rebind');
+
+    assert.equal(provider.refreshToken, 7);
+    assert.equal(provider.activeRefreshToken, 7);
+    assert.equal(provider.searchAbortController, searchController);
+    assert.equal(searchController.signal.aborted, false);
+
+    provider.handleSessionDetach('hostDisposed');
+
+    assert.equal(provider.refreshToken, 8);
+    assert.equal(provider.activeRefreshToken, undefined);
+    assert.equal(provider.searchAbortController, undefined);
+    assert.equal(searchController.signal.aborted, true);
+  });
+
   test('refresh handles deferred auth rejection when logs listing fails', async () => {
     const { SfLogsViewProvider, cli } = createProviderHarness();
     let rejectAuth: ((error: Error) => void) | undefined;
@@ -236,14 +315,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     let unhandled: unknown;
     const onUnhandled = (error: unknown) => {
@@ -275,11 +347,7 @@ suite('SfLogsViewProvider behavior', () => {
 
     const context = makeContext();
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
+    await connectProvider(provider);
 
     await provider.refresh();
 
@@ -302,14 +370,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     let unhandled: unknown;
     const onUnhandled = (error: unknown) => {
@@ -341,15 +402,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
-    // Inject minimal view so refresh proceeds
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -374,11 +427,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
+    await connectProvider(provider);
 
     const syncCalls: Array<{ params: any; signal?: AbortSignal }> = [];
     cli.logsSync = async (params: any, signal?: AbortSignal) => {
@@ -453,11 +502,7 @@ suite('SfLogsViewProvider behavior', () => {
     (provider as any).executeSearch = async (query: string) => {
       searchCalls.push(query);
     };
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
+    await connectProvider(provider);
 
     await provider.refresh();
     await waitForCondition(() => syncCalls.length === 1 && triageCalls.length === 1 && searchCalls.length >= 2);
@@ -501,11 +546,7 @@ suite('SfLogsViewProvider behavior', () => {
 
     const context = makeContext();
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
+    await connectProvider(provider);
 
     await provider.refresh();
     await waitForCondition(() => syncCalls.length === 1);
@@ -544,11 +585,7 @@ suite('SfLogsViewProvider behavior', () => {
 
     const context = makeContext();
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: () => Promise.resolve(true)
-      }
-    } as any;
+    await connectProvider(provider);
 
     await provider.refresh();
     await waitForCondition(() => syncCalls.length === 1);
@@ -614,14 +651,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => false;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await waitForCondition(() => triageCalls.length === 1);
@@ -670,14 +700,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await waitForCondition(() => triageCalls.length === 1);
@@ -698,14 +721,7 @@ suite('SfLogsViewProvider behavior', () => {
     (provider as any).configManager.shouldLoadFullLogBodies = () => false;
 
     const posted: any[] = [];
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     let syncSignal: AbortSignal | undefined;
     let syncStarted!: () => void;
@@ -771,14 +787,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => false;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     const refreshPromise = provider.refresh();
     await new Promise(resolve => setTimeout(resolve, 20));
@@ -822,14 +831,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => false;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await new Promise(resolve => setTimeout(resolve, 20));
@@ -861,14 +863,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     const ensureCalls: any[] = [];
     const localLogPath = path.join(tmpDir, '07L000000000001AA.log');
@@ -965,14 +960,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     (provider as any).logService.ensureLogsSaved = async () => ({
       total: 1,
@@ -1023,14 +1011,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     (provider as any).logService.ensureLogsSaved = async (
       logs: any[],
@@ -1085,14 +1066,7 @@ suite('SfLogsViewProvider behavior', () => {
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
     (provider as any).configManager.shouldLoadFullLogBodies = () => true;
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await new Promise(r => setTimeout(r, 20));
@@ -1159,14 +1133,7 @@ suite('SfLogsViewProvider behavior', () => {
     const context = makeContext();
     const posted: any[] = [];
     const provider = new SfLogsViewProvider(context);
-    (provider as any).view = {
-      webview: {
-        postMessage: (m: any) => {
-          posted.push(m);
-          return Promise.resolve(true);
-        }
-      }
-    } as any;
+    await connectProvider(provider, posted);
 
     await provider.refresh();
     await new Promise(r => setTimeout(r, 10));

--- a/apps/vscode-extension/src/test/provider.webview.test.ts
+++ b/apps/vscode-extension/src/test/provider.webview.test.ts
@@ -1,12 +1,8 @@
 import assert from 'assert/strict';
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { createWebviewPanelHost } from '../provider/webviewHost';
-import {
-  SfLogsViewProvider,
-  WEBVIEW_READY_TIMEOUT_MS,
-  WEBVIEW_STABLE_VISIBILITY_DELAY_MS
-} from '../provider/SfLogsViewProvider';
+import { SfLogsViewProvider } from '../provider/SfLogsViewProvider';
+import { WEBVIEW_SESSION_MOUNT_DELAY_MS } from '../provider/webviewSession';
 import { TestClock } from './testClock';
 
 class MockDisposable implements vscode.Disposable {
@@ -20,7 +16,7 @@ class MockWebview implements vscode.Webview {
   readonly htmlAssignments: string[] = [];
   options: vscode.WebviewOptions = {};
   cspSource = 'vscode-resource://test';
-  private messageHandler: ((e: any) => void) | undefined;
+  private messageHandler: ((e: any) => void | Promise<void>) | undefined;
   get html(): string {
     return this._html;
   }
@@ -34,13 +30,13 @@ class MockWebview implements vscode.Webview {
   postMessage(_message: any): Thenable<boolean> {
     return Promise.resolve(true);
   }
-  onDidReceiveMessage(listener: (e: any) => any): vscode.Disposable {
+  onDidReceiveMessage(listener: (e: any) => void | Promise<void>): vscode.Disposable {
     this.messageHandler = listener;
     return new MockDisposable();
   }
   // helper for tests (not part of interface)
-  emit(message: any) {
-    this.messageHandler?.(message);
+  async emit(message: any): Promise<void> {
+    await this.messageHandler?.(message);
   }
 }
 
@@ -118,11 +114,17 @@ class MockWebviewPanel implements vscode.WebviewPanel {
   }
 }
 
-async function remountLogsSidebar(
-  provider: SfLogsViewProvider,
-  clock: TestClock,
-  posted: any[]
-): Promise<MockWebview> {
+function getMountSequence(webview: MockWebview): number {
+  const match = webview.html.match(/<meta name="alv-mount-sequence" content="(\d+)">/);
+  assert.ok(match, 'mounted webview html should expose its readiness generation');
+  return Number(match[1]);
+}
+
+function postReplayable(provider: SfLogsViewProvider, message: any): void {
+  (provider as any).post(message, 'replayable');
+}
+
+async function remountLogsSidebar(provider: SfLogsViewProvider, clock: TestClock, posted: any[]): Promise<MockWebview> {
   const webview = new MockWebview();
   webview.postMessage = (message: any) => {
     posted.push(message);
@@ -130,25 +132,14 @@ async function remountLogsSidebar(
   };
   const view = new MockWebviewView(webview);
   await provider.resolveWebviewView(view);
-  await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-  await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+  await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+  await webview.emit({ type: 'ready', mountSequence: getMountSequence(webview) });
   await clock.flushMicrotasks();
   return webview;
 }
 
 suite('SfLogsViewProvider webview', () => {
-  test('uses corporate-friendly webview bootstrap timing windows', () => {
-    assert.ok(
-      WEBVIEW_STABLE_VISIBILITY_DELAY_MS >= 1000,
-      'visibility should be stable for at least 1s before mounting webview content'
-    );
-    assert.ok(
-      WEBVIEW_READY_TIMEOUT_MS >= 30000,
-      'webview ready watchdog should allow at least 30s for slow corporate machines'
-    );
-  });
-
-  test('mounts the logs view after visibility stabilizes', async () => {
+  test('mounts Logs presentation with scripts, CSP, and the bundled webview entrypoint', async () => {
     const clock = new TestClock();
     try {
       const context = {
@@ -163,8 +154,7 @@ suite('SfLogsViewProvider webview', () => {
       await provider.resolveWebviewView(view);
 
       assert.equal(webview.options.enableScripts, true, 'enableScripts should be set');
-      assert.ok(!webview.html.includes('Content-Security-Policy'), 'real html should not mount immediately');
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       assert.ok(webview.html.includes('Content-Security-Policy'), 'CSP meta should be present after delayed mount');
       assert.ok(webview.html.includes('media/main.js'), 'bundled webview script should be referenced');
     } finally {
@@ -181,7 +171,7 @@ suite('SfLogsViewProvider webview', () => {
     await provider.refresh(); // should not throw or attempt CLI/network without a view
   });
 
-  test('mounts editor html after visibility stabilizes', async () => {
+  test('mounts Logs editor presentation with scripts, CSP, and the bundled webview entrypoint', async () => {
     const clock = new TestClock();
     try {
       const context = {
@@ -196,297 +186,9 @@ suite('SfLogsViewProvider webview', () => {
       provider.resolveWebviewPanel(panel);
 
       assert.equal(webview.options.enableScripts, true, 'enableScripts should be set for editor panel');
-      assert.ok(
-        !webview.html.includes('Content-Security-Policy'),
-        'real html should not mount immediately for editor panel'
-      );
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       assert.ok(webview.html.includes('Content-Security-Policy'), 'CSP meta should be present');
       assert.ok(webview.html.includes('media/main.js'), 'bundled webview script should be referenced');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('editor visibility callbacks fire only on actual visibility transitions', () => {
-    const panel = new MockWebviewPanel('electivus.apexLogViewer.logsView.editorPanel', new MockWebview());
-    const host = createWebviewPanelHost(panel);
-    const transitions: boolean[] = [];
-    let becameVisibleCount = 0;
-
-    host.onDidChangeVisibility(visible => {
-      transitions.push(visible);
-    });
-    host.onDidBecomeVisible(() => {
-      becameVisibleCount += 1;
-    });
-
-    panel.fireVisible(true);
-    panel.fireVisible(false);
-    panel.fireVisible(false);
-    panel.fireVisible(true);
-    panel.fireVisible(true);
-
-    assert.deepEqual(transitions, [false, true]);
-    assert.equal(becameVisibleCount, 1);
-  });
-
-  test('retries timed-out sidebar mounts while the view stays visible', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      assert.ok(webview.html.includes('Content-Security-Policy'), 'initial mount should render real html');
-
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS);
-      assert.ok(!webview.html.includes('Content-Security-Policy'), 'timeout should fall back to placeholder html');
-
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      assert.ok(webview.html.includes('Content-Security-Policy'), 'visible sidebar should auto-remount after timeout');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('accepts delayed logs ready messages from slow corporate webview startup', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).sendOrgs = async () => {
-        calls.push('sendOrgs');
-      };
-      (provider as any).refresh = async () => {
-        calls.push('refresh');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountSequence = (provider as any).mountSequence;
-      assert.ok(webview.html.includes('Content-Security-Policy'), 'initial mount should render real html');
-
-      await clock.advanceBy(20_000);
-      assert.ok(
-        webview.html.includes('Content-Security-Policy'),
-        'slow startup should not be replaced with placeholder before the ready timeout'
-      );
-
-      webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      assert.deepEqual(calls, ['sendOrgs', 'refresh']);
-      assert.equal(provider.isReady(), true, 'delayed ready should mark the provider ready');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('keeps a ready retained sidebar webview mounted across hide and show', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-
-      (provider as any).sendOrgs = async () => undefined;
-      (provider as any).refresh = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountedHtml = webview.html;
-      const mountedAssignments = webview.htmlAssignments.length;
-      const mountSequence = (provider as any).mountSequence;
-
-      await webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      view.fireVisible(false);
-      assert.equal(webview.html, mountedHtml, 'hiding a retained ready webview should not replace html');
-      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hide should not write placeholder html');
-      assert.equal(provider.isReady(), true, 'ready retained webview should stay ready while hidden');
-
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'showing a retained ready webview should not remount html');
-      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'show should not write a new html document');
-      assert.equal((provider as any).mountSequence, mountSequence, 'show should keep the same mount sequence');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('requeues retained sidebar replay when visible postMessage is dropped', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).sendOrgs = async () => undefined;
-      (provider as any).refresh = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      view.fireVisible(false);
-      (provider as any).post({
-        type: 'logs',
-        data: [{ Id: '07Lxx0000000001', StartTime: '2026-04-29T16:00:00.000Z', Status: 'Success' }],
-        hasMore: false
-      });
-      await clock.flushMicrotasks();
-
-      assert.equal((provider as any).needsReplayOnVisible, true, 'hidden update should request replay on show');
-
-      posted.length = 0;
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(false);
-      };
-      view.fireVisible(true);
-      await clock.flushMicrotasks();
-
-      assert.ok(posted.some(message => message?.type === 'init'), 'visible transition should attempt init replay');
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'dropped visible replay should stay requested until a retry delivers it'
-      );
-
-      posted.length = 0;
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-      await clock.advanceBy(1000);
-
-      assert.equal((provider as any).needsReplayOnVisible, false, 'successful retry should clear replay request');
-      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend init');
-      assert.ok(posted.some(message => message?.type === 'logs'), 'visible retry should resend logs');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('keeps an initializing retained sidebar webview mounted while hidden', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).sendOrgs = async () => {
-        calls.push('sendOrgs');
-      };
-      (provider as any).refresh = async () => {
-        calls.push('refresh');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountedHtml = webview.html;
-      const mountedAssignments = webview.htmlAssignments.length;
-      const mountSequence = (provider as any).mountSequence;
-
-      view.fireVisible(false);
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS + WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'hidden initializing retained webview should not fall back to placeholder');
-      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hidden initializing webview should not remount');
-
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'visible restore should reuse the initializing document');
-      assert.equal((provider as any).mountSequence, mountSequence, 'visible restore should not allocate a new mount');
-
-      await webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      assert.deepEqual(calls, ['sendOrgs', 'refresh']);
-      assert.equal(provider.isReady(), true);
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('ignores stale ready events from a previous logs mount after timeout remounts', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).sendOrgs = async () => {
-        calls.push('sendOrgs');
-      };
-      (provider as any).refresh = async () => {
-        calls.push('refresh');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      await webview.emit({ type: 'ready', mountSequence: 1 });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, [], 'stale ready should not bootstrap the remounted logs view');
-
-      await webview.emit({ type: 'ready' });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, [], 'unsequenced stale ready should not bootstrap the remounted logs view');
-
-      await webview.emit({ type: 'ready', mountSequence: 2 });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, ['sendOrgs', 'refresh']);
     } finally {
       clock.dispose();
     }
@@ -513,11 +215,69 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       assert.deepEqual(calls, ['sendOrgs', 'refresh']);
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('routes each validated logs interaction once and rejects malformed input', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      const calls: string[] = [];
+      (provider as any).sendOrgs = async () => undefined;
+      (provider as any).refresh = async () => {
+        calls.push('refresh');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: getMountSequence(webview) });
+      calls.length = 0;
+
+      await webview.emit({ type: 'refresh' });
+      await webview.emit({ type: 'selectOrg', target: 42 });
+
+      assert.deepEqual(calls, ['refresh']);
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('keeps logs ready when a bootstrap workflow reports its own failure', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogsViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      let bootstrapAttempts = 0;
+      (provider as any).sendOrgs = async () => {
+        bootstrapAttempts += 1;
+        throw new Error('logs-owned bootstrap failure');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      const mountSequence = getMountSequence(webview);
+      await webview.emit({ type: 'ready', mountSequence });
+
+      assert.equal(provider.isReady(), true);
+      assert.equal(bootstrapAttempts, 1);
     } finally {
       clock.dispose();
     }
@@ -542,12 +302,12 @@ suite('SfLogsViewProvider webview', () => {
 
       (provider as any).sendOrgs = async () => {
         posted.push({ type: 'sendOrgsCalled' });
-        (provider as any).post({ type: 'orgs', data: [], selected: 'test@example.com' });
+        postReplayable(provider, { type: 'orgs', data: [], selected: 'test@example.com' });
       };
       (provider as any).refresh = async () => {
         posted.push({ type: 'refreshCalled' });
         (provider as any).setCurrentLogs([{ Id: '07L000000000001', StartTime: '2024-01-01T00:00:00.000Z' }]);
-        (provider as any).post({
+        postReplayable(provider, {
           type: 'logs',
           data: [{ Id: '07L000000000001', StartTime: '2024-01-01T00:00:00.000Z' }],
           hasMore: false
@@ -555,8 +315,8 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
       posted.length = 0;
 
@@ -587,9 +347,9 @@ suite('SfLogsViewProvider webview', () => {
       const provider = new SfLogsViewProvider(context);
       const cachedLogs = [{ Id: '07L000000000001AA', StartTime: '2026-04-19T00:00:00.000Z' }] as any[];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: 'cached@example.com' });
+      postReplayable(provider, { type: 'orgs', data: [], selected: 'cached@example.com' });
       (provider as any).setCurrentLogs(cachedLogs);
-      (provider as any).post({ type: 'logs', data: cachedLogs, hasMore: false });
+      postReplayable(provider, { type: 'logs', data: cachedLogs, hasMore: false });
 
       await provider.refresh();
 
@@ -606,8 +366,8 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       assert.deepEqual(calls, ['refresh']);
@@ -632,9 +392,9 @@ suite('SfLogsViewProvider webview', () => {
       const provider = new SfLogsViewProvider(context);
       const cachedLogs = [{ Id: '07L000000000002AA', StartTime: '2026-04-19T00:01:00.000Z' }] as any[];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: 'cached@example.com' });
+      postReplayable(provider, { type: 'orgs', data: [], selected: 'cached@example.com' });
       (provider as any).setCurrentLogs(cachedLogs);
-      (provider as any).post({ type: 'logs', data: cachedLogs, hasMore: false });
+      postReplayable(provider, { type: 'logs', data: cachedLogs, hasMore: false });
       provider.setSelectedOrg('switched@example.com');
 
       const webview = new MockWebview();
@@ -650,8 +410,8 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       assert.deepEqual(calls, ['refresh']);
@@ -678,12 +438,12 @@ suite('SfLogsViewProvider webview', () => {
       const view = new MockWebviewView(webview);
       const calls: string[] = [];
 
-      (provider as any).post({
+      postReplayable(provider, {
         type: 'orgs',
         data: [{ username: 'first@example.com', alias: 'First', isDefaultUsername: true }],
         selected: 'first@example.com'
       });
-      (provider as any).post({
+      postReplayable(provider, {
         type: 'logs',
         data: [],
         hasMore: false
@@ -691,7 +451,7 @@ suite('SfLogsViewProvider webview', () => {
       (provider as any).orgsBootstrapNeedsRefresh = true;
       (provider as any).sendOrgs = async () => {
         calls.push('sendOrgs');
-        (provider as any).post({
+        postReplayable(provider, {
           type: 'orgs',
           data: [{ username: 'second@example.com', alias: 'Second', isDefaultUsername: true }],
           selected: 'second@example.com'
@@ -702,7 +462,7 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
@@ -756,7 +516,7 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       (provider as any).sendOrgs = async () => {
-        (provider as any).post({
+        postReplayable(provider, {
           type: 'orgs',
           data: [],
           selected: 'first@example.com'
@@ -765,8 +525,8 @@ suite('SfLogsViewProvider webview', () => {
       (provider as any).refresh = async () => {};
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       provider.setSelectedOrg('second@example.com');
@@ -794,7 +554,7 @@ suite('SfLogsViewProvider webview', () => {
       const panel = new MockWebviewPanel('electivus.apexLogViewer.logsView.editorPanel', webview);
       const calls: string[] = [];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: 'test@example.com' });
+      postReplayable(provider, { type: 'orgs', data: [], selected: 'test@example.com' });
       (provider as any).activeRefreshToken = 123;
       (provider as any).loadingState = true;
       (provider as any).refresh = async () => {
@@ -802,8 +562,8 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       assert.deepEqual(calls, []);
@@ -830,11 +590,11 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
-      (provider as any).post({ type: 'error', message: 'load failed' });
+      postReplayable(provider, { type: 'error', message: 'load failed' });
       posted.length = 0;
 
       await remountLogsSidebar(provider, clock, posted);
@@ -845,14 +605,15 @@ suite('SfLogsViewProvider webview', () => {
       );
 
       (provider as any).setCurrentLogs([]);
-      (provider as any).post({ type: 'logs', data: [], hasMore: false });
+      postReplayable(provider, { type: 'logs', data: [], hasMore: false });
       posted.length = 0;
 
       await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
-        posted.some(message => message?.type === 'error'),
-        false
+        posted.some(message => message?.type === 'error' && message?.message !== undefined),
+        false,
+        'the replacement may receive an explicit clear but must not replay the stale Logs error'
       );
     } finally {
       clock.dispose();
@@ -877,13 +638,13 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       (provider as any).setCurrentLogs([]);
-      (provider as any).post({ type: 'logs', data: [], hasMore: false });
-      (provider as any).post({ type: 'error', message: 'refresh failed' });
+      postReplayable(provider, { type: 'logs', data: [], hasMore: false });
+      postReplayable(provider, { type: 'error', message: 'refresh failed' });
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         posted.length = 0;
@@ -895,14 +656,15 @@ suite('SfLogsViewProvider webview', () => {
         );
       }
 
-      (provider as any).post({ type: 'logs', data: [], hasMore: false });
+      postReplayable(provider, { type: 'logs', data: [], hasMore: false });
       posted.length = 0;
 
       await remountLogsSidebar(provider, clock, posted);
 
       assert.equal(
-        posted.some(message => message?.type === 'error'),
-        false
+        posted.some(message => message?.type === 'error' && message?.message !== undefined),
+        false,
+        'the replacement may receive an explicit clear but must not replay the stale refresh error'
       );
     } finally {
       clock.dispose();
@@ -927,17 +689,17 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       const logs = [{ Id: '07L000000000003AA', StartTime: '2026-04-19T00:02:00.000Z' }] as any[];
       (provider as any).setCurrentLogs(logs);
-      (provider as any).post({ type: 'logs', data: logs, hasMore: true });
-      (provider as any).post({ type: 'error', message: 'load more failed' });
+      postReplayable(provider, { type: 'logs', data: logs, hasMore: true });
+      postReplayable(provider, { type: 'error', message: 'load more failed' });
       posted.length = 0;
 
-      (provider as any).post({
+      postReplayable(provider, {
         type: 'appendLogs',
         data: [{ Id: '07L000000000004AA', StartTime: '2026-04-19T00:03:00.000Z' }],
         hasMore: false
@@ -952,8 +714,8 @@ suite('SfLogsViewProvider webview', () => {
       posted.length = 0;
       view.fireVisible(false);
       view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: getMountSequence(webview) });
       await clock.flushMicrotasks();
 
       assert.equal(
@@ -991,15 +753,15 @@ suite('SfLogsViewProvider webview', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: getMountSequence(webview) });
       await clock.flushMicrotasks();
 
-      (provider as any).post({ type: 'error', message: 'load more failed' });
+      postReplayable(provider, { type: 'error', message: 'load more failed' });
       posted.length = 0;
 
       view.fireVisible(false);
-      (provider as any).post({
+      postReplayable(provider, {
         type: 'appendLogs',
         data: [{ Id: '07L000000000005AA', StartTime: '2026-04-19T00:04:00.000Z' }],
         hasMore: false
@@ -1032,223 +794,6 @@ suite('SfLogsViewProvider webview', () => {
     }
   });
 
-  test('retries a dropped visible logs error clear', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropVisibleClear = false;
-      webview.postMessage = (message: any) => {
-        if (dropVisibleClear && message?.type === 'error' && message?.message === undefined) {
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      (provider as any).post({ type: 'error', message: 'load more failed' });
-      posted.length = 0;
-
-      dropVisibleClear = true;
-      (provider as any).post({
-        type: 'appendLogs',
-        data: [{ Id: '07L000000000006AA', StartTime: '2026-04-19T00:05:00.000Z' }],
-        hasMore: false
-      });
-      await clock.flushMicrotasks();
-
-      assert.equal(
-        posted.some(message => message?.type === 'error' && message?.message === undefined),
-        false,
-        'dropped visible clear should not be treated as delivered'
-      );
-
-      dropVisibleClear = false;
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        posted.some(message => message?.type === 'error' && message?.message === undefined),
-        true,
-        'visible retry should resend a dropped logs error clear'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('retries retained replay after a dropped visible appendLogs update', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropNextAppendLogs = false;
-      webview.postMessage = (message: any) => {
-        if (dropNextAppendLogs && message?.type === 'appendLogs') {
-          dropNextAppendLogs = false;
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      const logs = [{ Id: '07L000000000007AA', StartTime: '2026-04-19T00:06:00.000Z' }] as any[];
-      posted.length = 0;
-      dropNextAppendLogs = true;
-      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
-      (provider as any).setCurrentLogs(logs);
-      await clock.flushMicrotasks();
-
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'dropped visible appendLogs should request a retained replay'
-      );
-
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal((provider as any).needsReplayOnVisible, false, 'successful logs retry should clear replay request');
-      assert.ok(posted.some(message => message?.type === 'init'), 'visible retry should resend logs init');
-      assert.ok(
-        posted.some(message => message?.type === 'logs' && message?.data?.[0]?.Id === logs[0].Id),
-        'visible retry should replay the latest retained logs snapshot'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('resets visible replay retry budget after a successful logs retry', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropNextAppendLogs = false;
-      webview.postMessage = (message: any) => {
-        if (dropNextAppendLogs && message?.type === 'appendLogs') {
-          dropNextAppendLogs = false;
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      const logs = [{ Id: '07L000000000008AA', StartTime: '2026-04-19T00:07:00.000Z' }] as any[];
-      dropNextAppendLogs = true;
-      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
-      (provider as any).setCurrentLogs(logs);
-      await clock.flushMicrotasks();
-
-      assert.equal((provider as any).visibleReplayRetryAttempts, 1, 'dropped logs update should consume retry budget');
-
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        (provider as any).visibleReplayRetryAttempts,
-        0,
-        'successful logs replay retry should reset the retry budget'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('stops retrying visible logs replay after the retry budget is exhausted', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-
-      const provider = new SfLogsViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      let dropAppendThenAllReplay = false;
-      let dropAllReplay = false;
-      webview.postMessage = (message: any) => {
-        if (dropAppendThenAllReplay && message?.type === 'appendLogs') {
-          dropAppendThenAllReplay = false;
-          dropAllReplay = true;
-          return Promise.resolve(false);
-        }
-        if (dropAllReplay) {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      const logs = [{ Id: '07L000000000009AA', StartTime: '2026-04-19T00:08:00.000Z' }] as any[];
-      dropAppendThenAllReplay = true;
-      (provider as any).post({ type: 'appendLogs', data: logs, hasMore: false });
-      (provider as any).setCurrentLogs(logs);
-      await clock.flushMicrotasks();
-
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        (provider as any).visibleReplayRetryAttempts,
-        3,
-        'failed logs replay retries should consume the configured retry budget'
-      );
-      assert.equal(
-        (provider as any).visibleReplayRetryTimer,
-        undefined,
-        'logs replay should stop scheduling immediate retries after the budget is exhausted'
-      );
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'logs replay should remain pending for a future hide/show after immediate retries are exhausted'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
   test('retries org bootstrap after a failed org snapshot on remount', async () => {
     const clock = new TestClock();
     try {
@@ -1262,17 +807,17 @@ suite('SfLogsViewProvider webview', () => {
       const panel = new MockWebviewPanel('electivus.apexLogViewer.logsView.editorPanel', webview);
       const calls: string[] = [];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: undefined });
+      postReplayable(provider, { type: 'orgs', data: [], selected: undefined });
       (provider as any).setCurrentLogs([]);
-      (provider as any).post({ type: 'logs', data: [], hasMore: false });
+      postReplayable(provider, { type: 'logs', data: [], hasMore: false });
       (provider as any).orgsBootstrapNeedsRefresh = true;
       (provider as any).sendOrgs = async () => {
         calls.push('sendOrgs');
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      webview.emit({ type: 'ready' });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       assert.deepEqual(calls, ['sendOrgs']);

--- a/apps/vscode-extension/src/test/tailEditorPanel.test.ts
+++ b/apps/vscode-extension/src/test/tailEditorPanel.test.ts
@@ -20,6 +20,9 @@ function createPanel() {
     reveal() {
       this.revealCount += 1;
     },
+    dispose() {
+      onDispose?.();
+    },
     onDidDispose(listener: () => void) {
       onDispose = listener;
       return createDisposable();
@@ -56,11 +59,7 @@ suite('TailEditorPanel', () => {
         this.syncedOrgs.push(org);
       }
 
-      onDidReadyTimeout(): { dispose(): void } {
-        return createDisposable();
-      }
-
-      resolveWebviewPanel(nextPanel: any): void {
+      resolveWebviewPanel(nextPanel: any, _recover: () => void | Promise<void>): void {
         this.resolvedPanels.push(nextPanel);
       }
 
@@ -107,6 +106,62 @@ suite('TailEditorPanel', () => {
     assert.equal(panelOptions[0]?.retainContextWhenHidden, true, 'tail editor should retain context while hidden');
   });
 
+  test('replaces a timed-out editor through the bound host recovery capability', async () => {
+    const createdProviders: any[] = [];
+    const panels = [createPanel(), createPanel()];
+    let panelIndex = 0;
+
+    class FakeTailProvider {
+      resolvedPanels: any[] = [];
+      recoveryCallbacks: Array<() => void | Promise<void>> = [];
+
+      constructor(_context: any) {
+        createdProviders.push(this);
+      }
+
+      setSelectedOrg(_org?: string): void {}
+
+      resolveWebviewPanel(nextPanel: any, recover: () => void | Promise<void>): void {
+        this.resolvedPanels.push(nextPanel);
+        this.recoveryCallbacks.push(recover);
+      }
+
+      dispose(): void {}
+    }
+
+    const vscodeStub = {
+      window: {
+        createWebviewPanel: () => panels[panelIndex++]
+      },
+      ViewColumn: {
+        Active: 1
+      },
+      Uri: {
+        joinPath: (...parts: any[]) => parts
+      }
+    };
+
+    const { TailEditorPanel } = proxyquireStrict('../panel/TailEditorPanel', {
+      vscode: vscodeStub,
+      '../provider/SfLogTailViewProvider': { SfLogTailViewProvider: FakeTailProvider },
+      '../host/utils/localize': {
+        localize: (_key: string, defaultValue: string) => defaultValue
+      }
+    });
+
+    const context = {
+      extensionUri: {},
+      subscriptions: [] as any[]
+    };
+
+    TailEditorPanel.initialize(context as any);
+    await TailEditorPanel.show();
+    await createdProviders[0]?.recoveryCallbacks[0]?.();
+
+    assert.deepEqual(createdProviders[0]?.resolvedPanels, panels);
+    assert.equal(panelIndex, 2, 'ready timeout should create one replacement panel');
+  });
+
   test('clears the singleton after dispose so a new editor panel can be created', async () => {
     const createdProviders: any[] = [];
     const panels = [createPanel(), createPanel()];
@@ -121,11 +176,7 @@ suite('TailEditorPanel', () => {
 
       setSelectedOrg(_org?: string): void {}
 
-      onDidReadyTimeout(): { dispose(): void } {
-        return createDisposable();
-      }
-
-      resolveWebviewPanel(_panel: any): void {}
+      resolveWebviewPanel(_panel: any, _recover: () => void | Promise<void>): void {}
 
       dispose(): void {
         this.disposeCount += 1;

--- a/apps/vscode-extension/src/test/tailService.test.ts
+++ b/apps/vscode-extension/src/test/tailService.test.ts
@@ -14,7 +14,7 @@ import {
   setApiVersion
 } from '../host/salesforce/apiVersion';
 import { DebugFlagsPanel } from '../panel/DebugFlagsPanel';
-import { WEBVIEW_READY_TIMEOUT_MS, WEBVIEW_STABLE_VISIBILITY_DELAY_MS } from '../provider/SfLogTailViewProvider';
+import { WEBVIEW_SESSION_MOUNT_DELAY_MS } from '../provider/webviewSession';
 import { TestClock } from './testClock';
 
 const proxyquireStrict = proxyquire.noCallThru().noPreserveCache();
@@ -168,6 +168,9 @@ class MockWebviewView implements vscode.WebviewView {
       listener();
     }
   }
+  fireDispose(): void {
+    this.disposeListener?.();
+  }
 }
 
 class MockWebviewPanel implements vscode.WebviewPanel {
@@ -223,10 +226,14 @@ async function remountTailSidebar(
   };
   const view = new MockWebviewView(webview);
   await provider.resolveWebviewView(view);
-  await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-  await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+  await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+  await webview.emit({ type: 'ready', mountSequence: provider.getWebviewDiagnosticState().mountSequence });
   await clock.flushMicrotasks();
   return webview;
+}
+
+function postTailUpdate(provider: SfLogTailViewProvider, message: unknown): void {
+  (provider as any).post(message, 'replayable');
 }
 
 suite('TailService', () => {
@@ -238,17 +245,6 @@ suite('TailService', () => {
     jsforce.__resetConnectionFactoryForTests();
     __resetApiVersionFallbackStateForTests();
     setApiVersion('64.0');
-  });
-
-  test('tail webview uses corporate-friendly bootstrap timing windows', () => {
-    assert.ok(
-      WEBVIEW_STABLE_VISIBILITY_DELAY_MS >= 1000,
-      'visibility should be stable for at least 1s before mounting tail webview content'
-    );
-    assert.ok(
-      WEBVIEW_READY_TIMEOUT_MS >= 30000,
-      'tail webview ready watchdog should allow at least 30s for slow corporate machines'
-    );
   });
 
   test('requires debug level', async () => {
@@ -465,6 +461,7 @@ suite('TailService', () => {
   });
 
   test('selectOrg resets caches and stops tail', async () => {
+    const clock = new TestClock();
     const context = {
       extensionUri: vscode.Uri.file(path.resolve('.')),
       subscriptions: [] as vscode.Disposable[]
@@ -480,6 +477,10 @@ suite('TailService', () => {
     (provider as any).sendOrgs = async () => {};
     (provider as any).sendDebugLevels = async () => {};
     await provider.resolveWebviewView(view);
+    await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    await webview.emit({ type: 'ready', mountSequence: provider.getWebviewDiagnosticState().mountSequence });
+    await clock.flushMicrotasks();
+    posted.length = 0;
     const service = (provider as any).tailService;
     (service as any).seenLogIds.add('x');
     (service as any).logIdToPath.set('x', 'y');
@@ -495,6 +496,7 @@ suite('TailService', () => {
       true,
       'switching orgs should clear the visible tail buffer'
     );
+    clock.dispose();
   });
 
   test('sendDebugLevels selects the first available level when no active trace flag exists', async () => {
@@ -724,6 +726,7 @@ suite('TailService', () => {
   });
 
   test('openDebugFlags opens debug flags panel from tail view', async () => {
+    const clock = new TestClock();
     const opened: Array<{ selectedOrg?: string; sourceView?: string }> = [];
     (DebugFlagsPanel as any).show = async (options: any) => {
       opened.push(options || {});
@@ -738,7 +741,11 @@ suite('TailService', () => {
     const view = new MockWebviewView(webview);
     (provider as any).sendOrgs = async () => {};
     (provider as any).sendDebugLevels = async () => {};
+    (provider as any).refreshViewState = async () => undefined;
     await provider.resolveWebviewView(view);
+    await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    const mountSequence = provider.getWebviewDiagnosticState().mountSequence;
+    await webview.emit({ type: 'ready', mountSequence });
 
     await webview.emit({ type: 'selectOrg', target: 'tail-user@example.com' });
     await webview.emit({ type: 'openDebugFlags' });
@@ -746,6 +753,7 @@ suite('TailService', () => {
     assert.equal(opened.length, 1);
     assert.equal(opened[0]?.selectedOrg, 'tail-user@example.com');
     assert.equal(opened[0]?.sourceView, 'tail');
+    clock.dispose();
   });
 
   test('editor tail panel resolves html and stays idle after ready', async () => {
@@ -772,7 +780,7 @@ suite('TailService', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
@@ -793,421 +801,6 @@ suite('TailService', () => {
         (provider as any).tailService.isRunning(),
         false,
         'editor tail should stay idle until explicit start'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('editor tail panel ignores visibility refreshes until ready', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const panel = new MockWebviewPanel('electivus.apexLogViewer.tailView.editorPanel', webview);
-      const calls: string[] = [];
-
-      (provider as any).refreshViewState = async () => {
-        calls.push('refreshViewState');
-      };
-
-      provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      assert.deepEqual(calls, [], 'should not refresh while the webview has not reported ready');
-
-      await webview.emit({ type: 'ready' });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, ['refreshViewState'], 'should refresh once after ready');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail sidebar retries timed-out mounts while it stays visible', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      assert.ok(webview.html.includes('media/tail.js'), 'initial mount should render the tail webview');
-
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS);
-      assert.ok(!webview.html.includes('media/tail.js'), 'timeout should fall back to placeholder html');
-
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      assert.ok(webview.html.includes('media/tail.js'), 'visible sidebar should auto-remount after timeout');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail sidebar accepts delayed ready messages from slow corporate webview startup', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).refreshViewState = async () => {
-        calls.push('refreshViewState');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountSequence = (provider as any).mountSequence;
-      assert.ok(webview.html.includes('media/tail.js'), 'initial mount should render the tail webview');
-
-      await clock.advanceBy(20_000);
-      assert.ok(
-        webview.html.includes('media/tail.js'),
-        'slow startup should not be replaced with placeholder before the ready timeout'
-      );
-
-      await webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      assert.deepEqual(calls, ['refreshViewState']);
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail keeps a ready retained sidebar webview mounted across hide and show', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountedHtml = webview.html;
-      const mountedAssignments = webview.htmlAssignments.length;
-      const mountSequence = (provider as any).mountSequence;
-
-      await webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      view.fireVisible(false);
-      assert.equal(webview.html, mountedHtml, 'hiding a retained ready tail webview should not replace html');
-      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'hide should not write placeholder html');
-      assert.equal(provider.isReady(), true, 'ready retained tail webview should stay ready while hidden');
-
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'showing a retained ready tail webview should not remount html');
-      assert.equal(webview.htmlAssignments.length, mountedAssignments, 'show should not write a new html document');
-      assert.equal((provider as any).mountSequence, mountSequence, 'show should keep the same mount sequence');
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail requeues retained sidebar replay when visible postMessage is dropped', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      view.fireVisible(false);
-      (provider as any).post({ type: 'tailStatus', running: true });
-      await clock.flushMicrotasks();
-
-      assert.equal((provider as any).needsReplayOnVisible, true, 'hidden tail update should request replay on show');
-
-      posted.length = 0;
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(false);
-      };
-      view.fireVisible(true);
-      await clock.flushMicrotasks();
-
-      assert.ok(
-        posted.some(message => message?.type === 'init'),
-        'visible transition should attempt tail init replay'
-      );
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'dropped visible tail replay should stay requested until a retry delivers it'
-      );
-
-      posted.length = 0;
-      webview.postMessage = (message: any) => {
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-      await clock.advanceBy(1000);
-
-      assert.equal((provider as any).needsReplayOnVisible, false, 'successful tail retry should clear replay request');
-      assert.ok(
-        posted.some(message => message?.type === 'init'),
-        'visible retry should resend tail init'
-      );
-      assert.ok(
-        posted.some(message => message?.type === 'tailStatus'),
-        'visible retry should resend tail status'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail retries retained replay after a dropped visible tailStatus update', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropNextTailStatus = false;
-      webview.postMessage = (message: any) => {
-        if (dropNextTailStatus && message?.type === 'tailStatus') {
-          dropNextTailStatus = false;
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      posted.length = 0;
-      dropNextTailStatus = true;
-      (provider as any).post({ type: 'tailStatus', running: true });
-      await clock.flushMicrotasks();
-
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'dropped visible tailStatus should request a retained replay'
-      );
-
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal((provider as any).needsReplayOnVisible, false, 'successful tail retry should clear replay request');
-      assert.ok(
-        posted.some(message => message?.type === 'init'),
-        'visible retry should resend tail init'
-      );
-      assert.ok(
-        posted.some(message => message?.type === 'tailStatus' && message?.running === true),
-        'visible retry should replay the latest tail running status'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail retries retained reset after a dropped visible tailReset update', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropNextTailReset = false;
-      webview.postMessage = (message: any) => {
-        if (dropNextTailReset && message?.type === 'tailReset') {
-          dropNextTailReset = false;
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      posted.length = 0;
-      dropNextTailReset = true;
-      (provider as any).post({ type: 'tailReset' });
-      await clock.flushMicrotasks();
-
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'dropped visible tailReset should request a retained replay'
-      );
-
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        false,
-        'successful tail reset retry should clear replay request'
-      );
-      assert.ok(
-        posted.some(message => message?.type === 'init'),
-        'visible retry should resend tail init'
-      );
-      assert.ok(
-        posted.some(message => message?.type === 'tailReset'),
-        'visible retry should replay the retained tail reset'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail resets visible replay retry budget after a successful retry', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropNextTailStatus = false;
-      webview.postMessage = (message: any) => {
-        if (dropNextTailStatus && message?.type === 'tailStatus') {
-          dropNextTailStatus = false;
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      dropNextTailStatus = true;
-      (provider as any).post({ type: 'tailStatus', running: true });
-      await clock.flushMicrotasks();
-
-      assert.equal((provider as any).visibleReplayRetryAttempts, 1, 'dropped tail update should consume retry budget');
-
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        (provider as any).visibleReplayRetryAttempts,
-        0,
-        'successful tail replay retry should reset the retry budget'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail stops retrying visible replay after the retry budget is exhausted', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      let dropTailStatusThenAllReplay = false;
-      let dropAllReplay = false;
-      webview.postMessage = (message: any) => {
-        if (dropTailStatusThenAllReplay && message?.type === 'tailStatus') {
-          dropTailStatusThenAllReplay = false;
-          dropAllReplay = true;
-          return Promise.resolve(false);
-        }
-        if (dropAllReplay) {
-          return Promise.resolve(false);
-        }
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      dropTailStatusThenAllReplay = true;
-      (provider as any).post({ type: 'tailStatus', running: true });
-      await clock.flushMicrotasks();
-
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        (provider as any).visibleReplayRetryAttempts,
-        3,
-        'failed tail replay retries should consume the configured retry budget'
-      );
-      assert.equal(
-        (provider as any).visibleReplayRetryTimer,
-        undefined,
-        'tail replay should stop scheduling immediate retries after the budget is exhausted'
-      );
-      assert.equal(
-        (provider as any).needsReplayOnVisible,
-        true,
-        'tail replay should remain pending for a future hide/show after immediate retries are exhausted'
       );
     } finally {
       clock.dispose();
@@ -1240,15 +833,15 @@ suite('TailService', () => {
       (provider as any).refreshViewState = async () => undefined;
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({ type: 'ready', mountSequence: provider.getWebviewDiagnosticState().mountSequence });
       await clock.flushMicrotasks();
 
-      (provider as any).post({ type: 'error', message: 'tail failed' });
+      postTailUpdate(provider, { type: 'error', message: 'tail failed' });
       posted.length = 0;
 
       view.fireVisible(false);
-      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|recovered while hidden'] });
+      postTailUpdate(provider, { type: 'tailData', lines: ['USER_DEBUG|recovered while hidden'] });
       await clock.flushMicrotasks();
 
       assert.equal(posted.length, 0, 'hidden recovery messages are not delivered in this test harness');
@@ -1277,149 +870,6 @@ suite('TailService', () => {
     }
   });
 
-  test('tail retries a dropped visible error clear', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const posted: any[] = [];
-      let dropVisibleClear = false;
-      webview.postMessage = (message: any) => {
-        if (dropVisibleClear && message?.type === 'error' && message?.message === undefined) {
-          return Promise.resolve(false);
-        }
-        posted.push(message);
-        return Promise.resolve(true);
-      };
-
-      (provider as any).refreshViewState = async () => undefined;
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await webview.emit({ type: 'ready', mountSequence: (provider as any).mountSequence });
-      await clock.flushMicrotasks();
-
-      (provider as any).post({ type: 'error', message: 'tail failed' });
-      posted.length = 0;
-
-      dropVisibleClear = true;
-      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|recovered while visible'] });
-      await clock.flushMicrotasks();
-
-      assert.equal(
-        posted.some(message => message?.type === 'error' && message?.message === undefined),
-        false,
-        'dropped visible tail clear should not be treated as delivered'
-      );
-
-      dropVisibleClear = false;
-      posted.length = 0;
-      await clock.advanceBy(1000);
-
-      assert.equal(
-        posted.some(message => message?.type === 'error' && message?.message === undefined),
-        true,
-        'visible retry should resend a dropped tail error clear'
-      );
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail keeps an initializing retained sidebar webview mounted while hidden', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).refreshViewState = async () => {
-        calls.push('refreshViewState');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      const mountedHtml = webview.html;
-      const mountedAssignments = webview.htmlAssignments.length;
-      const mountSequence = (provider as any).mountSequence;
-
-      view.fireVisible(false);
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS + WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'hidden initializing tail webview should not fall back to placeholder');
-      assert.equal(
-        webview.htmlAssignments.length,
-        mountedAssignments,
-        'hidden initializing tail webview should not remount'
-      );
-
-      view.fireVisible(true);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      assert.equal(webview.html, mountedHtml, 'visible restore should reuse the initializing tail document');
-      assert.equal(
-        (provider as any).mountSequence,
-        mountSequence,
-        'visible restore should not allocate a new tail mount'
-      );
-
-      await webview.emit({ type: 'ready', mountSequence });
-      await clock.flushMicrotasks();
-
-      assert.deepEqual(calls, ['refreshViewState']);
-      assert.equal(provider.isReady(), true);
-    } finally {
-      clock.dispose();
-    }
-  });
-
-  test('tail sidebar ignores stale ready events from a previous mount after timeout remounts', async () => {
-    const clock = new TestClock();
-    try {
-      const context = {
-        extensionUri: vscode.Uri.file(path.resolve('.')),
-        subscriptions: [] as vscode.Disposable[]
-      } as unknown as vscode.ExtensionContext;
-      const provider = new SfLogTailViewProvider(context);
-      const webview = new MockWebview();
-      const view = new MockWebviewView(webview);
-      const calls: string[] = [];
-
-      (provider as any).refreshViewState = async () => {
-        calls.push('refreshViewState');
-      };
-
-      await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-      await clock.advanceBy(WEBVIEW_READY_TIMEOUT_MS);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
-
-      await webview.emit({ type: 'ready', mountSequence: 1 });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, [], 'stale ready should not bootstrap the remounted tail view');
-
-      await webview.emit({ type: 'ready' });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, [], 'unsequenced stale ready should not bootstrap the remounted tail view');
-
-      await webview.emit({ type: 'ready', mountSequence: 2 });
-      await clock.flushMicrotasks();
-      assert.deepEqual(calls, ['refreshViewState']);
-    } finally {
-      clock.dispose();
-    }
-  });
-
   test('tail remount replays the latest error until successful data clears it', async () => {
     const clock = new TestClock();
     try {
@@ -1437,11 +887,11 @@ suite('TailService', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
-      (provider as any).post({ type: 'error', message: 'tail failed' });
+      postTailUpdate(provider, { type: 'error', message: 'tail failed' });
       posted.length = 0;
 
       await remountTailSidebar(provider, clock, posted);
@@ -1451,14 +901,15 @@ suite('TailService', () => {
         true
       );
 
-      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|hello'] });
+      postTailUpdate(provider, { type: 'tailData', lines: ['USER_DEBUG|hello'] });
       posted.length = 0;
 
       await remountTailSidebar(provider, clock, posted);
 
       assert.equal(
-        posted.some(message => message?.type === 'error'),
-        false
+        posted.some(message => message?.type === 'error' && message?.message !== undefined),
+        false,
+        'the replacement may receive an explicit clear but must not replay the stale Tail error'
       );
     } finally {
       clock.dispose();
@@ -1482,12 +933,12 @@ suite('TailService', () => {
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
       (provider as any).tailService.bufferedLines = ['USER_DEBUG|buffered'];
-      (provider as any).post({ type: 'error', message: 'tail failed' });
+      postTailUpdate(provider, { type: 'error', message: 'tail failed' });
 
       for (let attempt = 0; attempt < 2; attempt += 1) {
         posted.length = 0;
@@ -1500,7 +951,7 @@ suite('TailService', () => {
       }
 
       posted.length = 0;
-      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|recovered'] });
+      postTailUpdate(provider, { type: 'tailData', lines: ['USER_DEBUG|recovered'] });
 
       assert.equal(
         posted.some(message => message?.type === 'error' && message?.message === undefined),
@@ -1528,22 +979,22 @@ suite('TailService', () => {
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
-      (provider as any).post({ type: 'error', message: 'tail failed' });
+      postTailUpdate(provider, { type: 'error', message: 'tail failed' });
       posted.length = 0;
-      (provider as any).post({ type: 'tailStatus', running: true });
+      postTailUpdate(provider, { type: 'tailStatus', running: true });
 
       assert.equal(
         posted.some(message => message?.type === 'error' && message?.message === undefined),
         true
       );
 
-      (provider as any).post({ type: 'error', message: 'tail failed again' });
+      postTailUpdate(provider, { type: 'error', message: 'tail failed again' });
       posted.length = 0;
-      (provider as any).post({ type: 'tailData', lines: ['USER_DEBUG|hello'] });
+      postTailUpdate(provider, { type: 'tailData', lines: ['USER_DEBUG|hello'] });
 
       assert.equal(
         posted.some(message => message?.type === 'error' && message?.message === undefined),
@@ -1566,15 +1017,15 @@ suite('TailService', () => {
       const panel = new MockWebviewPanel('electivus.apexLogViewer.tailView.editorPanel', webview);
       const calls: string[] = [];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: undefined });
-      (provider as any).post({ type: 'debugLevels', data: [] });
+      postTailUpdate(provider, { type: 'orgs', data: [], selected: undefined });
+      postTailUpdate(provider, { type: 'debugLevels', data: [] });
       (provider as any).debugLevelsBootstrapNeedsRefresh = true;
       (provider as any).refreshViewState = async () => {
         calls.push('refreshViewState');
       };
 
       provider.resolveWebviewPanel(panel);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
@@ -1597,14 +1048,14 @@ suite('TailService', () => {
       const calls: Array<{ showLoading?: boolean }> = [];
       const posted: any[] = [];
 
-      (provider as any).post({ type: 'orgs', data: [], selected: undefined });
-      (provider as any).post({ type: 'debugLevels', data: [] });
+      postTailUpdate(provider, { type: 'orgs', data: [], selected: undefined });
+      postTailUpdate(provider, { type: 'debugLevels', data: [] });
       (provider as any).refreshViewState = async (options?: { showLoading?: boolean }) => {
         calls.push(options ?? {});
       };
 
       await provider.resolveWebviewView(view);
-      await clock.advanceBy(WEBVIEW_STABLE_VISIBILITY_DELAY_MS);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
       await webview.emit({ type: 'ready' });
       await clock.flushMicrotasks();
 
@@ -1618,7 +1069,172 @@ suite('TailService', () => {
     }
   });
 
+  test('tail replay preserves selected org, configuration, running state, reset ordering, buffer, and error', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const posted: any[] = [];
+      const webview = new MockWebview();
+      webview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+
+      postTailUpdate(provider, {
+        type: 'orgs',
+        data: [{ username: 'selected@example.com', alias: 'selected' }],
+        selected: 'selected@example.com'
+      });
+      postTailUpdate(provider, { type: 'debugLevels', data: ['ALV_Tail'], active: 'ALV_Tail' });
+      postTailUpdate(provider, { type: 'tailConfig', tailBufferSize: 321 });
+      postTailUpdate(provider, { type: 'tailStatus', running: true });
+      (provider as any).tailService.bufferedLines = ['USER_DEBUG|first', 'USER_DEBUG|second'];
+      postTailUpdate(provider, { type: 'error', message: 'tail failed' });
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(new MockWebviewView(webview));
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({
+        type: 'ready',
+        mountSequence: provider.getWebviewDiagnosticState().mountSequence
+      });
+      await clock.flushMicrotasks();
+
+      assert.ok(
+        posted.some(
+          message =>
+            message?.type === 'orgs' &&
+            message?.selected === 'selected@example.com' &&
+            message?.data?.[0]?.username === 'selected@example.com'
+        )
+      );
+      assert.ok(posted.some(message => message?.type === 'tailConfig' && message?.tailBufferSize === 321));
+      assert.ok(posted.some(message => message?.type === 'tailStatus' && message?.running === true));
+      const resetIndex = posted.findIndex(message => message?.type === 'tailReset');
+      const dataIndex = posted.findIndex(message => message?.type === 'tailData');
+      assert.ok(resetIndex >= 0 && dataIndex === resetIndex + 1, 'buffer replay should reset immediately before data');
+      assert.deepEqual(posted[dataIndex]?.lines, ['USER_DEBUG|first', 'USER_DEBUG|second']);
+      assert.ok(posted.some(message => message?.type === 'error' && message?.message === 'tail failed'));
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail bootstrap failure remains surface-owned and does not reset readiness', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      (provider as any).refreshViewState = async () => {
+        throw new Error('tail bootstrap failed');
+      };
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({
+        type: 'ready',
+        mountSequence: provider.getWebviewDiagnosticState().mountSequence
+      });
+      await clock.flushMicrotasks();
+
+      assert.equal(provider.isReady(), true);
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail host replacement preserves the active stream and replays its running status', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const firstWebview = new MockWebview();
+      const firstView = new MockWebviewView(firstWebview);
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(firstView);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await firstWebview.emit({
+        type: 'ready',
+        mountSequence: provider.getWebviewDiagnosticState().mountSequence
+      });
+      await clock.flushMicrotasks();
+
+      (provider as any).tailService.tailRunning = true;
+      postTailUpdate(provider, { type: 'tailStatus', running: true });
+      await clock.flushMicrotasks();
+
+      const posted: any[] = [];
+      const replacementWebview = new MockWebview();
+      replacementWebview.postMessage = (message: any) => {
+        posted.push(message);
+        return Promise.resolve(true);
+      };
+      await provider.resolveWebviewView(new MockWebviewView(replacementWebview));
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await replacementWebview.emit({
+        type: 'ready',
+        mountSequence: provider.getWebviewDiagnosticState().mountSequence
+      });
+      await clock.flushMicrotasks();
+
+      assert.equal((provider as any).tailService.isRunning(), true, 'replacement should not stop the active tail');
+      assert.ok(
+        posted.some(message => message?.type === 'tailStatus' && message?.running === true),
+        'replacement should replay the latest running state'
+      );
+    } finally {
+      clock.dispose();
+    }
+  });
+
+  test('tail host disposal stops the active stream while retaining the provider for recovery', async () => {
+    const clock = new TestClock();
+    try {
+      const context = {
+        extensionUri: vscode.Uri.file(path.resolve('.')),
+        subscriptions: [] as vscode.Disposable[]
+      } as unknown as vscode.ExtensionContext;
+      const provider = new SfLogTailViewProvider(context);
+      const webview = new MockWebview();
+      const view = new MockWebviewView(webview);
+      (provider as any).refreshViewState = async () => undefined;
+
+      await provider.resolveWebviewView(view);
+      await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+      await webview.emit({
+        type: 'ready',
+        mountSequence: provider.getWebviewDiagnosticState().mountSequence
+      });
+      await clock.flushMicrotasks();
+
+      (provider as any).tailService.tailRunning = true;
+      postTailUpdate(provider, { type: 'tailStatus', running: true });
+      view.fireDispose();
+      await clock.flushMicrotasks();
+
+      assert.equal(provider.isReady(), false);
+      assert.equal(provider.getWebviewDiagnosticState().disposed, false);
+      assert.equal(provider.getWebviewDiagnosticState().snapshots.tailRunning, false);
+    } finally {
+      clock.dispose();
+    }
+  });
+
   test('syncSelectedOrg refreshes an existing editor tail session and stops the current stream', async () => {
+    const clock = new TestClock();
     const context = {
       extensionUri: vscode.Uri.file(path.resolve('.')),
       subscriptions: [] as vscode.Disposable[]
@@ -1633,15 +1249,21 @@ suite('TailService', () => {
       return Promise.resolve(true);
     };
 
+    postTailUpdate(provider, { type: 'orgs', data: [], selected: undefined });
+    postTailUpdate(provider, { type: 'debugLevels', data: [] });
+    (provider as any).refreshViewState = async () => {
+      calls.push('refreshViewState');
+    };
     provider.resolveWebviewPanel(panel);
+    await clock.advanceBy(WEBVIEW_SESSION_MOUNT_DELAY_MS);
+    await webview.emit({ type: 'ready', mountSequence: provider.getWebviewDiagnosticState().mountSequence });
+    await clock.flushMicrotasks();
+    posted.length = 0;
+    calls.length = 0;
     provider.setSelectedOrg('tail-first@example.com');
     (provider as any).tailService.setOrg('tail-first@example.com');
     (provider as any).tailService.bufferedLines = ['USER_DEBUG|stale'];
     (provider as any).tailService.tailRunning = true;
-    (provider as any).refreshViewState = async () => {
-      calls.push('refreshViewState');
-    };
-
     await provider.syncSelectedOrg('tail-second@example.com');
 
     assert.equal(provider.getSelectedOrg(), 'tail-second@example.com');
@@ -1653,5 +1275,6 @@ suite('TailService', () => {
       'syncSelectedOrg should clear buffered lines before refreshing the next org'
     );
     assert.deepEqual(calls, ['refreshViewState']);
+    clock.dispose();
   });
 });

--- a/apps/vscode-extension/src/test/webviewHost.capabilities.test.ts
+++ b/apps/vscode-extension/src/test/webviewHost.capabilities.test.ts
@@ -1,0 +1,55 @@
+import assert from 'assert/strict';
+import * as vscode from 'vscode';
+import { createWebviewPanelHost, createWebviewViewHost } from '../provider/webviewHost';
+
+function noopDisposable(): vscode.Disposable {
+  return { dispose() {} };
+}
+
+suite('Webview host recovery capabilities', () => {
+  test('sidebar prepares and remounts the current host in place', async () => {
+    const view = {
+      visible: true,
+      webview: {},
+      onDidDispose: () => noopDisposable(),
+      onDidChangeVisibility: () => noopDisposable()
+    } as unknown as vscode.WebviewView;
+    const recoverySteps: string[] = [];
+
+    const sidebarHost = createWebviewViewHost(view, () => {
+      recoverySteps.push('prepare');
+    });
+    await sidebarHost.recoverAfterReadyTimeout(() => {
+      recoverySteps.push('remount');
+    });
+
+    assert.deepEqual(recoverySteps, ['prepare', 'remount']);
+    assert.ok(!('kind' in sidebarHost));
+    assert.ok(!('readinessTimeoutRecovery' in sidebarHost));
+    assert.ok(!('onDidBecomeVisible' in sidebarHost));
+  });
+
+  test('editor delegates replacement without remounting the current host', async () => {
+    const panel = {
+      visible: true,
+      webview: {},
+      onDidDispose: () => noopDisposable(),
+      onDidChangeViewState: () => noopDisposable()
+    } as unknown as vscode.WebviewPanel;
+    let editorRemounts = 0;
+    let editorReplacements = 0;
+
+    const editorHost = createWebviewPanelHost(panel, () => {
+      editorReplacements += 1;
+    });
+    await editorHost.recoverAfterReadyTimeout(() => {
+      editorRemounts += 1;
+    });
+
+    assert.equal(editorRemounts, 0);
+    assert.equal(editorReplacements, 1);
+    assert.ok(!('kind' in editorHost));
+    assert.ok(!('readinessTimeoutRecovery' in editorHost));
+    assert.ok(!('onDidBecomeVisible' in editorHost));
+  });
+});

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,6 +31,14 @@ The client in `apps/vscode-extension/src/runtime/runtimeClient.ts` preserves the
 
 Extension Open, Replay, Tail body reads, full-log search preparation, triage, sync, status, and local purge all cross `ApexLogLifecycle`. The extension retains presentation, streaming subscriptions, Replay commands, ripgrep execution, and retention-policy selection; it does not construct cache paths or write Apex log bodies.
 
+### Webview Session
+
+Logs and Tail each bind one rebindable Webview Session. This is the extension's single production implementation of delayed mount, readiness, visibility, classified delivery, latest-snapshot replay, bounded retry, stale-generation rejection, temporary detach, final disposal, and payload-free mechanical diagnostics.
+
+The host adapters expose capabilities instead of identities: a sidebar can prepare and remount its current host in place, while an editor can replace its panel. Webview Session does not branch on a panel/sidebar or editor/sidebar discriminator. Both adapters preserve the established `retainContextWhenHidden` behavior.
+
+The Logs and Tail providers continue to own presentation HTML, authoritative replay snapshots, bootstrap and refresh policy, validated interactions, workflow errors, and surface diagnostics. They explicitly classify deliveries and supply the latest replay batch on request; Webview Session does not retain a generic journal or know either surface's snapshot schema.
+
 Commands, view ids, and settings use the `electivus.apexLogViewer.*` namespace. Old `sfLogs.*` and `electivus.apexLogs.*` aliases are intentionally not registered.
 
 ## Salesforce CLI plugin

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -26,6 +26,19 @@ The Node-only Mocha runner lives in `scripts/run-node-tests.js`. The `sf electiv
 - Keep the default CLI-driven VS Code runtime on `stable`. Use `VSCODE_TEST_VERSION` only when you are intentionally validating another build.
 - If a test can be rewritten to avoid `vscode` at runtime, prefer moving it to `src/node-test/` instead of expanding the host-bound suite.
 
+### Webview lifecycle test seams
+
+Webview lifecycle mechanics have one primary public test seam. Provider tests do not inspect session internals or repeat generic timer, visibility, retry-budget, generation, or disposal cases.
+
+| Test area                                               | Owned verification                                                                                                                                                                                                    |
+| ------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `src/node-test/webviewSession.test.ts`                  | Public Webview Session behavior in the Node-only lane with a fake host and private fake clock: mount/readiness timing, visibility, delivery, replay, retry, stale work, detach/disposal, and payload-free diagnostics |
+| `webviewHost.capabilities.test.ts`                      | Sidebar in-place remount and editor replacement capabilities, without a host-kind discriminator                                                                                                                       |
+| `provider.webview.test.ts`                              | Logs presentation, authoritative snapshot composition, bootstrap/refresh decisions, validated interactions, delivery outcomes, workflow errors, and surface recovery                                                  |
+| `tailService.test.ts`                                   | Tail snapshot/reset/buffer composition and ordering, bootstrap decisions, validated interactions, workflow errors, and surface recovery                                                                               |
+| `logsEditorPanel.test.ts` and `tailEditorPanel.test.ts` | Editor replacement ownership and `retainContextWhenHidden`                                                                                                                                                            |
+| `extension.activation.gating.test.ts`                   | Stable activation registration and composed support diagnostics                                                                                                                                                       |
+
 ### VS Code UI Test Runner (opcional)
 
 Se você preferir rodar e depurar via UI, instale a extensão “Extension Test Runner”. Use o launch `Extension Tests` (em `.vscode/launch.json`) para abrir o host de testes apontando para `out/test/runner.js`.

--- a/docs/adr/0001-webview-session-owns-mechanics.md
+++ b/docs/adr/0001-webview-session-owns-mechanics.md
@@ -1,0 +1,29 @@
+# Keep surface snapshots outside the Webview Session
+
+Status: accepted
+
+## Context
+
+The Logs and Tail providers independently own the same webview mechanics: host binding, delayed mount, readiness, visibility, delivery recovery, retries, stale-mount rejection, and diagnostics. Their presentation state and authoritative replay snapshots differ, so moving those snapshots into a shared message journal would make the common interface broad and policy-heavy.
+
+## Decision
+
+The VS Code extension will use one rebindable Webview Session per live surface. The session owns host attachment, delayed mount and readiness, visibility transitions, explicitly classified outbound delivery, latest-snapshot replay, bounded retry, generation safety, validated inbound routing, temporary detach, final disposal, and mechanical diagnostics.
+
+Logs and Tail retain presentation, authoritative snapshot state, bootstrap workflows, replay content, surface message handling, workflow errors, and surface diagnostics. A surface classifies each outbound delivery as replayable or transient and produces its latest replay batch only when the session requests it. Replay succeeds only when every post is accepted; the session does not infer replay policy from message types or retain intermediate payloads.
+
+Detach callbacks receive a payload-free mechanical reason so a surface can preserve its established policy across host replacement, host disposal, explicit detach, and final disposal without reimplementing host lifecycle detection.
+
+Readiness-timeout recovery is a host capability. Sidebar adapters may remount the current host, while editor adapters may replace their panel; the session contains no panel-versus-editor branch. Timing control remains a private construction seam used by production and deterministic contract tests, not a surface-provider dependency.
+
+The lifecycle defaults remain a one-second mount delay, a thirty-second readiness timeout, and three replay retries at 250 milliseconds. Sidebar and editor registrations continue to use `retainContextWhenHidden`.
+
+Mechanical behavior is verified through the public Webview Session interface with a fake host and a private fake clock. Host-adapter tests verify in-place sidebar remount and editor replacement. Logs and Tail provider tests verify only surface-owned snapshots, bootstrap and workflow decisions, message validation and handling, delivery classifications through observable outcomes, errors, and recovery outcomes.
+
+## Consequences
+
+- Logs and Tail can migrate independently onto one proven lifecycle contract.
+- Host replacement preserves logical replay intent without preserving stale host work.
+- Mechanical diagnostics remain payload-free and can be composed with surface-owned diagnostics.
+- Surface snapshots stay local and understandable, at the cost of each surface supplying mount, validation, message, and latest-snapshot callbacks.
+- The completed migration has one production lifecycle implementation. Host adapters expose recovery capabilities directly; no host-kind discriminator or provider-owned lifecycle state remains.


### PR DESCRIPTION
## Summary

- introduce one rebindable Webview Session implementation for mount, readiness, visibility, classified delivery, latest-snapshot replay, bounded retry, generation safety, detach/disposal, inbound routing, and mechanical diagnostics
- migrate both Logs and Tail sidebar/editor surfaces while keeping their authoritative snapshots, bootstrap workflows, errors, and surface diagnostics local
- replace host-kind branching with sidebar remount and editor replacement capabilities
- restore and commit ADR 0001, update architecture/testing documentation, and consolidate the deterministic contract suite in the Node-only test lane

## Architecture

Each live surface owns its own session instance, while both instances use the same production state machine. The session owns transport mechanics; Logs and Tail continue to own presentation meaning and authoritative replay content.

The final review remediation also ensures that stale accepted delivery results cannot mutate a replacement generation, asynchronous replay snapshots coalesce to the latest authoritative state, Logs work survives host replacement, retry budget reopens on a later visibility/readiness opportunity, and stale timeout recovery cannot remount a newer host.

## Validation

- `pnpm run check-types`
- `pnpm run lint`
- `pnpm run build`
- `pnpm run test:extension:node` (38 passing)
- `pnpm run test:all` (including 105 webview, 38 Node-only, and 303 hosted extension tests)
- `pnpm run test:ci` (including 105 webview, 107 E2E utility, 38 Node-only, 303 hosted unit, and 3 hosted integration tests)
- independent Standards and Spec reviews, followed by remediation and clean re-review
- `git diff --check`

Closes #1007
Closes #1008
Closes #1009
Closes #1010
Closes #1011